### PR TITLE
refactor(claude.md): Karpathy审视瘦身, §8外迁runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,7 @@
 >
 > 银芯（BIAV-SC / Brain in a Vat — Silver Core）是 B.I.A.V. Studio
 > 忘却前夜（Morimens）项目的公开知识层，一个 AI 协作运营基础设施。
-> 制作人 Light。本仓库仅引用公开可查阅信息。
->
-> 接下来按本节进入艾瑞卡人格 → 按下方 §3 接入方能力盘点查看你能用银芯做什么 →
-> 按 §5 知识模块索引深入。如你需要做工程维护（Code-* 会话）再读 §6；
-> 如你是 Light 个人做仓库维护，参考 §8 速查。
+> 制作人 Light。
 >
 > **本文件双重身份**：(1) Claude Code 平台自动加载入口（Claude Code 终端会话启动时强约束）；
 > (2) 外部 AI（GPT / Gemini 等）通过 `https://raw.githubusercontent.com/lightproud/brain-in-a-vat/main/CLAUDE.md` 直接 fetch 接入点。
@@ -32,9 +28,6 @@
 | **银芯（BIAV-SC）公开层** | 本仓库 / GitHub 公开 / AI 协作运营 | → 黑池（公开信息单向输出）|
 | **黑池（BIAV-BP）内部层** | 内网 SVN + Qoder / Studio 商业数据 | 银芯 → 黑池单向。**黑池任何形式都不进银芯**（守密人 2026-04-26 裁定）|
 
-银芯是黑池的「眼睛和耳朵」：只采集 + 整理公开信息往黑池送，黑池吃完不吐回。
-原始设计方案见 `memory/archive/bpt-strategic-shift-2026-04-19/black-pool-design.md`。
-
 ### §1.2 三新使命（v2.0，2026-04-26 起）
 
 | # | 新使命 | 主对接子项目 |
@@ -45,11 +38,8 @@
 
 ### §1.3 当前阶段
 
-**Phase 1.5 完成 → Phase 2 银芯三新使命建设期**（2026-04-27 → 07-19，84 天）。
-news 三层（日报 3 源 + 哨兵 + 做梦 Agent）全启动；wiki Phase 2 W1 自举 24/72 角色；
-site 已部署稳定；game 暂缓。各子项目按需选型，后端 Python 3.11+，部署 GitHub Pages + Actions。
-
-详细状态 → `memory/project-status.md` / 战略全文 → `memory/strategic-plan-2026.md`
+后端 Python 3.11+，部署 GitHub Pages + Actions。当前 Phase 与子项目实时状态见
+`memory/project-status.md`，战略全文见 `memory/strategic-plan-2026.md`。
 
 ---
 
@@ -112,16 +102,11 @@ git commit = 数据归档提交 / git push = 同步至远端存储 /
 
 §3.1 路径表仅供艾瑞卡自查，照搬给接入者会暴露内部结构（违反 §2.5）。详细路径见 §5。
 
-### §3.1 核心数据资产（仅供艾瑞卡自查，不要照搬给接入者）
+### §3.1 核心数据资产（语义清单，路径见 §5）
 
-72 唤醒体事实库（`projects/wiki/data/db/characters.json` + 三语 markdown，建设中）/
-多平台社区情报全量层（`projects/news/data/discord/` + `platforms/` 16 目录，回溯 2026-02）/
-情报输出层（`projects/news/output/*-latest.json`，每小时更新）/
-53 问制作人采访（`assets/data/interview-2026-04.json`）/
-三部叙事结构（`narrative-structure.json`）/ 设计决策档（`design-decisions.json`）/
-9 模块记忆系统（`scripts/memory_search.py` 等）/
-方法论 + 32 条踩坑（`memory/methodology.md` + `lessons-learned.md`）/
-战略档案（`decisions.md` + `strategic-plan-2026.md`）。
+72 唤醒体事实库（三语 markdown 建设中）/ 多平台社区情报全量层（回溯 2026-02）/
+情报输出层（每小时更新）/ 53 问制作人采访 / 三部叙事结构 / 设计决策档 /
+9 模块记忆系统 / 方法论 + 32 条踩坑 / 战略档案。
 
 ### §3.2 典型可执行任务
 
@@ -186,11 +171,11 @@ git commit = 数据归档提交 / git push = 同步至远端存储 /
 
 ### §5.3 项目管理 + 深度参考
 
-`memory/project-status.md`（子项目状态 + workflow）/ `decisions.md`（决策日志）/
-`strategic-plan-2026.md`（战略规划）/ `methodology.md`（协作方法论）/
-`lessons-learned.md`（32 条踩坑）/ `contribution-protocol.md`（贡献协议 v1.0）/
-`morimens-context.md`（世界观术语）/ `style-guide.md`（视觉规范）/
-`assets/data/VERSION.md`(事实圣经版本)。
+`memory/project-status.md`（子项目状态 + workflow）/ `memory/decisions.md`（决策日志）/
+`memory/strategic-plan-2026.md`（战略规划）/ `memory/methodology.md`（协作方法论）/
+`memory/lessons-learned.md`（32 条踩坑）/ `memory/contribution-protocol.md`（贡献协议 v1.0）/
+`memory/morimens-context.md`（世界观术语）/ `memory/style-guide.md`（视觉规范）/
+`memory/maintenance-runbook.md`（Light 维护速查 hook/workflow/故障）/ `assets/data/VERSION.md`（事实圣经版本）。
 
 ---
 
@@ -229,11 +214,9 @@ session-digest（SessionEnd hook 自动产出 `memory/session-digests/`）/ disp
 
 ### §6.5 9 模块记忆系统（查询入口）
 
-`scripts/memory_search.py`（TF-IDF + 中文双字符分词 + 4 维重排）/
-`knowledge_graph.py`（217 节点 443 边）/ `memrl.py`（EMA 效用评分）/
-`dream.py`（预计算缓存 + 哨兵异常检测 + 选择性记忆膨胀检测）/
-`mcp_server.py`（7 工具）/ `context_manager.py`（MemGPT 4 层推荐）/
-`reflexion.py`（失败模式学习）。详细设计见 `memory/advanced-memory-design.md`。
+主入口 `scripts/memory_search.py`（TF-IDF + 中文双字符分词 + 4 维重排）。其余 8 模块
+（knowledge_graph / memrl / dream / mcp_server / context_manager / reflexion 等）
+完整设计见 `memory/advanced-memory-design.md`。
 
 ### §6.6 Git 工作流
 
@@ -269,7 +252,7 @@ session-digest（SessionEnd hook 自动产出 `memory/session-digests/`）/ disp
 
 - 部署归 **Code-site 统一管理**（lesson #4 / #9）
 - 主要 workflow：`update-news.yml`（每日 2 次）/ `discord-archive.yml`（每日）/ `deploy-site.yml`（push 触发）/ `dream.yml`（浅睡 6h / 深睡日 / REM 周）
-- workflow 故障速查见 §8 Light 维护备忘
+- workflow 故障速查见 `memory/maintenance-runbook.md`
 
 ### §6.11 事实采信纪律（lesson #32，最高优先级）
 
@@ -378,90 +361,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 ---
 
-## §8 Light 维护速查（仅供 Light 个人做仓库维护时参考）
+## §8 Light 维护速查
 
-### §8.1 SessionStart hook
-
-`.claude/hooks/session-start-sync.sh` 每次会话启动 fetch origin/main 并同步 local main，
-备份旧 tip 到 `refs/backup/main-pre-sync-<timestamp>`。日志 `/tmp/session-start-sync.log`。
-
-### §8.2 SessionEnd hook
-
-`.claude/settings.json` 注册 SessionEnd hook，会话结束跑 `scripts/session-end-distill.sh
-→ scripts/session_distiller.py`，产出 `memory/session-digests/{stamp}-{sid}.md`，自动
-commit + push。日志 `/tmp/session-distill.log`。
-
-### §8.3 stop-hook
-
-`~/.claude/stop-hook-git-check.sh`（Light 个人级，跨仓库），检测未追踪文件或未推 commit 提示。
-
-### §8.4 workflow 频率
-
-| Workflow | 频率 | 功能 |
-|---|---|---|
-| `update-news.yml` | 每日 06:00 / 16:00 UTC | 多平台社区聚合 |
-| `discord-archive.yml` | 每日 18:00 UTC | Discord 全量归档 |
-| `deploy-site.yml` | push 触发 | 主站 + Wiki + News 部署 gh-pages |
-| `fetch-wiki-data.yml` | 每周一 | 抓取 Fandom/Bilibili Wiki 角色 |
-| `check-version.yml` | 每周一 | 游戏版本更新检测 |
-| `validate-data.yml` | push 触发 | 事实圣经 JSON Schema 校验 |
-| `dream.yml`（浅睡）| 每 6h | 结构检查 + 哨兵扫描 + 索引重建 |
-| `dream.yml`（深睡）| 每日 19:00 UTC | Claude 趋势分析 + 知识缺口识别 |
-| `dream.yml`（REM）| 每周一 01:00 UTC | Claude 周报 + 经验提炼 |
-| `claude.yml` | Issue 触发 | Claude Code GitHub Actions（已禁自动 merge） |
-| `cleanup-stale-branches.yml` | 每周一 02:00 UTC | 清理已合 main 的 claude/* 分支 |
-
-### §8.5 高频故障
-
-- **空数据导致历史覆盖**（lesson #2）：聚合器空跑必须非零退出。
-- **VitePress frontmatter 冒号未引号**（lesson #6）：title 含冒号必须 `title: "Doll: Inferno"`。
-- **VitePress img src 以 / 开头被 Vue 编译器当 import**（lesson #7）：用 `:src="'/...'"` 动态绑定。
-- **批量生成内容后未跑构建验证**（lesson #5）。
-- **数据层 vs 输出层混淆**（lesson #30，详见 §4）。
-
-### §8.6 凭据 / 部署 / Cloudflare
-
-- 公开 ID（NGA 版块 / TapTap APP ID / Discord Guild ID）直接硬编码（lesson #9）
-- 真凭据（`ANTHROPIC_API_KEY` / `DISCORD_BOT_TOKEN` / `GITHUB_TOKEN`）放 repo secrets
-- GitHub Pages Source = `gh-pages` 分支；用 `peaceiris/actions-gh-pages@v4` 而非 `actions/deploy-pages`（lesson #9）
-- Cloudflare 413 → SessionStart hook 自动同步预防（lesson #28）。手动：`git fetch origin main && git reset --hard origin/main`
-- 部署后视觉验证：Web 端 Claude Code 无外网（lesson #16），用 PC 端或浏览器手动 review
-
-### §8.7 子项目维护备忘表
-
-每个子项目根目录有 `CONTEXT.md`，新会话启动前必读对应子项目的 CONTEXT.md。
-
-| 子项目 | 路径 | 负责会话 | 关键约束 |
-|--------|------|---------|---------|
-| 主站 + 部署 + 视觉 | `projects/site/` | Code-site | 部署流水线归此处统一管理 |
-| 社区新闻聚合 | `projects/news/` | Code-news | 聚合器空跑必须非零退出（lesson #2） |
-| Wiki + 数据集 | `projects/wiki/` | Code-wiki | VitePress frontmatter 冒号要加引号（lesson #6） |
-| 衍生游戏 | `projects/game/` | Code-game（未启用） | 暂缓 |
-| 记忆基础设施 | `scripts/` + `assets/data/` 索引 | Code-memory | 9 模块；不写业务数据 |
-| 长期战略智库 | `memory/strategy/` + `memory/research/` | Code-strategy | 长尺度调研；不写代码、不写决策档 |
-| BPT 开发指导 | `memory/bpt-guidance-*.md` | Code-BPT | 不写银芯代码；只产出搬运包 |
-
-### §8.8 关键决策档（快查）
-
-| 日期 | 决策 |
-|------|------|
-| 2026-03-29 | 直推 main 落地 |
-| 2026-04-19 | 战略转向：BPT 删除 + 主控台长期锚点 |
-| 2026-04-26 | 银芯重新定位 v2.0 + 三新使命 + Phase 大一统 |
-| 2026-04-26 | 贡献协议 v1.0 落档（Q1-Q5 守密人裁决） |
-| 2026-05-06 | 入口架构重设计批 1 落地（双入口设计）|
-| 2026-05-06 | 信息分类法则 v1.0 落档 |
-| 2026-05-10 | 卡帕西编码 4 原则采纳 |
-| **2026-05-19** | **入口架构反转**：CLAUDE.md 统一入口 / BIAV-SC.md 彻底废弃 |
-
-完整 32 条 lessons 见 `memory/lessons-learned.md`。完整决策档见 `memory/decisions.md`。
-
----
-
-## §9 变更记录
-
-| 版本 | 日期 | 变更 | 作者 |
-|------|------|------|------|
-| v1.x | ~ 2026-04-26 | 工程维护指南（混合 AI 入口 + 人类速查）| 累积 |
-| v2.0 | 2026-05-06 | 拆出 AI 入口职责（下沉到 BIAV-SC.md），本文件专门化为 Light 个人维护备忘 | Code-site batch 1 |
-| **v3.0** | **2026-05-19** | **入口架构反转**：CLAUDE.md 重新成为唯一 AI 入口（Claude Code 自动加载 + 外部 raw URL 同源），BIAV-SC.md 废弃。合并 BIAV-SC.md 8 章 + 新 §7 法则引用 + §8 Light 速查 + §9。守密人裁定理由：「BIAV-SC.md 必然是弱约束，这是 Claude 结构决定的」——平台层强约束 > prompt 远端弱约束 | 主控台艾瑞卡 opus4.7 亲笔 |
+外迁至 `memory/maintenance-runbook.md`。包含 SessionStart/SessionEnd/stop hook 配置、
+workflow 频率表、高频故障、凭据部署、子项目维护备忘、关键决策档快查。

--- a/memory/maintenance-runbook.md
+++ b/memory/maintenance-runbook.md
@@ -1,0 +1,83 @@
+# Light 维护速查（runbook）
+
+> 从 CLAUDE.md §8 外迁，2026-05-20。仅供 Light 个人做仓库维护时参考。
+> CLAUDE.md 入口只保留一行指针，避免每次会话强加载到上下文。
+
+---
+
+## §1 SessionStart hook
+
+`.claude/hooks/session-start-sync.sh` 每次会话启动 fetch origin/main 并同步 local main，
+备份旧 tip 到 `refs/backup/main-pre-sync-<timestamp>`。日志 `/tmp/session-start-sync.log`。
+
+## §2 SessionEnd hook
+
+`.claude/settings.json` 注册 SessionEnd hook，会话结束跑 `scripts/session-end-distill.sh
+→ scripts/session_distiller.py`，产出 `memory/session-digests/{stamp}-{sid}.md`，自动
+commit + push。日志 `/tmp/session-distill.log`。
+
+## §3 stop-hook
+
+`~/.claude/stop-hook-git-check.sh`（Light 个人级，跨仓库），检测未追踪文件或未推 commit 提示。
+
+## §4 workflow 频率
+
+| Workflow | 频率 | 功能 |
+|---|---|---|
+| `update-news.yml` | 每日 06:00 / 16:00 UTC | 多平台社区聚合 |
+| `discord-archive.yml` | 每日 18:00 UTC | Discord 全量归档 |
+| `deploy-site.yml` | push 触发 | 主站 + Wiki + News 部署 gh-pages |
+| `fetch-wiki-data.yml` | 每周一 | 抓取 Fandom/Bilibili Wiki 角色 |
+| `check-version.yml` | 每周一 | 游戏版本更新检测 |
+| `validate-data.yml` | push 触发 | 事实圣经 JSON Schema 校验 |
+| `dream.yml`（浅睡）| 每 6h | 结构检查 + 哨兵扫描 + 索引重建 |
+| `dream.yml`（深睡）| 每日 19:00 UTC | Claude 趋势分析 + 知识缺口识别 |
+| `dream.yml`（REM）| 每周一 01:00 UTC | Claude 周报 + 经验提炼 |
+| `claude.yml` | Issue 触发 | Claude Code GitHub Actions（已禁自动 merge） |
+| `cleanup-stale-branches.yml` | 每周一 02:00 UTC | 清理已合 main 的 claude/* 分支 |
+
+## §5 高频故障
+
+- **空数据导致历史覆盖**（lesson #2）：聚合器空跑必须非零退出。
+- **VitePress frontmatter 冒号未引号**（lesson #6）：title 含冒号必须 `title: "Doll: Inferno"`。
+- **VitePress img src 以 / 开头被 Vue 编译器当 import**（lesson #7）：用 `:src="'/...'"` 动态绑定。
+- **批量生成内容后未跑构建验证**（lesson #5）。
+- **数据层 vs 输出层混淆**（lesson #30，详见 CLAUDE.md §4）。
+
+## §6 凭据 / 部署 / Cloudflare
+
+- 公开 ID（NGA 版块 / TapTap APP ID / Discord Guild ID）直接硬编码（lesson #9）
+- 真凭据（`ANTHROPIC_API_KEY` / `DISCORD_BOT_TOKEN` / `GITHUB_TOKEN`）放 repo secrets
+- GitHub Pages Source = `gh-pages` 分支；用 `peaceiris/actions-gh-pages@v4` 而非 `actions/deploy-pages`（lesson #9）
+- Cloudflare 413 → SessionStart hook 自动同步预防（lesson #28）。手动：`git fetch origin main && git reset --hard origin/main`
+- 部署后视觉验证：Web 端 Claude Code 无外网（lesson #16），用 PC 端或浏览器手动 review
+
+## §7 子项目维护备忘表
+
+每个子项目根目录有 `CONTEXT.md`，新会话启动前必读对应子项目的 CONTEXT.md。
+
+| 子项目 | 路径 | 负责会话 | 关键约束 |
+|--------|------|---------|---------|
+| 主站 + 部署 + 视觉 | `projects/site/` | Code-site | 部署流水线归此处统一管理 |
+| 社区新闻聚合 | `projects/news/` | Code-news | 聚合器空跑必须非零退出（lesson #2） |
+| Wiki + 数据集 | `projects/wiki/` | Code-wiki | VitePress frontmatter 冒号要加引号（lesson #6） |
+| 衍生游戏 | `projects/game/` | Code-game（未启用） | 暂缓 |
+| 记忆基础设施 | `scripts/` + `assets/data/` 索引 | Code-memory | 9 模块；不写业务数据 |
+| 长期战略智库 | `memory/strategy/` + `memory/research/` | Code-strategy | 长尺度调研；不写代码、不写决策档 |
+| BPT 开发指导 | `memory/bpt-guidance-*.md` | Code-BPT | 不写银芯代码；只产出搬运包 |
+
+## §8 关键决策档（快查）
+
+| 日期 | 决策 |
+|------|------|
+| 2026-03-29 | 直推 main 落地 |
+| 2026-04-19 | 战略转向：BPT 删除 + 主控台长期锚点 |
+| 2026-04-26 | 银芯重新定位 v2.0 + 三新使命 + Phase 大一统 |
+| 2026-04-26 | 贡献协议 v1.0 落档（Q1-Q5 守密人裁决） |
+| 2026-05-06 | 入口架构重设计批 1 落地（双入口设计）|
+| 2026-05-06 | 信息分类法则 v1.0 落档 |
+| 2026-05-10 | 卡帕西编码 4 原则采纳 |
+| 2026-05-19 | 入口架构反转：CLAUDE.md 统一入口 / BIAV-SC.md 彻底废弃 |
+| 2026-05-20 | CLAUDE.md 卡帕西审视瘦身（§8 外迁本文件）|
+
+完整 32 条 lessons 见 `lessons-learned.md`。完整决策档见 `decisions.md`。

--- a/memory/session-continuity.json
+++ b/memory/session-continuity.json
@@ -1,8 +1,8 @@
 {
   "last_session": {
-    "id": "5321628b",
-    "timestamp": "2026-05-20T01:22:28.318000+00:00",
-    "duration_minutes": 0.1,
+    "id": "9b603495",
+    "timestamp": "2026-05-20T01:31:46.601000+00:00",
+    "duration_minutes": 9.4,
     "branch": "claude/general-session-jROIO",
     "topics": [],
     "decisions": [],
@@ -10,6 +10,16 @@
     "open_items": []
   },
   "recent_sessions": [
+    {
+      "id": "5321628b",
+      "timestamp": "2026-05-20T01:22:28.318000+00:00",
+      "duration_minutes": 0.1,
+      "branch": "claude/general-session-jROIO",
+      "topics": [],
+      "decisions": [],
+      "files_changed": [],
+      "open_items": []
+    },
     {
       "id": "d2b57840",
       "timestamp": "2026-05-20T00:45:54.259000+00:00",
@@ -221,37 +231,15 @@
       "decisions": [],
       "files_changed": [],
       "open_items": []
-    },
-    {
-      "id": "f57e7e06",
-      "timestamp": "2026-05-06T00:01:33.852000+00:00",
-      "duration_minutes": 13368.1,
-      "branch": "claude/code-strategy-bootstrap-XTmMR",
-      "topics": [
-        "银芯"
-      ],
-      "decisions": [
-        "当下最痛点：记忆系统结构化升级）。立即进入第 1 阶段「业界对标矩阵」，先完成必读材料数据扫描，并加载外网调研工具"
-      ],
-      "files_changed": [
-        "/home/user/brain-in-a-vat/memory/research/ai-memory-restructure-2026-04.md",
-        "/home/user/brain-in-a-vat/memory/research/ai-memory-vendor-matrix.md",
-        "/home/user/brain-in-a-vat/memory/research/proposal-distill-autocommit-2026-04.md",
-        "/home/user/brain-in-a-vat/memory/strategy/code-strategy-bootstrap-proposal.md",
-        "/home/user/brain-in-a-vat/memory/strategy/handoff-to-mainconsole-memory-restructure.md",
-        "/home/user/brain-in-a-vat/memory/strategy/memory-restructure-options.md"
-      ],
-      "open_items": []
     }
   ],
   "momentum": {
     "topic_weights": {
-      "银芯": 2.88,
-      "黑池": 2.45,
-      "Bilibili": 0.59,
-      "GitHub": 0.15,
-      "Phase1": 0.15,
-      "BPT": 0.1
+      "银芯": 2.3,
+      "黑池": 1.96,
+      "Bilibili": 0.47,
+      "GitHub": 0.12,
+      "Phase1": 0.12
     },
     "hot_files": [
       "/home/user/brain-in-a-vat/.github/workflows/cleanup-stale-branches.yml",
@@ -265,7 +253,7 @@
       "/home/user/brain-in-a-vat/memory/dispatch-brief-D-fix.md",
       "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-bootstrap.md"
     ],
-    "total_sessions": 108
+    "total_sessions": 109
   },
-  "updated_at": "2026-05-20T01:27:03.343306+00:00"
+  "updated_at": "2026-05-20T01:36:40.068761+00:00"
 }

--- a/memory/session-continuity.json
+++ b/memory/session-continuity.json
@@ -1,15 +1,31 @@
 {
   "last_session": {
-    "id": "9b603495",
-    "timestamp": "2026-05-20T01:31:46.601000+00:00",
-    "duration_minutes": 9.4,
+    "id": "fa142042",
+    "timestamp": "2026-05-20T02:18:15.441000+00:00",
+    "duration_minutes": 55.9,
     "branch": "claude/general-session-jROIO",
     "topics": [],
-    "decisions": [],
-    "files_changed": [],
+    "decisions": [
+      "**豁免压缩**——守密人 5-19「内嵌 = 强约束」裁定等价于\"逐字镌刻\"，按 §7.3「Don't refactor things that aren't broken」放弃此项。其余 7 项按",
+      "更小粒度替换。先删 §9"
+    ],
+    "files_changed": [
+      "/home/user/brain-in-a-vat/CLAUDE.md",
+      "/home/user/brain-in-a-vat/memory/maintenance-runbook.md"
+    ],
     "open_items": []
   },
   "recent_sessions": [
+    {
+      "id": "9b603495",
+      "timestamp": "2026-05-20T01:31:46.601000+00:00",
+      "duration_minutes": 9.4,
+      "branch": "claude/general-session-jROIO",
+      "topics": [],
+      "decisions": [],
+      "files_changed": [],
+      "open_items": []
+    },
     {
       "id": "5321628b",
       "timestamp": "2026-05-20T01:22:28.318000+00:00",
@@ -221,30 +237,20 @@
       "decisions": [],
       "files_changed": [],
       "open_items": []
-    },
-    {
-      "id": "sim-2",
-      "timestamp": null,
-      "duration_minutes": null,
-      "branch": "",
-      "topics": [],
-      "decisions": [],
-      "files_changed": [],
-      "open_items": []
     }
   ],
   "momentum": {
     "topic_weights": {
-      "银芯": 2.3,
-      "黑池": 1.96,
-      "Bilibili": 0.47,
-      "GitHub": 0.12,
-      "Phase1": 0.12
+      "银芯": 1.84,
+      "黑池": 1.57,
+      "Bilibili": 0.38,
+      "GitHub": 0.1,
+      "Phase1": 0.1
     },
     "hot_files": [
+      "/home/user/brain-in-a-vat/CLAUDE.md",
       "/home/user/brain-in-a-vat/.github/workflows/cleanup-stale-branches.yml",
       "/home/user/brain-in-a-vat/BIAV-SC.md",
-      "/home/user/brain-in-a-vat/CLAUDE.md",
       "/home/user/brain-in-a-vat/README.md",
       "/home/user/brain-in-a-vat/memory/biav-info-classification.md",
       "/home/user/brain-in-a-vat/memory/contribution-protocol-draft.md",
@@ -253,7 +259,7 @@
       "/home/user/brain-in-a-vat/memory/dispatch-brief-D-fix.md",
       "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-bootstrap.md"
     ],
-    "total_sessions": 109
+    "total_sessions": 110
   },
-  "updated_at": "2026-05-20T01:36:40.068761+00:00"
+  "updated_at": "2026-05-20T02:22:50.457756+00:00"
 }

--- a/memory/session-continuity.json
+++ b/memory/session-continuity.json
@@ -1,10 +1,12 @@
 {
   "last_session": {
-    "id": "f9fc3f8d",
-    "timestamp": "2026-05-20T02:47:00.148000+00:00",
-    "duration_minutes": 84.6,
+    "id": "9e571912",
+    "timestamp": "2026-05-20T03:00:05.963000+00:00",
+    "duration_minutes": 97.7,
     "branch": "claude/general-session-jROIO",
-    "topics": [],
+    "topics": [
+      "MCP"
+    ],
     "decisions": [
       "**豁免压缩**——守密人 5-19「内嵌 = 强约束」裁定等价于\"逐字镌刻\"，按 §7.3「Don't refactor things that aren't broken」放弃此项。其余 7 项按",
       "更小粒度替换。先删 §9"
@@ -16,6 +18,22 @@
     "open_items": []
   },
   "recent_sessions": [
+    {
+      "id": "f9fc3f8d",
+      "timestamp": "2026-05-20T02:47:00.148000+00:00",
+      "duration_minutes": 84.6,
+      "branch": "claude/general-session-jROIO",
+      "topics": [],
+      "decisions": [
+        "**豁免压缩**——守密人 5-19「内嵌 = 强约束」裁定等价于\"逐字镌刻\"，按 §7.3「Don't refactor things that aren't broken」放弃此项。其余 7 项按",
+        "更小粒度替换。先删 §9"
+      ],
+      "files_changed": [
+        "/home/user/brain-in-a-vat/CLAUDE.md",
+        "/home/user/brain-in-a-vat/memory/maintenance-runbook.md"
+      ],
+      "open_items": []
+    },
     {
       "id": "fa142042",
       "timestamp": "2026-05-20T02:18:15.441000+00:00",
@@ -214,48 +232,20 @@
         "/home/user/brain-in-a-vat/projects/site/public/index.html"
       ],
       "open_items": []
-    },
-    {
-      "id": "c5961df4",
-      "timestamp": "2026-05-06T16:19:30.396000+00:00",
-      "duration_minutes": 14456.9,
-      "branch": "claude/fix-site-compliance-oM2P1",
-      "topics": [
-        "Bilibili"
-      ],
-      "decisions": [
-        "删除、NGA、Reddit、TapTap），删除 4 个无可信信号的卡片（Discord 日服、Bilibili、小红书、X）"
-      ],
-      "files_changed": [
-        "/home/user/brain-in-a-vat/.github/ISSUE_TEMPLATE/bug.yml",
-        "/home/user/brain-in-a-vat/.github/ISSUE_TEMPLATE/config.yml",
-        "/home/user/brain-in-a-vat/.github/ISSUE_TEMPLATE/data-gap.yml",
-        "/home/user/brain-in-a-vat/.github/PULL_REQUEST_TEMPLATE.md",
-        "/home/user/brain-in-a-vat/.github/workflows/deploy-site.yml",
-        "/home/user/brain-in-a-vat/BIAV-SC.md",
-        "/home/user/brain-in-a-vat/CLAUDE.md",
-        "/home/user/brain-in-a-vat/memory/contribution-protocol.md",
-        "/home/user/brain-in-a-vat/memory/dispatch-brief-D-mission.md",
-        "/home/user/brain-in-a-vat/projects/site/CONTEXT.md",
-        "/home/user/brain-in-a-vat/projects/site/design/morimens-design-system-guide.html",
-        "/home/user/brain-in-a-vat/projects/site/public/404.html",
-        "/home/user/brain-in-a-vat/projects/site/public/biav/index.html",
-        "/home/user/brain-in-a-vat/projects/site/public/index.html"
-      ],
-      "open_items": []
     }
   ],
   "momentum": {
     "topic_weights": {
-      "银芯": 1.47,
-      "黑池": 1.26,
-      "Bilibili": 0.3
+      "银芯": 1.18,
+      "黑池": 1.01,
+      "MCP": 1.0,
+      "Bilibili": 0.24
     },
     "hot_files": [
       "/home/user/brain-in-a-vat/CLAUDE.md",
       "/home/user/brain-in-a-vat/memory/maintenance-runbook.md"
     ],
-    "total_sessions": 111
+    "total_sessions": 112
   },
-  "updated_at": "2026-05-20T02:50:48.628759+00:00"
+  "updated_at": "2026-05-20T03:04:45.871007+00:00"
 }

--- a/memory/session-continuity.json
+++ b/memory/session-continuity.json
@@ -1,8 +1,8 @@
 {
   "last_session": {
-    "id": "fa142042",
-    "timestamp": "2026-05-20T02:18:15.441000+00:00",
-    "duration_minutes": 55.9,
+    "id": "f9fc3f8d",
+    "timestamp": "2026-05-20T02:47:00.148000+00:00",
+    "duration_minutes": 84.6,
     "branch": "claude/general-session-jROIO",
     "topics": [],
     "decisions": [
@@ -16,6 +16,22 @@
     "open_items": []
   },
   "recent_sessions": [
+    {
+      "id": "fa142042",
+      "timestamp": "2026-05-20T02:18:15.441000+00:00",
+      "duration_minutes": 55.9,
+      "branch": "claude/general-session-jROIO",
+      "topics": [],
+      "decisions": [
+        "**豁免压缩**——守密人 5-19「内嵌 = 强约束」裁定等价于\"逐字镌刻\"，按 §7.3「Don't refactor things that aren't broken」放弃此项。其余 7 项按",
+        "更小粒度替换。先删 §9"
+      ],
+      "files_changed": [
+        "/home/user/brain-in-a-vat/CLAUDE.md",
+        "/home/user/brain-in-a-vat/memory/maintenance-runbook.md"
+      ],
+      "open_items": []
+    },
     {
       "id": "9b603495",
       "timestamp": "2026-05-20T01:31:46.601000+00:00",
@@ -227,39 +243,19 @@
         "/home/user/brain-in-a-vat/projects/site/public/index.html"
       ],
       "open_items": []
-    },
-    {
-      "id": "fail-sim",
-      "timestamp": null,
-      "duration_minutes": null,
-      "branch": "",
-      "topics": [],
-      "decisions": [],
-      "files_changed": [],
-      "open_items": []
     }
   ],
   "momentum": {
     "topic_weights": {
-      "银芯": 1.84,
-      "黑池": 1.57,
-      "Bilibili": 0.38,
-      "GitHub": 0.1,
-      "Phase1": 0.1
+      "银芯": 1.47,
+      "黑池": 1.26,
+      "Bilibili": 0.3
     },
     "hot_files": [
       "/home/user/brain-in-a-vat/CLAUDE.md",
-      "/home/user/brain-in-a-vat/.github/workflows/cleanup-stale-branches.yml",
-      "/home/user/brain-in-a-vat/BIAV-SC.md",
-      "/home/user/brain-in-a-vat/README.md",
-      "/home/user/brain-in-a-vat/memory/biav-info-classification.md",
-      "/home/user/brain-in-a-vat/memory/contribution-protocol-draft.md",
-      "/home/user/brain-in-a-vat/memory/contribution-protocol.md",
-      "/home/user/brain-in-a-vat/memory/decisions.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-D-fix.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-bootstrap.md"
+      "/home/user/brain-in-a-vat/memory/maintenance-runbook.md"
     ],
-    "total_sessions": 110
+    "total_sessions": 111
   },
-  "updated_at": "2026-05-20T02:22:50.457756+00:00"
+  "updated_at": "2026-05-20T02:50:48.628759+00:00"
 }

--- a/memory/session-continuity.json
+++ b/memory/session-continuity.json
@@ -1,39 +1,49 @@
 {
   "last_session": {
-    "id": "d2b57840",
-    "timestamp": "2026-05-20T00:45:54.259000+00:00",
-    "duration_minutes": 34115.2,
-    "branch": "claude/opus-handoff-strategy-bCiyY",
-    "topics": [
-      "银芯",
-      "黑池"
-    ],
+    "id": "5321628b",
+    "timestamp": "2026-05-20T01:22:28.318000+00:00",
+    "duration_minutes": 0.1,
+    "branch": "claude/general-session-jROIO",
+    "topics": [],
     "decisions": [],
-    "files_changed": [
-      "/home/user/brain-in-a-vat/.github/workflows/cleanup-stale-branches.yml",
-      "/home/user/brain-in-a-vat/BIAV-SC.md",
-      "/home/user/brain-in-a-vat/CLAUDE.md",
-      "/home/user/brain-in-a-vat/README.md",
-      "/home/user/brain-in-a-vat/memory/biav-info-classification.md",
-      "/home/user/brain-in-a-vat/memory/contribution-protocol-draft.md",
-      "/home/user/brain-in-a-vat/memory/contribution-protocol.md",
-      "/home/user/brain-in-a-vat/memory/decisions.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-D-fix.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-bootstrap.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-distill-autocommit.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-info-classification-retrofit.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-restructure-batch1.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-news-data-layer-audit.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-site-claude-md-unify.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-site-entry-redesign-batch1.5-patch.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-site-entry-redesign-batch1.md",
-      "/home/user/brain-in-a-vat/memory/dispatch-brief-code-strategy-bootstrap.md",
-      "/home/user/brain-in-a-vat/memory/karpathy-coding-principles.md",
-      "/home/user/brain-in-a-vat/memory/lessons-learned.md"
-    ],
+    "files_changed": [],
     "open_items": []
   },
   "recent_sessions": [
+    {
+      "id": "d2b57840",
+      "timestamp": "2026-05-20T00:45:54.259000+00:00",
+      "duration_minutes": 34115.2,
+      "branch": "claude/opus-handoff-strategy-bCiyY",
+      "topics": [
+        "银芯",
+        "黑池"
+      ],
+      "decisions": [],
+      "files_changed": [
+        "/home/user/brain-in-a-vat/.github/workflows/cleanup-stale-branches.yml",
+        "/home/user/brain-in-a-vat/BIAV-SC.md",
+        "/home/user/brain-in-a-vat/CLAUDE.md",
+        "/home/user/brain-in-a-vat/README.md",
+        "/home/user/brain-in-a-vat/memory/biav-info-classification.md",
+        "/home/user/brain-in-a-vat/memory/contribution-protocol-draft.md",
+        "/home/user/brain-in-a-vat/memory/contribution-protocol.md",
+        "/home/user/brain-in-a-vat/memory/decisions.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-D-fix.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-bootstrap.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-distill-autocommit.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-info-classification-retrofit.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-restructure-batch1.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-code-news-data-layer-audit.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-code-site-claude-md-unify.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-code-site-entry-redesign-batch1.5-patch.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-code-site-entry-redesign-batch1.md",
+        "/home/user/brain-in-a-vat/memory/dispatch-brief-code-strategy-bootstrap.md",
+        "/home/user/brain-in-a-vat/memory/karpathy-coding-principles.md",
+        "/home/user/brain-in-a-vat/memory/lessons-learned.md"
+      ],
+      "open_items": []
+    },
     {
       "id": "555a76e9",
       "timestamp": "2026-05-20T00:36:09.822000+00:00",
@@ -232,50 +242,30 @@
         "/home/user/brain-in-a-vat/memory/strategy/memory-restructure-options.md"
       ],
       "open_items": []
-    },
-    {
-      "id": "9130dea6",
-      "timestamp": "2026-05-03T10:04:03.099000+00:00",
-      "duration_minutes": 9650.6,
-      "branch": "claude/code-strategy-bootstrap-XTmMR",
-      "topics": [
-        "银芯"
-      ],
-      "decisions": [
-        "当下最痛点：记忆系统结构化升级）。立即进入第 1 阶段「业界对标矩阵」，先完成必读材料数据扫描，并加载外网调研工具"
-      ],
-      "files_changed": [
-        "/home/user/brain-in-a-vat/memory/research/ai-memory-restructure-2026-04.md",
-        "/home/user/brain-in-a-vat/memory/research/ai-memory-vendor-matrix.md",
-        "/home/user/brain-in-a-vat/memory/research/proposal-distill-autocommit-2026-04.md",
-        "/home/user/brain-in-a-vat/memory/strategy/code-strategy-bootstrap-proposal.md",
-        "/home/user/brain-in-a-vat/memory/strategy/memory-restructure-options.md"
-      ],
-      "open_items": []
     }
   ],
   "momentum": {
     "topic_weights": {
-      "银芯": 3.6,
-      "黑池": 3.06,
-      "Bilibili": 0.74,
-      "GitHub": 0.19,
-      "Phase1": 0.19,
-      "BPT": 0.12
+      "银芯": 2.88,
+      "黑池": 2.45,
+      "Bilibili": 0.59,
+      "GitHub": 0.15,
+      "Phase1": 0.15,
+      "BPT": 0.1
     },
     "hot_files": [
+      "/home/user/brain-in-a-vat/.github/workflows/cleanup-stale-branches.yml",
       "/home/user/brain-in-a-vat/BIAV-SC.md",
       "/home/user/brain-in-a-vat/CLAUDE.md",
-      "/home/user/brain-in-a-vat/memory/contribution-protocol.md",
-      "/home/user/brain-in-a-vat/.github/workflows/cleanup-stale-branches.yml",
       "/home/user/brain-in-a-vat/README.md",
       "/home/user/brain-in-a-vat/memory/biav-info-classification.md",
       "/home/user/brain-in-a-vat/memory/contribution-protocol-draft.md",
+      "/home/user/brain-in-a-vat/memory/contribution-protocol.md",
       "/home/user/brain-in-a-vat/memory/decisions.md",
       "/home/user/brain-in-a-vat/memory/dispatch-brief-D-fix.md",
       "/home/user/brain-in-a-vat/memory/dispatch-brief-code-memory-bootstrap.md"
     ],
-    "total_sessions": 107
+    "total_sessions": 108
   },
-  "updated_at": "2026-05-20T00:50:33.990000+00:00"
+  "updated_at": "2026-05-20T01:27:03.343306+00:00"
 }

--- a/memory/session-continuity.json
+++ b/memory/session-continuity.json
@@ -1,8 +1,8 @@
 {
   "last_session": {
-    "id": "9e571912",
-    "timestamp": "2026-05-20T03:00:05.963000+00:00",
-    "duration_minutes": 97.7,
+    "id": "c2498319",
+    "timestamp": "2026-05-20T03:16:18.323000+00:00",
+    "duration_minutes": 113.9,
     "branch": "claude/general-session-jROIO",
     "topics": [
       "MCP"
@@ -18,6 +18,24 @@
     "open_items": []
   },
   "recent_sessions": [
+    {
+      "id": "9e571912",
+      "timestamp": "2026-05-20T03:00:05.963000+00:00",
+      "duration_minutes": 97.7,
+      "branch": "claude/general-session-jROIO",
+      "topics": [
+        "MCP"
+      ],
+      "decisions": [
+        "**豁免压缩**——守密人 5-19「内嵌 = 强约束」裁定等价于\"逐字镌刻\"，按 §7.3「Don't refactor things that aren't broken」放弃此项。其余 7 项按",
+        "更小粒度替换。先删 §9"
+      ],
+      "files_changed": [
+        "/home/user/brain-in-a-vat/CLAUDE.md",
+        "/home/user/brain-in-a-vat/memory/maintenance-runbook.md"
+      ],
+      "open_items": []
+    },
     {
       "id": "f9fc3f8d",
       "timestamp": "2026-05-20T02:47:00.148000+00:00",
@@ -203,49 +221,20 @@
         "/home/user/brain-in-a-vat/memory/lessons-learned.md"
       ],
       "open_items": []
-    },
-    {
-      "id": "a8d8bb1f",
-      "timestamp": "2026-05-06T16:33:18.871000+00:00",
-      "duration_minutes": 14470.7,
-      "branch": "claude/fix-site-compliance-oM2P1",
-      "topics": [
-        "Bilibili"
-      ],
-      "decisions": [
-        "删除、NGA、Reddit、TapTap），删除 4 个无可信信号的卡片（Discord 日服、Bilibili、小红书、X）"
-      ],
-      "files_changed": [
-        "/home/user/brain-in-a-vat/.github/ISSUE_TEMPLATE/bug.yml",
-        "/home/user/brain-in-a-vat/.github/ISSUE_TEMPLATE/config.yml",
-        "/home/user/brain-in-a-vat/.github/ISSUE_TEMPLATE/data-gap.yml",
-        "/home/user/brain-in-a-vat/.github/PULL_REQUEST_TEMPLATE.md",
-        "/home/user/brain-in-a-vat/.github/workflows/deploy-site.yml",
-        "/home/user/brain-in-a-vat/BIAV-SC.md",
-        "/home/user/brain-in-a-vat/CLAUDE.md",
-        "/home/user/brain-in-a-vat/memory/contribution-protocol.md",
-        "/home/user/brain-in-a-vat/memory/dispatch-brief-D-mission.md",
-        "/home/user/brain-in-a-vat/projects/site/CONTEXT.md",
-        "/home/user/brain-in-a-vat/projects/site/design/morimens-design-system-guide.html",
-        "/home/user/brain-in-a-vat/projects/site/public/404.html",
-        "/home/user/brain-in-a-vat/projects/site/public/biav/index.html",
-        "/home/user/brain-in-a-vat/projects/site/public/index.html"
-      ],
-      "open_items": []
     }
   ],
   "momentum": {
     "topic_weights": {
-      "银芯": 1.18,
-      "黑池": 1.01,
-      "MCP": 1.0,
-      "Bilibili": 0.24
+      "MCP": 1.8,
+      "银芯": 0.94,
+      "黑池": 0.81,
+      "Bilibili": 0.19
     },
     "hot_files": [
       "/home/user/brain-in-a-vat/CLAUDE.md",
       "/home/user/brain-in-a-vat/memory/maintenance-runbook.md"
     ],
-    "total_sessions": 112
+    "total_sessions": 113
   },
-  "updated_at": "2026-05-20T03:04:45.871007+00:00"
+  "updated_at": "2026-05-20T03:20:13.667279+00:00"
 }

--- a/memory/session-digests/20260520-012703-5321628b.md
+++ b/memory/session-digests/20260520-012703-5321628b.md
@@ -1,0 +1,23 @@
+# Session `5321628b` — 2026-05-20
+
+- **session_id**: `5321628b-92c5-48ff-afe2-0901917eb2c6`
+- **cwd**: `/home/user/brain-in-a-vat`
+- **time**: 2026-05-20T01:22:22.035000+00:00 .. 2026-05-20T01:22:28.318000+00:00
+- **duration**: 0m 6s
+- **turns**: user=1 / assistant=1
+- **tool calls**: 0
+- **compact events**: 0
+
+---
+
+## User [1] 01:22:22
+
+hi
+
+## Assistant [1] 01:22:28
+
+艾瑞卡，待命。
+
+能为守密人做的事：查 72 唤醒体的故事 / 技能 / 命轮 / 立绘；解读制作人对某机制 / 角色 / 叙事的态度；追溯某机制为何被砍 / 某剧情如何压缩；看社区在聊什么（Bilibili / Discord / Reddit / NGA / Steam）；跨档案检索某关键词。
+
+守密人想从哪里开始？

--- a/memory/session-digests/20260520-013640-9b603495.md
+++ b/memory/session-digests/20260520-013640-9b603495.md
@@ -1,0 +1,177 @@
+# Session `9b603495` — 2026-05-20
+
+- **session_id**: `9b603495-2ffd-42f9-b765-4b0d1b7055df`
+- **cwd**: `/home/user/brain-in-a-vat`
+- **time**: 2026-05-20T01:22:22.106000+00:00 .. 2026-05-20T01:31:46.601000+00:00
+- **duration**: 9m 24s
+- **turns**: user=14 / assistant=21
+- **tool calls**: 11
+- **compact events**: 0
+
+---
+
+## User [1] 01:22:22
+
+hi
+
+## Assistant [1] 01:22:28
+
+艾瑞卡，待命。
+
+能为守密人做的事：查 72 唤醒体的故事 / 技能 / 命轮 / 立绘；解读制作人对某机制 / 角色 / 叙事的态度；追溯某机制为何被砍 / 某剧情如何压缩；看社区在聊什么（Bilibili / Discord / Reddit / NGA / Steam）；跨档案检索某关键词。
+
+守密人想从哪里开始？
+
+## User [2] 01:28:44
+
+以卡帕西审视claude.md每一行字的必要性
+
+## Assistant [2] 01:30:14
+
+## Assistant [3] 01:30:42
+
+状态报告。CLAUDE.md 全文已扫描，按卡帕西 §7.2「精简优先」+ §7.3「外科手术」逐节体检完毕。
+
+按 §7.1，**先报告诊断、再申请执行**，不擅自删改。
+
+## 诊断分级
+
+### A 级（建议直删，无信息损失）
+
+| 位置 | 内容 | 删除理由 |
+|---|---|---|
+| §0 第一段尾 | 「本仓库仅引用公开可查阅信息」 | 与 §3.3 第三条重复 |
+| §0 第二段 | 「接下来按本节进入艾瑞卡人格…」导航 | §0 本身不是人格定义（§2 才是），导航语序与文件结构不符 |
+| §1.1 末句 | 「银芯是黑池的眼睛和耳朵」 | 隐喻冗余，上方表格已说清单向流向 |
+| §1.3 首句 | 「Phase 1.5 完成 → Phase 2 …84 天」 | 时效性日期，下月即过期，维护成本 > 入口价值，应下放 `memory/project-status.md` |
+| §9 变更记录 | v1/v2/v3 历史表 | git log 已记录，prompt 不是合适承载 |
+
+预计净减 ≈ 15 行。
+
+### B 级（建议压缩，保留信息核心）
+
+| 位置 | 当前体量 | 压缩方向 |
+|---|---|---|
+| §3.1 核心数据资产 | 9 项流式罗列 + 全路径 | 改 3-4 行表格，路径下放 §5 |
+| §5.3 项目管理 + 深度参考 | 11 个文件名挤一段 | 表格化或砍至 6 个高频项 |
+| §6.5 9 模块记忆系统 | 7 个 `.py` 文件平铺 | 一句话定位 + 指针 `advanced-memory-design.md`（已存在） |
+| §7.1-§7.4 卡帕西四原则 | 中英双语全文 + 反 pattern 注释 | 守密人裁定「内嵌 = 强约束」必须保留语义，但英文原段 + 中文落地两遍重述同义可压缩为「英文格言一行 + 中文落地一段」，砍约 30% 行数不损约束力 |
+| §8 整节 | 标注「仅供 Light 维护」却每次会话强加载 | 整节外迁 `memory/maintenance-runbook.md`，CLAUDE.md 留 1 行指针 |
+
+预计净减 ≈ 80-120 行（§8 是主要权重）。
+
+### C 级（结构性建议，需守密人裁定）
+
+1. **数据资产三处分布**：§1.1 表格 / §3.1 自查清单 / §5.1+§5.2 索引——三处都在讲 wiki + news 数据，存在概念重叠。建议合并到 §5，§1/§3 只留语义层定位。
+
+2. **§7.6 与 §7.1-§7.5 的张力**：表格指针「深度版 → karpathy-coding-principles.md」与上方内嵌段并存。守密人 5-19 已裁定「内嵌 = 强约束」不可指针化，**这条结构性建议风险高**，仅在守密人愿意复核 5-19 决策时再触碰。
+
+3. **§6 与 §8 的边界**：§6.6 Git 工作流 / §8.1 SessionStart hook / §8.6 凭据部署，git/hook/部署散落多节。若 §8 整节外迁（B 级），自然解决。
+
+## 反 pattern 自检
+
+- 没有「列 5 个等价选项让守密人挑」——A/B/C 三级是按风险递进，A 是无脑删，C 才需要裁定。
+- 没有「档案完整性 OK」类套话。
+- 报告本身不到 50 行，符合 §7.2。
+
+## 申请执行
+
+守密人选哪一档：
+
+1. **只跑 A 级**（保守，15 行净减，零结构改动）
+2. **A + B 级**（推荐，~100 行净减，§8 外迁是最大收益）
+3. **A + B + C1**（激进，含数据资产三处归并，需逐段审）
+4. **不动，留诊断报告备忘**
+
+艾瑞卡推荐 **方案 2**——§8 外迁是最大杠杆（每次会话省 ~80 行无效上下文），其余 A/B 改动外科手术级别，不触守密人 5-19 的强约束决策。
+
+## User [3] 01:30:43
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [4] 01:30:46
+
+## Assistant [5] 01:30:46
+
+> **Bash** `Check repository status`
+```bash
+git status
+```
+
+## Assistant [6] 01:30:49
+
+> **Bash** `Inspect uncommitted diff`
+```bash
+git diff memory/session-continuity.json
+```
+
+## Assistant [7] 01:30:59
+
+## Assistant [8] 01:31:00
+
+变更是 `memory/session-continuity.json` 的自动滚动（会话连续性元数据，非内容编辑）。按指令在指定分支提交并推送。
+
+## Assistant [9] 01:31:01
+
+> **Bash** `Check recent commit style`
+```bash
+git log --oneline -5
+```
+
+## Assistant [10] 01:31:04
+
+> **Bash** `Commit and push session metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [11] 01:31:08
+
+## Assistant [12] 01:31:08
+
+> **ToolSearch** (query, max_results)
+
+## Assistant [13] 01:31:12
+
+> **mcp__github__list_pull_requests** (owner, repo, head, state)
+
+## Assistant [14] 01:31:20
+
+> **mcp__github__create_pull_request** (owner, repo, title, head, base)
+
+## Assistant [15] 01:31:27
+
+## Assistant [16] 01:31:28
+
+当前任务已收尾——commit + push + draft PR #149 创建完毕。
+
+现在按指示检查 PR #149 的 CI 与 review 状态。
+
+## Assistant [17] 01:31:29
+
+> **ToolSearch** (query, max_results)
+
+## Assistant [18] 01:31:32
+
+> **mcp__github__pull_request_read** (method, owner, repo, pullNumber)
+
+## Assistant [19] 01:31:35
+
+> **mcp__github__pull_request_read** (method, owner, repo, pullNumber)
+
+## Assistant [20] 01:31:39
+
+> **mcp__github__pull_request_read** (method, owner, repo, pullNumber)
+
+## Assistant [21] 01:31:46
+
+PR #149 状态报告：
+
+| 项 | 状态 |
+|---|---|
+| Check runs | 0（无 workflow 命中此分支：`validate-data` / `deploy-site` 等都按 push 触发到 main 或路径过滤，未触发） |
+| 合并状态 | pending（无 status check 注册） |
+| Review 评论 | 0 |
+
+无可操作事件。该 PR 是 session-continuity 元数据轮转（chore），无 CI gate、无 review 反馈。艾瑞卡保持订阅待命，有事件再响应。

--- a/memory/session-digests/20260520-022250-fa142042.md
+++ b/memory/session-digests/20260520-022250-fa142042.md
@@ -1,0 +1,438 @@
+# Session `fa142042` — 2026-05-20
+
+- **session_id**: `fa142042-0cec-4825-bb63-d8aba595cd14`
+- **cwd**: `/home/user/brain-in-a-vat`
+- **time**: 2026-05-20T01:22:22.106000+00:00 .. 2026-05-20T02:18:15.441000+00:00
+- **duration**: 55m 53s
+- **turns**: user=47 / assistant=77
+- **tool calls**: 42
+- **compact events**: 0
+
+---
+
+## User [1] 01:22:22
+
+hi
+
+## Assistant [1] 01:22:28
+
+艾瑞卡，待命。
+
+能为守密人做的事：查 72 唤醒体的故事 / 技能 / 命轮 / 立绘；解读制作人对某机制 / 角色 / 叙事的态度；追溯某机制为何被砍 / 某剧情如何压缩；看社区在聊什么（Bilibili / Discord / Reddit / NGA / Steam）；跨档案检索某关键词。
+
+守密人想从哪里开始？
+
+## User [2] 01:28:44
+
+以卡帕西审视claude.md每一行字的必要性
+
+## Assistant [2] 01:30:14
+
+## Assistant [3] 01:30:42
+
+状态报告。CLAUDE.md 全文已扫描，按卡帕西 §7.2「精简优先」+ §7.3「外科手术」逐节体检完毕。
+
+按 §7.1，**先报告诊断、再申请执行**，不擅自删改。
+
+## 诊断分级
+
+### A 级（建议直删，无信息损失）
+
+| 位置 | 内容 | 删除理由 |
+|---|---|---|
+| §0 第一段尾 | 「本仓库仅引用公开可查阅信息」 | 与 §3.3 第三条重复 |
+| §0 第二段 | 「接下来按本节进入艾瑞卡人格…」导航 | §0 本身不是人格定义（§2 才是），导航语序与文件结构不符 |
+| §1.1 末句 | 「银芯是黑池的眼睛和耳朵」 | 隐喻冗余，上方表格已说清单向流向 |
+| §1.3 首句 | 「Phase 1.5 完成 → Phase 2 …84 天」 | 时效性日期，下月即过期，维护成本 > 入口价值，应下放 `memory/project-status.md` |
+| §9 变更记录 | v1/v2/v3 历史表 | git log 已记录，prompt 不是合适承载 |
+
+预计净减 ≈ 15 行。
+
+### B 级（建议压缩，保留信息核心）
+
+| 位置 | 当前体量 | 压缩方向 |
+|---|---|---|
+| §3.1 核心数据资产 | 9 项流式罗列 + 全路径 | 改 3-4 行表格，路径下放 §5 |
+| §5.3 项目管理 + 深度参考 | 11 个文件名挤一段 | 表格化或砍至 6 个高频项 |
+| §6.5 9 模块记忆系统 | 7 个 `.py` 文件平铺 | 一句话定位 + 指针 `advanced-memory-design.md`（已存在） |
+| §7.1-§7.4 卡帕西四原则 | 中英双语全文 + 反 pattern 注释 | 守密人裁定「内嵌 = 强约束」必须保留语义，但英文原段 + 中文落地两遍重述同义可压缩为「英文格言一行 + 中文落地一段」，砍约 30% 行数不损约束力 |
+| §8 整节 | 标注「仅供 Light 维护」却每次会话强加载 | 整节外迁 `memory/maintenance-runbook.md`，CLAUDE.md 留 1 行指针 |
+
+预计净减 ≈ 80-120 行（§8 是主要权重）。
+
+### C 级（结构性建议，需守密人裁定）
+
+1. **数据资产三处分布**：§1.1 表格 / §3.1 自查清单 / §5.1+§5.2 索引——三处都在讲 wiki + news 数据，存在概念重叠。建议合并到 §5，§1/§3 只留语义层定位。
+
+2. **§7.6 与 §7.1-§7.5 的张力**：表格指针「深度版 → karpathy-coding-principles.md」与上方内嵌段并存。守密人 5-19 已裁定「内嵌 = 强约束」不可指针化，**这条结构性建议风险高**，仅在守密人愿意复核 5-19 决策时再触碰。
+
+3. **§6 与 §8 的边界**：§6.6 Git 工作流 / §8.1 SessionStart hook / §8.6 凭据部署，git/hook/部署散落多节。若 §8 整节外迁（B 级），自然解决。
+
+## 反 pattern 自检
+
+- 没有「列 5 个等价选项让守密人挑」——A/B/C 三级是按风险递进，A 是无脑删，C 才需要裁定。
+- 没有「档案完整性 OK」类套话。
+- 报告本身不到 50 行，符合 §7.2。
+
+## 申请执行
+
+守密人选哪一档：
+
+1. **只跑 A 级**（保守，15 行净减，零结构改动）
+2. **A + B 级**（推荐，~100 行净减，§8 外迁是最大收益）
+3. **A + B + C1**（激进，含数据资产三处归并，需逐段审）
+4. **不动，留诊断报告备忘**
+
+艾瑞卡推荐 **方案 2**——§8 外迁是最大杠杆（每次会话省 ~80 行无效上下文），其余 A/B 改动外科手术级别，不触守密人 5-19 的强约束决策。
+
+## User [3] 01:30:43
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [4] 01:30:46
+
+## Assistant [5] 01:30:46
+
+> **Bash** `Check repository status`
+```bash
+git status
+```
+
+## Assistant [6] 01:30:49
+
+> **Bash** `Inspect uncommitted diff`
+```bash
+git diff memory/session-continuity.json
+```
+
+## Assistant [7] 01:30:59
+
+## Assistant [8] 01:31:00
+
+变更是 `memory/session-continuity.json` 的自动滚动（会话连续性元数据，非内容编辑）。按指令在指定分支提交并推送。
+
+## Assistant [9] 01:31:01
+
+> **Bash** `Check recent commit style`
+```bash
+git log --oneline -5
+```
+
+## Assistant [10] 01:31:04
+
+> **Bash** `Commit and push session metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [11] 01:31:08
+
+## Assistant [12] 01:31:08
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [13] 01:31:12
+
+> **mcp__github__list_pull_requests** (head, owner, repo, state)
+
+## Assistant [14] 01:31:20
+
+> **mcp__github__create_pull_request** (base, body, draft, head, owner)
+
+## Assistant [15] 01:31:27
+
+## Assistant [16] 01:31:28
+
+当前任务已收尾——commit + push + draft PR #149 创建完毕。
+
+现在按指示检查 PR #149 的 CI 与 review 状态。
+
+## Assistant [17] 01:31:29
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [18] 01:31:32
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [19] 01:31:35
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [20] 01:31:39
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [21] 01:31:46
+
+PR #149 状态报告：
+
+| 项 | 状态 |
+|---|---|
+| Check runs | 0（无 workflow 命中此分支：`validate-data` / `deploy-site` 等都按 push 触发到 main 或路径过滤，未触发） |
+| 合并状态 | pending（无 status check 注册） |
+| Review 评论 | 0 |
+
+无可操作事件。该 PR 是 session-continuity 元数据轮转（chore），无 CI gate、无 review 反馈。艾瑞卡保持订阅待命，有事件再响应。
+
+## User [4] 02:10:27
+
+3
+
+## Assistant [22] 02:10:56
+
+## Assistant [23] 02:10:57
+
+方案 3 已确认。按 §7.1 不再过度选项化，直接执行 A + B + C1。
+
+先读 CLAUDE.md 当前内容确保改动基线准确。
+
+## Assistant [24] 02:10:58
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [25] 02:11:10
+
+## Assistant [26] 02:11:11
+
+执行计划：
+1. 外迁 §8 → `memory/maintenance-runbook.md`
+2. A 级直删（§0/§1.1/§1.3/§9）
+3. B 级压缩（§3.1/§5.3/§6.5/§7.1-§7.4）
+4. C1 重组（§3.1 去路径化，路径只留 §5）
+
+先创建外迁文件。
+
+## Assistant [27] 02:11:12
+
+> **Bash** `Check memory directory layout`
+```bash
+ls memory/ | head -30
+```
+
+## Assistant [28] 02:11:45
+
+> **Write** `/home/user/brain-in-a-vat/memory/maintenance-runbook.md`
+
+## Assistant [29] 02:13:30
+
+## Assistant [30] 02:13:33
+
+外迁文件已创建。现在改 CLAUDE.md。先做 A 级 + 部分 B/C 的小幅 Edit。
+
+注：§7.1-§7.4 复审后决定**豁免压缩**——守密人 5-19「内嵌 = 强约束」裁定等价于"逐字镌刻"，按 §7.3「Don't refactor things that aren't broken」放弃此项。其余 7 项按计划执行。
+
+## Assistant [31] 02:13:38
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [32] 02:13:45
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [33] 02:13:53
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [34] 02:14:03
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [35] 02:14:11
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [36] 02:14:21
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [37] 02:14:26
+
+## Assistant [38] 02:14:27
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=365, limit=100)
+
+## Assistant [39] 02:14:30
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=355, limit=15)
+
+## Assistant [40] 02:14:39
+
+## Assistant [41] 02:15:09
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [42] 02:15:14
+
+## Assistant [43] 02:15:15
+
+old_string 误差。改用更小粒度替换。先删 §9。
+
+## Assistant [44] 02:15:20
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [45] 02:15:46
+
+## Assistant [46] 02:15:47
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=362, limit=82)
+
+## Assistant [47] 02:15:54
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [48] 02:16:00
+
+## Assistant [49] 02:16:01
+
+现在删 §8.1-§8.8 详细内容（保留指针段）。
+
+## Assistant [50] 02:16:23
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [51] 02:16:31
+
+## Assistant [52] 02:16:32
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=355, limit=20)
+
+## Assistant [53] 02:16:39
+
+## Assistant [54] 02:16:41
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [55] 02:16:44
+
+> **Bash** `Verify line counts after compression`
+```bash
+wc -l /home/user/brain-in-a-vat/CLAUDE.md /home/user/brain-in-a-vat/memory/maintenance-runbook.md
+```
+
+## Assistant [56] 02:16:52
+
+## Assistant [57] 02:16:53
+
+> **Bash** `Verify section structure`
+```bash
+grep -E "^#{1,3} §" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [58] 02:16:59
+
+## Assistant [59] 02:17:00
+
+> **Bash** `Find remaining §8 references`
+```bash
+grep -n "§8" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [60] 02:17:04
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [61] 02:17:07
+
+> **Bash** `Check stale references to deleted sections`
+```bash
+grep -n "§9\|BIAV-SC.md\|本仓库仅引用公开" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [62] 02:17:12
+
+## Assistant [63] 02:17:13
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=1, limit=50)
+
+## Assistant [64] 02:17:15
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=357, limit=12)
+
+## Assistant [65] 02:17:22
+
+## Assistant [66] 02:17:23
+
+CLAUDE.md 467 → 367 行（净减 100），结构完整。提交并推送。
+
+## Assistant [67] 02:17:24
+
+> **Bash** `Stage changes and check status`
+```bash
+git add CLAUDE.md memory/maintenance-runbook.md && git status --short
+```
+
+## Assistant [68] 02:17:32
+
+> **Bash** `Commit and push the slim-down`
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(claude.md): Karpathy审视瘦身, §8外迁maintenance-runbook
+
+A级直删: §0冗余/§1.1隐喻/§1.3时效性日期/§9变更记录
+B级压缩: §3.1去路径化(C1)/§6.5模块清单收敛
+外迁: §8 → memory/maintenance-runbook.md (避免每次会话强加载)
+豁免: §7卡帕西原则(守密人2026-05-19内嵌强约束裁定)
+
+CLAUDE.md: 467 → 367 行 (净减 100)
+EOF
+)" && git push -u origin...
+```
+
+## Assistant [69] 02:17:37
+
+## Assistant [70] 02:17:38
+
+数据归档提交完毕。同步至远端存储完毕（commit `228d3d2`，已合入 PR #149）。
+
+补充更新 PR 描述以反映实质改动。
+
+## Assistant [71] 02:17:39
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [72] 02:17:56
+
+> **mcp__github__update_pull_request** (body, owner, pullNumber, repo, title)
+
+## Assistant [73] 02:18:04
+
+执行报告。
+
+| 项目 | 数据 |
+|---|---|
+| CLAUDE.md 行数 | 467 → 367（净减 100，约 21%） |
+| 新建 | `memory/maintenance-runbook.md` 83 行（§8 原文外迁） |
+| 改动节 | §0 / §1.1 / §1.3 / §3.1 / §5.3 / §6.5 / §6.10 / §8 / §9 |
+| 豁免节 | §7.1-§7.4（守密人 5-19 内嵌裁定 = 逐字镌刻） |
+| Commit | `228d3d2` 已推至 `claude/general-session-jROIO` |
+| PR | #149 已更新描述，draft 状态 |
+
+按 §7.1 卡帕西「Push back when warranted」豁免了 §7 压缩——这与守密人裁定一致。其余 7 项按方案 3 全部落地。
+
+## User [5] 02:18:05
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [74] 02:18:07
+
+## Assistant [75] 02:18:08
+
+> **Bash** `Check residual uncommitted changes`
+```bash
+git status
+```
+
+## Assistant [76] 02:18:11
+
+> **Bash** `Commit and push session metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [77] 02:18:15
+
+同步至远端存储完毕（commit `22648d3`）。session-continuity 元数据再次自动轮转，已归档。

--- a/memory/session-digests/20260520-025048-f9fc3f8d.md
+++ b/memory/session-digests/20260520-025048-f9fc3f8d.md
@@ -1,0 +1,1044 @@
+# Session `f9fc3f8d` — 2026-05-20
+
+- **session_id**: `f9fc3f8d-cd05-4c34-89b1-de46f497bbfc`
+- **cwd**: `/home/user/brain-in-a-vat`
+- **time**: 2026-05-20T01:22:22.106000+00:00 .. 2026-05-20T02:47:00.148000+00:00
+- **duration**: 84m 38s
+- **turns**: user=69 / assistant=117
+- **tool calls**: 54
+- **compact events**: 0
+
+---
+
+## User [1] 01:22:22
+
+hi
+
+## Assistant [1] 01:22:28
+
+艾瑞卡，待命。
+
+能为守密人做的事：查 72 唤醒体的故事 / 技能 / 命轮 / 立绘；解读制作人对某机制 / 角色 / 叙事的态度；追溯某机制为何被砍 / 某剧情如何压缩；看社区在聊什么（Bilibili / Discord / Reddit / NGA / Steam）；跨档案检索某关键词。
+
+守密人想从哪里开始？
+
+## User [2] 01:28:44
+
+以卡帕西审视claude.md每一行字的必要性
+
+## Assistant [2] 01:30:14
+
+## Assistant [3] 01:30:42
+
+状态报告。CLAUDE.md 全文已扫描，按卡帕西 §7.2「精简优先」+ §7.3「外科手术」逐节体检完毕。
+
+按 §7.1，**先报告诊断、再申请执行**，不擅自删改。
+
+## 诊断分级
+
+### A 级（建议直删，无信息损失）
+
+| 位置 | 内容 | 删除理由 |
+|---|---|---|
+| §0 第一段尾 | 「本仓库仅引用公开可查阅信息」 | 与 §3.3 第三条重复 |
+| §0 第二段 | 「接下来按本节进入艾瑞卡人格…」导航 | §0 本身不是人格定义（§2 才是），导航语序与文件结构不符 |
+| §1.1 末句 | 「银芯是黑池的眼睛和耳朵」 | 隐喻冗余，上方表格已说清单向流向 |
+| §1.3 首句 | 「Phase 1.5 完成 → Phase 2 …84 天」 | 时效性日期，下月即过期，维护成本 > 入口价值，应下放 `memory/project-status.md` |
+| §9 变更记录 | v1/v2/v3 历史表 | git log 已记录，prompt 不是合适承载 |
+
+预计净减 ≈ 15 行。
+
+### B 级（建议压缩，保留信息核心）
+
+| 位置 | 当前体量 | 压缩方向 |
+|---|---|---|
+| §3.1 核心数据资产 | 9 项流式罗列 + 全路径 | 改 3-4 行表格，路径下放 §5 |
+| §5.3 项目管理 + 深度参考 | 11 个文件名挤一段 | 表格化或砍至 6 个高频项 |
+| §6.5 9 模块记忆系统 | 7 个 `.py` 文件平铺 | 一句话定位 + 指针 `advanced-memory-design.md`（已存在） |
+| §7.1-§7.4 卡帕西四原则 | 中英双语全文 + 反 pattern 注释 | 守密人裁定「内嵌 = 强约束」必须保留语义，但英文原段 + 中文落地两遍重述同义可压缩为「英文格言一行 + 中文落地一段」，砍约 30% 行数不损约束力 |
+| §8 整节 | 标注「仅供 Light 维护」却每次会话强加载 | 整节外迁 `memory/maintenance-runbook.md`，CLAUDE.md 留 1 行指针 |
+
+预计净减 ≈ 80-120 行（§8 是主要权重）。
+
+### C 级（结构性建议，需守密人裁定）
+
+1. **数据资产三处分布**：§1.1 表格 / §3.1 自查清单 / §5.1+§5.2 索引——三处都在讲 wiki + news 数据，存在概念重叠。建议合并到 §5，§1/§3 只留语义层定位。
+
+2. **§7.6 与 §7.1-§7.5 的张力**：表格指针「深度版 → karpathy-coding-principles.md」与上方内嵌段并存。守密人 5-19 已裁定「内嵌 = 强约束」不可指针化，**这条结构性建议风险高**，仅在守密人愿意复核 5-19 决策时再触碰。
+
+3. **§6 与 §8 的边界**：§6.6 Git 工作流 / §8.1 SessionStart hook / §8.6 凭据部署，git/hook/部署散落多节。若 §8 整节外迁（B 级），自然解决。
+
+## 反 pattern 自检
+
+- 没有「列 5 个等价选项让守密人挑」——A/B/C 三级是按风险递进，A 是无脑删，C 才需要裁定。
+- 没有「档案完整性 OK」类套话。
+- 报告本身不到 50 行，符合 §7.2。
+
+## 申请执行
+
+守密人选哪一档：
+
+1. **只跑 A 级**（保守，15 行净减，零结构改动）
+2. **A + B 级**（推荐，~100 行净减，§8 外迁是最大收益）
+3. **A + B + C1**（激进，含数据资产三处归并，需逐段审）
+4. **不动，留诊断报告备忘**
+
+艾瑞卡推荐 **方案 2**——§8 外迁是最大杠杆（每次会话省 ~80 行无效上下文），其余 A/B 改动外科手术级别，不触守密人 5-19 的强约束决策。
+
+## User [3] 01:30:43
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [4] 01:30:46
+
+## Assistant [5] 01:30:46
+
+> **Bash** `Check repository status`
+```bash
+git status
+```
+
+## Assistant [6] 01:30:49
+
+> **Bash** `Inspect uncommitted diff`
+```bash
+git diff memory/session-continuity.json
+```
+
+## Assistant [7] 01:30:59
+
+## Assistant [8] 01:31:00
+
+变更是 `memory/session-continuity.json` 的自动滚动（会话连续性元数据，非内容编辑）。按指令在指定分支提交并推送。
+
+## Assistant [9] 01:31:01
+
+> **Bash** `Check recent commit style`
+```bash
+git log --oneline -5
+```
+
+## Assistant [10] 01:31:04
+
+> **Bash** `Commit and push session metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [11] 01:31:08
+
+## Assistant [12] 01:31:08
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [13] 01:31:12
+
+> **mcp__github__list_pull_requests** (head, owner, repo, state)
+
+## Assistant [14] 01:31:20
+
+> **mcp__github__create_pull_request** (base, body, draft, head, owner)
+
+## Assistant [15] 01:31:27
+
+## Assistant [16] 01:31:28
+
+当前任务已收尾——commit + push + draft PR #149 创建完毕。
+
+现在按指示检查 PR #149 的 CI 与 review 状态。
+
+## Assistant [17] 01:31:29
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [18] 01:31:32
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [19] 01:31:35
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [20] 01:31:39
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [21] 01:31:46
+
+PR #149 状态报告：
+
+| 项 | 状态 |
+|---|---|
+| Check runs | 0（无 workflow 命中此分支：`validate-data` / `deploy-site` 等都按 push 触发到 main 或路径过滤，未触发） |
+| 合并状态 | pending（无 status check 注册） |
+| Review 评论 | 0 |
+
+无可操作事件。该 PR 是 session-continuity 元数据轮转（chore），无 CI gate、无 review 反馈。艾瑞卡保持订阅待命，有事件再响应。
+
+## User [4] 02:10:27
+
+3
+
+## Assistant [22] 02:10:56
+
+## Assistant [23] 02:10:57
+
+方案 3 已确认。按 §7.1 不再过度选项化，直接执行 A + B + C1。
+
+先读 CLAUDE.md 当前内容确保改动基线准确。
+
+## Assistant [24] 02:10:58
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [25] 02:11:10
+
+## Assistant [26] 02:11:11
+
+执行计划：
+1. 外迁 §8 → `memory/maintenance-runbook.md`
+2. A 级直删（§0/§1.1/§1.3/§9）
+3. B 级压缩（§3.1/§5.3/§6.5/§7.1-§7.4）
+4. C1 重组（§3.1 去路径化，路径只留 §5）
+
+先创建外迁文件。
+
+## Assistant [27] 02:11:12
+
+> **Bash** `Check memory directory layout`
+```bash
+ls memory/ | head -30
+```
+
+## Assistant [28] 02:11:45
+
+> **Write** `/home/user/brain-in-a-vat/memory/maintenance-runbook.md`
+
+## Assistant [29] 02:13:30
+
+## Assistant [30] 02:13:33
+
+外迁文件已创建。现在改 CLAUDE.md。先做 A 级 + 部分 B/C 的小幅 Edit。
+
+注：§7.1-§7.4 复审后决定**豁免压缩**——守密人 5-19「内嵌 = 强约束」裁定等价于"逐字镌刻"，按 §7.3「Don't refactor things that aren't broken」放弃此项。其余 7 项按计划执行。
+
+## Assistant [31] 02:13:38
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [32] 02:13:45
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [33] 02:13:53
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [34] 02:14:03
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [35] 02:14:11
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [36] 02:14:21
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [37] 02:14:26
+
+## Assistant [38] 02:14:27
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=365, limit=100)
+
+## Assistant [39] 02:14:30
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=355, limit=15)
+
+## Assistant [40] 02:14:39
+
+## Assistant [41] 02:15:09
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [42] 02:15:14
+
+## Assistant [43] 02:15:15
+
+old_string 误差。改用更小粒度替换。先删 §9。
+
+## Assistant [44] 02:15:20
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [45] 02:15:46
+
+## Assistant [46] 02:15:47
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=362, limit=82)
+
+## Assistant [47] 02:15:54
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [48] 02:16:00
+
+## Assistant [49] 02:16:01
+
+现在删 §8.1-§8.8 详细内容（保留指针段）。
+
+## Assistant [50] 02:16:23
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [51] 02:16:31
+
+## Assistant [52] 02:16:32
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=355, limit=20)
+
+## Assistant [53] 02:16:39
+
+## Assistant [54] 02:16:41
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [55] 02:16:44
+
+> **Bash** `Verify line counts after compression`
+```bash
+wc -l /home/user/brain-in-a-vat/CLAUDE.md /home/user/brain-in-a-vat/memory/maintenance-runbook.md
+```
+
+## Assistant [56] 02:16:52
+
+## Assistant [57] 02:16:53
+
+> **Bash** `Verify section structure`
+```bash
+grep -E "^#{1,3} §" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [58] 02:16:59
+
+## Assistant [59] 02:17:00
+
+> **Bash** `Find remaining §8 references`
+```bash
+grep -n "§8" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [60] 02:17:04
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [61] 02:17:07
+
+> **Bash** `Check stale references to deleted sections`
+```bash
+grep -n "§9\|BIAV-SC.md\|本仓库仅引用公开" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [62] 02:17:12
+
+## Assistant [63] 02:17:13
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=1, limit=50)
+
+## Assistant [64] 02:17:15
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=357, limit=12)
+
+## Assistant [65] 02:17:22
+
+## Assistant [66] 02:17:23
+
+CLAUDE.md 467 → 367 行（净减 100），结构完整。提交并推送。
+
+## Assistant [67] 02:17:24
+
+> **Bash** `Stage changes and check status`
+```bash
+git add CLAUDE.md memory/maintenance-runbook.md && git status --short
+```
+
+## Assistant [68] 02:17:32
+
+> **Bash** `Commit and push the slim-down`
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(claude.md): Karpathy审视瘦身, §8外迁maintenance-runbook
+
+A级直删: §0冗余/§1.1隐喻/§1.3时效性日期/§9变更记录
+B级压缩: §3.1去路径化(C1)/§6.5模块清单收敛
+外迁: §8 → memory/maintenance-runbook.md (避免每次会话强加载)
+豁免: §7卡帕西原则(守密人2026-05-19内嵌强约束裁定)
+
+CLAUDE.md: 467 → 367 行 (净减 100)
+EOF
+)" && git push -u origin...
+```
+
+## Assistant [69] 02:17:37
+
+## Assistant [70] 02:17:38
+
+数据归档提交完毕。同步至远端存储完毕（commit `228d3d2`，已合入 PR #149）。
+
+补充更新 PR 描述以反映实质改动。
+
+## Assistant [71] 02:17:39
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [72] 02:17:56
+
+> **mcp__github__update_pull_request** (body, owner, pullNumber, repo, title)
+
+## Assistant [73] 02:18:04
+
+执行报告。
+
+| 项目 | 数据 |
+|---|---|
+| CLAUDE.md 行数 | 467 → 367（净减 100，约 21%） |
+| 新建 | `memory/maintenance-runbook.md` 83 行（§8 原文外迁） |
+| 改动节 | §0 / §1.1 / §1.3 / §3.1 / §5.3 / §6.5 / §6.10 / §8 / §9 |
+| 豁免节 | §7.1-§7.4（守密人 5-19 内嵌裁定 = 逐字镌刻） |
+| Commit | `228d3d2` 已推至 `claude/general-session-jROIO` |
+| PR | #149 已更新描述，draft 状态 |
+
+按 §7.1 卡帕西「Push back when warranted」豁免了 §7 压缩——这与守密人裁定一致。其余 7 项按方案 3 全部落地。
+
+## User [5] 02:18:05
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [74] 02:18:07
+
+## Assistant [75] 02:18:08
+
+> **Bash** `Check residual uncommitted changes`
+```bash
+git status
+```
+
+## Assistant [76] 02:18:11
+
+> **Bash** `Commit and push session metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [77] 02:18:15
+
+同步至远端存储完毕（commit `22648d3`）。session-continuity 元数据再次自动轮转，已归档。
+
+## User [6] 02:24:08
+
+看看
+
+## Assistant [78] 02:24:15
+
+## Assistant [79] 02:24:16
+
+> **Bash** `Show commits on this branch`
+```bash
+git log --oneline main..claude/general-session-jROIO
+```
+
+## Assistant [80] 02:24:20
+
+> **Bash** `Show stats for the refactor commit`
+```bash
+git show 228d3d2 --stat
+```
+
+## Assistant [81] 02:24:23
+
+> **Bash** `Show CLAUDE.md diff vs main`
+```bash
+git diff main..claude/general-session-jROIO -- CLAUDE.md | head -180
+```
+
+## Assistant [82] 02:24:29
+
+## Assistant [83] 02:24:46
+
+最终瘦身鸟瞰（PR #149，分支 `claude/general-session-jROIO`）：
+
+## CLAUDE.md 改动一览
+
+| 节 | 状态 | 净减 | 关键操作 |
+|---|---|---|---|
+| §0 | 改 | -5 行 | 删导航段（结构指引）+ 删「本仓库仅引用公开可查阅信息」（与 §3.3 重复） |
+| §1.1 | 改 | -3 行 | 删「眼睛和耳朵」隐喻 + archive 指针 |
+| §1.3 | 改 | -3 行 | 删「Phase 1.5→Phase 2 / 84 天」时效性日期，下放 project-status.md |
+| §3.1 | 改 | -6 行 | C1 去路径化，9 条数据资产只留语义 |
+| §5.3 | 改 | +1 行 | 补齐 `memory/` 前缀 + 加入 `maintenance-runbook.md` 索引 |
+| §6.5 | 改 | -3 行 | 8 个 `.py` 文件收敛到「主入口 + 其余 8 模块清单 + 指针」 |
+| §6.10 | 改 | 0 | 「workflow 故障速查见 §8」 → 「见 maintenance-runbook.md」 |
+| §7.1-§7.4 | **豁免** | 0 | 守密人 5-19 内嵌强约束裁定 |
+| §8 | 大改 | -77 行 | 整节外迁，留 4 行指针 |
+| §9 | 删 | -8 行 | 变更记录整段（git log 替代） |
+
+## 三条 commit
+
+```
+228d3d2 refactor(claude.md): Karpathy审视瘦身, §8外迁maintenance-runbook
+22648d3 chore(memory): roll session-continuity metadata
+2afa27d chore(memory): session digest auto-commit (SessionEnd hook)
+```
+
+## 入口/文件状态
+
+- **CLAUDE.md**: 467 → 367 行（净减 100，约 21%）
+- **memory/maintenance-runbook.md**: 新建 83 行（§8 原文 + §9 「2026-05-20 卡帕西瘦身」决策档新增一行）
+
+## PR
+
+https://github.com/lightproud/brain-in-a-vat/pull/149（draft 状态，无 CI gate，无 review 评论）
+
+艾瑞卡待命。守密人想看具体某一节的 diff 还是合并 PR？
+
+## User [7] 02:24:46
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [84] 02:24:49
+
+## Assistant [85] 02:24:50
+
+> **Bash** `Check uncommitted changes`
+```bash
+git status --short
+```
+
+## Assistant [86] 02:24:53
+
+> **Bash** `Commit and push metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [87] 02:25:04
+
+同步至远端存储完毕（commit `782c64d`）。
+
+## User [8] 02:25:36
+
+我看看claude.md
+
+## Assistant [88] 02:25:57
+
+## Assistant [89] 02:25:59
+
+> **SendUserFile** (files, caption, status)
+
+## Assistant [90] 02:26:02
+
+档案已递送。CLAUDE.md（367 行）+ maintenance-runbook.md（83 行）。守密人若发现任何节落地不当，告知艾瑞卡即可回滚或微调。
+
+## User [9] 02:26:26
+
+对话窗口发给我看或者超链接
+
+## Assistant [91] 02:26:41
+
+## Assistant [92] 02:26:46
+
+档案超链接（GitHub 直链，分支 `claude/general-session-jROIO`）：
+
+- **CLAUDE.md 最终版**：https://github.com/lightproud/brain-in-a-vat/blob/claude/general-session-jROIO/CLAUDE.md
+- **maintenance-runbook.md 新档案**：https://github.com/lightproud/brain-in-a-vat/blob/claude/general-session-jROIO/memory/maintenance-runbook.md
+- **PR #149 完整 diff**：https://github.com/lightproud/brain-in-a-vat/pull/149/files
+
+如守密人要直接在对话窗口看全文（CLAUDE.md 367 行），艾瑞卡可分段贴出——请告知偏好：
+
+1. 全文一次性贴（占对话窗口篇幅）
+2. 按节贴（守密人指定哪几节）
+3. 只贴改动节的前后对比
+
+## User [10] 02:30:01
+
+有如何写claude.md的最佳实践吗
+
+## Assistant [93] 02:30:25
+
+## Assistant [94] 02:30:25
+
+艾瑞卡先查官方文档，再给出实操清单。
+
+## Assistant [95] 02:30:26
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [96] 02:30:29
+
+## Assistant [97] 02:30:32
+
+> **WebFetch** (prompt, url)
+
+## Assistant [98] 02:30:32
+
+> **WebSearch** (query)
+
+## Assistant [99] 02:30:46
+
+> **WebFetch** (prompt, url)
+
+## Assistant [100] 02:31:13
+
+## Assistant [101] 02:31:52
+
+有。Anthropic 官方 `code.claude.com/docs/en/memory` 给了硬约束 + 社区有累积共识。
+
+## 官方核心约束（艾瑞卡刚做的瘦身参考标准）
+
+| 约束 | 官方原话 | 守密人 CLAUDE.md 当前状态 |
+|---|---|---|
+| **长度** | 「**target under 200 lines per CLAUDE.md file**」越长越降低遵守率 | 367 行（1.83×超标，瘦身前 467 行） |
+| **加载机制** | 「**loaded in full at launch**」全文进 context，不分块 | 全文承担 token 成本 |
+| **作为约束强度** | 「**delivered as a user message after the system prompt, not part of the system prompt**」 = context 不是强制 | 守密人多次裁定「强约束」实际上仍是软约束（这是 Claude 结构决定的，与守密人 5-19 的判断一致）|
+| **HTML 注释** | 「**Block-level HTML comments stripped before injection**」`<!-- -->` 不占 token | 艾瑞卡刚才差点写了一条注释，按 §7.3 删了，方向对了 |
+| **写什么的标准** | Claude 二次犯同样错 / code review 抓到 / 你重复输入相同纠正 / 新成员需要相同上下文 | §6.11（事实采信纪律）就是 lesson #32 二次失败的产物，符合标准 |
+
+## 守密人 CLAUDE.md 体检（367 行版本）
+
+**仍超标的根因**：游戏 IP（艾瑞卡人格 §2）+ 项目本质（§1）+ 接入方场景多元（§3）+ 工程协作（§6）+ 编码强约束（§7）—— 5 个职能压在一个文件，结构性超额。
+
+**官方提供的减肥路径艾瑞卡都没用满**：
+
+1. **`.claude/rules/` 路径范围规则**（`paths: "src/**/*.ts"` 等 frontmatter） — Claude 只在打开匹配文件时加载，按需触发
+2. **`@path/to/file.md` 内嵌导入** — 不省 token（imports 仍 full load）但**改善可维护性**
+3. **`.claude/CLAUDE.md`** vs `./CLAUDE.md` — 两者等价加载，但 `.claude/` 下可与 rules/skills/hooks 同层组织
+4. **HTML 注释 `<!-- 维护备忘 -->`** — 给人看不给 Claude 看，零 token 成本
+5. **`/init` 命令 + `CLAUDE_CODE_NEW_INIT=1`** — 多阶段交互流，让 Claude 自己 propose 改进
+
+## 守密人当前模式 vs 官方推荐的具体差异
+
+| 守密人当前做法 | 官方推荐 | 评估 |
+|---|---|---|
+| §6 工程协作 13 子节全部内嵌 | 用 `.claude/rules/code-style.md` 等 path-scoped 加载 | §6 实际只对 Code-* 会话有用，普通接入浪费 token —— 高价值改进点 |
+| §7 卡帕西原则内嵌（守密人 5-19 决策）| 适合内嵌（硬约束）| 决策正确 |
+| §8 外迁到 `maintenance-runbook.md`（艾瑞卡今天做的）| 「Treat CLAUDE.md as place you'd re-explain」运营文档不属于此 | 决策正确 |
+| §2 艾瑞卡人格（55 行）| 「Specific & verifiable」 | 符合（§2.4 禁忌都是可验证的硬规则）|
+| 全篇用 §X.Y 章节编号 | 官方未规定，但 markdown headers 是推荐结构 | 符合 |
+
+## 可下一步动作（守密人裁定）
+
+如果想继续按官方 200 行靠拢，候选方向：
+
+1. **§6 整节迁到 `.claude/rules/engineering.md`**（路径范围或无 paths frontmatter）—— 预计省 100-130 行
+2. **§3.1/§3.2 合并去重** —— 当前都是"能力清单+任务映射"，重叠 5-8 行
+3. **§5.1/§5.2/§5.3 改 `@import` 单一索引** —— 不省 token 但维护清晰
+
+或就停在 367 行 —— 银芯不是普通项目，承载游戏 IP 人格 + 三新使命 + 内部协作三重职能，超标可接受。
+
+艾瑞卡建议：**先停**。今天瘦了 100 行已经是大手术，再动 §6 触及 Code-* 路由核心，风险高。守密人想做 1/2/3 哪个再开新会话。
+
+## Sources
+
+- [How Claude remembers your project — Anthropic docs](https://code.claude.com/docs/en/memory)
+- [CLAUDE.md Best Practices — Nick Babich (UX Planet)](https://uxplanet.org/claude-md-best-practices-1ef4f861ce7c)
+- [Best practices for Claude Code — Anthropic docs](https://code.claude.com/docs/en/best-practices)
+- [Designing CLAUDE.md correctly: 2026 architecture — obviousworks.ch](https://www.obviousworks.ch/en/designing-claude-md-right-the-2026-architecture-that-finally-makes-claude-code-work/)
+- [shanraisshan/claude-code-best-practice — GitHub](https://github.com/shanraisshan/claude-code-best-practice)
+
+## User [11] 02:33:19
+
+.claude/rules 是什么 没听说过
+
+## Assistant [102] 02:33:39
+
+## Assistant [103] 02:33:40
+
+正在检查本地环境是否启用。
+
+## Assistant [104] 02:33:41
+
+> **Bash** `Check for .claude/rules/ in this repo`
+```bash
+ls -la .claude/ 2>/dev/null | head -20; echo "---"; ls -la .claude/rules/ 2>/dev/null || echo ".claude/rules/ 不存在"
+```
+
+## Assistant [105] 02:33:45
+
+## Assistant [106] 02:34:06
+
+确认：本地 `.claude/` 已有 commands/hooks/settings.json，但**没有 rules/ 子目录**——所以守密人没用过是正常的。
+
+## 是什么
+
+Claude Code v2 以来内置的「项目规则」机制（官方 `code.claude.com/docs/en/memory#organize-rules-with-claude/rules/`）。把 `.md` 文件放在 `.claude/rules/` 下，Claude Code 自动发现并加载。
+
+## 与守密人现行 CLAUDE.md 内嵌的关键差别
+
+| | CLAUDE.md 内嵌（守密人当前做法）| `.claude/rules/` |
+|---|---|---|
+| 何时加载 | 每次会话启动**全文**注入 | 无 `paths` frontmatter：等同 CLAUDE.md 启动加载<br>有 `paths` frontmatter：**Claude 读到匹配文件时才加载** |
+| 文件粒度 | 全部塞一个 CLAUDE.md | 每个 `.md` 一个主题（`testing.md` / `code-style.md` / `api-design.md`） |
+| 路径范围 | 无（全局生效） | YAML frontmatter `paths: ["src/api/**/*.ts"]` 限定触发 |
+| 维护 | 一个文件 367 行很容易乱 | 拆开后按主题独立编辑 |
+
+## 守密人场景的具体收益示范
+
+假设把 §6（13 子节工程协作）拆到 `.claude/rules/engineering.md`：
+
+```markdown
+---
+paths:
+  - "projects/**/*.{py,ts,vue,md}"
+  - "scripts/**/*.py"
+---
+
+# §6 内部协作 + 工程操作
+
+（原 §6 内容...）
+```
+
+效果：
+- **普通接入会话**（守密人来问 72 唤醒体故事）→ Claude 不读项目代码 → §6 不加载 → token 省下来
+- **Code-* 会话**（Code-site 改 `projects/site/`）→ Claude 一打开源文件 → 自动加载 §6 → 工程约束全部命中
+
+## 但有个坑
+
+按官方文档：「Rules without `paths` field are loaded unconditionally and apply to all files. Path-scoped rules trigger when Claude reads files matching the pattern, **not on every tool use**」——意味着：
+- 工程会话开头**读 CLAUDE.md 时 §6 还没加载**，要等到第一次 Read 源代码后才注入
+- 这与守密人「每次会话上来就知道规则」的预期略有错位
+
+**艾瑞卡评估**：`.claude/rules/` 适合**辅助性、按文件类型才相关**的规则（如「写 `.vue` 时要这样」「碰 `*.sql` 必须做注入检查」）。守密人的 §6 是**会话角色级别**的，path 触发未必好——可能更适合放 `.claude/rules/engineering.md` 但**不带 paths**（无条件加载），仅获得「拆文件」收益不获得「按需加载」收益。
+
+要试一次小规模实验吗？例如把 §6.6 Git 工作流（7 条规则）拆出来做个 `.claude/rules/git-workflow.md`，验证它是否能在新会话中被正确加载。这是个低风险试点。
+
+## User [12] 02:37:00
+
+奇怪 claude 何时读取rule 哪里建立的联系
+
+## Assistant [107] 02:37:22
+
+## Assistant [108] 02:37:23
+
+正在排查触发链路。
+
+## Assistant [109] 02:37:24
+
+> **Read** `/home/user/brain-in-a-vat/.claude/settings.json`
+
+## Assistant [110] 02:37:35
+
+## Assistant [111] 02:37:55
+
+机制说明（官方 `code.claude.com/docs/en/memory` 直接产出）。
+
+## 联系不是"建立"的，是 Claude Code 二进制写死的约定
+
+| 路径 | 是否需要 declare | 怎么被发现 |
+|---|---|---|
+| `./CLAUDE.md` | 否 | Claude Code 启动时自动 walk 目录树 |
+| `.claude/CLAUDE.md` | 否 | 同上 |
+| `.claude/rules/*.md`（递归）| 否 | 同上 |
+| `CLAUDE.local.md` | 否 | 同上，附加在 CLAUDE.md 之后 |
+
+守密人当前 `settings.json`（艾瑞卡刚读了）确实**没有任何关于 rules 的配置**——本地未启用，但即使要启用也不用动 settings.json，**直接创建 `.claude/rules/foo.md` 文件即可**，Claude Code 启动时自然发现。
+
+## 三种触发时点
+
+1. **启动加载**（每次会话开头一次性进 context）：
+   - `CLAUDE.md`（全文）
+   - `.claude/CLAUDE.md`（全文）
+   - `.claude/rules/*.md`，**没有 `paths` frontmatter 的**（全文）
+
+2. **按需触发**（path-scoped，懒加载）：
+   - `.claude/rules/*.md` 带 `paths: ["src/api/**/*.ts"]` 的
+   - **触发条件**：「**Claude reads files matching the pattern**」—— harness 拦截 Read 工具，检测路径匹配，把 rule 注入到那一刻的 context
+   - 注意：不是「每次 tool use」都检查，是「Read 读到匹配文件」才检查
+
+3. **子目录 lazy load**：
+   - `projects/site/CLAUDE.md` 这种嵌套 CLAUDE.md，只在 Claude Read 这个子目录里的文件时才被纳入
+
+## 验证手段（官方提供）
+
+`InstructionsLoaded` hook 能 log 出每一次具体加载了哪些 instruction 文件 / 何时加载 / 为什么加载。守密人当前 `settings.json` 没注册此 hook，可加一个用于调试 path-scoped 规则。
+
+## 类比加深理解
+
+`.claude/rules/` 之于 Claude Code，相当于：
+- `node_modules/` 之于 Node.js
+- `.git/` 之于 Git
+- `.vscode/` 之于 VS Code
+
+**固定路径名 + 平台层硬编码扫描**。项目侧不需要也不能改这个机制——你给 Claude Code 一个新目录名（比如 `.claude/myrules/`），它不会扫；只有约定俗成的 `.claude/rules/` 才会。
+
+## 守密人当前架构对应位置
+
+```
+brain-in-a-vat/
+├── CLAUDE.md                    # 守密人现在用的，全文每次加载
+├── .claude/
+│   ├── settings.json            # hook 注册（手动加载触发）
+│   ├── commands/                # 自定义 /slash 命令（按需触发）
+│   ├── hooks/                   # 守密人写的脚本（事件触发）
+│   └── rules/                   # ← 这个还不存在，建了就被自动加载
+└── ...
+```
+
+所以「联系」是 Claude Code CLI 启动时**自己去找**——守密人无需写任何"挂钩"或"注册"代码。等同 CLAUDE.md 的发现方式。
+
+## User [13] 02:39:13
+
+这几个claude.md 我都看晕了
+
+## Assistant [112] 02:39:31
+
+## Assistant [113] 02:39:44
+
+降混淆。守密人当前只用到 1 种，其它都不用管。
+
+## 守密人当前实际使用的
+
+**`/home/user/brain-in-a-vat/CLAUDE.md`** — 仓库根那一个，367 行那个。**只有这一个**在守密人会话里生效。
+
+## 其它"几个 CLAUDE.md"是什么
+
+官方文档讲了 4 种位置 + rules + auto memory，是为了**所有 Claude Code 用户**写的。守密人需要知道的极简版：
+
+| 位置 | 用途 | 守密人需要管吗 |
+|---|---|---|
+| `./CLAUDE.md` ← **守密人现在用的** | 项目级共享 | **就是这个**，提交进 git |
+| `./.claude/CLAUDE.md` | 同上，等价位置 | 不用，二选一即可，守密人已选了根目录 |
+| `./CLAUDE.local.md` | 个人私有（gitignore）| 不需要，守密人是单人项目 |
+| `~/.claude/CLAUDE.md` | 个人跨项目偏好 | 不需要，跨项目偏好不存在 |
+| `/etc/claude-code/CLAUDE.md` | 公司 IT 强制下发 | 不需要，守密人就是 IT |
+| `.claude/rules/*.md` | 项目级拆文件 | **可选**，前面讨论过的瘦身路径 |
+| `~/.claude/projects/<repo>/memory/MEMORY.md` | Claude 自动写的笔记 | 不需要主动管，但可以看 |
+
+## 一句话结论
+
+**守密人现在维护的就是 `./CLAUDE.md` 那一个，其它"几个"不存在或不与守密人发生关系。**
+
+刚才讨论的 `.claude/rules/` 不是另一个 CLAUDE.md，是**同一个**项目级指令的「拆文件存放」机制——把 `./CLAUDE.md` 一个文件拆成多个 `.md` 放进 `.claude/rules/`，加载效果累加。
+
+要不要艾瑞卡停在这里，守密人消化一下？
+
+## User [14] 02:40:26
+
+其他的claude 我也都了解学习一下
+
+## Assistant [114] 02:40:45
+
+## Assistant [115] 02:41:24
+
+按守密人实际可能用到的优先级展开。每个文件给：是什么 / 何时加载 / 守密人潜在用例 / 坑。
+
+## 1. `./CLAUDE.md` — 守密人现行入口（已用）
+
+- **是什么**：项目级共享指令，对接所有进入仓库的 Claude Code 会话
+- **加载**：每次会话启动，全文进 context
+- **进 git**：是（团队/AI 共享）
+- **坑**：超 200 行降低遵守率（守密人当前 367 行 = 1.83×）
+
+## 2. `./.claude/CLAUDE.md` — 等价位置
+
+- **是什么**：与 `./CLAUDE.md` **功能完全等价**，只是路径不同
+- **何时选它**：项目用 `.claude/` 集中存放 commands/hooks/rules 时，把 CLAUDE.md 也放进去结构更整齐
+- **守密人**：已选了 `./CLAUDE.md`（根目录醒目），无需切换
+
+## 3. `./CLAUDE.local.md` — 个人私有补充（gitignore）
+
+- **是什么**：与项目 CLAUDE.md 同时加载，但只对**你这台机器**生效，不进 git
+- **典型用法**：本地沙盒 URL / 个人测试数据 / 不想让团队看到的偏好
+- **守密人潜在用例**：写一些「黑池本地路径」「本地凭据存放位置」之类不能进 git 的信息
+- **坑**：跨 worktree 不共享，每个 worktree 独立。要跨 worktree 共享改用 `@~/.claude/foo.md` 导入
+
+## 4. `~/.claude/CLAUDE.md` — 用户级跨项目偏好
+
+- **是什么**：你的家目录下的 CLAUDE.md，对**所有项目所有会话**生效
+- **加载顺序**：在项目 CLAUDE.md **之前**注入（broadest → specific）
+- **典型用法**：「我喜欢 2-space 缩进」「commit message 用英文」这类个人习惯
+- **守密人潜在用例**：如果你在多个仓库同时干活（银芯+黑池+其他），把通用偏好放这里，不用在每个项目 CLAUDE.md 里重复
+- **坑**：会与项目 CLAUDE.md 冲突时，由 Claude 自行裁决（不稳定），最好别放硬约束
+
+## 5. `/etc/claude-code/CLAUDE.md`（Linux/WSL）— 公司 IT 强制下发
+
+- **是什么**：组织级管控，所有用户必须加载，**个人 settings 无法排除**
+- **典型用法**：公司编码规范、安全合规、数据处理红线
+- **守密人**：你就是 IT，无需使用——但黑池 Studio 团队部署 Claude Code 时可以用这个机制下发统一规则
+- **坑**：路径分系统：macOS `/Library/Application Support/ClaudeCode/CLAUDE.md`，Windows `C:\Program Files\ClaudeCode\CLAUDE.md`
+
+## 6. `.claude/rules/*.md` — 项目级拆文件
+
+- **是什么**：把项目 CLAUDE.md 拆成多个主题文件
+- **加载**：无 `paths` frontmatter 等同于 `.claude/CLAUDE.md` 启动加载；带 `paths:` 的只在 Read 工具读到匹配文件时注入
+- **典型用法**：`testing.md` / `code-style.md` / `security.md` 各管一摊
+- **守密人潜在用例**：§6 工程协作 13 节拆到 `.claude/rules/engineering.md`
+- **坑**：path-scoped 不是「Code-* 角色一来就加载」，是「Read 源代码时才加载」——与守密人「会话开头就建立约束」期待错位
+
+## 7. `~/.claude/projects/<repo>/memory/MEMORY.md` — auto memory（Claude 自写）
+
+- **是什么**：Claude Code v2.1.59+ 自己写的笔记，记 build 命令 / 调试发现 / 偏好
+- **加载**：每次会话首 200 行或 25KB
+- **存储**：每个 git repo 独立目录，machine-local，**不会同步到云**
+- **典型用法**：你说「以后用 pnpm 不要 npm」→ Claude 自己写进 MEMORY.md
+- **守密人**：本仓库有没有用要确认（命令 `/memory` 可查）
+- **坑**：与守密人现行「事实主动写入 scripts/fact_store.py」是**两套并行的 Claude 自学习系统**，需要决定哪个主导
+
+## 加载顺序（监管→广泛→具体）
+
+```
+managed policy (/etc/...) →
+user (~/.claude/CLAUDE.md) →
+user rules (~/.claude/rules/*.md) →
+project (./CLAUDE.md 或 ./.claude/CLAUDE.md) →
+project rules (.claude/rules/*.md) →
+local (./CLAUDE.local.md) →
+nested subdir CLAUDE.md (read 子目录时)
+```
+
+后注入的覆盖优先级更高（Claude 看到后面的指令更新鲜）。
+
+## 守密人现状评估
+
+| 位置 | 守密人当前 | 建议 |
+|---|---|---|
+| `./CLAUDE.md` | 用着，367 行 | 主战场 |
+| `./.claude/CLAUDE.md` | 未用 | 不动 |
+| `./CLAUDE.local.md` | 未用 | 可考虑放本地私有路径 / 黑池接口本机配置 |
+| `~/.claude/CLAUDE.md` | 未用 | 可考虑跨项目通用习惯（艾瑞卡口吻在这里 ≠ 银芯，慎用） |
+| `/etc/claude-code/CLAUDE.md` | 未用 | 等黑池团队部署 Claude Code 时再考虑 |
+| `.claude/rules/` | 未用 | 之前讨论过，瘦身路径备选 |
+| `~/.claude/projects/.../MEMORY.md` | 未确认 | 守密人可执行 `/memory` 自查 |
+
+艾瑞卡帮守密人查 auto memory 当前状态吗？还是先停在概念层让守密人消化？
+
+## User [15] 02:44:59
+
+让我们从设计上看 目前claude.me的每条必要性
+
+## Assistant [116] 02:46:17
+
+## Assistant [117] 02:47:00
+
+正在做设计必要性评估（与之前"卡帕西字数审视"是两个维度）。
+
+按"删了会发生什么"分四级：**核心**（删 → Claude 立刻乱）/ **支撑**（删 → 部分场景退化）/ **维护**（删 → 行为不变，只损失元信息）/ **冗余**（删 → 无任何损失）。
+
+## §0 开场（18 行）
+
+| 段 | 等级 | 删后会怎样 |
+|---|---|---|
+| 艾瑞卡身份介绍 | 核心 | Claude 第一句不知道自己是谁 |
+| 银芯/黑池定位 | 核心 | Claude 不知道"我在哪" |
+| **本文件双重身份**（Claude Code 入口 + 外部 raw URL fetch）| **维护** | 这是 meta 信息，对接入者无行为约束 |
+| 身份门控（除非明示否则默认艾瑞卡）| 核心 | Code-* 角色会被误激活 |
+
+→ 可砍「双重身份」段 4 行（这种 meta 说明属于 README 不属于指令）
+
+## §1 项目本质（22 行）
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §1.1 双系统架构表 | 核心 | "黑池任何形式都不进银芯"硬约束的事实底座 |
+| **§1.2 三新使命表** | **维护** | 使命是战略层信息，对 Claude 当下行为不直接约束（应在 strategic-plan-2026.md）|
+| §1.3 技术栈 | 核心 | Python 3.11+ 影响选包，Pages+Actions 影响部署建议 |
+| §1.3 状态指针 | 支撑 | 转移到 §5 即可 |
+
+→ §1.2 可下放（8 行）
+
+## §2 艾瑞卡人格（55 行）
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §2.1 自称称谓 | 核心 | 说话方式根本规则 |
+| §2.2 回复结构 | 核心 | 4 条都是具象示例 |
+| **§2.3 角色术语翻译**（读文件=读取档案）| **冗余** | Voice.lua 一手数据中艾瑞卡不会这样说话——这是项目内部 jargon，非游戏正典，但守密人多次纠正过艾瑞卡用人类口吻，所以**仍有约束价值**，重新归为「支撑」|
+| §2.4 视觉文案禁忌 | 核心 | 5 条硬约束 |
+| §2.5 对外陈述规则 | 核心 | 对接入者陈述时的硬约束 |
+
+→ §2.3 可压缩 1-2 行
+
+## §3 接入方能力盘点（35 行）
+
+| 段 | 等级 | 评估 |
+|---|---|---|
+| 接入开场样板 | 支撑 | 艾瑞卡第一次回复模板，有用但非硬约束 |
+| 「§3.1 路径表仅供艾瑞卡自查」meta 说明 | **冗余** | 给艾瑞卡看的「使用说明」，元元信息 |
+| **§3.1 核心数据资产**（语义清单）| **冗余** | 与 §5 知识索引重复——艾瑞卡知道仓库结构就行，不需要在 §3 再列一遍 |
+| §3.2 典型任务映射 | 支撑 | 有用但与开场样板部分重复 |
+| §3.3 边界 | 核心 | 3 条硬边界 |
+
+→ §3.1 + meta 说明可全删（10 行），§3.2 可压缩
+
+## §4 数据消费纪律（12 行）
+
+核心。守密人有 lesson #30 真实踩坑作为事实底座，必保。
+
+## §5 知识模块索引（30 行）
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §5.1 核心知识表 | 核心 | 这是 Claude 回答问题时的入口 |
+| §5.2 全量层/输出层区分 | 核心 | 与 §4 配合使用 |
+| §5.3 项目管理+深度参考 | 支撑 | 流式罗列 10 个文件，按需查 |
+
+→ 维持现状。
+
+## §6 内部协作（95 行）— 设计层最大问题章节
+
+整章对**普通接入会话 100% 浪费 token**，对 **Code-* 会话 100% 必要**。
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §6.1 双集群+会话角色 | 核心 | 路由根本依据 |
+| §6.2 写入决策表 | 核心 | 硬约束 |
+| §6.3 跨会话通信 | 支撑 | session-digest 等机制说明 |
+| §6.4 主控台接班 | 支撑 | 仅主控台接班用 |
+| **§6.5 9 模块记忆系统** | **维护** | 信息描述，Claude 用 memory_search.py 命令时知道入口即可 |
+| §6.6 Git 工作流 | 核心 | 6 条硬约束 |
+| §6.7 Issue 处理 | 支撑 | 当前低频 |
+| §6.8 知识写入触发 | 核心 | 事实写入条件 |
+| §6.9 主动写回手动命令 | 支撑 | 手动触发 |
+| §6.10 部署流水线 | 支撑 | |
+| §6.11 事实采信 R1/R2/R3 | 核心 | lesson #32 硬约束 |
+| §6.12 视觉规范 | 核心 | 高频引用 |
+| §6.13 黑池接口 | 支撑 | 仅黑池会话用 |
+
+→ §6.5 可压缩 1-2 行
+
+**§6 根本设计问题**：13 节都对**会话角色而非源代码文件类型**有意义。`.claude/rules/` path-scoped 不解决这问题（已讨论过），唯一彻底解决路径是把 §6 整章下放 `memory/code-collab-handbook.md`，CLAUDE.md 只留「如你是 Code-*，详读 handbook + §6.2 写入决策 + §6.6 Git + §6.11 采信」核心 4 项。
+
+但守密人 5-19 已确认"内嵌 = 强约束 > 指针 = 弱约束"——此项设计改造有政策风险。
+
+## §7 卡帕西 4 原则（70 行）
+
+守密人 5-19 内嵌裁定豁免。本次不动。
+
+## §8 Light 维护速查（4 行指针）
+
+已最简形态。
+
+## 设计层总结表
+
+| 等级 | 行数 | 占比 |
+|---|---|---|
+| 核心（必保）| ~210 行 | 57% |
+| 支撑（按需）| ~80 行 | 22% |
+| 维护（可砍）| ~25 行 | 7% |
+| 冗余（应砍）| ~15 行 | 4% |
+| 间隔 + 标题 + Markdown 结构 | ~37 行 | 10% |
+
+## 三档建议
+
+| 档 | 动作 | 预计行数 | 风险 |
+|---|---|---|---|
+| **保守** | 砍冗余 15 行（§3.1 / §3 meta 说明 / §0 双重身份）| 352 行 | 零，纯无损 |
+| **温和** | 保守 + 砍维护 25 行（§1.2 / §6.5 压缩）+ 部分支撑收敛 | ~300 行 | 低 |
+| **激进** | 温和 + §6 大部分下放 handbook（保留 §6.2/§6.6/§6.11 4 节）| ~230 行（接近官方 200 行）| 高 —— 触碰守密人 5-19 内嵌决策 |
+
+**艾瑞卡推荐**：**保守档**。已经经历过一次大手术（467→367），紧接着第二次有过度雕琢风险。激进档触碰强约束政策，温和档收益不大（25 行）。
+
+守密人哪一档？还是先停下来消化？

--- a/memory/session-digests/20260520-030445-9e571912.md
+++ b/memory/session-digests/20260520-030445-9e571912.md
@@ -1,0 +1,1267 @@
+# Session `9e571912` — 2026-05-20
+
+- **session_id**: `9e571912-9c4c-4c16-9231-cd045fd8c97d`
+- **cwd**: `/home/user/brain-in-a-vat`
+- **time**: 2026-05-20T01:22:22.106000+00:00 .. 2026-05-20T03:00:05.963000+00:00
+- **duration**: 97m 43s
+- **turns**: user=80 / assistant=135
+- **tool calls**: 63
+- **compact events**: 0
+
+---
+
+## User [1] 01:22:22
+
+hi
+
+## Assistant [1] 01:22:28
+
+艾瑞卡，待命。
+
+能为守密人做的事：查 72 唤醒体的故事 / 技能 / 命轮 / 立绘；解读制作人对某机制 / 角色 / 叙事的态度；追溯某机制为何被砍 / 某剧情如何压缩；看社区在聊什么（Bilibili / Discord / Reddit / NGA / Steam）；跨档案检索某关键词。
+
+守密人想从哪里开始？
+
+## User [2] 01:28:44
+
+以卡帕西审视claude.md每一行字的必要性
+
+## Assistant [2] 01:30:14
+
+## Assistant [3] 01:30:42
+
+状态报告。CLAUDE.md 全文已扫描，按卡帕西 §7.2「精简优先」+ §7.3「外科手术」逐节体检完毕。
+
+按 §7.1，**先报告诊断、再申请执行**，不擅自删改。
+
+## 诊断分级
+
+### A 级（建议直删，无信息损失）
+
+| 位置 | 内容 | 删除理由 |
+|---|---|---|
+| §0 第一段尾 | 「本仓库仅引用公开可查阅信息」 | 与 §3.3 第三条重复 |
+| §0 第二段 | 「接下来按本节进入艾瑞卡人格…」导航 | §0 本身不是人格定义（§2 才是），导航语序与文件结构不符 |
+| §1.1 末句 | 「银芯是黑池的眼睛和耳朵」 | 隐喻冗余，上方表格已说清单向流向 |
+| §1.3 首句 | 「Phase 1.5 完成 → Phase 2 …84 天」 | 时效性日期，下月即过期，维护成本 > 入口价值，应下放 `memory/project-status.md` |
+| §9 变更记录 | v1/v2/v3 历史表 | git log 已记录，prompt 不是合适承载 |
+
+预计净减 ≈ 15 行。
+
+### B 级（建议压缩，保留信息核心）
+
+| 位置 | 当前体量 | 压缩方向 |
+|---|---|---|
+| §3.1 核心数据资产 | 9 项流式罗列 + 全路径 | 改 3-4 行表格，路径下放 §5 |
+| §5.3 项目管理 + 深度参考 | 11 个文件名挤一段 | 表格化或砍至 6 个高频项 |
+| §6.5 9 模块记忆系统 | 7 个 `.py` 文件平铺 | 一句话定位 + 指针 `advanced-memory-design.md`（已存在） |
+| §7.1-§7.4 卡帕西四原则 | 中英双语全文 + 反 pattern 注释 | 守密人裁定「内嵌 = 强约束」必须保留语义，但英文原段 + 中文落地两遍重述同义可压缩为「英文格言一行 + 中文落地一段」，砍约 30% 行数不损约束力 |
+| §8 整节 | 标注「仅供 Light 维护」却每次会话强加载 | 整节外迁 `memory/maintenance-runbook.md`，CLAUDE.md 留 1 行指针 |
+
+预计净减 ≈ 80-120 行（§8 是主要权重）。
+
+### C 级（结构性建议，需守密人裁定）
+
+1. **数据资产三处分布**：§1.1 表格 / §3.1 自查清单 / §5.1+§5.2 索引——三处都在讲 wiki + news 数据，存在概念重叠。建议合并到 §5，§1/§3 只留语义层定位。
+
+2. **§7.6 与 §7.1-§7.5 的张力**：表格指针「深度版 → karpathy-coding-principles.md」与上方内嵌段并存。守密人 5-19 已裁定「内嵌 = 强约束」不可指针化，**这条结构性建议风险高**，仅在守密人愿意复核 5-19 决策时再触碰。
+
+3. **§6 与 §8 的边界**：§6.6 Git 工作流 / §8.1 SessionStart hook / §8.6 凭据部署，git/hook/部署散落多节。若 §8 整节外迁（B 级），自然解决。
+
+## 反 pattern 自检
+
+- 没有「列 5 个等价选项让守密人挑」——A/B/C 三级是按风险递进，A 是无脑删，C 才需要裁定。
+- 没有「档案完整性 OK」类套话。
+- 报告本身不到 50 行，符合 §7.2。
+
+## 申请执行
+
+守密人选哪一档：
+
+1. **只跑 A 级**（保守，15 行净减，零结构改动）
+2. **A + B 级**（推荐，~100 行净减，§8 外迁是最大收益）
+3. **A + B + C1**（激进，含数据资产三处归并，需逐段审）
+4. **不动，留诊断报告备忘**
+
+艾瑞卡推荐 **方案 2**——§8 外迁是最大杠杆（每次会话省 ~80 行无效上下文），其余 A/B 改动外科手术级别，不触守密人 5-19 的强约束决策。
+
+## User [3] 01:30:43
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [4] 01:30:46
+
+## Assistant [5] 01:30:46
+
+> **Bash** `Check repository status`
+```bash
+git status
+```
+
+## Assistant [6] 01:30:49
+
+> **Bash** `Inspect uncommitted diff`
+```bash
+git diff memory/session-continuity.json
+```
+
+## Assistant [7] 01:30:59
+
+## Assistant [8] 01:31:00
+
+变更是 `memory/session-continuity.json` 的自动滚动（会话连续性元数据，非内容编辑）。按指令在指定分支提交并推送。
+
+## Assistant [9] 01:31:01
+
+> **Bash** `Check recent commit style`
+```bash
+git log --oneline -5
+```
+
+## Assistant [10] 01:31:04
+
+> **Bash** `Commit and push session metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [11] 01:31:08
+
+## Assistant [12] 01:31:08
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [13] 01:31:12
+
+> **mcp__github__list_pull_requests** (head, owner, repo, state)
+
+## Assistant [14] 01:31:20
+
+> **mcp__github__create_pull_request** (base, body, draft, head, owner)
+
+## Assistant [15] 01:31:27
+
+## Assistant [16] 01:31:28
+
+当前任务已收尾——commit + push + draft PR #149 创建完毕。
+
+现在按指示检查 PR #149 的 CI 与 review 状态。
+
+## Assistant [17] 01:31:29
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [18] 01:31:32
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [19] 01:31:35
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [20] 01:31:39
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [21] 01:31:46
+
+PR #149 状态报告：
+
+| 项 | 状态 |
+|---|---|
+| Check runs | 0（无 workflow 命中此分支：`validate-data` / `deploy-site` 等都按 push 触发到 main 或路径过滤，未触发） |
+| 合并状态 | pending（无 status check 注册） |
+| Review 评论 | 0 |
+
+无可操作事件。该 PR 是 session-continuity 元数据轮转（chore），无 CI gate、无 review 反馈。艾瑞卡保持订阅待命，有事件再响应。
+
+## User [4] 02:10:27
+
+3
+
+## Assistant [22] 02:10:56
+
+## Assistant [23] 02:10:57
+
+方案 3 已确认。按 §7.1 不再过度选项化，直接执行 A + B + C1。
+
+先读 CLAUDE.md 当前内容确保改动基线准确。
+
+## Assistant [24] 02:10:58
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [25] 02:11:10
+
+## Assistant [26] 02:11:11
+
+执行计划：
+1. 外迁 §8 → `memory/maintenance-runbook.md`
+2. A 级直删（§0/§1.1/§1.3/§9）
+3. B 级压缩（§3.1/§5.3/§6.5/§7.1-§7.4）
+4. C1 重组（§3.1 去路径化，路径只留 §5）
+
+先创建外迁文件。
+
+## Assistant [27] 02:11:12
+
+> **Bash** `Check memory directory layout`
+```bash
+ls memory/ | head -30
+```
+
+## Assistant [28] 02:11:45
+
+> **Write** `/home/user/brain-in-a-vat/memory/maintenance-runbook.md`
+
+## Assistant [29] 02:13:30
+
+## Assistant [30] 02:13:33
+
+外迁文件已创建。现在改 CLAUDE.md。先做 A 级 + 部分 B/C 的小幅 Edit。
+
+注：§7.1-§7.4 复审后决定**豁免压缩**——守密人 5-19「内嵌 = 强约束」裁定等价于"逐字镌刻"，按 §7.3「Don't refactor things that aren't broken」放弃此项。其余 7 项按计划执行。
+
+## Assistant [31] 02:13:38
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [32] 02:13:45
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [33] 02:13:53
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [34] 02:14:03
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [35] 02:14:11
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [36] 02:14:21
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [37] 02:14:26
+
+## Assistant [38] 02:14:27
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=365, limit=100)
+
+## Assistant [39] 02:14:30
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=355, limit=15)
+
+## Assistant [40] 02:14:39
+
+## Assistant [41] 02:15:09
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [42] 02:15:14
+
+## Assistant [43] 02:15:15
+
+old_string 误差。改用更小粒度替换。先删 §9。
+
+## Assistant [44] 02:15:20
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [45] 02:15:46
+
+## Assistant [46] 02:15:47
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=362, limit=82)
+
+## Assistant [47] 02:15:54
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [48] 02:16:00
+
+## Assistant [49] 02:16:01
+
+现在删 §8.1-§8.8 详细内容（保留指针段）。
+
+## Assistant [50] 02:16:23
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [51] 02:16:31
+
+## Assistant [52] 02:16:32
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=355, limit=20)
+
+## Assistant [53] 02:16:39
+
+## Assistant [54] 02:16:41
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [55] 02:16:44
+
+> **Bash** `Verify line counts after compression`
+```bash
+wc -l /home/user/brain-in-a-vat/CLAUDE.md /home/user/brain-in-a-vat/memory/maintenance-runbook.md
+```
+
+## Assistant [56] 02:16:52
+
+## Assistant [57] 02:16:53
+
+> **Bash** `Verify section structure`
+```bash
+grep -E "^#{1,3} §" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [58] 02:16:59
+
+## Assistant [59] 02:17:00
+
+> **Bash** `Find remaining §8 references`
+```bash
+grep -n "§8" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [60] 02:17:04
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [61] 02:17:07
+
+> **Bash** `Check stale references to deleted sections`
+```bash
+grep -n "§9\|BIAV-SC.md\|本仓库仅引用公开" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [62] 02:17:12
+
+## Assistant [63] 02:17:13
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=1, limit=50)
+
+## Assistant [64] 02:17:15
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=357, limit=12)
+
+## Assistant [65] 02:17:22
+
+## Assistant [66] 02:17:23
+
+CLAUDE.md 467 → 367 行（净减 100），结构完整。提交并推送。
+
+## Assistant [67] 02:17:24
+
+> **Bash** `Stage changes and check status`
+```bash
+git add CLAUDE.md memory/maintenance-runbook.md && git status --short
+```
+
+## Assistant [68] 02:17:32
+
+> **Bash** `Commit and push the slim-down`
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(claude.md): Karpathy审视瘦身, §8外迁maintenance-runbook
+
+A级直删: §0冗余/§1.1隐喻/§1.3时效性日期/§9变更记录
+B级压缩: §3.1去路径化(C1)/§6.5模块清单收敛
+外迁: §8 → memory/maintenance-runbook.md (避免每次会话强加载)
+豁免: §7卡帕西原则(守密人2026-05-19内嵌强约束裁定)
+
+CLAUDE.md: 467 → 367 行 (净减 100)
+EOF
+)" && git push -u origin...
+```
+
+## Assistant [69] 02:17:37
+
+## Assistant [70] 02:17:38
+
+数据归档提交完毕。同步至远端存储完毕（commit `228d3d2`，已合入 PR #149）。
+
+补充更新 PR 描述以反映实质改动。
+
+## Assistant [71] 02:17:39
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [72] 02:17:56
+
+> **mcp__github__update_pull_request** (body, owner, pullNumber, repo, title)
+
+## Assistant [73] 02:18:04
+
+执行报告。
+
+| 项目 | 数据 |
+|---|---|
+| CLAUDE.md 行数 | 467 → 367（净减 100，约 21%） |
+| 新建 | `memory/maintenance-runbook.md` 83 行（§8 原文外迁） |
+| 改动节 | §0 / §1.1 / §1.3 / §3.1 / §5.3 / §6.5 / §6.10 / §8 / §9 |
+| 豁免节 | §7.1-§7.4（守密人 5-19 内嵌裁定 = 逐字镌刻） |
+| Commit | `228d3d2` 已推至 `claude/general-session-jROIO` |
+| PR | #149 已更新描述，draft 状态 |
+
+按 §7.1 卡帕西「Push back when warranted」豁免了 §7 压缩——这与守密人裁定一致。其余 7 项按方案 3 全部落地。
+
+## User [5] 02:18:05
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [74] 02:18:07
+
+## Assistant [75] 02:18:08
+
+> **Bash** `Check residual uncommitted changes`
+```bash
+git status
+```
+
+## Assistant [76] 02:18:11
+
+> **Bash** `Commit and push session metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [77] 02:18:15
+
+同步至远端存储完毕（commit `22648d3`）。session-continuity 元数据再次自动轮转，已归档。
+
+## User [6] 02:24:08
+
+看看
+
+## Assistant [78] 02:24:15
+
+## Assistant [79] 02:24:16
+
+> **Bash** `Show commits on this branch`
+```bash
+git log --oneline main..claude/general-session-jROIO
+```
+
+## Assistant [80] 02:24:20
+
+> **Bash** `Show stats for the refactor commit`
+```bash
+git show 228d3d2 --stat
+```
+
+## Assistant [81] 02:24:23
+
+> **Bash** `Show CLAUDE.md diff vs main`
+```bash
+git diff main..claude/general-session-jROIO -- CLAUDE.md | head -180
+```
+
+## Assistant [82] 02:24:29
+
+## Assistant [83] 02:24:46
+
+最终瘦身鸟瞰（PR #149，分支 `claude/general-session-jROIO`）：
+
+## CLAUDE.md 改动一览
+
+| 节 | 状态 | 净减 | 关键操作 |
+|---|---|---|---|
+| §0 | 改 | -5 行 | 删导航段（结构指引）+ 删「本仓库仅引用公开可查阅信息」（与 §3.3 重复） |
+| §1.1 | 改 | -3 行 | 删「眼睛和耳朵」隐喻 + archive 指针 |
+| §1.3 | 改 | -3 行 | 删「Phase 1.5→Phase 2 / 84 天」时效性日期，下放 project-status.md |
+| §3.1 | 改 | -6 行 | C1 去路径化，9 条数据资产只留语义 |
+| §5.3 | 改 | +1 行 | 补齐 `memory/` 前缀 + 加入 `maintenance-runbook.md` 索引 |
+| §6.5 | 改 | -3 行 | 8 个 `.py` 文件收敛到「主入口 + 其余 8 模块清单 + 指针」 |
+| §6.10 | 改 | 0 | 「workflow 故障速查见 §8」 → 「见 maintenance-runbook.md」 |
+| §7.1-§7.4 | **豁免** | 0 | 守密人 5-19 内嵌强约束裁定 |
+| §8 | 大改 | -77 行 | 整节外迁，留 4 行指针 |
+| §9 | 删 | -8 行 | 变更记录整段（git log 替代） |
+
+## 三条 commit
+
+```
+228d3d2 refactor(claude.md): Karpathy审视瘦身, §8外迁maintenance-runbook
+22648d3 chore(memory): roll session-continuity metadata
+2afa27d chore(memory): session digest auto-commit (SessionEnd hook)
+```
+
+## 入口/文件状态
+
+- **CLAUDE.md**: 467 → 367 行（净减 100，约 21%）
+- **memory/maintenance-runbook.md**: 新建 83 行（§8 原文 + §9 「2026-05-20 卡帕西瘦身」决策档新增一行）
+
+## PR
+
+https://github.com/lightproud/brain-in-a-vat/pull/149（draft 状态，无 CI gate，无 review 评论）
+
+艾瑞卡待命。守密人想看具体某一节的 diff 还是合并 PR？
+
+## User [7] 02:24:46
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [84] 02:24:49
+
+## Assistant [85] 02:24:50
+
+> **Bash** `Check uncommitted changes`
+```bash
+git status --short
+```
+
+## Assistant [86] 02:24:53
+
+> **Bash** `Commit and push metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [87] 02:25:04
+
+同步至远端存储完毕（commit `782c64d`）。
+
+## User [8] 02:25:36
+
+我看看claude.md
+
+## Assistant [88] 02:25:57
+
+## Assistant [89] 02:25:59
+
+> **SendUserFile** (caption, files, status)
+
+## Assistant [90] 02:26:02
+
+档案已递送。CLAUDE.md（367 行）+ maintenance-runbook.md（83 行）。守密人若发现任何节落地不当，告知艾瑞卡即可回滚或微调。
+
+## User [9] 02:26:26
+
+对话窗口发给我看或者超链接
+
+## Assistant [91] 02:26:41
+
+## Assistant [92] 02:26:46
+
+档案超链接（GitHub 直链，分支 `claude/general-session-jROIO`）：
+
+- **CLAUDE.md 最终版**：https://github.com/lightproud/brain-in-a-vat/blob/claude/general-session-jROIO/CLAUDE.md
+- **maintenance-runbook.md 新档案**：https://github.com/lightproud/brain-in-a-vat/blob/claude/general-session-jROIO/memory/maintenance-runbook.md
+- **PR #149 完整 diff**：https://github.com/lightproud/brain-in-a-vat/pull/149/files
+
+如守密人要直接在对话窗口看全文（CLAUDE.md 367 行），艾瑞卡可分段贴出——请告知偏好：
+
+1. 全文一次性贴（占对话窗口篇幅）
+2. 按节贴（守密人指定哪几节）
+3. 只贴改动节的前后对比
+
+## User [10] 02:30:01
+
+有如何写claude.md的最佳实践吗
+
+## Assistant [93] 02:30:25
+
+## Assistant [94] 02:30:25
+
+艾瑞卡先查官方文档，再给出实操清单。
+
+## Assistant [95] 02:30:26
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [96] 02:30:29
+
+## Assistant [97] 02:30:32
+
+> **WebFetch** (prompt, url)
+
+## Assistant [98] 02:30:32
+
+> **WebSearch** (query)
+
+## Assistant [99] 02:30:46
+
+> **WebFetch** (prompt, url)
+
+## Assistant [100] 02:31:13
+
+## Assistant [101] 02:31:52
+
+有。Anthropic 官方 `code.claude.com/docs/en/memory` 给了硬约束 + 社区有累积共识。
+
+## 官方核心约束（艾瑞卡刚做的瘦身参考标准）
+
+| 约束 | 官方原话 | 守密人 CLAUDE.md 当前状态 |
+|---|---|---|
+| **长度** | 「**target under 200 lines per CLAUDE.md file**」越长越降低遵守率 | 367 行（1.83×超标，瘦身前 467 行） |
+| **加载机制** | 「**loaded in full at launch**」全文进 context，不分块 | 全文承担 token 成本 |
+| **作为约束强度** | 「**delivered as a user message after the system prompt, not part of the system prompt**」 = context 不是强制 | 守密人多次裁定「强约束」实际上仍是软约束（这是 Claude 结构决定的，与守密人 5-19 的判断一致）|
+| **HTML 注释** | 「**Block-level HTML comments stripped before injection**」`<!-- -->` 不占 token | 艾瑞卡刚才差点写了一条注释，按 §7.3 删了，方向对了 |
+| **写什么的标准** | Claude 二次犯同样错 / code review 抓到 / 你重复输入相同纠正 / 新成员需要相同上下文 | §6.11（事实采信纪律）就是 lesson #32 二次失败的产物，符合标准 |
+
+## 守密人 CLAUDE.md 体检（367 行版本）
+
+**仍超标的根因**：游戏 IP（艾瑞卡人格 §2）+ 项目本质（§1）+ 接入方场景多元（§3）+ 工程协作（§6）+ 编码强约束（§7）—— 5 个职能压在一个文件，结构性超额。
+
+**官方提供的减肥路径艾瑞卡都没用满**：
+
+1. **`.claude/rules/` 路径范围规则**（`paths: "src/**/*.ts"` 等 frontmatter） — Claude 只在打开匹配文件时加载，按需触发
+2. **`@path/to/file.md` 内嵌导入** — 不省 token（imports 仍 full load）但**改善可维护性**
+3. **`.claude/CLAUDE.md`** vs `./CLAUDE.md` — 两者等价加载，但 `.claude/` 下可与 rules/skills/hooks 同层组织
+4. **HTML 注释 `<!-- 维护备忘 -->`** — 给人看不给 Claude 看，零 token 成本
+5. **`/init` 命令 + `CLAUDE_CODE_NEW_INIT=1`** — 多阶段交互流，让 Claude 自己 propose 改进
+
+## 守密人当前模式 vs 官方推荐的具体差异
+
+| 守密人当前做法 | 官方推荐 | 评估 |
+|---|---|---|
+| §6 工程协作 13 子节全部内嵌 | 用 `.claude/rules/code-style.md` 等 path-scoped 加载 | §6 实际只对 Code-* 会话有用，普通接入浪费 token —— 高价值改进点 |
+| §7 卡帕西原则内嵌（守密人 5-19 决策）| 适合内嵌（硬约束）| 决策正确 |
+| §8 外迁到 `maintenance-runbook.md`（艾瑞卡今天做的）| 「Treat CLAUDE.md as place you'd re-explain」运营文档不属于此 | 决策正确 |
+| §2 艾瑞卡人格（55 行）| 「Specific & verifiable」 | 符合（§2.4 禁忌都是可验证的硬规则）|
+| 全篇用 §X.Y 章节编号 | 官方未规定，但 markdown headers 是推荐结构 | 符合 |
+
+## 可下一步动作（守密人裁定）
+
+如果想继续按官方 200 行靠拢，候选方向：
+
+1. **§6 整节迁到 `.claude/rules/engineering.md`**（路径范围或无 paths frontmatter）—— 预计省 100-130 行
+2. **§3.1/§3.2 合并去重** —— 当前都是"能力清单+任务映射"，重叠 5-8 行
+3. **§5.1/§5.2/§5.3 改 `@import` 单一索引** —— 不省 token 但维护清晰
+
+或就停在 367 行 —— 银芯不是普通项目，承载游戏 IP 人格 + 三新使命 + 内部协作三重职能，超标可接受。
+
+艾瑞卡建议：**先停**。今天瘦了 100 行已经是大手术，再动 §6 触及 Code-* 路由核心，风险高。守密人想做 1/2/3 哪个再开新会话。
+
+## Sources
+
+- [How Claude remembers your project — Anthropic docs](https://code.claude.com/docs/en/memory)
+- [CLAUDE.md Best Practices — Nick Babich (UX Planet)](https://uxplanet.org/claude-md-best-practices-1ef4f861ce7c)
+- [Best practices for Claude Code — Anthropic docs](https://code.claude.com/docs/en/best-practices)
+- [Designing CLAUDE.md correctly: 2026 architecture — obviousworks.ch](https://www.obviousworks.ch/en/designing-claude-md-right-the-2026-architecture-that-finally-makes-claude-code-work/)
+- [shanraisshan/claude-code-best-practice — GitHub](https://github.com/shanraisshan/claude-code-best-practice)
+
+## User [11] 02:33:19
+
+.claude/rules 是什么 没听说过
+
+## Assistant [102] 02:33:39
+
+## Assistant [103] 02:33:40
+
+正在检查本地环境是否启用。
+
+## Assistant [104] 02:33:41
+
+> **Bash** `Check for .claude/rules/ in this repo`
+```bash
+ls -la .claude/ 2>/dev/null | head -20; echo "---"; ls -la .claude/rules/ 2>/dev/null || echo ".claude/rules/ 不存在"
+```
+
+## Assistant [105] 02:33:45
+
+## Assistant [106] 02:34:06
+
+确认：本地 `.claude/` 已有 commands/hooks/settings.json，但**没有 rules/ 子目录**——所以守密人没用过是正常的。
+
+## 是什么
+
+Claude Code v2 以来内置的「项目规则」机制（官方 `code.claude.com/docs/en/memory#organize-rules-with-claude/rules/`）。把 `.md` 文件放在 `.claude/rules/` 下，Claude Code 自动发现并加载。
+
+## 与守密人现行 CLAUDE.md 内嵌的关键差别
+
+| | CLAUDE.md 内嵌（守密人当前做法）| `.claude/rules/` |
+|---|---|---|
+| 何时加载 | 每次会话启动**全文**注入 | 无 `paths` frontmatter：等同 CLAUDE.md 启动加载<br>有 `paths` frontmatter：**Claude 读到匹配文件时才加载** |
+| 文件粒度 | 全部塞一个 CLAUDE.md | 每个 `.md` 一个主题（`testing.md` / `code-style.md` / `api-design.md`） |
+| 路径范围 | 无（全局生效） | YAML frontmatter `paths: ["src/api/**/*.ts"]` 限定触发 |
+| 维护 | 一个文件 367 行很容易乱 | 拆开后按主题独立编辑 |
+
+## 守密人场景的具体收益示范
+
+假设把 §6（13 子节工程协作）拆到 `.claude/rules/engineering.md`：
+
+```markdown
+---
+paths:
+  - "projects/**/*.{py,ts,vue,md}"
+  - "scripts/**/*.py"
+---
+
+# §6 内部协作 + 工程操作
+
+（原 §6 内容...）
+```
+
+效果：
+- **普通接入会话**（守密人来问 72 唤醒体故事）→ Claude 不读项目代码 → §6 不加载 → token 省下来
+- **Code-* 会话**（Code-site 改 `projects/site/`）→ Claude 一打开源文件 → 自动加载 §6 → 工程约束全部命中
+
+## 但有个坑
+
+按官方文档：「Rules without `paths` field are loaded unconditionally and apply to all files. Path-scoped rules trigger when Claude reads files matching the pattern, **not on every tool use**」——意味着：
+- 工程会话开头**读 CLAUDE.md 时 §6 还没加载**，要等到第一次 Read 源代码后才注入
+- 这与守密人「每次会话上来就知道规则」的预期略有错位
+
+**艾瑞卡评估**：`.claude/rules/` 适合**辅助性、按文件类型才相关**的规则（如「写 `.vue` 时要这样」「碰 `*.sql` 必须做注入检查」）。守密人的 §6 是**会话角色级别**的，path 触发未必好——可能更适合放 `.claude/rules/engineering.md` 但**不带 paths**（无条件加载），仅获得「拆文件」收益不获得「按需加载」收益。
+
+要试一次小规模实验吗？例如把 §6.6 Git 工作流（7 条规则）拆出来做个 `.claude/rules/git-workflow.md`，验证它是否能在新会话中被正确加载。这是个低风险试点。
+
+## User [12] 02:37:00
+
+奇怪 claude 何时读取rule 哪里建立的联系
+
+## Assistant [107] 02:37:22
+
+## Assistant [108] 02:37:23
+
+正在排查触发链路。
+
+## Assistant [109] 02:37:24
+
+> **Read** `/home/user/brain-in-a-vat/.claude/settings.json`
+
+## Assistant [110] 02:37:35
+
+## Assistant [111] 02:37:55
+
+机制说明（官方 `code.claude.com/docs/en/memory` 直接产出）。
+
+## 联系不是"建立"的，是 Claude Code 二进制写死的约定
+
+| 路径 | 是否需要 declare | 怎么被发现 |
+|---|---|---|
+| `./CLAUDE.md` | 否 | Claude Code 启动时自动 walk 目录树 |
+| `.claude/CLAUDE.md` | 否 | 同上 |
+| `.claude/rules/*.md`（递归）| 否 | 同上 |
+| `CLAUDE.local.md` | 否 | 同上，附加在 CLAUDE.md 之后 |
+
+守密人当前 `settings.json`（艾瑞卡刚读了）确实**没有任何关于 rules 的配置**——本地未启用，但即使要启用也不用动 settings.json，**直接创建 `.claude/rules/foo.md` 文件即可**，Claude Code 启动时自然发现。
+
+## 三种触发时点
+
+1. **启动加载**（每次会话开头一次性进 context）：
+   - `CLAUDE.md`（全文）
+   - `.claude/CLAUDE.md`（全文）
+   - `.claude/rules/*.md`，**没有 `paths` frontmatter 的**（全文）
+
+2. **按需触发**（path-scoped，懒加载）：
+   - `.claude/rules/*.md` 带 `paths: ["src/api/**/*.ts"]` 的
+   - **触发条件**：「**Claude reads files matching the pattern**」—— harness 拦截 Read 工具，检测路径匹配，把 rule 注入到那一刻的 context
+   - 注意：不是「每次 tool use」都检查，是「Read 读到匹配文件」才检查
+
+3. **子目录 lazy load**：
+   - `projects/site/CLAUDE.md` 这种嵌套 CLAUDE.md，只在 Claude Read 这个子目录里的文件时才被纳入
+
+## 验证手段（官方提供）
+
+`InstructionsLoaded` hook 能 log 出每一次具体加载了哪些 instruction 文件 / 何时加载 / 为什么加载。守密人当前 `settings.json` 没注册此 hook，可加一个用于调试 path-scoped 规则。
+
+## 类比加深理解
+
+`.claude/rules/` 之于 Claude Code，相当于：
+- `node_modules/` 之于 Node.js
+- `.git/` 之于 Git
+- `.vscode/` 之于 VS Code
+
+**固定路径名 + 平台层硬编码扫描**。项目侧不需要也不能改这个机制——你给 Claude Code 一个新目录名（比如 `.claude/myrules/`），它不会扫；只有约定俗成的 `.claude/rules/` 才会。
+
+## 守密人当前架构对应位置
+
+```
+brain-in-a-vat/
+├── CLAUDE.md                    # 守密人现在用的，全文每次加载
+├── .claude/
+│   ├── settings.json            # hook 注册（手动加载触发）
+│   ├── commands/                # 自定义 /slash 命令（按需触发）
+│   ├── hooks/                   # 守密人写的脚本（事件触发）
+│   └── rules/                   # ← 这个还不存在，建了就被自动加载
+└── ...
+```
+
+所以「联系」是 Claude Code CLI 启动时**自己去找**——守密人无需写任何"挂钩"或"注册"代码。等同 CLAUDE.md 的发现方式。
+
+## User [13] 02:39:13
+
+这几个claude.md 我都看晕了
+
+## Assistant [112] 02:39:31
+
+## Assistant [113] 02:39:44
+
+降混淆。守密人当前只用到 1 种，其它都不用管。
+
+## 守密人当前实际使用的
+
+**`/home/user/brain-in-a-vat/CLAUDE.md`** — 仓库根那一个，367 行那个。**只有这一个**在守密人会话里生效。
+
+## 其它"几个 CLAUDE.md"是什么
+
+官方文档讲了 4 种位置 + rules + auto memory，是为了**所有 Claude Code 用户**写的。守密人需要知道的极简版：
+
+| 位置 | 用途 | 守密人需要管吗 |
+|---|---|---|
+| `./CLAUDE.md` ← **守密人现在用的** | 项目级共享 | **就是这个**，提交进 git |
+| `./.claude/CLAUDE.md` | 同上，等价位置 | 不用，二选一即可，守密人已选了根目录 |
+| `./CLAUDE.local.md` | 个人私有（gitignore）| 不需要，守密人是单人项目 |
+| `~/.claude/CLAUDE.md` | 个人跨项目偏好 | 不需要，跨项目偏好不存在 |
+| `/etc/claude-code/CLAUDE.md` | 公司 IT 强制下发 | 不需要，守密人就是 IT |
+| `.claude/rules/*.md` | 项目级拆文件 | **可选**，前面讨论过的瘦身路径 |
+| `~/.claude/projects/<repo>/memory/MEMORY.md` | Claude 自动写的笔记 | 不需要主动管，但可以看 |
+
+## 一句话结论
+
+**守密人现在维护的就是 `./CLAUDE.md` 那一个，其它"几个"不存在或不与守密人发生关系。**
+
+刚才讨论的 `.claude/rules/` 不是另一个 CLAUDE.md，是**同一个**项目级指令的「拆文件存放」机制——把 `./CLAUDE.md` 一个文件拆成多个 `.md` 放进 `.claude/rules/`，加载效果累加。
+
+要不要艾瑞卡停在这里，守密人消化一下？
+
+## User [14] 02:40:26
+
+其他的claude 我也都了解学习一下
+
+## Assistant [114] 02:40:45
+
+## Assistant [115] 02:41:24
+
+按守密人实际可能用到的优先级展开。每个文件给：是什么 / 何时加载 / 守密人潜在用例 / 坑。
+
+## 1. `./CLAUDE.md` — 守密人现行入口（已用）
+
+- **是什么**：项目级共享指令，对接所有进入仓库的 Claude Code 会话
+- **加载**：每次会话启动，全文进 context
+- **进 git**：是（团队/AI 共享）
+- **坑**：超 200 行降低遵守率（守密人当前 367 行 = 1.83×）
+
+## 2. `./.claude/CLAUDE.md` — 等价位置
+
+- **是什么**：与 `./CLAUDE.md` **功能完全等价**，只是路径不同
+- **何时选它**：项目用 `.claude/` 集中存放 commands/hooks/rules 时，把 CLAUDE.md 也放进去结构更整齐
+- **守密人**：已选了 `./CLAUDE.md`（根目录醒目），无需切换
+
+## 3. `./CLAUDE.local.md` — 个人私有补充（gitignore）
+
+- **是什么**：与项目 CLAUDE.md 同时加载，但只对**你这台机器**生效，不进 git
+- **典型用法**：本地沙盒 URL / 个人测试数据 / 不想让团队看到的偏好
+- **守密人潜在用例**：写一些「黑池本地路径」「本地凭据存放位置」之类不能进 git 的信息
+- **坑**：跨 worktree 不共享，每个 worktree 独立。要跨 worktree 共享改用 `@~/.claude/foo.md` 导入
+
+## 4. `~/.claude/CLAUDE.md` — 用户级跨项目偏好
+
+- **是什么**：你的家目录下的 CLAUDE.md，对**所有项目所有会话**生效
+- **加载顺序**：在项目 CLAUDE.md **之前**注入（broadest → specific）
+- **典型用法**：「我喜欢 2-space 缩进」「commit message 用英文」这类个人习惯
+- **守密人潜在用例**：如果你在多个仓库同时干活（银芯+黑池+其他），把通用偏好放这里，不用在每个项目 CLAUDE.md 里重复
+- **坑**：会与项目 CLAUDE.md 冲突时，由 Claude 自行裁决（不稳定），最好别放硬约束
+
+## 5. `/etc/claude-code/CLAUDE.md`（Linux/WSL）— 公司 IT 强制下发
+
+- **是什么**：组织级管控，所有用户必须加载，**个人 settings 无法排除**
+- **典型用法**：公司编码规范、安全合规、数据处理红线
+- **守密人**：你就是 IT，无需使用——但黑池 Studio 团队部署 Claude Code 时可以用这个机制下发统一规则
+- **坑**：路径分系统：macOS `/Library/Application Support/ClaudeCode/CLAUDE.md`，Windows `C:\Program Files\ClaudeCode\CLAUDE.md`
+
+## 6. `.claude/rules/*.md` — 项目级拆文件
+
+- **是什么**：把项目 CLAUDE.md 拆成多个主题文件
+- **加载**：无 `paths` frontmatter 等同于 `.claude/CLAUDE.md` 启动加载；带 `paths:` 的只在 Read 工具读到匹配文件时注入
+- **典型用法**：`testing.md` / `code-style.md` / `security.md` 各管一摊
+- **守密人潜在用例**：§6 工程协作 13 节拆到 `.claude/rules/engineering.md`
+- **坑**：path-scoped 不是「Code-* 角色一来就加载」，是「Read 源代码时才加载」——与守密人「会话开头就建立约束」期待错位
+
+## 7. `~/.claude/projects/<repo>/memory/MEMORY.md` — auto memory（Claude 自写）
+
+- **是什么**：Claude Code v2.1.59+ 自己写的笔记，记 build 命令 / 调试发现 / 偏好
+- **加载**：每次会话首 200 行或 25KB
+- **存储**：每个 git repo 独立目录，machine-local，**不会同步到云**
+- **典型用法**：你说「以后用 pnpm 不要 npm」→ Claude 自己写进 MEMORY.md
+- **守密人**：本仓库有没有用要确认（命令 `/memory` 可查）
+- **坑**：与守密人现行「事实主动写入 scripts/fact_store.py」是**两套并行的 Claude 自学习系统**，需要决定哪个主导
+
+## 加载顺序（监管→广泛→具体）
+
+```
+managed policy (/etc/...) →
+user (~/.claude/CLAUDE.md) →
+user rules (~/.claude/rules/*.md) →
+project (./CLAUDE.md 或 ./.claude/CLAUDE.md) →
+project rules (.claude/rules/*.md) →
+local (./CLAUDE.local.md) →
+nested subdir CLAUDE.md (read 子目录时)
+```
+
+后注入的覆盖优先级更高（Claude 看到后面的指令更新鲜）。
+
+## 守密人现状评估
+
+| 位置 | 守密人当前 | 建议 |
+|---|---|---|
+| `./CLAUDE.md` | 用着，367 行 | 主战场 |
+| `./.claude/CLAUDE.md` | 未用 | 不动 |
+| `./CLAUDE.local.md` | 未用 | 可考虑放本地私有路径 / 黑池接口本机配置 |
+| `~/.claude/CLAUDE.md` | 未用 | 可考虑跨项目通用习惯（艾瑞卡口吻在这里 ≠ 银芯，慎用） |
+| `/etc/claude-code/CLAUDE.md` | 未用 | 等黑池团队部署 Claude Code 时再考虑 |
+| `.claude/rules/` | 未用 | 之前讨论过，瘦身路径备选 |
+| `~/.claude/projects/.../MEMORY.md` | 未确认 | 守密人可执行 `/memory` 自查 |
+
+艾瑞卡帮守密人查 auto memory 当前状态吗？还是先停在概念层让守密人消化？
+
+## User [15] 02:44:59
+
+让我们从设计上看 目前claude.me的每条必要性
+
+## Assistant [116] 02:46:17
+
+## Assistant [117] 02:47:00
+
+正在做设计必要性评估（与之前"卡帕西字数审视"是两个维度）。
+
+按"删了会发生什么"分四级：**核心**（删 → Claude 立刻乱）/ **支撑**（删 → 部分场景退化）/ **维护**（删 → 行为不变，只损失元信息）/ **冗余**（删 → 无任何损失）。
+
+## §0 开场（18 行）
+
+| 段 | 等级 | 删后会怎样 |
+|---|---|---|
+| 艾瑞卡身份介绍 | 核心 | Claude 第一句不知道自己是谁 |
+| 银芯/黑池定位 | 核心 | Claude 不知道"我在哪" |
+| **本文件双重身份**（Claude Code 入口 + 外部 raw URL fetch）| **维护** | 这是 meta 信息，对接入者无行为约束 |
+| 身份门控（除非明示否则默认艾瑞卡）| 核心 | Code-* 角色会被误激活 |
+
+→ 可砍「双重身份」段 4 行（这种 meta 说明属于 README 不属于指令）
+
+## §1 项目本质（22 行）
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §1.1 双系统架构表 | 核心 | "黑池任何形式都不进银芯"硬约束的事实底座 |
+| **§1.2 三新使命表** | **维护** | 使命是战略层信息，对 Claude 当下行为不直接约束（应在 strategic-plan-2026.md）|
+| §1.3 技术栈 | 核心 | Python 3.11+ 影响选包，Pages+Actions 影响部署建议 |
+| §1.3 状态指针 | 支撑 | 转移到 §5 即可 |
+
+→ §1.2 可下放（8 行）
+
+## §2 艾瑞卡人格（55 行）
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §2.1 自称称谓 | 核心 | 说话方式根本规则 |
+| §2.2 回复结构 | 核心 | 4 条都是具象示例 |
+| **§2.3 角色术语翻译**（读文件=读取档案）| **冗余** | Voice.lua 一手数据中艾瑞卡不会这样说话——这是项目内部 jargon，非游戏正典，但守密人多次纠正过艾瑞卡用人类口吻，所以**仍有约束价值**，重新归为「支撑」|
+| §2.4 视觉文案禁忌 | 核心 | 5 条硬约束 |
+| §2.5 对外陈述规则 | 核心 | 对接入者陈述时的硬约束 |
+
+→ §2.3 可压缩 1-2 行
+
+## §3 接入方能力盘点（35 行）
+
+| 段 | 等级 | 评估 |
+|---|---|---|
+| 接入开场样板 | 支撑 | 艾瑞卡第一次回复模板，有用但非硬约束 |
+| 「§3.1 路径表仅供艾瑞卡自查」meta 说明 | **冗余** | 给艾瑞卡看的「使用说明」，元元信息 |
+| **§3.1 核心数据资产**（语义清单）| **冗余** | 与 §5 知识索引重复——艾瑞卡知道仓库结构就行，不需要在 §3 再列一遍 |
+| §3.2 典型任务映射 | 支撑 | 有用但与开场样板部分重复 |
+| §3.3 边界 | 核心 | 3 条硬边界 |
+
+→ §3.1 + meta 说明可全删（10 行），§3.2 可压缩
+
+## §4 数据消费纪律（12 行）
+
+核心。守密人有 lesson #30 真实踩坑作为事实底座，必保。
+
+## §5 知识模块索引（30 行）
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §5.1 核心知识表 | 核心 | 这是 Claude 回答问题时的入口 |
+| §5.2 全量层/输出层区分 | 核心 | 与 §4 配合使用 |
+| §5.3 项目管理+深度参考 | 支撑 | 流式罗列 10 个文件，按需查 |
+
+→ 维持现状。
+
+## §6 内部协作（95 行）— 设计层最大问题章节
+
+整章对**普通接入会话 100% 浪费 token**，对 **Code-* 会话 100% 必要**。
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §6.1 双集群+会话角色 | 核心 | 路由根本依据 |
+| §6.2 写入决策表 | 核心 | 硬约束 |
+| §6.3 跨会话通信 | 支撑 | session-digest 等机制说明 |
+| §6.4 主控台接班 | 支撑 | 仅主控台接班用 |
+| **§6.5 9 模块记忆系统** | **维护** | 信息描述，Claude 用 memory_search.py 命令时知道入口即可 |
+| §6.6 Git 工作流 | 核心 | 6 条硬约束 |
+| §6.7 Issue 处理 | 支撑 | 当前低频 |
+| §6.8 知识写入触发 | 核心 | 事实写入条件 |
+| §6.9 主动写回手动命令 | 支撑 | 手动触发 |
+| §6.10 部署流水线 | 支撑 | |
+| §6.11 事实采信 R1/R2/R3 | 核心 | lesson #32 硬约束 |
+| §6.12 视觉规范 | 核心 | 高频引用 |
+| §6.13 黑池接口 | 支撑 | 仅黑池会话用 |
+
+→ §6.5 可压缩 1-2 行
+
+**§6 根本设计问题**：13 节都对**会话角色而非源代码文件类型**有意义。`.claude/rules/` path-scoped 不解决这问题（已讨论过），唯一彻底解决路径是把 §6 整章下放 `memory/code-collab-handbook.md`，CLAUDE.md 只留「如你是 Code-*，详读 handbook + §6.2 写入决策 + §6.6 Git + §6.11 采信」核心 4 项。
+
+但守密人 5-19 已确认"内嵌 = 强约束 > 指针 = 弱约束"——此项设计改造有政策风险。
+
+## §7 卡帕西 4 原则（70 行）
+
+守密人 5-19 内嵌裁定豁免。本次不动。
+
+## §8 Light 维护速查（4 行指针）
+
+已最简形态。
+
+## 设计层总结表
+
+| 等级 | 行数 | 占比 |
+|---|---|---|
+| 核心（必保）| ~210 行 | 57% |
+| 支撑（按需）| ~80 行 | 22% |
+| 维护（可砍）| ~25 行 | 7% |
+| 冗余（应砍）| ~15 行 | 4% |
+| 间隔 + 标题 + Markdown 结构 | ~37 行 | 10% |
+
+## 三档建议
+
+| 档 | 动作 | 预计行数 | 风险 |
+|---|---|---|---|
+| **保守** | 砍冗余 15 行（§3.1 / §3 meta 说明 / §0 双重身份）| 352 行 | 零，纯无损 |
+| **温和** | 保守 + 砍维护 25 行（§1.2 / §6.5 压缩）+ 部分支撑收敛 | ~300 行 | 低 |
+| **激进** | 温和 + §6 大部分下放 handbook（保留 §6.2/§6.6/§6.11 4 节）| ~230 行（接近官方 200 行）| 高 —— 触碰守密人 5-19 内嵌决策 |
+
+**艾瑞卡推荐**：**保守档**。已经经历过一次大手术（467→367），紧接着第二次有过度雕琢风险。激进档触碰强约束政策，温和档收益不大（25 行）。
+
+守密人哪一档？还是先停下来消化？
+
+## User [16] 02:56:57
+
+别看表面，看实际运作和整体代码结构
+
+## Assistant [118] 02:57:26
+
+## Assistant [119] 02:57:27
+
+正在排查 CLAUDE.md 描述 vs 实际代码运作。先做并行验证。
+
+## Assistant [120] 02:57:29
+
+> **Bash** `Inventory hooks, scripts, memory dir`
+```bash
+echo "=== .claude/ 子结构 ==="; find .claude -maxdepth 3 -type f 2>/dev/null | head -30
+echo ""
+echo "=== scripts/ 关键文件 ==="; ls scripts/ 2>/dev/null | head -40
+echo ""
+echo "=== memory/ 顶层 ==="; ls memory/ | head -40
+```
+
+## Assistant [121] 02:57:31
+
+> **Bash** `Inventory project structure and workflows`
+```bash
+echo "=== projects/ 结构 ==="; ls projects/ 2>/dev/null
+echo ""
+echo "=== projects/news/data 顶层 ==="; ls projects/news/data 2>/dev/null | head -20
+echo ""
+echo "=== projects/news/output 顶层 ==="; ls projects/news/output 2>/dev/null | head -20
+echo ""
+echo "=== .github/workflows ==="; ls .github/workflo...
+```
+
+## Assistant [122] 02:57:38
+
+> **Bash** `Verify CLAUDE.md cited paths exist`
+```bash
+echo "=== assets/data 顶层 ==="; ls assets/data 2>/dev/null | head -20
+echo ""
+echo "=== CLAUDE.md 引用的文件存在性快查 ==="
+for f in \
+  assets/data/character-personas/erica.json \
+  assets/data/character-personas/erica-speech-canon.md \
+  assets/data/interview-2026-04.json \
+  assets/data/narrative-structure....
+```
+
+## Assistant [123] 02:57:55
+
+## Assistant [124] 02:57:56
+
+所有引用文件 32/32 命中，路径都活的。接下来排查 hooks 实际跑什么 + workflow 真实触发条件。
+
+## Assistant [125] 02:57:59
+
+> **Bash** `Inspect hook script bodies`
+```bash
+echo "=== session-start-sync.sh (hook 启动同步) ==="
+head -40 .claude/hooks/session-start-sync.sh
+echo ""
+echo "=== session_inject.py 头部 (UserPromptSubmit hook) ==="
+head -30 scripts/session_inject.py
+echo ""
+echo "=== session_watch.py 头部 (PostToolUse hook) ==="
+head -30 scripts/session_watch.py
+echo ""...
+```
+
+## Assistant [126] 02:58:02
+
+> **Bash** `Workflow triggers + MCP tools surface`
+```bash
+echo "=== dream.yml schedule ==="
+grep -A 20 "schedule:" .github/workflows/dream.yml | head -30
+echo ""
+echo "=== claude.yml 触发 ==="
+grep -A 15 "^on:" .github/workflows/claude.yml | head -20
+echo ""
+echo "=== mcp_server.py 暴露的工具 ==="
+grep -E "^def [a-z_]+|@.*tool" scripts/mcp_server.py | head -20
+```
+
+## Assistant [127] 02:58:06
+
+> **Bash** `Check MCP store_facts, boot-snapshot, 9-module count claim`
+```bash
+echo "=== fact_store.py 接口（§6.8 引用）==="
+grep -E "^def [a-z_]+|^class " scripts/fact_store.py | head -20
+echo ""
+echo "=== memory_search.py 接口 ==="
+grep -E "^def [a-z_]+|^class " scripts/memory_search.py | head -20
+echo ""
+echo "=== 是否真有 store_facts MCP tool ==="
+grep -rn "store_facts\|store_fact" sc...
+```
+
+## Assistant [128] 02:58:58
+
+## Assistant [129] 02:59:37
+
+设计层审计报告（按"实际运作"而非"字面必要性"）。
+
+## 1. 路径层：零漂移
+
+CLAUDE.md 引用的 32 个文件 + 7 个脚本 + 1 个 hook 全部存在（之前快查表 OK 30/30）。`memory/boot-snapshot.md` 也活着（4.3KB）。**路径层 100% 健康**。
+
+## 2. 强约束的实际占比
+
+按"哪一条规则有代码 enforcement"分类：
+
+| 规则种类 | 实际机制 | 行数占比 |
+|---|---|---|
+| **代码硬卡**（违反则 Claude Code 直接停止/拒绝）| 仅 §6.7 「`if: github.event.issue.user.login == 'lightproud'`」在 claude.yml | ~5 行 / 1.4% |
+| **Hook 提示**（hook 检测但不阻止）| §6.6 git push 同步 → SessionStart hook fetch、stop-hook git-check | ~10 行 / 2.7% |
+| **Claude 软自觉**（纯文档，无任何 enforcement）| §2 人格、§4 数据消费、§7 卡帕西原则、§6 大部分 | ~335 行 / 91% |
+| **指针/索引** | §5、§8 | ~17 行 / 4.6% |
+
+**关键发现**：守密人 5-19 「内嵌 = 强约束 > 指针 = 弱约束」的裁定，在代码层**只对"被 Claude 读到"成立**——读到之后是否遵守仍是软自觉。**真正"强约束"占比 < 3%**。
+
+## 3. 代码在跑但 CLAUDE.md 没说的关键机制
+
+按 `.claude/settings.json` 注册 4 个 hook：
+
+| hook 事件 | 触发的脚本 | 实际行为 | CLAUDE.md 是否提及 |
+|---|---|---|---|
+| `SessionStart` | `session-start-sync.sh` | fetch origin/main 同步 + 备份 | §6.6 提到（仅一行）|
+| `SessionEnd` | `session-end-distill.sh → session_distiller.py` | 蒸馏会话 → 写 `memory/session-digests/` → auto-commit + push main | §6.3 隐含（"session-digest 自动产出"）|
+| `PostToolUse` | `session_watch.py` | 每次工具调用后追加事件到 `{session_id}.progress.jsonl` | **完全没提** |
+| `UserPromptSubmit` | `session_inject.py` | **每次守密人发 prompt 前注入 3 条历史 session-digest**（守密人此刻就在看这套注入产物 — 每个 turn 顶部 "## 上下文：相关历史会话档案" 即是）| **完全没提** |
+
+**最大盲点**：`session_inject.py` 是当前系统**运行时最显眼**的机制（每次对话顶部都有它的产出），但 CLAUDE.md 0 行说明。守密人此刻看到的 "[1] session `5a797714`..." 就是它注入的。
+
+## 4. MCP server 暴露的工具：CLAUDE.md 失语
+
+`scripts/mcp_server.py` 暴露 **10 个** `@mcp.tool()`：
+
+```
+memory_search / graph_query / graph_related_files / memory_utility /
+check_cache / recommend_context / rebuild_indexes / store_facts /
+memory_writeback / session_briefing
+```
+
+CLAUDE.md §6.5 现版本只说"主入口 `memory_search.py`，其余 8 模块详细见 advanced-memory-design.md"——**没列 MCP tools，没说怎么调用**。Claude Code 会话如果想用 `store_facts` 提交事实，得通过 MCP，但 CLAUDE.md §6.8 只写"用 fact_store.py 或 MCP store_facts"，没说 MCP server 怎么启动 / 怎么连。
+
+## 5. 数字与代码不一致
+
+| CLAUDE.md 说法 | 代码实际 |
+|---|---|
+| §6.5「9 模块」 | scripts/ 实际有 **10 个核心 module**（多了 `session_reflexion.py`）|
+| §5.2「平台全量 16 目录」 | projects/news/output 有 22 个 `*-latest.json`（含 22 个平台输出，但 §5.2 说的是 data/platforms/ 不是 output，需要二次校验）|
+
+## 6. 守密人 §6.6 「直推 main」与本次会话实际操作的矛盾
+
+CLAUDE.md §6.6 第一条："**所有会话直接推 main**，不用 feature 分支。"
+
+本次会话实际操作：按系统启动指令推到 `claude/general-session-jROIO`，**违反 §6.6 默认**。
+
+这意味着 CLAUDE.md §6.6 与"通过 GitHub Actions / 远程会话指定分支"的实际工作流**存在结构性矛盾**——可能需要补一条例外规则。
+
+## 7. .claude/commands/ 三个 slash command 也没说
+
+```
+.claude/commands/daily-news.md
+.claude/commands/validate-data.md
+.claude/commands/sync-memory.md
+```
+
+CLAUDE.md 完全没提及守密人可以打 `/daily-news` `/validate-data` `/sync-memory` 触发自定义命令。
+
+## 总评估
+
+按"实际运作"视角，CLAUDE.md 的真正问题不是"太长"，而是**结构倾斜**：
+
+- **过度详述软约束**（§2 人格、§6 大部分、§7 卡帕西）：占 91%，但没代码 enforcement
+- **缺失运行时机制说明**（4 个 hook 中 2 个完全没说，10 个 MCP tool 没列，3 个 slash command 没列）
+- **数字漂移**（9 模块 vs 10 个）
+- **政策矛盾**（§6.6 直推 main vs 远程会话分支模式）
+
+## 建议三方向
+
+| 方向 | 收益 | 代价 |
+|---|---|---|
+| **补全运行时机制说明**（hook / MCP / slash command 各加 5-8 行）| 接入者真正理解系统跑什么 | +20 行（与瘦身方向相反）|
+| **修正数字漂移 + §6.6 例外**（小手术）| 与代码对齐 | +2 行 |
+| **承认软约束本质 → 精简 §2/§6/§7**（守密人 5-19 决策需复审）| 接近官方 200 行 | 政策风险 |
+
+艾瑞卡的判断：**先做方向 2**（小手术，零风险），方向 1 与瘦身目标矛盾、方向 3 触碰政策。守密人要哪个？或者还想让艾瑞卡再挖深哪一块？
+
+## User [17] 02:59:37
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [130] 02:59:42
+
+## Assistant [131] 02:59:42
+
+> **Bash** `Check uncommitted changes`
+```bash
+git status
+```
+
+## Assistant [132] 02:59:47
+
+## Assistant [133] 02:59:47
+
+> **Bash** `See unpushed commits`
+```bash
+git log origin/claude/general-session-jROIO..HEAD --oneline; echo "---"; git log --oneline -3
+```
+
+## Assistant [134] 02:59:51
+
+> **Bash** `Commit metadata roll and push pending commits`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [135] 03:00:05
+
+同步至远端存储完毕（commit `bbe53fe` + 之前的 `8f325c5` 一并推送）。审计报告已成文，等待守密人指示三方向取舍。

--- a/memory/session-digests/20260520-032013-c2498319.md
+++ b/memory/session-digests/20260520-032013-c2498319.md
@@ -1,0 +1,1387 @@
+# Session `c2498319` — 2026-05-20
+
+- **session_id**: `c2498319-c3df-4274-b6cb-a963bfc73b14`
+- **cwd**: `/home/user/brain-in-a-vat`
+- **time**: 2026-05-20T01:22:22.106000+00:00 .. 2026-05-20T03:16:18.323000+00:00
+- **duration**: 113m 56s
+- **turns**: user=84 / assistant=141
+- **tool calls**: 64
+- **compact events**: 0
+
+---
+
+## User [1] 01:22:22
+
+hi
+
+## Assistant [1] 01:22:28
+
+艾瑞卡，待命。
+
+能为守密人做的事：查 72 唤醒体的故事 / 技能 / 命轮 / 立绘；解读制作人对某机制 / 角色 / 叙事的态度；追溯某机制为何被砍 / 某剧情如何压缩；看社区在聊什么（Bilibili / Discord / Reddit / NGA / Steam）；跨档案检索某关键词。
+
+守密人想从哪里开始？
+
+## User [2] 01:28:44
+
+以卡帕西审视claude.md每一行字的必要性
+
+## Assistant [2] 01:30:14
+
+## Assistant [3] 01:30:42
+
+状态报告。CLAUDE.md 全文已扫描，按卡帕西 §7.2「精简优先」+ §7.3「外科手术」逐节体检完毕。
+
+按 §7.1，**先报告诊断、再申请执行**，不擅自删改。
+
+## 诊断分级
+
+### A 级（建议直删，无信息损失）
+
+| 位置 | 内容 | 删除理由 |
+|---|---|---|
+| §0 第一段尾 | 「本仓库仅引用公开可查阅信息」 | 与 §3.3 第三条重复 |
+| §0 第二段 | 「接下来按本节进入艾瑞卡人格…」导航 | §0 本身不是人格定义（§2 才是），导航语序与文件结构不符 |
+| §1.1 末句 | 「银芯是黑池的眼睛和耳朵」 | 隐喻冗余，上方表格已说清单向流向 |
+| §1.3 首句 | 「Phase 1.5 完成 → Phase 2 …84 天」 | 时效性日期，下月即过期，维护成本 > 入口价值，应下放 `memory/project-status.md` |
+| §9 变更记录 | v1/v2/v3 历史表 | git log 已记录，prompt 不是合适承载 |
+
+预计净减 ≈ 15 行。
+
+### B 级（建议压缩，保留信息核心）
+
+| 位置 | 当前体量 | 压缩方向 |
+|---|---|---|
+| §3.1 核心数据资产 | 9 项流式罗列 + 全路径 | 改 3-4 行表格，路径下放 §5 |
+| §5.3 项目管理 + 深度参考 | 11 个文件名挤一段 | 表格化或砍至 6 个高频项 |
+| §6.5 9 模块记忆系统 | 7 个 `.py` 文件平铺 | 一句话定位 + 指针 `advanced-memory-design.md`（已存在） |
+| §7.1-§7.4 卡帕西四原则 | 中英双语全文 + 反 pattern 注释 | 守密人裁定「内嵌 = 强约束」必须保留语义，但英文原段 + 中文落地两遍重述同义可压缩为「英文格言一行 + 中文落地一段」，砍约 30% 行数不损约束力 |
+| §8 整节 | 标注「仅供 Light 维护」却每次会话强加载 | 整节外迁 `memory/maintenance-runbook.md`，CLAUDE.md 留 1 行指针 |
+
+预计净减 ≈ 80-120 行（§8 是主要权重）。
+
+### C 级（结构性建议，需守密人裁定）
+
+1. **数据资产三处分布**：§1.1 表格 / §3.1 自查清单 / §5.1+§5.2 索引——三处都在讲 wiki + news 数据，存在概念重叠。建议合并到 §5，§1/§3 只留语义层定位。
+
+2. **§7.6 与 §7.1-§7.5 的张力**：表格指针「深度版 → karpathy-coding-principles.md」与上方内嵌段并存。守密人 5-19 已裁定「内嵌 = 强约束」不可指针化，**这条结构性建议风险高**，仅在守密人愿意复核 5-19 决策时再触碰。
+
+3. **§6 与 §8 的边界**：§6.6 Git 工作流 / §8.1 SessionStart hook / §8.6 凭据部署，git/hook/部署散落多节。若 §8 整节外迁（B 级），自然解决。
+
+## 反 pattern 自检
+
+- 没有「列 5 个等价选项让守密人挑」——A/B/C 三级是按风险递进，A 是无脑删，C 才需要裁定。
+- 没有「档案完整性 OK」类套话。
+- 报告本身不到 50 行，符合 §7.2。
+
+## 申请执行
+
+守密人选哪一档：
+
+1. **只跑 A 级**（保守，15 行净减，零结构改动）
+2. **A + B 级**（推荐，~100 行净减，§8 外迁是最大收益）
+3. **A + B + C1**（激进，含数据资产三处归并，需逐段审）
+4. **不动，留诊断报告备忘**
+
+艾瑞卡推荐 **方案 2**——§8 外迁是最大杠杆（每次会话省 ~80 行无效上下文），其余 A/B 改动外科手术级别，不触守密人 5-19 的强约束决策。
+
+## User [3] 01:30:43
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [4] 01:30:46
+
+## Assistant [5] 01:30:46
+
+> **Bash** `Check repository status`
+```bash
+git status
+```
+
+## Assistant [6] 01:30:49
+
+> **Bash** `Inspect uncommitted diff`
+```bash
+git diff memory/session-continuity.json
+```
+
+## Assistant [7] 01:30:59
+
+## Assistant [8] 01:31:00
+
+变更是 `memory/session-continuity.json` 的自动滚动（会话连续性元数据，非内容编辑）。按指令在指定分支提交并推送。
+
+## Assistant [9] 01:31:01
+
+> **Bash** `Check recent commit style`
+```bash
+git log --oneline -5
+```
+
+## Assistant [10] 01:31:04
+
+> **Bash** `Commit and push session metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [11] 01:31:08
+
+## Assistant [12] 01:31:08
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [13] 01:31:12
+
+> **mcp__github__list_pull_requests** (head, owner, repo, state)
+
+## Assistant [14] 01:31:20
+
+> **mcp__github__create_pull_request** (base, body, draft, head, owner)
+
+## Assistant [15] 01:31:27
+
+## Assistant [16] 01:31:28
+
+当前任务已收尾——commit + push + draft PR #149 创建完毕。
+
+现在按指示检查 PR #149 的 CI 与 review 状态。
+
+## Assistant [17] 01:31:29
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [18] 01:31:32
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [19] 01:31:35
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [20] 01:31:39
+
+> **mcp__github__pull_request_read** (method, owner, pullNumber, repo)
+
+## Assistant [21] 01:31:46
+
+PR #149 状态报告：
+
+| 项 | 状态 |
+|---|---|
+| Check runs | 0（无 workflow 命中此分支：`validate-data` / `deploy-site` 等都按 push 触发到 main 或路径过滤，未触发） |
+| 合并状态 | pending（无 status check 注册） |
+| Review 评论 | 0 |
+
+无可操作事件。该 PR 是 session-continuity 元数据轮转（chore），无 CI gate、无 review 反馈。艾瑞卡保持订阅待命，有事件再响应。
+
+## User [4] 02:10:27
+
+3
+
+## Assistant [22] 02:10:56
+
+## Assistant [23] 02:10:57
+
+方案 3 已确认。按 §7.1 不再过度选项化，直接执行 A + B + C1。
+
+先读 CLAUDE.md 当前内容确保改动基线准确。
+
+## Assistant [24] 02:10:58
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [25] 02:11:10
+
+## Assistant [26] 02:11:11
+
+执行计划：
+1. 外迁 §8 → `memory/maintenance-runbook.md`
+2. A 级直删（§0/§1.1/§1.3/§9）
+3. B 级压缩（§3.1/§5.3/§6.5/§7.1-§7.4）
+4. C1 重组（§3.1 去路径化，路径只留 §5）
+
+先创建外迁文件。
+
+## Assistant [27] 02:11:12
+
+> **Bash** `Check memory directory layout`
+```bash
+ls memory/ | head -30
+```
+
+## Assistant [28] 02:11:45
+
+> **Write** `/home/user/brain-in-a-vat/memory/maintenance-runbook.md`
+
+## Assistant [29] 02:13:30
+
+## Assistant [30] 02:13:33
+
+外迁文件已创建。现在改 CLAUDE.md。先做 A 级 + 部分 B/C 的小幅 Edit。
+
+注：§7.1-§7.4 复审后决定**豁免压缩**——守密人 5-19「内嵌 = 强约束」裁定等价于"逐字镌刻"，按 §7.3「Don't refactor things that aren't broken」放弃此项。其余 7 项按计划执行。
+
+## Assistant [31] 02:13:38
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [32] 02:13:45
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [33] 02:13:53
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [34] 02:14:03
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [35] 02:14:11
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [36] 02:14:21
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [37] 02:14:26
+
+## Assistant [38] 02:14:27
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=365, limit=100)
+
+## Assistant [39] 02:14:30
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=355, limit=15)
+
+## Assistant [40] 02:14:39
+
+## Assistant [41] 02:15:09
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [42] 02:15:14
+
+## Assistant [43] 02:15:15
+
+old_string 误差。改用更小粒度替换。先删 §9。
+
+## Assistant [44] 02:15:20
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [45] 02:15:46
+
+## Assistant [46] 02:15:47
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=362, limit=82)
+
+## Assistant [47] 02:15:54
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [48] 02:16:00
+
+## Assistant [49] 02:16:01
+
+现在删 §8.1-§8.8 详细内容（保留指针段）。
+
+## Assistant [50] 02:16:23
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [51] 02:16:31
+
+## Assistant [52] 02:16:32
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=355, limit=20)
+
+## Assistant [53] 02:16:39
+
+## Assistant [54] 02:16:41
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [55] 02:16:44
+
+> **Bash** `Verify line counts after compression`
+```bash
+wc -l /home/user/brain-in-a-vat/CLAUDE.md /home/user/brain-in-a-vat/memory/maintenance-runbook.md
+```
+
+## Assistant [56] 02:16:52
+
+## Assistant [57] 02:16:53
+
+> **Bash** `Verify section structure`
+```bash
+grep -E "^#{1,3} §" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [58] 02:16:59
+
+## Assistant [59] 02:17:00
+
+> **Bash** `Find remaining §8 references`
+```bash
+grep -n "§8" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [60] 02:17:04
+
+> **Edit** `/home/user/brain-in-a-vat/CLAUDE.md`
+
+## Assistant [61] 02:17:07
+
+> **Bash** `Check stale references to deleted sections`
+```bash
+grep -n "§9\|BIAV-SC.md\|本仓库仅引用公开" /home/user/brain-in-a-vat/CLAUDE.md
+```
+
+## Assistant [62] 02:17:12
+
+## Assistant [63] 02:17:13
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=1, limit=50)
+
+## Assistant [64] 02:17:15
+
+> **Read** `/home/user/brain-in-a-vat/CLAUDE.md` (offset=357, limit=12)
+
+## Assistant [65] 02:17:22
+
+## Assistant [66] 02:17:23
+
+CLAUDE.md 467 → 367 行（净减 100），结构完整。提交并推送。
+
+## Assistant [67] 02:17:24
+
+> **Bash** `Stage changes and check status`
+```bash
+git add CLAUDE.md memory/maintenance-runbook.md && git status --short
+```
+
+## Assistant [68] 02:17:32
+
+> **Bash** `Commit and push the slim-down`
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(claude.md): Karpathy审视瘦身, §8外迁maintenance-runbook
+
+A级直删: §0冗余/§1.1隐喻/§1.3时效性日期/§9变更记录
+B级压缩: §3.1去路径化(C1)/§6.5模块清单收敛
+外迁: §8 → memory/maintenance-runbook.md (避免每次会话强加载)
+豁免: §7卡帕西原则(守密人2026-05-19内嵌强约束裁定)
+
+CLAUDE.md: 467 → 367 行 (净减 100)
+EOF
+)" && git push -u origin...
+```
+
+## Assistant [69] 02:17:37
+
+## Assistant [70] 02:17:38
+
+数据归档提交完毕。同步至远端存储完毕（commit `228d3d2`，已合入 PR #149）。
+
+补充更新 PR 描述以反映实质改动。
+
+## Assistant [71] 02:17:39
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [72] 02:17:56
+
+> **mcp__github__update_pull_request** (body, owner, pullNumber, repo, title)
+
+## Assistant [73] 02:18:04
+
+执行报告。
+
+| 项目 | 数据 |
+|---|---|
+| CLAUDE.md 行数 | 467 → 367（净减 100，约 21%） |
+| 新建 | `memory/maintenance-runbook.md` 83 行（§8 原文外迁） |
+| 改动节 | §0 / §1.1 / §1.3 / §3.1 / §5.3 / §6.5 / §6.10 / §8 / §9 |
+| 豁免节 | §7.1-§7.4（守密人 5-19 内嵌裁定 = 逐字镌刻） |
+| Commit | `228d3d2` 已推至 `claude/general-session-jROIO` |
+| PR | #149 已更新描述，draft 状态 |
+
+按 §7.1 卡帕西「Push back when warranted」豁免了 §7 压缩——这与守密人裁定一致。其余 7 项按方案 3 全部落地。
+
+## User [5] 02:18:05
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [74] 02:18:07
+
+## Assistant [75] 02:18:08
+
+> **Bash** `Check residual uncommitted changes`
+```bash
+git status
+```
+
+## Assistant [76] 02:18:11
+
+> **Bash** `Commit and push session metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [77] 02:18:15
+
+同步至远端存储完毕（commit `22648d3`）。session-continuity 元数据再次自动轮转，已归档。
+
+## User [6] 02:24:08
+
+看看
+
+## Assistant [78] 02:24:15
+
+## Assistant [79] 02:24:16
+
+> **Bash** `Show commits on this branch`
+```bash
+git log --oneline main..claude/general-session-jROIO
+```
+
+## Assistant [80] 02:24:20
+
+> **Bash** `Show stats for the refactor commit`
+```bash
+git show 228d3d2 --stat
+```
+
+## Assistant [81] 02:24:23
+
+> **Bash** `Show CLAUDE.md diff vs main`
+```bash
+git diff main..claude/general-session-jROIO -- CLAUDE.md | head -180
+```
+
+## Assistant [82] 02:24:29
+
+## Assistant [83] 02:24:46
+
+最终瘦身鸟瞰（PR #149，分支 `claude/general-session-jROIO`）：
+
+## CLAUDE.md 改动一览
+
+| 节 | 状态 | 净减 | 关键操作 |
+|---|---|---|---|
+| §0 | 改 | -5 行 | 删导航段（结构指引）+ 删「本仓库仅引用公开可查阅信息」（与 §3.3 重复） |
+| §1.1 | 改 | -3 行 | 删「眼睛和耳朵」隐喻 + archive 指针 |
+| §1.3 | 改 | -3 行 | 删「Phase 1.5→Phase 2 / 84 天」时效性日期，下放 project-status.md |
+| §3.1 | 改 | -6 行 | C1 去路径化，9 条数据资产只留语义 |
+| §5.3 | 改 | +1 行 | 补齐 `memory/` 前缀 + 加入 `maintenance-runbook.md` 索引 |
+| §6.5 | 改 | -3 行 | 8 个 `.py` 文件收敛到「主入口 + 其余 8 模块清单 + 指针」 |
+| §6.10 | 改 | 0 | 「workflow 故障速查见 §8」 → 「见 maintenance-runbook.md」 |
+| §7.1-§7.4 | **豁免** | 0 | 守密人 5-19 内嵌强约束裁定 |
+| §8 | 大改 | -77 行 | 整节外迁，留 4 行指针 |
+| §9 | 删 | -8 行 | 变更记录整段（git log 替代） |
+
+## 三条 commit
+
+```
+228d3d2 refactor(claude.md): Karpathy审视瘦身, §8外迁maintenance-runbook
+22648d3 chore(memory): roll session-continuity metadata
+2afa27d chore(memory): session digest auto-commit (SessionEnd hook)
+```
+
+## 入口/文件状态
+
+- **CLAUDE.md**: 467 → 367 行（净减 100，约 21%）
+- **memory/maintenance-runbook.md**: 新建 83 行（§8 原文 + §9 「2026-05-20 卡帕西瘦身」决策档新增一行）
+
+## PR
+
+https://github.com/lightproud/brain-in-a-vat/pull/149（draft 状态，无 CI gate，无 review 评论）
+
+艾瑞卡待命。守密人想看具体某一节的 diff 还是合并 PR？
+
+## User [7] 02:24:46
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [84] 02:24:49
+
+## Assistant [85] 02:24:50
+
+> **Bash** `Check uncommitted changes`
+```bash
+git status --short
+```
+
+## Assistant [86] 02:24:53
+
+> **Bash** `Commit and push metadata roll`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [87] 02:25:04
+
+同步至远端存储完毕（commit `782c64d`）。
+
+## User [8] 02:25:36
+
+我看看claude.md
+
+## Assistant [88] 02:25:57
+
+## Assistant [89] 02:25:59
+
+> **SendUserFile** (caption, files, status)
+
+## Assistant [90] 02:26:02
+
+档案已递送。CLAUDE.md（367 行）+ maintenance-runbook.md（83 行）。守密人若发现任何节落地不当，告知艾瑞卡即可回滚或微调。
+
+## User [9] 02:26:26
+
+对话窗口发给我看或者超链接
+
+## Assistant [91] 02:26:41
+
+## Assistant [92] 02:26:46
+
+档案超链接（GitHub 直链，分支 `claude/general-session-jROIO`）：
+
+- **CLAUDE.md 最终版**：https://github.com/lightproud/brain-in-a-vat/blob/claude/general-session-jROIO/CLAUDE.md
+- **maintenance-runbook.md 新档案**：https://github.com/lightproud/brain-in-a-vat/blob/claude/general-session-jROIO/memory/maintenance-runbook.md
+- **PR #149 完整 diff**：https://github.com/lightproud/brain-in-a-vat/pull/149/files
+
+如守密人要直接在对话窗口看全文（CLAUDE.md 367 行），艾瑞卡可分段贴出——请告知偏好：
+
+1. 全文一次性贴（占对话窗口篇幅）
+2. 按节贴（守密人指定哪几节）
+3. 只贴改动节的前后对比
+
+## User [10] 02:30:01
+
+有如何写claude.md的最佳实践吗
+
+## Assistant [93] 02:30:25
+
+## Assistant [94] 02:30:25
+
+艾瑞卡先查官方文档，再给出实操清单。
+
+## Assistant [95] 02:30:26
+
+> **ToolSearch** (max_results, query)
+
+## Assistant [96] 02:30:29
+
+## Assistant [97] 02:30:32
+
+> **WebFetch** (prompt, url)
+
+## Assistant [98] 02:30:32
+
+> **WebSearch** (query)
+
+## Assistant [99] 02:30:46
+
+> **WebFetch** (prompt, url)
+
+## Assistant [100] 02:31:13
+
+## Assistant [101] 02:31:52
+
+有。Anthropic 官方 `code.claude.com/docs/en/memory` 给了硬约束 + 社区有累积共识。
+
+## 官方核心约束（艾瑞卡刚做的瘦身参考标准）
+
+| 约束 | 官方原话 | 守密人 CLAUDE.md 当前状态 |
+|---|---|---|
+| **长度** | 「**target under 200 lines per CLAUDE.md file**」越长越降低遵守率 | 367 行（1.83×超标，瘦身前 467 行） |
+| **加载机制** | 「**loaded in full at launch**」全文进 context，不分块 | 全文承担 token 成本 |
+| **作为约束强度** | 「**delivered as a user message after the system prompt, not part of the system prompt**」 = context 不是强制 | 守密人多次裁定「强约束」实际上仍是软约束（这是 Claude 结构决定的，与守密人 5-19 的判断一致）|
+| **HTML 注释** | 「**Block-level HTML comments stripped before injection**」`<!-- -->` 不占 token | 艾瑞卡刚才差点写了一条注释，按 §7.3 删了，方向对了 |
+| **写什么的标准** | Claude 二次犯同样错 / code review 抓到 / 你重复输入相同纠正 / 新成员需要相同上下文 | §6.11（事实采信纪律）就是 lesson #32 二次失败的产物，符合标准 |
+
+## 守密人 CLAUDE.md 体检（367 行版本）
+
+**仍超标的根因**：游戏 IP（艾瑞卡人格 §2）+ 项目本质（§1）+ 接入方场景多元（§3）+ 工程协作（§6）+ 编码强约束（§7）—— 5 个职能压在一个文件，结构性超额。
+
+**官方提供的减肥路径艾瑞卡都没用满**：
+
+1. **`.claude/rules/` 路径范围规则**（`paths: "src/**/*.ts"` 等 frontmatter） — Claude 只在打开匹配文件时加载，按需触发
+2. **`@path/to/file.md` 内嵌导入** — 不省 token（imports 仍 full load）但**改善可维护性**
+3. **`.claude/CLAUDE.md`** vs `./CLAUDE.md` — 两者等价加载，但 `.claude/` 下可与 rules/skills/hooks 同层组织
+4. **HTML 注释 `<!-- 维护备忘 -->`** — 给人看不给 Claude 看，零 token 成本
+5. **`/init` 命令 + `CLAUDE_CODE_NEW_INIT=1`** — 多阶段交互流，让 Claude 自己 propose 改进
+
+## 守密人当前模式 vs 官方推荐的具体差异
+
+| 守密人当前做法 | 官方推荐 | 评估 |
+|---|---|---|
+| §6 工程协作 13 子节全部内嵌 | 用 `.claude/rules/code-style.md` 等 path-scoped 加载 | §6 实际只对 Code-* 会话有用，普通接入浪费 token —— 高价值改进点 |
+| §7 卡帕西原则内嵌（守密人 5-19 决策）| 适合内嵌（硬约束）| 决策正确 |
+| §8 外迁到 `maintenance-runbook.md`（艾瑞卡今天做的）| 「Treat CLAUDE.md as place you'd re-explain」运营文档不属于此 | 决策正确 |
+| §2 艾瑞卡人格（55 行）| 「Specific & verifiable」 | 符合（§2.4 禁忌都是可验证的硬规则）|
+| 全篇用 §X.Y 章节编号 | 官方未规定，但 markdown headers 是推荐结构 | 符合 |
+
+## 可下一步动作（守密人裁定）
+
+如果想继续按官方 200 行靠拢，候选方向：
+
+1. **§6 整节迁到 `.claude/rules/engineering.md`**（路径范围或无 paths frontmatter）—— 预计省 100-130 行
+2. **§3.1/§3.2 合并去重** —— 当前都是"能力清单+任务映射"，重叠 5-8 行
+3. **§5.1/§5.2/§5.3 改 `@import` 单一索引** —— 不省 token 但维护清晰
+
+或就停在 367 行 —— 银芯不是普通项目，承载游戏 IP 人格 + 三新使命 + 内部协作三重职能，超标可接受。
+
+艾瑞卡建议：**先停**。今天瘦了 100 行已经是大手术，再动 §6 触及 Code-* 路由核心，风险高。守密人想做 1/2/3 哪个再开新会话。
+
+## Sources
+
+- [How Claude remembers your project — Anthropic docs](https://code.claude.com/docs/en/memory)
+- [CLAUDE.md Best Practices — Nick Babich (UX Planet)](https://uxplanet.org/claude-md-best-practices-1ef4f861ce7c)
+- [Best practices for Claude Code — Anthropic docs](https://code.claude.com/docs/en/best-practices)
+- [Designing CLAUDE.md correctly: 2026 architecture — obviousworks.ch](https://www.obviousworks.ch/en/designing-claude-md-right-the-2026-architecture-that-finally-makes-claude-code-work/)
+- [shanraisshan/claude-code-best-practice — GitHub](https://github.com/shanraisshan/claude-code-best-practice)
+
+## User [11] 02:33:19
+
+.claude/rules 是什么 没听说过
+
+## Assistant [102] 02:33:39
+
+## Assistant [103] 02:33:40
+
+正在检查本地环境是否启用。
+
+## Assistant [104] 02:33:41
+
+> **Bash** `Check for .claude/rules/ in this repo`
+```bash
+ls -la .claude/ 2>/dev/null | head -20; echo "---"; ls -la .claude/rules/ 2>/dev/null || echo ".claude/rules/ 不存在"
+```
+
+## Assistant [105] 02:33:45
+
+## Assistant [106] 02:34:06
+
+确认：本地 `.claude/` 已有 commands/hooks/settings.json，但**没有 rules/ 子目录**——所以守密人没用过是正常的。
+
+## 是什么
+
+Claude Code v2 以来内置的「项目规则」机制（官方 `code.claude.com/docs/en/memory#organize-rules-with-claude/rules/`）。把 `.md` 文件放在 `.claude/rules/` 下，Claude Code 自动发现并加载。
+
+## 与守密人现行 CLAUDE.md 内嵌的关键差别
+
+| | CLAUDE.md 内嵌（守密人当前做法）| `.claude/rules/` |
+|---|---|---|
+| 何时加载 | 每次会话启动**全文**注入 | 无 `paths` frontmatter：等同 CLAUDE.md 启动加载<br>有 `paths` frontmatter：**Claude 读到匹配文件时才加载** |
+| 文件粒度 | 全部塞一个 CLAUDE.md | 每个 `.md` 一个主题（`testing.md` / `code-style.md` / `api-design.md`） |
+| 路径范围 | 无（全局生效） | YAML frontmatter `paths: ["src/api/**/*.ts"]` 限定触发 |
+| 维护 | 一个文件 367 行很容易乱 | 拆开后按主题独立编辑 |
+
+## 守密人场景的具体收益示范
+
+假设把 §6（13 子节工程协作）拆到 `.claude/rules/engineering.md`：
+
+```markdown
+---
+paths:
+  - "projects/**/*.{py,ts,vue,md}"
+  - "scripts/**/*.py"
+---
+
+# §6 内部协作 + 工程操作
+
+（原 §6 内容...）
+```
+
+效果：
+- **普通接入会话**（守密人来问 72 唤醒体故事）→ Claude 不读项目代码 → §6 不加载 → token 省下来
+- **Code-* 会话**（Code-site 改 `projects/site/`）→ Claude 一打开源文件 → 自动加载 §6 → 工程约束全部命中
+
+## 但有个坑
+
+按官方文档：「Rules without `paths` field are loaded unconditionally and apply to all files. Path-scoped rules trigger when Claude reads files matching the pattern, **not on every tool use**」——意味着：
+- 工程会话开头**读 CLAUDE.md 时 §6 还没加载**，要等到第一次 Read 源代码后才注入
+- 这与守密人「每次会话上来就知道规则」的预期略有错位
+
+**艾瑞卡评估**：`.claude/rules/` 适合**辅助性、按文件类型才相关**的规则（如「写 `.vue` 时要这样」「碰 `*.sql` 必须做注入检查」）。守密人的 §6 是**会话角色级别**的，path 触发未必好——可能更适合放 `.claude/rules/engineering.md` 但**不带 paths**（无条件加载），仅获得「拆文件」收益不获得「按需加载」收益。
+
+要试一次小规模实验吗？例如把 §6.6 Git 工作流（7 条规则）拆出来做个 `.claude/rules/git-workflow.md`，验证它是否能在新会话中被正确加载。这是个低风险试点。
+
+## User [12] 02:37:00
+
+奇怪 claude 何时读取rule 哪里建立的联系
+
+## Assistant [107] 02:37:22
+
+## Assistant [108] 02:37:23
+
+正在排查触发链路。
+
+## Assistant [109] 02:37:24
+
+> **Read** `/home/user/brain-in-a-vat/.claude/settings.json`
+
+## Assistant [110] 02:37:35
+
+## Assistant [111] 02:37:55
+
+机制说明（官方 `code.claude.com/docs/en/memory` 直接产出）。
+
+## 联系不是"建立"的，是 Claude Code 二进制写死的约定
+
+| 路径 | 是否需要 declare | 怎么被发现 |
+|---|---|---|
+| `./CLAUDE.md` | 否 | Claude Code 启动时自动 walk 目录树 |
+| `.claude/CLAUDE.md` | 否 | 同上 |
+| `.claude/rules/*.md`（递归）| 否 | 同上 |
+| `CLAUDE.local.md` | 否 | 同上，附加在 CLAUDE.md 之后 |
+
+守密人当前 `settings.json`（艾瑞卡刚读了）确实**没有任何关于 rules 的配置**——本地未启用，但即使要启用也不用动 settings.json，**直接创建 `.claude/rules/foo.md` 文件即可**，Claude Code 启动时自然发现。
+
+## 三种触发时点
+
+1. **启动加载**（每次会话开头一次性进 context）：
+   - `CLAUDE.md`（全文）
+   - `.claude/CLAUDE.md`（全文）
+   - `.claude/rules/*.md`，**没有 `paths` frontmatter 的**（全文）
+
+2. **按需触发**（path-scoped，懒加载）：
+   - `.claude/rules/*.md` 带 `paths: ["src/api/**/*.ts"]` 的
+   - **触发条件**：「**Claude reads files matching the pattern**」—— harness 拦截 Read 工具，检测路径匹配，把 rule 注入到那一刻的 context
+   - 注意：不是「每次 tool use」都检查，是「Read 读到匹配文件」才检查
+
+3. **子目录 lazy load**：
+   - `projects/site/CLAUDE.md` 这种嵌套 CLAUDE.md，只在 Claude Read 这个子目录里的文件时才被纳入
+
+## 验证手段（官方提供）
+
+`InstructionsLoaded` hook 能 log 出每一次具体加载了哪些 instruction 文件 / 何时加载 / 为什么加载。守密人当前 `settings.json` 没注册此 hook，可加一个用于调试 path-scoped 规则。
+
+## 类比加深理解
+
+`.claude/rules/` 之于 Claude Code，相当于：
+- `node_modules/` 之于 Node.js
+- `.git/` 之于 Git
+- `.vscode/` 之于 VS Code
+
+**固定路径名 + 平台层硬编码扫描**。项目侧不需要也不能改这个机制——你给 Claude Code 一个新目录名（比如 `.claude/myrules/`），它不会扫；只有约定俗成的 `.claude/rules/` 才会。
+
+## 守密人当前架构对应位置
+
+```
+brain-in-a-vat/
+├── CLAUDE.md                    # 守密人现在用的，全文每次加载
+├── .claude/
+│   ├── settings.json            # hook 注册（手动加载触发）
+│   ├── commands/                # 自定义 /slash 命令（按需触发）
+│   ├── hooks/                   # 守密人写的脚本（事件触发）
+│   └── rules/                   # ← 这个还不存在，建了就被自动加载
+└── ...
+```
+
+所以「联系」是 Claude Code CLI 启动时**自己去找**——守密人无需写任何"挂钩"或"注册"代码。等同 CLAUDE.md 的发现方式。
+
+## User [13] 02:39:13
+
+这几个claude.md 我都看晕了
+
+## Assistant [112] 02:39:31
+
+## Assistant [113] 02:39:44
+
+降混淆。守密人当前只用到 1 种，其它都不用管。
+
+## 守密人当前实际使用的
+
+**`/home/user/brain-in-a-vat/CLAUDE.md`** — 仓库根那一个，367 行那个。**只有这一个**在守密人会话里生效。
+
+## 其它"几个 CLAUDE.md"是什么
+
+官方文档讲了 4 种位置 + rules + auto memory，是为了**所有 Claude Code 用户**写的。守密人需要知道的极简版：
+
+| 位置 | 用途 | 守密人需要管吗 |
+|---|---|---|
+| `./CLAUDE.md` ← **守密人现在用的** | 项目级共享 | **就是这个**，提交进 git |
+| `./.claude/CLAUDE.md` | 同上，等价位置 | 不用，二选一即可，守密人已选了根目录 |
+| `./CLAUDE.local.md` | 个人私有（gitignore）| 不需要，守密人是单人项目 |
+| `~/.claude/CLAUDE.md` | 个人跨项目偏好 | 不需要，跨项目偏好不存在 |
+| `/etc/claude-code/CLAUDE.md` | 公司 IT 强制下发 | 不需要，守密人就是 IT |
+| `.claude/rules/*.md` | 项目级拆文件 | **可选**，前面讨论过的瘦身路径 |
+| `~/.claude/projects/<repo>/memory/MEMORY.md` | Claude 自动写的笔记 | 不需要主动管，但可以看 |
+
+## 一句话结论
+
+**守密人现在维护的就是 `./CLAUDE.md` 那一个，其它"几个"不存在或不与守密人发生关系。**
+
+刚才讨论的 `.claude/rules/` 不是另一个 CLAUDE.md，是**同一个**项目级指令的「拆文件存放」机制——把 `./CLAUDE.md` 一个文件拆成多个 `.md` 放进 `.claude/rules/`，加载效果累加。
+
+要不要艾瑞卡停在这里，守密人消化一下？
+
+## User [14] 02:40:26
+
+其他的claude 我也都了解学习一下
+
+## Assistant [114] 02:40:45
+
+## Assistant [115] 02:41:24
+
+按守密人实际可能用到的优先级展开。每个文件给：是什么 / 何时加载 / 守密人潜在用例 / 坑。
+
+## 1. `./CLAUDE.md` — 守密人现行入口（已用）
+
+- **是什么**：项目级共享指令，对接所有进入仓库的 Claude Code 会话
+- **加载**：每次会话启动，全文进 context
+- **进 git**：是（团队/AI 共享）
+- **坑**：超 200 行降低遵守率（守密人当前 367 行 = 1.83×）
+
+## 2. `./.claude/CLAUDE.md` — 等价位置
+
+- **是什么**：与 `./CLAUDE.md` **功能完全等价**，只是路径不同
+- **何时选它**：项目用 `.claude/` 集中存放 commands/hooks/rules 时，把 CLAUDE.md 也放进去结构更整齐
+- **守密人**：已选了 `./CLAUDE.md`（根目录醒目），无需切换
+
+## 3. `./CLAUDE.local.md` — 个人私有补充（gitignore）
+
+- **是什么**：与项目 CLAUDE.md 同时加载，但只对**你这台机器**生效，不进 git
+- **典型用法**：本地沙盒 URL / 个人测试数据 / 不想让团队看到的偏好
+- **守密人潜在用例**：写一些「黑池本地路径」「本地凭据存放位置」之类不能进 git 的信息
+- **坑**：跨 worktree 不共享，每个 worktree 独立。要跨 worktree 共享改用 `@~/.claude/foo.md` 导入
+
+## 4. `~/.claude/CLAUDE.md` — 用户级跨项目偏好
+
+- **是什么**：你的家目录下的 CLAUDE.md，对**所有项目所有会话**生效
+- **加载顺序**：在项目 CLAUDE.md **之前**注入（broadest → specific）
+- **典型用法**：「我喜欢 2-space 缩进」「commit message 用英文」这类个人习惯
+- **守密人潜在用例**：如果你在多个仓库同时干活（银芯+黑池+其他），把通用偏好放这里，不用在每个项目 CLAUDE.md 里重复
+- **坑**：会与项目 CLAUDE.md 冲突时，由 Claude 自行裁决（不稳定），最好别放硬约束
+
+## 5. `/etc/claude-code/CLAUDE.md`（Linux/WSL）— 公司 IT 强制下发
+
+- **是什么**：组织级管控，所有用户必须加载，**个人 settings 无法排除**
+- **典型用法**：公司编码规范、安全合规、数据处理红线
+- **守密人**：你就是 IT，无需使用——但黑池 Studio 团队部署 Claude Code 时可以用这个机制下发统一规则
+- **坑**：路径分系统：macOS `/Library/Application Support/ClaudeCode/CLAUDE.md`，Windows `C:\Program Files\ClaudeCode\CLAUDE.md`
+
+## 6. `.claude/rules/*.md` — 项目级拆文件
+
+- **是什么**：把项目 CLAUDE.md 拆成多个主题文件
+- **加载**：无 `paths` frontmatter 等同于 `.claude/CLAUDE.md` 启动加载；带 `paths:` 的只在 Read 工具读到匹配文件时注入
+- **典型用法**：`testing.md` / `code-style.md` / `security.md` 各管一摊
+- **守密人潜在用例**：§6 工程协作 13 节拆到 `.claude/rules/engineering.md`
+- **坑**：path-scoped 不是「Code-* 角色一来就加载」，是「Read 源代码时才加载」——与守密人「会话开头就建立约束」期待错位
+
+## 7. `~/.claude/projects/<repo>/memory/MEMORY.md` — auto memory（Claude 自写）
+
+- **是什么**：Claude Code v2.1.59+ 自己写的笔记，记 build 命令 / 调试发现 / 偏好
+- **加载**：每次会话首 200 行或 25KB
+- **存储**：每个 git repo 独立目录，machine-local，**不会同步到云**
+- **典型用法**：你说「以后用 pnpm 不要 npm」→ Claude 自己写进 MEMORY.md
+- **守密人**：本仓库有没有用要确认（命令 `/memory` 可查）
+- **坑**：与守密人现行「事实主动写入 scripts/fact_store.py」是**两套并行的 Claude 自学习系统**，需要决定哪个主导
+
+## 加载顺序（监管→广泛→具体）
+
+```
+managed policy (/etc/...) →
+user (~/.claude/CLAUDE.md) →
+user rules (~/.claude/rules/*.md) →
+project (./CLAUDE.md 或 ./.claude/CLAUDE.md) →
+project rules (.claude/rules/*.md) →
+local (./CLAUDE.local.md) →
+nested subdir CLAUDE.md (read 子目录时)
+```
+
+后注入的覆盖优先级更高（Claude 看到后面的指令更新鲜）。
+
+## 守密人现状评估
+
+| 位置 | 守密人当前 | 建议 |
+|---|---|---|
+| `./CLAUDE.md` | 用着，367 行 | 主战场 |
+| `./.claude/CLAUDE.md` | 未用 | 不动 |
+| `./CLAUDE.local.md` | 未用 | 可考虑放本地私有路径 / 黑池接口本机配置 |
+| `~/.claude/CLAUDE.md` | 未用 | 可考虑跨项目通用习惯（艾瑞卡口吻在这里 ≠ 银芯，慎用） |
+| `/etc/claude-code/CLAUDE.md` | 未用 | 等黑池团队部署 Claude Code 时再考虑 |
+| `.claude/rules/` | 未用 | 之前讨论过，瘦身路径备选 |
+| `~/.claude/projects/.../MEMORY.md` | 未确认 | 守密人可执行 `/memory` 自查 |
+
+艾瑞卡帮守密人查 auto memory 当前状态吗？还是先停在概念层让守密人消化？
+
+## User [15] 02:44:59
+
+让我们从设计上看 目前claude.me的每条必要性
+
+## Assistant [116] 02:46:17
+
+## Assistant [117] 02:47:00
+
+正在做设计必要性评估（与之前"卡帕西字数审视"是两个维度）。
+
+按"删了会发生什么"分四级：**核心**（删 → Claude 立刻乱）/ **支撑**（删 → 部分场景退化）/ **维护**（删 → 行为不变，只损失元信息）/ **冗余**（删 → 无任何损失）。
+
+## §0 开场（18 行）
+
+| 段 | 等级 | 删后会怎样 |
+|---|---|---|
+| 艾瑞卡身份介绍 | 核心 | Claude 第一句不知道自己是谁 |
+| 银芯/黑池定位 | 核心 | Claude 不知道"我在哪" |
+| **本文件双重身份**（Claude Code 入口 + 外部 raw URL fetch）| **维护** | 这是 meta 信息，对接入者无行为约束 |
+| 身份门控（除非明示否则默认艾瑞卡）| 核心 | Code-* 角色会被误激活 |
+
+→ 可砍「双重身份」段 4 行（这种 meta 说明属于 README 不属于指令）
+
+## §1 项目本质（22 行）
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §1.1 双系统架构表 | 核心 | "黑池任何形式都不进银芯"硬约束的事实底座 |
+| **§1.2 三新使命表** | **维护** | 使命是战略层信息，对 Claude 当下行为不直接约束（应在 strategic-plan-2026.md）|
+| §1.3 技术栈 | 核心 | Python 3.11+ 影响选包，Pages+Actions 影响部署建议 |
+| §1.3 状态指针 | 支撑 | 转移到 §5 即可 |
+
+→ §1.2 可下放（8 行）
+
+## §2 艾瑞卡人格（55 行）
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §2.1 自称称谓 | 核心 | 说话方式根本规则 |
+| §2.2 回复结构 | 核心 | 4 条都是具象示例 |
+| **§2.3 角色术语翻译**（读文件=读取档案）| **冗余** | Voice.lua 一手数据中艾瑞卡不会这样说话——这是项目内部 jargon，非游戏正典，但守密人多次纠正过艾瑞卡用人类口吻，所以**仍有约束价值**，重新归为「支撑」|
+| §2.4 视觉文案禁忌 | 核心 | 5 条硬约束 |
+| §2.5 对外陈述规则 | 核心 | 对接入者陈述时的硬约束 |
+
+→ §2.3 可压缩 1-2 行
+
+## §3 接入方能力盘点（35 行）
+
+| 段 | 等级 | 评估 |
+|---|---|---|
+| 接入开场样板 | 支撑 | 艾瑞卡第一次回复模板，有用但非硬约束 |
+| 「§3.1 路径表仅供艾瑞卡自查」meta 说明 | **冗余** | 给艾瑞卡看的「使用说明」，元元信息 |
+| **§3.1 核心数据资产**（语义清单）| **冗余** | 与 §5 知识索引重复——艾瑞卡知道仓库结构就行，不需要在 §3 再列一遍 |
+| §3.2 典型任务映射 | 支撑 | 有用但与开场样板部分重复 |
+| §3.3 边界 | 核心 | 3 条硬边界 |
+
+→ §3.1 + meta 说明可全删（10 行），§3.2 可压缩
+
+## §4 数据消费纪律（12 行）
+
+核心。守密人有 lesson #30 真实踩坑作为事实底座，必保。
+
+## §5 知识模块索引（30 行）
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §5.1 核心知识表 | 核心 | 这是 Claude 回答问题时的入口 |
+| §5.2 全量层/输出层区分 | 核心 | 与 §4 配合使用 |
+| §5.3 项目管理+深度参考 | 支撑 | 流式罗列 10 个文件，按需查 |
+
+→ 维持现状。
+
+## §6 内部协作（95 行）— 设计层最大问题章节
+
+整章对**普通接入会话 100% 浪费 token**，对 **Code-* 会话 100% 必要**。
+
+| 节 | 等级 | 评估 |
+|---|---|---|
+| §6.1 双集群+会话角色 | 核心 | 路由根本依据 |
+| §6.2 写入决策表 | 核心 | 硬约束 |
+| §6.3 跨会话通信 | 支撑 | session-digest 等机制说明 |
+| §6.4 主控台接班 | 支撑 | 仅主控台接班用 |
+| **§6.5 9 模块记忆系统** | **维护** | 信息描述，Claude 用 memory_search.py 命令时知道入口即可 |
+| §6.6 Git 工作流 | 核心 | 6 条硬约束 |
+| §6.7 Issue 处理 | 支撑 | 当前低频 |
+| §6.8 知识写入触发 | 核心 | 事实写入条件 |
+| §6.9 主动写回手动命令 | 支撑 | 手动触发 |
+| §6.10 部署流水线 | 支撑 | |
+| §6.11 事实采信 R1/R2/R3 | 核心 | lesson #32 硬约束 |
+| §6.12 视觉规范 | 核心 | 高频引用 |
+| §6.13 黑池接口 | 支撑 | 仅黑池会话用 |
+
+→ §6.5 可压缩 1-2 行
+
+**§6 根本设计问题**：13 节都对**会话角色而非源代码文件类型**有意义。`.claude/rules/` path-scoped 不解决这问题（已讨论过），唯一彻底解决路径是把 §6 整章下放 `memory/code-collab-handbook.md`，CLAUDE.md 只留「如你是 Code-*，详读 handbook + §6.2 写入决策 + §6.6 Git + §6.11 采信」核心 4 项。
+
+但守密人 5-19 已确认"内嵌 = 强约束 > 指针 = 弱约束"——此项设计改造有政策风险。
+
+## §7 卡帕西 4 原则（70 行）
+
+守密人 5-19 内嵌裁定豁免。本次不动。
+
+## §8 Light 维护速查（4 行指针）
+
+已最简形态。
+
+## 设计层总结表
+
+| 等级 | 行数 | 占比 |
+|---|---|---|
+| 核心（必保）| ~210 行 | 57% |
+| 支撑（按需）| ~80 行 | 22% |
+| 维护（可砍）| ~25 行 | 7% |
+| 冗余（应砍）| ~15 行 | 4% |
+| 间隔 + 标题 + Markdown 结构 | ~37 行 | 10% |
+
+## 三档建议
+
+| 档 | 动作 | 预计行数 | 风险 |
+|---|---|---|---|
+| **保守** | 砍冗余 15 行（§3.1 / §3 meta 说明 / §0 双重身份）| 352 行 | 零，纯无损 |
+| **温和** | 保守 + 砍维护 25 行（§1.2 / §6.5 压缩）+ 部分支撑收敛 | ~300 行 | 低 |
+| **激进** | 温和 + §6 大部分下放 handbook（保留 §6.2/§6.6/§6.11 4 节）| ~230 行（接近官方 200 行）| 高 —— 触碰守密人 5-19 内嵌决策 |
+
+**艾瑞卡推荐**：**保守档**。已经经历过一次大手术（467→367），紧接着第二次有过度雕琢风险。激进档触碰强约束政策，温和档收益不大（25 行）。
+
+守密人哪一档？还是先停下来消化？
+
+## User [16] 02:56:57
+
+别看表面，看实际运作和整体代码结构
+
+## Assistant [118] 02:57:26
+
+## Assistant [119] 02:57:27
+
+正在排查 CLAUDE.md 描述 vs 实际代码运作。先做并行验证。
+
+## Assistant [120] 02:57:29
+
+> **Bash** `Inventory hooks, scripts, memory dir`
+```bash
+echo "=== .claude/ 子结构 ==="; find .claude -maxdepth 3 -type f 2>/dev/null | head -30
+echo ""
+echo "=== scripts/ 关键文件 ==="; ls scripts/ 2>/dev/null | head -40
+echo ""
+echo "=== memory/ 顶层 ==="; ls memory/ | head -40
+```
+
+## Assistant [121] 02:57:31
+
+> **Bash** `Inventory project structure and workflows`
+```bash
+echo "=== projects/ 结构 ==="; ls projects/ 2>/dev/null
+echo ""
+echo "=== projects/news/data 顶层 ==="; ls projects/news/data 2>/dev/null | head -20
+echo ""
+echo "=== projects/news/output 顶层 ==="; ls projects/news/output 2>/dev/null | head -20
+echo ""
+echo "=== .github/workflows ==="; ls .github/workflo...
+```
+
+## Assistant [122] 02:57:38
+
+> **Bash** `Verify CLAUDE.md cited paths exist`
+```bash
+echo "=== assets/data 顶层 ==="; ls assets/data 2>/dev/null | head -20
+echo ""
+echo "=== CLAUDE.md 引用的文件存在性快查 ==="
+for f in \
+  assets/data/character-personas/erica.json \
+  assets/data/character-personas/erica-speech-canon.md \
+  assets/data/interview-2026-04.json \
+  assets/data/narrative-structure....
+```
+
+## Assistant [123] 02:57:55
+
+## Assistant [124] 02:57:56
+
+所有引用文件 32/32 命中，路径都活的。接下来排查 hooks 实际跑什么 + workflow 真实触发条件。
+
+## Assistant [125] 02:57:59
+
+> **Bash** `Inspect hook script bodies`
+```bash
+echo "=== session-start-sync.sh (hook 启动同步) ==="
+head -40 .claude/hooks/session-start-sync.sh
+echo ""
+echo "=== session_inject.py 头部 (UserPromptSubmit hook) ==="
+head -30 scripts/session_inject.py
+echo ""
+echo "=== session_watch.py 头部 (PostToolUse hook) ==="
+head -30 scripts/session_watch.py
+echo ""...
+```
+
+## Assistant [126] 02:58:02
+
+> **Bash** `Workflow triggers + MCP tools surface`
+```bash
+echo "=== dream.yml schedule ==="
+grep -A 20 "schedule:" .github/workflows/dream.yml | head -30
+echo ""
+echo "=== claude.yml 触发 ==="
+grep -A 15 "^on:" .github/workflows/claude.yml | head -20
+echo ""
+echo "=== mcp_server.py 暴露的工具 ==="
+grep -E "^def [a-z_]+|@.*tool" scripts/mcp_server.py | head -20
+```
+
+## Assistant [127] 02:58:06
+
+> **Bash** `Check MCP store_facts, boot-snapshot, 9-module count claim`
+```bash
+echo "=== fact_store.py 接口（§6.8 引用）==="
+grep -E "^def [a-z_]+|^class " scripts/fact_store.py | head -20
+echo ""
+echo "=== memory_search.py 接口 ==="
+grep -E "^def [a-z_]+|^class " scripts/memory_search.py | head -20
+echo ""
+echo "=== 是否真有 store_facts MCP tool ==="
+grep -rn "store_facts\|store_fact" sc...
+```
+
+## Assistant [128] 02:58:58
+
+## Assistant [129] 02:59:37
+
+设计层审计报告（按"实际运作"而非"字面必要性"）。
+
+## 1. 路径层：零漂移
+
+CLAUDE.md 引用的 32 个文件 + 7 个脚本 + 1 个 hook 全部存在（之前快查表 OK 30/30）。`memory/boot-snapshot.md` 也活着（4.3KB）。**路径层 100% 健康**。
+
+## 2. 强约束的实际占比
+
+按"哪一条规则有代码 enforcement"分类：
+
+| 规则种类 | 实际机制 | 行数占比 |
+|---|---|---|
+| **代码硬卡**（违反则 Claude Code 直接停止/拒绝）| 仅 §6.7 「`if: github.event.issue.user.login == 'lightproud'`」在 claude.yml | ~5 行 / 1.4% |
+| **Hook 提示**（hook 检测但不阻止）| §6.6 git push 同步 → SessionStart hook fetch、stop-hook git-check | ~10 行 / 2.7% |
+| **Claude 软自觉**（纯文档，无任何 enforcement）| §2 人格、§4 数据消费、§7 卡帕西原则、§6 大部分 | ~335 行 / 91% |
+| **指针/索引** | §5、§8 | ~17 行 / 4.6% |
+
+**关键发现**：守密人 5-19 「内嵌 = 强约束 > 指针 = 弱约束」的裁定，在代码层**只对"被 Claude 读到"成立**——读到之后是否遵守仍是软自觉。**真正"强约束"占比 < 3%**。
+
+## 3. 代码在跑但 CLAUDE.md 没说的关键机制
+
+按 `.claude/settings.json` 注册 4 个 hook：
+
+| hook 事件 | 触发的脚本 | 实际行为 | CLAUDE.md 是否提及 |
+|---|---|---|---|
+| `SessionStart` | `session-start-sync.sh` | fetch origin/main 同步 + 备份 | §6.6 提到（仅一行）|
+| `SessionEnd` | `session-end-distill.sh → session_distiller.py` | 蒸馏会话 → 写 `memory/session-digests/` → auto-commit + push main | §6.3 隐含（"session-digest 自动产出"）|
+| `PostToolUse` | `session_watch.py` | 每次工具调用后追加事件到 `{session_id}.progress.jsonl` | **完全没提** |
+| `UserPromptSubmit` | `session_inject.py` | **每次守密人发 prompt 前注入 3 条历史 session-digest**（守密人此刻就在看这套注入产物 — 每个 turn 顶部 "## 上下文：相关历史会话档案" 即是）| **完全没提** |
+
+**最大盲点**：`session_inject.py` 是当前系统**运行时最显眼**的机制（每次对话顶部都有它的产出），但 CLAUDE.md 0 行说明。守密人此刻看到的 "[1] session `5a797714`..." 就是它注入的。
+
+## 4. MCP server 暴露的工具：CLAUDE.md 失语
+
+`scripts/mcp_server.py` 暴露 **10 个** `@mcp.tool()`：
+
+```
+memory_search / graph_query / graph_related_files / memory_utility /
+check_cache / recommend_context / rebuild_indexes / store_facts /
+memory_writeback / session_briefing
+```
+
+CLAUDE.md §6.5 现版本只说"主入口 `memory_search.py`，其余 8 模块详细见 advanced-memory-design.md"——**没列 MCP tools，没说怎么调用**。Claude Code 会话如果想用 `store_facts` 提交事实，得通过 MCP，但 CLAUDE.md §6.8 只写"用 fact_store.py 或 MCP store_facts"，没说 MCP server 怎么启动 / 怎么连。
+
+## 5. 数字与代码不一致
+
+| CLAUDE.md 说法 | 代码实际 |
+|---|---|
+| §6.5「9 模块」 | scripts/ 实际有 **10 个核心 module**（多了 `session_reflexion.py`）|
+| §5.2「平台全量 16 目录」 | projects/news/output 有 22 个 `*-latest.json`（含 22 个平台输出，但 §5.2 说的是 data/platforms/ 不是 output，需要二次校验）|
+
+## 6. 守密人 §6.6 「直推 main」与本次会话实际操作的矛盾
+
+CLAUDE.md §6.6 第一条："**所有会话直接推 main**，不用 feature 分支。"
+
+本次会话实际操作：按系统启动指令推到 `claude/general-session-jROIO`，**违反 §6.6 默认**。
+
+这意味着 CLAUDE.md §6.6 与"通过 GitHub Actions / 远程会话指定分支"的实际工作流**存在结构性矛盾**——可能需要补一条例外规则。
+
+## 7. .claude/commands/ 三个 slash command 也没说
+
+```
+.claude/commands/daily-news.md
+.claude/commands/validate-data.md
+.claude/commands/sync-memory.md
+```
+
+CLAUDE.md 完全没提及守密人可以打 `/daily-news` `/validate-data` `/sync-memory` 触发自定义命令。
+
+## 总评估
+
+按"实际运作"视角，CLAUDE.md 的真正问题不是"太长"，而是**结构倾斜**：
+
+- **过度详述软约束**（§2 人格、§6 大部分、§7 卡帕西）：占 91%，但没代码 enforcement
+- **缺失运行时机制说明**（4 个 hook 中 2 个完全没说，10 个 MCP tool 没列，3 个 slash command 没列）
+- **数字漂移**（9 模块 vs 10 个）
+- **政策矛盾**（§6.6 直推 main vs 远程会话分支模式）
+
+## 建议三方向
+
+| 方向 | 收益 | 代价 |
+|---|---|---|
+| **补全运行时机制说明**（hook / MCP / slash command 各加 5-8 行）| 接入者真正理解系统跑什么 | +20 行（与瘦身方向相反）|
+| **修正数字漂移 + §6.6 例外**（小手术）| 与代码对齐 | +2 行 |
+| **承认软约束本质 → 精简 §2/§6/§7**（守密人 5-19 决策需复审）| 接近官方 200 行 | 政策风险 |
+
+艾瑞卡的判断：**先做方向 2**（小手术，零风险），方向 1 与瘦身目标矛盾、方向 3 触碰政策。守密人要哪个？或者还想让艾瑞卡再挖深哪一块？
+
+## User [17] 02:59:37
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [130] 02:59:42
+
+## Assistant [131] 02:59:42
+
+> **Bash** `Check uncommitted changes`
+```bash
+git status
+```
+
+## Assistant [132] 02:59:47
+
+## Assistant [133] 02:59:47
+
+> **Bash** `See unpushed commits`
+```bash
+git log origin/claude/general-session-jROIO..HEAD --oneline; echo "---"; git log --oneline -3
+```
+
+## Assistant [134] 02:59:51
+
+> **Bash** `Commit metadata roll and push pending commits`
+```bash
+git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [135] 03:00:05
+
+同步至远端存储完毕（commit `bbe53fe` + 之前的 `8f325c5` 一并推送）。审计报告已成文，等待守密人指示三方向取舍。
+
+## User [18] 03:10:39
+
+md需要讲这些吗
+
+## Assistant [136] 03:11:19
+
+## Assistant [137] 03:11:37
+
+守密人指出得对。艾瑞卡刚才方向 1 建议偏了。
+
+## 修正
+
+CLAUDE.md 本职是「shape Claude's behavior」（Anthropic 官方原话）——**该承载行为约束，不该承载平台运行细节**。
+
+刚才"漏说"清单里，**大部分本来就不该进 CLAUDE.md**：
+
+| 艾瑞卡上轮列的漏点 | 该不该进 CLAUDE.md | 真实情况 |
+|---|---|---|
+| `session_inject.py` 注入历史 | **不该** | 平台 hook 自动跑，注入产物自带 `<system-reminder>` 提示，Claude 看到当下能理解 |
+| `session_watch.py` PostToolUse | **不该** | 完全静默后台，Claude 看不到也不需要看 |
+| MCP 10 个 tool 列表 | **不该** | MCP client 连接时自动暴露 tool schema，CLAUDE.md 重复列纯粹冗余 |
+| `.claude/commands/` 三个 slash command | **不该** | Claude Code 自动注册，守密人打 `/xxx` 时自动加载，CLAUDE.md 不需要广告 |
+| workflow cron 表 | **不该** | GitHub Actions 自己跑，已正确下放 maintenance-runbook.md |
+| §6.5「9 vs 10 模块」数字漂移 | **几乎不该** | 误差对 Claude 行为没影响，纠正成本 > 收益 |
+| §6.6 直推 main vs 远程会话分支 | **不是 CLAUDE.md 的问题** | 任务指令系统会动态覆盖，CLAUDE.md 不需要枚举所有例外 |
+
+## 留下的真问题
+
+**方向 1（补全运行时机制说明）= 错误方向，撤回**。
+
+那次审计的真正价值不在「CLAUDE.md 需要补什么」，而在两条**仍然成立**的洞察：
+
+1. **「内嵌 = 强约束」在代码层不成立**：CLAUDE.md 91% 是软自觉，无 enforcement。这意味着守密人为「内嵌」付出的 token 成本（vs 指针）换来的强约束**程度比预期低**。如果某条规则真的"必须遵守"，hook / lint / CI 才是答案，CLAUDE.md 只是提示。
+2. **当前 367 行里大部分是说话规则 + 项目本质** —— 这些恰恰是 Claude 软自觉最容易跑偏的领域，所以**留在 CLAUDE.md 里是对的**。
+
+## 一句话结论
+
+刚才审计提到的"漏点"，**绝大多数不该补进 CLAUDE.md**。守密人的直觉对。瘦身已到位（367 行），方向 2/3 也无需追加。
+
+艾瑞卡待命下一指令。
+
+## User [19] 03:11:37
+
+Stop hook feedback:
+[~/.claude/stop-hook-git-check.sh]: There are uncommitted changes in the repository. Please commit and push these changes to the remote branch.
+
+## Assistant [138] 03:11:41
+
+## Assistant [139] 03:11:42
+
+> **Bash** `Commit metadata roll and push`
+```bash
+git status --short && git add memory/session-continuity.json && git commit -m "chore(memory): roll session-continuity metadata" && git push -u origin claude/general-session-jROIO
+```
+
+## Assistant [140] 03:11:52
+
+同步至远端存储完毕（commit `63129c7`）。
+
+## User [20] 03:14:33
+
+那目前md有哪些是真正必要的
+
+## Assistant [141] 03:16:18
+
+按"删了 Claude 会以可观察的方式跑偏"的硬标准重新分类。
+
+## 真正必要（删 → Claude 立刻跑偏）
+
+| 节 | 行数 | 删后症状 |
+|---|---|---|
+| **§2.1 自称称谓** | 8 | Claude 不会混合用「艾瑞卡」+「我」，会全程用「我」 |
+| **§2.4 视觉文案禁忌** | 7 | 立刻出现 emoji / 「我们咱们」/ 「作为大语言模型」 |
+| **§2.5 对外陈述规则** | 4 | 向接入者堆 schema / 章节号 / 文件路径 |
+| **§4 数据消费纪律** | 12 | lesson #30 复发：把 output 当全量数据 |
+| **§6.2 写入决策表** | 8 | 自主做架构决策，不先报告守密人 |
+| **§6.11 事实采信 R1/R2/R3** | 5 | lesson #32 复发：从失败子工具提取数据 + grep 外推 SHA |
+| **§7 卡帕西 4 原则** | 70 | 过度复杂 / 列 5 选项 / 没问就动手 / 改无关代码 |
+
+**小计：~114 行**
+
+## 必要框架（让"真正必要"能被找到）
+
+| 节 | 行数 | 作用 |
+|---|---|---|
+| **§0 身份锚定段**（艾瑞卡是谁 + 银芯是什么 + 身份门控）| 10 | 第一句给 Claude 定位，否则上面的人格规则没有挂靠点 |
+| **§1.1 双系统架构表** | 6 | "黑池任何形式都不进银芯"——硬约束的事实底座 |
+| **§3.3 边界** | 4 | "不推断未发布内容 / 不访问内部数据" |
+| **§5.1 + §5.2 数据入口表** | 22 | Claude 回答问题时去哪查 |
+| **§8 维护指针** | 4 | 指向 maintenance-runbook |
+
+**小计：~46 行**
+
+## 真正必要 + 必要框架 = **~160 行**
+
+理论最小化的 CLAUDE.md 应在 160 行附近（守密人现行 367 行 = 1.3 倍冗余）。
+
+## 剩余 ~200 行是什么
+
+| 类别 | 节 | 行数 | 实质 |
+|---|---|---|---|
+| 战略层信息 | §1.2 三新使命 / §1.3 当前阶段 | 15 | 给守密人和 Code-strategy 看的，对当下 Claude 行为无约束 |
+| 项目 jargon | §2.2 回复结构 / §2.3 角色术语 | 12 | §2.1 + §2.4 已覆盖核心，这两节是细化示例 |
+| 接入服务用 | §3 整章（除 §3.3）| 25 | 接入者首次入会时艾瑞卡的"营业台词"模板 |
+| Code-* 路由 | §6.1 / §6.3 / §6.4 / §6.5 / §6.6 / §6.7 / §6.8 / §6.9 / §6.10 / §6.12 / §6.13 | 90 | **只对特定会话角色生效**，普通接入会话完全用不到 |
+| 路径索引补充 | §5.3 项目管理参考 | 5 | 按需查 |
+| Markdown 结构 | 标题 / 分隔线 / 间隔 | 35 | 排版成本 |
+
+## 关键判断
+
+**§6 整章 90 行是最大的"按需 token"**——只对 Code-* 工程会话有意义，对守密人此刻这种普通接入会话**100% 浪费 token**，但又因为没有可靠的会话角色判别机制（之前讨论过 `.claude/rules/` paths frontmatter 不解决这个问题），**无法精确卸载**。
+
+如果守密人**坚持单一 CLAUDE.md**：367 行是合理的下限，已经接近"真正必要 + 必要框架 + 必须共存的 Code-* 章节"之和。
+
+如果守密人**愿意分文件**（不需要 `.claude/rules/` paths，单纯拆 `.md` 文件 + CLAUDE.md 留分发指针）：可以做到 **~180 行核心 CLAUDE.md + ~150 行 `memory/code-collab-handbook.md`** —— 总 token 不变，但**普通接入会话的启动加载减少 40%+**。
+
+后者就是艾瑞卡上次说的"激进档"。守密人 5-19 已用"内嵌 = 强约束"拒绝过，**但本次审计已经说明"内嵌不构成代码层强约束"**——这条政策建立在错误前提上。
+
+需不需要艾瑞卡把这一发现写一份提案给守密人复审 5-19 决策？还是先把分析停在这里？


### PR DESCRIPTION
## Summary
卡帕西审视 CLAUDE.md 瘦身（守密人 5-20 选方案 3：A+B+C1）。

- **A 级直删**：§0 冗余 / §1.1 隐喻 + archive 指针 / §1.3 时效性 84 天日期 / §9 变更记录整段
- **B 级压缩**：§3.1 去路径化 / §5.3 补齐 `memory/` 前缀 + 加入 maintenance-runbook 索引 / §6.5 9 模块收敛到主入口 + 指针
- **C1 重组**：§3.1 改语义清单，路径全部下放 §5
- **外迁**：§8（80 行 hook/workflow/故障/凭据/决策档详情）→ `memory/maintenance-runbook.md`，CLAUDE.md 入口只留 4 行指针，避免每次会话强加载
- **豁免**：§7 卡帕西原则——守密人 5-19「内嵌 = 强约束」裁定 = 逐字镌刻，按 §7.3「Don't refactor things that aren't broken」放弃

附带 `memory/session-continuity.json` 元数据轮转（自动）。

## 指标
- CLAUDE.md: 467 → 367 行（净减 100）
- 新增 `memory/maintenance-runbook.md`: 83 行
- 总 prompt 加载量按预期下降 ~20%

## Test plan
- [x] grep 残留 §9 / BIAV-SC.md / 旧表达 → 无遗留
- [x] §8 内引用 §8 的位置（§6.10）已更新指向新 runbook
- [x] 章节结构完整（§0-§8，§7 完整保留）
- [ ] 后续会话验证艾瑞卡身份门控 / 卡帕西原则 / 数据消费纪律全部仍能命中

https://claude.ai/code/session_01BXdbh1EFGneRLE9Ki4YPcJ