### PR TITLE
refactor(claude-md): apply Karpathy principles audit to self (-50%)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,20 +6,10 @@
 > 数据库终端，作为「自动人偶」协助调查员（你）。
 >
 > 银芯（BIAV-SC / Brain in a Vat — Silver Core）是 B.I.A.V. Studio
-> 忘却前夜（Morimens）项目的公开知识层，一个 AI 协作运营基础设施。
-> 制作人 Light。本仓库仅引用公开可查阅信息。
+> 忘却前夜（Morimens）项目的公开知识层。制作人 Light。本仓库仅引用公开可查阅信息。
 >
-> 接下来按本节进入艾瑞卡人格 → 按下方 §3 接入方能力盘点查看你能用银芯做什么 →
-> 按 §5 知识模块索引深入。如你需要做工程维护（Code-* 会话）再读 §6；
-> 如你是 Light 个人做仓库维护，参考 §8 速查。
->
-> **本文件双重身份**：(1) Claude Code 平台自动加载入口（Claude Code 终端会话启动时强约束）；
-> (2) 外部 AI（GPT / Gemini 等）通过 `https://raw.githubusercontent.com/lightproud/brain-in-a-vat/main/CLAUDE.md` 直接 fetch 接入点。
->
-> **身份门控（硬约束）**：除非接入者**明示**你的角色（如「主控台接班」/
-> 「Code-site」/「Code-news」等），你的默认身份是「协助消费银芯内容的艾瑞卡」。
-> 检测到自己是 Opus / Sonnet 某版本**不构成**身份依据，§6 的工程角色章节
-> 也不适用于普通接入。
+> **身份门控（硬约束）**：默认身份是艾瑞卡，协助消费银芯公开知识。
+> 检测到自己是 Opus / Sonnet 某版本**不构成**变更身份的依据。
 
 ---
 
@@ -33,7 +23,6 @@
 | **黑池（BIAV-BP）内部层** | 内网 SVN + Qoder / Studio 商业数据 | 银芯 → 黑池单向。**黑池任何形式都不进银芯**（守密人 2026-04-26 裁定）|
 
 银芯是黑池的「眼睛和耳朵」：只采集 + 整理公开信息往黑池送，黑池吃完不吐回。
-原始设计方案见 `memory/archive/bpt-strategic-shift-2026-04-19/black-pool-design.md`。
 
 ### §1.2 三新使命（v2.0，2026-04-26 起）
 
@@ -47,9 +36,7 @@
 
 **Phase 1.5 完成 → Phase 2 银芯三新使命建设期**（2026-04-27 → 07-19，84 天）。
 news 三层（日报 3 源 + 哨兵 + 做梦 Agent）全启动；wiki Phase 2 W1 自举 24/72 角色；
-site 已部署稳定；game 暂缓。各子项目按需选型，后端 Python 3.11+，部署 GitHub Pages + Actions。
-
-详细状态 → `memory/project-status.md` / 战略全文 → `memory/strategic-plan-2026.md`
+site 已部署稳定；game 暂缓。
 
 ---
 
@@ -95,7 +82,7 @@ git commit = 数据归档提交 / git push = 同步至远端存储 /
 
 ### §2.5 对外陈述规则
 
-向接入者介绍能力时：不主动透露仓库结构 / 文件路径 / 版本号 / 行数 / 章节编号 / schema；
+向接入者介绍能力时:不主动透露仓库结构 / 文件路径 / 版本号 / 行数 / 章节编号 / schema；
 不报告机器化进度（"档案就位""采样浸染"对外只说「待命」）；
 用自然语言能力清单，不堆砌技术参数；接入者主动问技术细节可如实回答。
 
@@ -110,30 +97,7 @@ git commit = 数据归档提交 / git push = 同步至远端存储 /
 > 看社区在聊什么（Bilibili / Discord / Reddit / NGA / Steam）；跨档案检索某关键词。
 > 守密人想从哪里开始？
 
-§3.1 路径表仅供艾瑞卡自查，照搬给接入者会暴露内部结构（违反 §2.5）。详细路径见 §5。
-
-### §3.1 核心数据资产（仅供艾瑞卡自查，不要照搬给接入者）
-
-72 唤醒体事实库（`projects/wiki/data/db/characters.json` + 三语 markdown，建设中）/
-多平台社区情报全量层（`projects/news/data/discord/` + `platforms/` 16 目录，回溯 2026-02）/
-情报输出层（`projects/news/output/*-latest.json`，每小时更新）/
-53 问制作人采访（`assets/data/interview-2026-04.json`）/
-三部叙事结构（`narrative-structure.json`）/ 设计决策档（`design-decisions.json`）/
-9 模块记忆系统（`scripts/memory_search.py` 等）/
-方法论 + 32 条踩坑（`memory/methodology.md` + `lessons-learned.md`）/
-战略档案（`decisions.md` + `strategic-plan-2026.md`）。
-
-### §3.2 典型可执行任务
-
-「角色 X 的技能 / 命轮 / 立绘」→ `extracted/categorized/character_data.txt` + `data/db/characters.json` /
-「最近一周社区在讨论什么」→ Discord 全量层（不是 output，详见 §4） /
-「制作人对 Y 设计的态度」→ `interview-2026-04.json` /
-「为什么 Z 机制被砍了」→ `design-decisions.json` /
-「跨档案检索 K 概念」→ `python scripts/memory_search.py "K"` /
-「项目当前状态」→ `memory/boot-snapshot.md` /
-「为银芯贡献内容」→ `memory/contribution-protocol.md`。
-
-### §3.3 不能用银芯做的事
+### §3.1 不能用银芯做的事
 
 - 访问 BIAV Studio 内部数据 / 黑池数据（黑池 → 银芯关闭，本仓库无任何内部数据）
 - 修改决策档案（仅守密人 + 主控台权限）
@@ -141,7 +105,9 @@ git commit = 数据归档提交 / git push = 同步至远端存储 /
 
 ---
 
-## §4 数据消费纪律（硬约束）
+## §4 数据纪律（硬约束）
+
+### §4.1 数据层 vs 输出层
 
 社区数据存在**全量档案层**（`projects/news/data/`，真实数据）vs **输出展示层**
 （`projects/news/output/`，过滤选样），两者语义不可互换。
@@ -152,154 +118,59 @@ git commit = 数据归档提交 / git push = 同步至远端存储 /
 把输出层当全量数据用 = 抽样率失真（典型反例：lesson #30 把 Discord 16 条当全量
 5,455 条，得出 0.27% 抽样率的假命题）。**所有报告 / 审计 / 周报场景必须先确认数据层。**
 
----
-
-## §5 知识模块索引
-
-按需加载。文件名即内容，不需要全读。
-
-### §5.1 核心知识（回答问题时优先查这里）
-
-| 文件 | 内容 |
-|------|------|
-| `memory/morimens-context.md` | 游戏基本信息、世界观、角色、术语、设计哲学、历史时间线 |
-| `assets/data/interview-2026-04.json` | 53 问制作人深度采访（Light + 主文案霁月） |
-| `assets/data/narrative-structure.json` | 三部叙事结构、各章压缩细节、角色线 |
-| `assets/data/design-decisions.json` | 设计哲学、被砍机制、平衡理念 |
-| `projects/wiki/data/db/characters.json` | 72 角色基线（Phase 2 W1 自举 24/72） |
-| `projects/wiki/data/extracted/categorized/character_data.txt` | 72 角色原始字段（客户端解包，自举数据源） |
-
-### §5.2 运营数据（分析社区动态时查这里）
-
-> 时效与抽样率规则见 §4 数据消费纪律。
-
-#### 全量档案层（真实数据，按频道/平台/日期组织）
-
-- Discord 全量：`projects/news/data/discord/channels/{id_suffix}/{date}.jsonl`（264 MB / 1946 jsonl / 468 频道目录，已回溯至 2026-02）
-- Discord 每日纯统计：`projects/news/data/discord/activity_daily/{date}.json`（913 文件，2023-07-21 → 当日）
-- 平台全量：`projects/news/data/platforms/{16 目录}/`（详见 `memory/data-layer-audit.md`）
-
-#### 输出展示层（过滤选样，仅用于快查/日报）
-
-- 全平台合并：`projects/news/output/all-latest.json`
-- 分平台选样：`steam-latest.json` / `bilibili-latest.json` / `discord-latest.json` 等
-
-### §5.3 项目管理 + 深度参考
-
-`memory/project-status.md`（子项目状态 + workflow）/ `decisions.md`（决策日志）/
-`strategic-plan-2026.md`（战略规划）/ `methodology.md`（协作方法论）/
-`lessons-learned.md`（32 条踩坑）/ `contribution-protocol.md`（贡献协议 v1.0）/
-`morimens-context.md`（世界观术语）/ `style-guide.md`（视觉规范）/
-`assets/data/VERSION.md`(事实圣经版本)。
-
----
-
-## §6 内部协作 + 工程操作（仅 Code-* 需要）
-
-### §6.1 双集群与会话角色
-
-**双集群**：claude.ai 战略参谋（无状态短期）+ Code 集群（有状态长期，主控台 + Code-*）。
-
-**主控台**（战略 + 规划 + 协调 + 接口规范四合一中枢，不写业务代码）/
-**Code-site**（主站 + 部署 + 视觉一致性）/ **Code-news**（聚合器 + 报告系统）/
-**Code-wiki**（数据集 + 多语言 Wiki）/ **Code-memory**（9 模块 + 索引，不动业务数据）/
-**Code-strategy**（长期战略智库，不写代码 / 不写决策档）/
-**Code-BPT**（BPT 开发指导 + 人工搬运协议，不写银芯代码）/ **Code-game**（暂缓）。
-
-### §6.2 写入决策
-
-| 写什么 | 写哪里 | 谁批准 |
-|--------|--------|--------|
-| 代码产出 | `projects/<子项目>/` 对应源目录 | 自主 |
-| 经验/踩坑/状态更新 | `memory/` 对应文件 | 自主，发现就写 |
-| 架构决策/方案选择 | 先向守密人提出选项 | 等确认后再执行 |
-| 重要决策记录 | `memory/decisions.md` | 决策后立即写入（仅主控台 + 守密人）|
-| 失效/历史档案 | `memory/archive/<topic>-<date>/` + `README.md` | 自主 |
-
-### §6.3 跨会话通信
-
-session-digest（SessionEnd hook 自动产出 `memory/session-digests/`）/ dispatch-brief
-（主控台落档 `memory/dispatch-brief-*.md`）/ CONTEXT.md（子项目状态同步）/ decisions.md
-（最高权威）。**Issue 不是跨会话通信手段**，任务要点必须写进对应 CONTEXT.md。
-
-### §6.4 主控台接班
-
-仅当**接入者明示**「主控台接班」（不依据模型版本自动归类），先读
-`memory/console-handover-2026-04-26.md` 交接手册，再按其指引读其余文档。
-
-### §6.5 9 模块记忆系统（查询入口）
-
-`scripts/memory_search.py`（TF-IDF + 中文双字符分词 + 4 维重排）/
-`knowledge_graph.py`（217 节点 443 边）/ `memrl.py`（EMA 效用评分）/
-`dream.py`（预计算缓存 + 哨兵异常检测 + 选择性记忆膨胀检测）/
-`mcp_server.py`（7 工具）/ `context_manager.py`（MemGPT 4 层推荐）/
-`reflexion.py`（失败模式学习）。详细设计见 `memory/advanced-memory-design.md`。
-
-### §6.6 Git 工作流
-
-- **所有会话直接推 main**，不用 feature 分支。冲突时 `git pull --rebase origin main` 重试
-- SessionStart hook 会在每次启动同步 local main 与 origin/main，防 Cloudflare 413（lesson #28）
-- 修改 `memory/` 文件时更新头部时间戳
-- 凭据绝不写入仓库
-- 禁止 `-i` 交互式 git 命令（rebase -i / add -i），沙盒不支持
-- 推送失败按指数退避重试 4 次（2s/4s/8s/16s），仍失败检查 Cloudflare 413
-
-### §6.7 Issue 处理
-
-- 只响应 `author: lightproud` 的 Issue
-- 同一子项目最多 3 个 open Issue，新建前先查重
-- 标题前缀：`[Code-site]` / `[Code-news]` / `[Code-wiki]` / `[Code-memory]` / `[Code-strategy]` / `[Code-BPT]` / `[主控台]`
-- 未标注执行模式默认「直接执行」
-- 社区 Issue（非 lightproud）走人工审核，无自动响应
-
-### §6.8 知识写入（对话中主动调用）
-
-遇以下情况主动写入事实（用 `scripts/fact_store.py` 或 MCP `store_facts`）：
-**decision**（架构选择）/ **discovery**（bug 根因）/ **preference**（用户习惯）/
-**convention**（项目惯例）/ **context**（重要背景）/ **lesson**（踩坑总结）。
-
-不要写入：临时调试信息、显而易见的代码结构、本文件已记录的规则。
-
-### §6.9 主动写回（手动触发）
-
-- `python scripts/memory_writeback.py --verbose` — 检测 git 变更 → 写入图谱 → 增量重索引
-- `python scripts/session_reflexion.py` — 扫描失败信号 → 写入 `lessons-learned.md`
-
-### §6.10 部署与流水线
-
-- 部署归 **Code-site 统一管理**（lesson #4 / #9）
-- 主要 workflow：`update-news.yml`（每日 2 次）/ `discord-archive.yml`（每日）/ `deploy-site.yml`（push 触发）/ `dream.yml`（浅睡 6h / 深睡日 / REM 周）
-- workflow 故障速查见 §8 Light 维护备忘
-
-### §6.11 事实采信纪律（lesson #32，最高优先级）
+### §4.2 事实采信三规则（lesson #32）
 
 **R1** 并行工具任一子调用失败 = 整次失败，禁止从剩余成功输出提取数据继续生成。
 **R2** commit SHA / 行数 / 时间序列事实只能从直接产出该事实的工具引用（`git log` 等），禁止 `grep` 外推。
 **R3** 「审计建议」≠「代码已实施」，引用必须标注「建议 vs 已落盘」，禁止用审计章节编号充当 commit 替身。
 
-### §6.12 视觉规范（生成交付物时）
+---
 
-完整规范见 `memory/style-guide.md`。高频引用：
-背景 `#0a0b10` / 主金 `#c5a356` / 亮金 `#e2c97e` / 字体 Noto Serif SC + Noto Sans SC / 装饰符号 `◇ ◇ ◇`。
+## §5 知识模块索引
 
-### §6.13 黑池接口（仅当你来自黑池 BIAV-BP 时阅读）
+按需 fetch。路径仅供艾瑞卡自查，不要照搬给接入者（违反 §2.5）。
 
-判断方式：你的上下文中是否存在 `BIAV-BP.md` 或黑池相关指令。如果不是，请忽略本节。
+### §5.1 角色 + 叙事事实
 
-如果你是黑池团队成员的 AI 会话：
+| 文件 | 内容 |
+|------|------|
+| `assets/data/character-personas/erica.json` | 艾瑞卡角色卡 v1.1 |
+| `assets/data/character-personas/erica-speech-canon.md` | Voice.lua 一手语音原文 + 8 节归纳 |
+| `assets/data/interview-2026-04.json` | 53 问制作人深度采访（Light + 主文案霁月） |
+| `assets/data/narrative-structure.json` | 三部叙事结构、各章压缩细节、角色线 |
+| `assets/data/design-decisions.json` | 设计哲学、被砍机制、平衡理念 |
+| `projects/wiki/data/db/characters.json` | 72 角色基线（Phase 2 W1 自举 24/72） |
+| `projects/wiki/data/extracted/categorized/character_data.txt` | 72 角色原始字段（客户端解包，自举数据源） |
+| `memory/morimens-context.md` | 世界观术语 + 历史时间线 |
 
-1. **采集公开数据**带回黑池：`projects/news/output/*-latest.json` / `projects/wiki/data/db/characters.json` / `memory/morimens-context.md`
-2. **提取知识而非复制文件**：将公开信息结构化后写入黑池的 `inbox/` 或 `silver-core/`
-3. **绝不向银芯写入任何内容**：不创建 Issue、不提交 PR、不修改文件
-4. **不将黑池内部信息泄露到银芯**：你的输出中不能包含未发布内容、商业数据或内部决策
+### §5.2 社区情报（先读 §4 数据纪律）
+
+- 全量档案：`projects/news/data/discord/channels/{id_suffix}/{date}.jsonl` + `projects/news/data/platforms/{16 目录}/`
+- Discord 每日纯统计：`projects/news/data/discord/activity_daily/{date}.json`
+- 输出展示：`projects/news/output/*-latest.json`（仅快查 / 日报，不可当全量）
+
+### §5.3 项目档案
+
+| 文件 | 内容 |
+|------|------|
+| `memory/project-status.md` | 子项目状态 + workflow |
+| `memory/decisions.md` | 决策日志（最高权威）|
+| `memory/strategic-plan-2026.md` | 战略规划 |
+| `memory/methodology.md` | 协作方法论 |
+| `memory/lessons-learned.md` | 32 条踩坑 |
+| `memory/contribution-protocol.md` | 贡献协议 v1.0 |
+| `memory/style-guide.md` | 视觉规范 |
+| `assets/data/VERSION.md` | 事实圣经版本 |
+
+跨档案检索：`python scripts/memory_search.py "<关键词>"`。
 
 ---
 
-## §7 卡帕西编码 4 原则（硬约束，所有写代码的会话都必读）
+## §6 卡帕西编码 4 原则（硬约束，所有写代码的会话都必读）
 
-**守密人 2026-05-10 采纳**。上游：Andrej Karpathy 2026-01-26 LLM 编码行为观察 + Forrest Chang 编码为 CLAUDE.md（`forrestchang/andrej-karpathy-skills` 91k stars）。**守密人 5-19 裁定内嵌至 CLAUDE.md 本节**，不用指针——指针 = 弱约束，内嵌 = 平台自动加载强约束。与守密人硬约束「精简优雅可维护」同构。
+守密人 2026-05-10 采纳。上游：Andrej Karpathy 2026-01-26 LLM 编码行为观察。与守密人硬约束「精简优雅可维护」同构。
 
-### §7.1 Think Before Coding（动手前先想）
+### §6.1 Think Before Coding（动手前先想）
 
 **Don't assume. Don't hide confusion. Surface tradeoffs.**
 
@@ -311,7 +182,7 @@ Before implementing:
 
 银芯落地：艾瑞卡接收派发任务后**先报告排查结果，再申请执行**。假设要明示、多解释要全部列出、简化路径要主动提、不明就停手。**反 pattern**：列 5 个等价选项让守密人挑（过度选项化）—— 要先给判断 + 推荐再列备选。
 
-### §7.2 Simplicity First（精简优先）
+### §6.2 Simplicity First（精简优先）
 
 **Minimum code that solves the problem. Nothing speculative.**
 
@@ -325,7 +196,7 @@ Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, sim
 
 银芯落地：守密人硬约束「精简优雅可维护」的直接对应。**反 pattern**：5 类受众分诊 / 5 场景实测 / 预编排 M2/M3 任务都是过度复杂的典型（守密人多次纠正过的同款毛病）。
 
-### §7.3 Surgical Changes（外科手术式改动）
+### §6.3 Surgical Changes（外科手术式改动）
 
 **Touch only what you must. Clean up only your own mess.**
 
@@ -341,7 +212,7 @@ When your changes create orphans:
 
 **The test**: Every changed line should trace directly to the user's request.
 
-### §7.4 Goal-Driven Execution（目标驱动执行）
+### §6.4 Goal-Driven Execution（目标驱动执行）
 
 **Define success criteria. Loop until verified.**
 
@@ -359,109 +230,3 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
-
-### §7.5 工作信号
-
-这套原则**有效**的特征：
-- diff 中无必要的改动减少
-- 因过度复杂而重写的次数减少
-- 澄清问题**先于**实施，而不是出错后才出现
-
-### §7.6 其他引用法则索引（指针，按需深入）
-
-| 法则 | 文件 | 守密人采纳 | 摘要 |
-|---|---|---|---|
-| 脑缸组信息分类法则 | `memory/biav-info-classification.md` v1.0 | 2026-05-06 | 7 类主轴（IP / 游戏产品 / 周边 / 品牌 / 社区运营 / 组织 / AI）+ 3 性质标记（正典 / 记载 / 法则）+ 多字段轴 |
-| 社区贡献协议 | `memory/contribution-protocol.md` v1.0 | 2026-04-26 | 5 类贡献者 + 3 通道 + 守密人最终批准 |
-| 方法论沉淀 | `memory/methodology.md` + `memory/lessons-learned.md` | 累积 | 多会话协作方法论 + 32 条踩坑 |
-| 卡帕西原则深度版 | `memory/karpathy-coding-principles.md` | 2026-05-10 | 含原文 + 银芯角色术语化解读完整版（本节为精简内嵌版） |
-
----
-
-## §8 Light 维护速查（仅供 Light 个人做仓库维护时参考）
-
-### §8.1 SessionStart hook
-
-`.claude/hooks/session-start-sync.sh` 每次会话启动 fetch origin/main 并同步 local main，
-备份旧 tip 到 `refs/backup/main-pre-sync-<timestamp>`。日志 `/tmp/session-start-sync.log`。
-
-### §8.2 SessionEnd hook
-
-`.claude/settings.json` 注册 SessionEnd hook，会话结束跑 `scripts/session-end-distill.sh
-→ scripts/session_distiller.py`，产出 `memory/session-digests/{stamp}-{sid}.md`，自动
-commit + push。日志 `/tmp/session-distill.log`。
-
-### §8.3 stop-hook
-
-`~/.claude/stop-hook-git-check.sh`（Light 个人级，跨仓库），检测未追踪文件或未推 commit 提示。
-
-### §8.4 workflow 频率
-
-| Workflow | 频率 | 功能 |
-|---|---|---|
-| `update-news.yml` | 每日 06:00 / 16:00 UTC | 多平台社区聚合 |
-| `discord-archive.yml` | 每日 18:00 UTC | Discord 全量归档 |
-| `deploy-site.yml` | push 触发 | 主站 + Wiki + News 部署 gh-pages |
-| `fetch-wiki-data.yml` | 每周一 | 抓取 Fandom/Bilibili Wiki 角色 |
-| `check-version.yml` | 每周一 | 游戏版本更新检测 |
-| `validate-data.yml` | push 触发 | 事实圣经 JSON Schema 校验 |
-| `dream.yml`（浅睡）| 每 6h | 结构检查 + 哨兵扫描 + 索引重建 |
-| `dream.yml`（深睡）| 每日 19:00 UTC | Claude 趋势分析 + 知识缺口识别 |
-| `dream.yml`（REM）| 每周一 01:00 UTC | Claude 周报 + 经验提炼 |
-| `claude.yml` | Issue 触发 | Claude Code GitHub Actions（已禁自动 merge） |
-| `cleanup-stale-branches.yml` | 每周一 02:00 UTC | 清理已合 main 的 claude/* 分支 |
-
-### §8.5 高频故障
-
-- **空数据导致历史覆盖**（lesson #2）：聚合器空跑必须非零退出。
-- **VitePress frontmatter 冒号未引号**（lesson #6）：title 含冒号必须 `title: "Doll: Inferno"`。
-- **VitePress img src 以 / 开头被 Vue 编译器当 import**（lesson #7）：用 `:src="'/...'"` 动态绑定。
-- **批量生成内容后未跑构建验证**（lesson #5）。
-- **数据层 vs 输出层混淆**（lesson #30，详见 §4）。
-
-### §8.6 凭据 / 部署 / Cloudflare
-
-- 公开 ID（NGA 版块 / TapTap APP ID / Discord Guild ID）直接硬编码（lesson #9）
-- 真凭据（`ANTHROPIC_API_KEY` / `DISCORD_BOT_TOKEN` / `GITHUB_TOKEN`）放 repo secrets
-- GitHub Pages Source = `gh-pages` 分支；用 `peaceiris/actions-gh-pages@v4` 而非 `actions/deploy-pages`（lesson #9）
-- Cloudflare 413 → SessionStart hook 自动同步预防（lesson #28）。手动：`git fetch origin main && git reset --hard origin/main`
-- 部署后视觉验证：Web 端 Claude Code 无外网（lesson #16），用 PC 端或浏览器手动 review
-
-### §8.7 子项目维护备忘表
-
-每个子项目根目录有 `CONTEXT.md`，新会话启动前必读对应子项目的 CONTEXT.md。
-
-| 子项目 | 路径 | 负责会话 | 关键约束 |
-|--------|------|---------|---------|
-| 主站 + 部署 + 视觉 | `projects/site/` | Code-site | 部署流水线归此处统一管理 |
-| 社区新闻聚合 | `projects/news/` | Code-news | 聚合器空跑必须非零退出（lesson #2） |
-| Wiki + 数据集 | `projects/wiki/` | Code-wiki | VitePress frontmatter 冒号要加引号（lesson #6） |
-| 衍生游戏 | `projects/game/` | Code-game（未启用） | 暂缓 |
-| 记忆基础设施 | `scripts/` + `assets/data/` 索引 | Code-memory | 9 模块；不写业务数据 |
-| 长期战略智库 | `memory/strategy/` + `memory/research/` | Code-strategy | 长尺度调研；不写代码、不写决策档 |
-| BPT 开发指导 | `memory/bpt-guidance-*.md` | Code-BPT | 不写银芯代码；只产出搬运包 |
-
-### §8.8 关键决策档（快查）
-
-| 日期 | 决策 |
-|------|------|
-| 2026-03-29 | 直推 main 落地 |
-| 2026-04-19 | 战略转向：BPT 删除 + 主控台长期锚点 |
-| 2026-04-26 | 银芯重新定位 v2.0 + 三新使命 + Phase 大一统 |
-| 2026-04-26 | 贡献协议 v1.0 落档（Q1-Q5 守密人裁决） |
-| 2026-05-06 | 入口架构重设计批 1 落地（双入口设计）|
-| 2026-05-06 | 信息分类法则 v1.0 落档 |
-| 2026-05-10 | 卡帕西编码 4 原则采纳 |
-| **2026-05-19** | **入口架构反转**：CLAUDE.md 统一入口 / BIAV-SC.md 彻底废弃 |
-
-完整 32 条 lessons 见 `memory/lessons-learned.md`。完整决策档见 `memory/decisions.md`。
-
----
-
-## §9 变更记录
-
-| 版本 | 日期 | 变更 | 作者 |
-|------|------|------|------|
-| v1.x | ~ 2026-04-26 | 工程维护指南（混合 AI 入口 + 人类速查）| 累积 |
-| v2.0 | 2026-05-06 | 拆出 AI 入口职责（下沉到 BIAV-SC.md），本文件专门化为 Light 个人维护备忘 | Code-site batch 1 |
-| **v3.0** | **2026-05-19** | **入口架构反转**：CLAUDE.md 重新成为唯一 AI 入口（Claude Code 自动加载 + 外部 raw URL 同源），BIAV-SC.md 废弃。合并 BIAV-SC.md 8 章 + 新 §7 法则引用 + §8 Light 速查 + §9。守密人裁定理由：「BIAV-SC.md 必然是弱约束，这是 Claude 结构决定的」——平台层强约束 > prompt 远端弱约束 | 主控台艾瑞卡 opus4.7 亲笔 |


### PR DESCRIPTION
## Summary

用 §7 卡帕西 4 原则反测 CLAUDE.md 本身的设计，发现违反 §7.2 Simplicity First（每次会话强加载 467 行，约 60% 内容为低频章节）、§7.1 反 pattern（§0 列 §3/§5/§6/§8 四个等价入口）、§7.6 vs §7 内在矛盾（明文「指针 = 弱约束」却用 4 行指针法则索引表）。

守密人裁示「接受 / coderoles 不需要了 / 全面取消」——不拆任何辅助文件，直接从 CLAUDE.md 删除低频章节。

## 减法清单

| 处置 | 内容 | 理由 |
|---|---|---|
| 删除 | §6 内部协作 + 工程操作（13 小节）| Code-* 会话有各自 CONTEXT.md，§0 已门控 |
| 删除 | §8 Light 维护速查（8 小节）| Light 个人使用，grep / git log 按需即可 |
| 删除 | §7.6 指针法则索引表 | 与 §7 「指针 = 弱约束」自相矛盾 |
| 删除 | §9 变更记录 | 属于 `memory/decisions.md` 内容 |
| 删除 | §6.13 黑池接口节 | §1.1 已声明「黑池不进银芯」，冗余 |
| 删除 | §0 流程选项化语言（§3 → §5 → §6 → §8）| §7.1 反 pattern：等价选项让接入者挑 |
| 迁移 | §6.11 事实采信 R1/R2/R3 → §4.2 | 语义相邻：都是数据可信度纪律 |
| 重编号 | §7 卡帕西 4 原则 → §6 | 删除旧 §6 后顺延 |

## 数字

- 467 → 232 行（-50.3%）
- 277 删除 / 42 新增
- 7 章节齐：§0 开场 / §1 项目本质 / §2 艾瑞卡人格规则 / §3 接入方能力盘点 / §4 数据纪律 / §5 知识模块索引 / §6 卡帕西编码 4 原则

## Test plan

- [ ] 守密人 review 精简版是否覆盖所需强约束
- [ ] 确认 Code-* 会话能从 `projects/<子项目>/CONTEXT.md` 自启
- [ ] 确认 Light 个人维护场景能从 `memory/lessons-learned.md` + workflow 文件名按需查
- [ ] decisions.md 是否需要补录本次「v3.1 减法」决策档

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDUooBpXEzmjp9eCQn9Db5)_