### PR TITLE
fix: 仓库代码结构审视修正（外科手术式）

### DIFF
--- a/.github/workflows/backfill-gap.yml
+++ b/.github/workflows/backfill-gap.yml
@@ -3,12 +3,17 @@ name: Backfill Apr 13-25 Data Gap
 on:
   workflow_dispatch:
 
+concurrency:
+  group: backfill-gap-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
 jobs:
   backfill:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/backfill-news.yml
+++ b/.github/workflows/backfill-news.yml
@@ -16,6 +16,10 @@ on:
         default: '5'
         type: string
 
+concurrency:
+  group: backfill-news-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+concurrency:
+  group: check-version-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write
@@ -14,6 +18,7 @@ jobs:
   check-version:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,10 +5,15 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: claude-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: github.event.issue.user.login == 'lightproud'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/cleanup-stale-branches.yml
+++ b/.github/workflows/cleanup-stale-branches.yml
@@ -20,6 +20,10 @@ on:
         default: '30'
         type: string
 
+concurrency:
+  group: cleanup-stale-branches-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -27,6 +31,7 @@ jobs:
   cleanup:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
       STALE_DAYS: ${{ github.event_name == 'workflow_dispatch' && inputs.stale_days || '30' }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -14,12 +14,17 @@ on:
       - '.github/workflows/deploy-site.yml'
   workflow_dispatch:
 
+concurrency:
+  group: deploy-site-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/discord-archive.yml
+++ b/.github/workflows/discord-archive.yml
@@ -17,6 +17,10 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: discord-archive-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -24,6 +28,7 @@ jobs:
   archive:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/discord-history-backfill.yml
+++ b/.github/workflows/discord-history-backfill.yml
@@ -6,6 +6,10 @@ on:
     - cron: '30 * * * *'
   workflow_dispatch:
 
+concurrency:
+  group: discord-history-backfill-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/extract-game-data.yml
+++ b/.github/workflows/extract-game-data.yml
@@ -17,6 +17,10 @@ on:
         default: 'true'
         type: boolean
 
+concurrency:
+  group: extract-game-data-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/fetch-wiki-data.yml
+++ b/.github/workflows/fetch-wiki-data.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: 'all'
 
+concurrency:
+  group: fetch-wiki-data-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/test-collectors.yml
+++ b/.github/workflows/test-collectors.yml
@@ -9,6 +9,10 @@ on:
         default: 'main'
         type: string
 
+concurrency:
+  group: test-collectors-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -16,6 +20,7 @@ jobs:
   test-aggregator:
     name: Test aggregator.py collectors
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -137,6 +142,7 @@ jobs:
   test-global-collectors:
     name: Test global_collectors
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/update-news.yml
+++ b/.github/workflows/update-news.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch:
 
+concurrency:
+  group: update-news-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -13,6 +17,7 @@ jobs:
   update:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -12,9 +12,14 @@ on:
       - 'projects/wiki/data/**'
   workflow_dispatch:
 
+concurrency:
+  group: validate-data-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ memory/session-digests/*.json
 # 但不入 git，避免反复 commit 噪音。
 memory/session-digests/*.jsonl
 memory/session-digests/*.progress.jsonl
+
+# frida hook 逆向工具临时产出（extracted_lua/ 下已入库的文件不受影响）
+extracted_lua/hook_capture/
+extracted_lua/plaintext_from_memory/

--- a/_frida_hook_v2.py
+++ b/_frida_hook_v2.py
@@ -4,10 +4,11 @@ Polls for Morimens.exe, attaches ASAP, captures both bytecode AND plaintext Lua 
 """
 import frida, sys, os, time, hashlib
 
-OUT_DIR = r"C:\Users\light\brain-in-a-vat\extracted_lua\hook_capture"
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+OUT_DIR = os.path.join(BASE_DIR, "extracted_lua", "hook_capture")
 os.makedirs(OUT_DIR, exist_ok=True)
 
-LOG = open(r"C:\Users\light\brain-in-a-vat\_frida_hook_v2.log", "w", encoding="utf-8")
+LOG = open(os.path.join(BASE_DIR, "_frida_hook_v2.log"), "w", encoding="utf-8")
 
 def log(*a):
     msg = time.strftime("[%H:%M:%S] ") + " ".join(str(x) for x in a)
@@ -112,7 +113,7 @@ if (xluaL_loadbuffer) {
 
 # Preload existing hashes for dedup
 seen_hashes = set()
-for d in [OUT_DIR, r"C:\Users\light\brain-in-a-vat\extracted_lua\plaintext_from_memory"]:
+for d in [OUT_DIR, os.path.join(BASE_DIR, "extracted_lua", "plaintext_from_memory")]:
     if not os.path.isdir(d):
         continue
     for f in os.listdir(d):

--- a/_run_hook_v2.bat
+++ b/_run_hook_v2.bat
@@ -4,6 +4,6 @@ echo Killing old python processes...
 taskkill /f /im python.exe 2>nul
 timeout /t 2 /nobreak >nul
 echo Starting hook V2 (will wait for game)...
-cd /d C:\Users\light\brain-in-a-vat
+cd /d "%~dp0"
 python _frida_hook_v2.py
 pause

--- a/projects/news/scripts/aggregator.py
+++ b/projects/news/scripts/aggregator.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import os
 import re
+import sys
 import time
 import logging
 import requests
@@ -2091,7 +2092,7 @@ def run():
             OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
             with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
                 json.dump(output, f, ensure_ascii=False, indent=2)
-        return
+        return False
 
     # Generate summary
     summary = generate_summary(unique_news)
@@ -2116,6 +2117,9 @@ def run():
     except ImportError:
         pass
 
+    return True
+
 
 if __name__ == '__main__':
-    run()
+    empty_run = run() is False
+    sys.exit(1 if empty_run else 0)

--- a/projects/wiki/.gitignore
+++ b/projects/wiki/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+dist/
 docs/.vitepress/dist/
 docs/.vitepress/cache/
 .DS_Store

--- a/projects/wiki/scripts/validate_data.py
+++ b/projects/wiki/scripts/validate_data.py
@@ -84,7 +84,12 @@ def validate_schemas(loaded: dict[str, object]) -> list[str]:
     errors = []
 
     if not HAS_JSONSCHEMA:
-        print("  SKIP  Schema validation (jsonschema not installed)")
+        print("  ERROR jsonschema not installed — schema validation cannot run.")
+        print("        Install with: pip install jsonschema")
+        errors.append(
+            "  FAIL  Schema validation: jsonschema library missing"
+            " (pip install jsonschema)"
+        )
         return errors
 
     for data_file, schema_file in SCHEMA_MAP.items():

--- a/scripts/context_manager.py
+++ b/scripts/context_manager.py
@@ -139,9 +139,10 @@ def recommend_context(
 
     recommended = []
     for fp, data in sorted_candidates:
+        score = min(1.0, max(0.0, data["score"]))
         recommended.append({
             "file": fp,
-            "score": round(data["score"], 3),
+            "score": round(score, 3),
             "reason": "+".join(data["reasons"]),
         })
 

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -26,6 +26,8 @@ from hashlib import md5
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from io_utils import write_text_atomic
 TODAY = date.today()
 DREAMS_DIR = REPO / "memory" / "dreams"
 INSIGHTS_FILE = DREAMS_DIR / "insights.json"
@@ -139,10 +141,7 @@ def load_sentinel_baseline() -> dict:
 
 def save_sentinel_baseline(data: dict):
     """Save sentinel baseline to disk."""
-    SENTINEL_BASELINE.parent.mkdir(parents=True, exist_ok=True)
-    SENTINEL_BASELINE.write_text(
-        json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
-    )
+    write_text_atomic(SENTINEL_BASELINE, json.dumps(data, ensure_ascii=False, indent=2))
 
 
 def extract_source_metrics(source: str, items: list) -> dict:
@@ -379,10 +378,7 @@ def archive_integrity_scan() -> list[dict]:
         },
     }
     try:
-        ARCHIVE_INTEGRITY_FILE.parent.mkdir(parents=True, exist_ok=True)
-        ARCHIVE_INTEGRITY_FILE.write_text(
-            json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
-        )
+        write_text_atomic(ARCHIVE_INTEGRITY_FILE, json.dumps(report, ensure_ascii=False, indent=2))
     except OSError:
         pass
 
@@ -556,9 +552,7 @@ def sentinel_scan() -> list[dict]:
                 pass
         existing_alerts.append(alert_record)
         existing_alerts = existing_alerts[-30:]
-        ALERTS_FILE.write_text(
-            json.dumps(existing_alerts, ensure_ascii=False, indent=2), encoding="utf-8"
-        )
+        write_text_atomic(ALERTS_FILE, json.dumps(existing_alerts, ensure_ascii=False, indent=2))
 
     return alerts
 
@@ -1024,10 +1018,7 @@ def update_precomputed_cache(entries: list[dict]):
         "entries": entries,
     }
 
-    CACHE_FILE.write_text(
-        json.dumps(cache, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+    write_text_atomic(CACHE_FILE, json.dumps(cache, ensure_ascii=False, indent=2))
     return len(entries)
 
 
@@ -1087,10 +1078,7 @@ def update_semantic_index(keyword_index: dict, ai_insights: dict = None):
     if ai_insights:
         index_data["ai_insights"] = ai_insights
 
-    SEMANTIC_INDEX.write_text(
-        json.dumps(index_data, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+    write_text_atomic(SEMANTIC_INDEX, json.dumps(index_data, ensure_ascii=False, indent=2))
     return str(SEMANTIC_INDEX.relative_to(REPO))
 
 
@@ -1108,10 +1096,7 @@ def save_dream_journal(phase1_results: dict, phase2_results: dict = None):
         journal["phase2"] = phase2_results
 
     journal_file = DREAMS_DIR / f"{TODAY.isoformat()}.json"
-    journal_file.write_text(
-        json.dumps(journal, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+    write_text_atomic(journal_file, json.dumps(journal, ensure_ascii=False, indent=2))
 
     # Also save/update insights.json
     if phase2_results and "insights" in phase2_results:
@@ -1139,10 +1124,7 @@ def save_insights(new_insights: list):
     # Keep last 100 insights
     existing = existing[-100:]
 
-    INSIGHTS_FILE.write_text(
-        json.dumps(existing, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+    write_text_atomic(INSIGHTS_FILE, json.dumps(existing, ensure_ascii=False, indent=2))
 
 
 def load_access_log(last_n: int = 30) -> list[dict]:
@@ -1184,10 +1166,7 @@ def log_access(files_accessed: list[str]):
     }
 
     entry_file = ACCESS_LOG_DIR / f"{TODAY.isoformat()}.json"
-    entry_file.write_text(
-        json.dumps(entry, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+    write_text_atomic(entry_file, json.dumps(entry, ensure_ascii=False, indent=2))
 
     # Cleanup: keep last 30 days of files
     all_files = sorted(ACCESS_LOG_DIR.glob("*.json"))
@@ -1237,7 +1216,7 @@ def run_phase1() -> dict:
     try:
         from boot_snapshot import generate_snapshot
         snapshot_path = REPO / "memory" / "boot-snapshot.md"
-        snapshot_path.write_text(generate_snapshot() + "\n", encoding="utf-8")
+        write_text_atomic(snapshot_path, generate_snapshot() + "\n")
         print("  Boot snapshot updated")
     except Exception as e:
         print(f"  Boot snapshot failed: {e}")
@@ -1637,7 +1616,7 @@ def run_rem(client=None) -> dict:
     }
 
     report_file = REPO / "memory" / "dreams" / f"{TODAY.isocalendar()[0]}-W{TODAY.isocalendar()[1]:02d}-weekly.json"
-    report_file.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    write_text_atomic(report_file, json.dumps(report, ensure_ascii=False, indent=2))
     print(f"  - Weekly report saved: {report_file.relative_to(REPO)}")
 
     return report
@@ -1832,10 +1811,7 @@ def _save_insights(new_insights: list[dict]):
 
     existing.extend(new_insights)
 
-    insights_file.write_text(
-        json.dumps(existing, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+    write_text_atomic(insights_file, json.dumps(existing, ensure_ascii=False, indent=2))
 
 
 def _append_lessons(new_lessons: list[dict]):
@@ -1870,7 +1846,7 @@ def _append_lessons(new_lessons: list[dict]):
             text, count=1,
         )
         text += "\n" + "\n".join(additions) + "\n"
-        ll_file.write_text(text, encoding="utf-8")
+        write_text_atomic(ll_file, text)
 
 
 def main():

--- a/scripts/fact_store.py
+++ b/scripts/fact_store.py
@@ -23,6 +23,8 @@ from datetime import date, datetime
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from io_utils import write_text_atomic
 FACTS_FILE = REPO / "memory" / "facts.json"
 TODAY = date.today()
 
@@ -100,11 +102,7 @@ def load_facts() -> list[dict]:
 
 def save_facts(facts: list[dict]):
     """Save facts to disk."""
-    FACTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    FACTS_FILE.write_text(
-        json.dumps(facts, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+    write_text_atomic(FACTS_FILE, json.dumps(facts, ensure_ascii=False, indent=2))
 
 
 def find_duplicate(new_fact: str, existing_facts: list[dict]) -> tuple[int, float]:

--- a/scripts/io_utils.py
+++ b/scripts/io_utils.py
@@ -1,0 +1,19 @@
+"""io_utils.py — shared atomic file write helper."""
+import os
+import tempfile
+from pathlib import Path
+
+
+def write_text_atomic(path, content, encoding="utf-8"):
+    """Atomically write text to path via temp-file-then-rename (POSIX atomic)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as f:
+            f.write(content)
+        os.replace(tmp, str(path))
+    except Exception:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise

--- a/scripts/reflexion.py
+++ b/scripts/reflexion.py
@@ -19,6 +19,8 @@ from datetime import date, datetime
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from io_utils import write_text_atomic
 DREAMS_DIR = REPO / "memory" / "dreams"
 SEARCH_FAILURES_FILE = DREAMS_DIR / "search-failures.json"
 LESSONS_FILE = REPO / "memory" / "lessons-learned.md"
@@ -232,7 +234,7 @@ def write_lesson_to_file(lesson: dict, number: int) -> bool:
 
     text += entry
 
-    LESSONS_FILE.write_text(text, encoding="utf-8")
+    write_text_atomic(LESSONS_FILE, text)
     return True
 
 


### PR DESCRIPTION
## 概述

基于全仓库代码与结构审视（scripts 9 模块 / news 采集系统 / wiki / 14 workflow / 根目录散落文件），本 PR 修正已核实、外科手术式、低风险的问题。推测性重构与架构/安全变更未纳入（见末尾）。

## 修正内容

**根目录与配置**
- `_frida_hook_v2.py` / `_run_hook_v2.bat`：硬编码个人绝对路径 `C:\Users\light\...` → 脚本相对路径（`BASE_DIR`），消除用户名泄露与零移植性
- `.gitignore` / `projects/wiki/.gitignore`：补逆向工具临时产出 + VitePress 规则

**news 采集**
- `aggregator.py`：空跑改为非零退出，CI 可侦测采集中断（lesson #2）；既有 news.json 仍保留不被覆盖

**记忆系统 scripts/**
- 新增 `io_utils.py`：共享原子写助手（temp-then-rename）
- `reflexion.py` / `fact_store.py` / `dream.py`：关键数据文件改原子写，防崩溃丢数据
- `context_manager.py`：推荐评分钳制至 [0,1]，修复 boost 叠加溢出

**wiki 校验**
- `validate_data.py`：缺 jsonschema 时由静默 SKIP+exit0 改为硬失败 exit1，消除质量关卡假阳性

**workflow**
- 13 个 workflow 补 concurrency 组（防 main 推送竞态）+ 缺失的 timeout-minutes
- `dream.yml` 既有 concurrency 保持原样

## 验证
- 全部 8 个改动 Python 文件 `py_compile` 通过
- 14 个 workflow YAML `safe_load` 通过

## 审计中主动未执行（待守密人单独裁决）
- claude.yml 用户门控改动（安全/架构变更，§6.2 需批准）
- news 采集器抽公共基类 / generate_pages 改 YAML 库（推测性重构，会改输出，§7.3）
- knowledge_graph 加索引（217 节点规模属推测性优化，§7.2）
- workflow 权限收窄 / realms.json 创建（前者易误伤部署，后者需真实数据）

https://claude.ai/code/session_01VtJYkY3Qw6XfhzApQX1i91

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtJYkY3Qw6XfhzApQX1i91)_