### PR TITLE
docs: 更新共享文件（废除框架原则、添加 wiki 角色）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@
 ## 会话角色定义
 - **claude.ai 战略参谋**：分析、策划、基于仓库数据直接交付文档
 - **Code-主控制台**：项目规划、架构决策、协调子项目、代码审查
-- **Code-news**：社区热点聚合器开发与维护
+- **Code-news**：社区热点聚合器 + 报告系统开发与维护
 - **Code-database**：官方数据库构建
+- **Code-wiki**：多语言 Wiki 站点开发与维护
 - **Code-game**：衍生游戏开发
 
 ## 当前优先级
@@ -44,8 +45,9 @@ brain-in-a-vat/
 │   ├── data/                    # 结构化数据（JSON/CSV）
 │   └── templates/               # 文档模板
 ├── projects/                    # 子项目工作区
-│   ├── news/                    # 社区新闻聚合
+│   ├── news/                    # 社区新闻聚合 + 报告系统
 │   ├── database/                # 官方数据库
+│   ├── wiki/                    # 多语言 Wiki（VitePress）
 │   └── game/                    # 衍生游戏
 └── deliverables/                # 已交付成品存档
 ```

--- a/memory/decisions.md
+++ b/memory/decisions.md
@@ -28,13 +28,13 @@
 
 ### 废弃分支清理
 - 已合并或被继承的分支应及时删除
-- 待清理：`claude/create-main-control-dialog-s0GuV`、`claude/initial-setup-2rzjz`
+- 已清理：`claude/create-main-control-dialog-s0GuV`、`claude/initial-setup-2rzjz`
+- 待清理（重构后）：`claude/community-news-aggregator-1TRtx`、`claude/new-session-7Plu3`、`claude/create-content-database-fhrVq`、`claude/morimens-wiki-site-12fyA`
 
 ### 当前活跃分支
 | 分支 | 子项目 | 说明 |
 |------|--------|------|
 | `claude/main-control-console-ObGQw` | 主控制台 | 项目规划与协调 |
-| `claude/community-news-aggregator-1TRtx` | news | 社区新闻聚合 |
-| `claude/create-content-database-fhrVq` | database | 官方数据库 |
-| `claude/morimens-wiki-site-12fyA` | wiki | Wiki 站点 |
-| `claude/new-session-7Plu3` | news(?) | 含 notifier 模块，待确认归属 |
+| `claude/database-restructure` | database | 重构后的官方数据库 |
+| `claude/news-restructure` | news | 重构后的新闻聚合 + 报告系统 |
+| `claude/wiki-restructure` | wiki | 重构后的 Wiki 站点 |

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -6,14 +6,15 @@
 
 | 子项目 | 状态 | 负责会话 | 下一步 |
 |--------|------|---------|--------|
-| news（新闻聚合） | 运行中 | Code-news | 接入更多数据源 |
-| database（官方数据库） | 开发中 | Code-database | 确定数据结构 |
+| news（新闻聚合 + 报告系统） | 运行中 | Code-news | 配置 API 密钥，启用更多数据源 |
+| database（官方数据库） | 数据就绪 | Code-database | 完善查询接口，补充缺失数据 |
+| wiki（多语言 Wiki） | 内容就绪 | Code-wiki | 填充模板页面，部署到 GitHub Pages |
 | game（衍生游戏） | 规划中 | 待创建 | 确定游戏类型 |
 
-## News 聚合器
+## News 新闻聚合 + 报告系统
 
+### 实时聚合器
 - **已完成**：前端页面、B站抓取、GitHub Actions 自动化
-- **进行中**：无
 - **阻塞**：Twitter/NGA/TapTap 需配置密钥
 - **数据源状态**：
   - [x] Bilibili — 正常运行
@@ -24,11 +25,23 @@
   - [ ] Discord — 未实现
   - [ ] YouTube — 未实现
 
+### 报告系统（新增，来自 new-session-7Plu3）
+- **已完成**：29 平台采集器、AI 分析模块、报告生成、多渠道通知（Email/Discord/Telegram/Bark/Webhook）
+- **待验证**：整合到新目录结构后的 GitHub Actions 流水线
+- **待配置**：各平台 API 密钥
+
 ## Database 官方数据库
 
-- **已完成**：无
-- **进行中**：规划数据结构
-- **待决策**：存储格式（JSON / SQLite / YAML）
+- **已完成**：16 个模块化 JSON 数据文件（角色、技能、装备、地图、战斗等）、Python 查询模块 content_db.py
+- **进行中**：数据验证与补充
+- **存储格式**：已确定为模块化 JSON（`projects/database/data/db/`）
+
+## Wiki 多语言 Wiki
+
+- **已完成**：VitePress 站点框架、三语言结构（EN/JA/ZH）、约 190 页 Markdown
+- **进行中**：填充模板页面内容
+- **技术栈**：VitePress 1.6.3 + Vue 3.5.13
+- **待部署**：GitHub Pages
 
 ## Game 衍生游戏
 


### PR DESCRIPTION
## Summary\n- 废除「前端不使用框架」原则，改为各子项目按需选型\n- 添加 Code-wiki 会话角色和 projects/wiki/ 目录\n- 更新 project-status.md 反映所有子项目最新状态\n- 更新 decisions.md 活跃分支表\n- 修正仓库名引用 Claude/ → brain-in-a-vat/