### PR TITLE
fix: 审视修正（已 rebase 至当前 main，剔除被取代的 news 工作）

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   claude:
-    if: github.event.issue.user.login == 'lightproud'
+    if: github.event.issue.user.login == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/dream.yml
+++ b/.github/workflows/dream.yml
@@ -29,7 +29,6 @@ permissions:
   contents: write
   actions: read
   issues: write
-  pull-requests: write
   id-token: write
 
 jobs:

--- a/.github/workflows/fetch-wiki-data.yml
+++ b/.github/workflows/fetch-wiki-data.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install dependencies
+        run: pip install pyyaml
+
       - name: Fetch portraits
         if: >-
           github.event_name != 'workflow_dispatch' ||

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -16,6 +16,9 @@ concurrency:
   group: validate-data-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/projects/wiki/data/db/realms.json
+++ b/projects/wiki/data/db/realms.json
@@ -1,0 +1,90 @@
+{
+  "description": "Morimens 四大界域（属性体系）定义。字段采信纪律：id / name / name_en / color / core_mechanic 为公开可查阅事实（来源 memory/morimens-context.md 界域系统 + schema enum）；icon / difficulty / team_rule_v1 / team_rule_v2 / realm_talent / pure_resonance / co_resonance / starter_tip 为 fixture 占位，待真实游戏数据覆盖，遵循与 characters.json（Pandia fixture）同款约定，不得当正典引用。",
+  "team_rule": "v1：同界域阵容触发纯色共鸣加成；v2（钥令系统，2025.1 上线）解锁混域组队。详见 memory/morimens-context.md。",
+  "realms": [
+    {
+      "id": "chaos",
+      "name": "混沌",
+      "name_en": "Chaos",
+      "color": "#8b5cf6",
+      "icon": "fixture-icon-chaos",
+      "difficulty": 3,
+      "team_rule_v1": "fixture: 待真实数据覆盖",
+      "team_rule_v2": "fixture: 钥令系统下混域组队，待真实数据覆盖",
+      "realm_talent": {
+        "name": "fixture: 混沌界域天赋",
+        "description": "fixture: 待真实游戏数据覆盖"
+      },
+      "pure_resonance": {
+        "name": "银钥共鸣",
+        "description": "纯混沌阵容触发；混沌可与任何界域协同"
+      },
+      "co_resonance": [],
+      "core_mechanic": "死亡抵抗；银钥共鸣（纯混沌）；可与任何界域协同",
+      "starter_tip": "fixture: 待真实游戏数据覆盖"
+    },
+    {
+      "id": "aequor",
+      "name": "深海",
+      "name_en": "Deep Sea",
+      "color": "#3b82f6",
+      "icon": "fixture-icon-aequor",
+      "difficulty": 2,
+      "team_rule_v1": "fixture: 待真实数据覆盖",
+      "team_rule_v2": "fixture: 钥令系统下混域组队，待真实数据覆盖",
+      "realm_talent": {
+        "name": "fixture: 深海界域天赋",
+        "description": "fixture: 待真实游戏数据覆盖"
+      },
+      "pure_resonance": {
+        "name": "纯深海共鸣",
+        "description": "纯深海阵容加倍触腕生成"
+      },
+      "co_resonance": [],
+      "core_mechanic": "触腕自动攻击；纯深海加倍触腕生成",
+      "starter_tip": "fixture: 待真实游戏数据覆盖"
+    },
+    {
+      "id": "caro",
+      "name": "血肉",
+      "name_en": "Flesh",
+      "color": "#ef4444",
+      "icon": "fixture-icon-caro",
+      "difficulty": 2,
+      "team_rule_v1": "fixture: 待真实数据覆盖",
+      "team_rule_v2": "fixture: 钥令系统下混域组队，待真实数据覆盖",
+      "realm_talent": {
+        "name": "fixture: 血肉界域天赋",
+        "description": "fixture: 待真实游戏数据覆盖"
+      },
+      "pure_resonance": {
+        "name": "纯血肉共鸣",
+        "description": "fixture: 胚胎融合相关，待真实游戏数据覆盖"
+      },
+      "co_resonance": [],
+      "core_mechanic": "胚胎融合系统（0→100% 生成胚胎卡）；吞噬机制",
+      "starter_tip": "fixture: 待真实游戏数据覆盖"
+    },
+    {
+      "id": "ultra",
+      "name": "超维",
+      "name_en": "Hyperdimension",
+      "color": "#eab308",
+      "icon": "fixture-icon-ultra",
+      "difficulty": 4,
+      "team_rule_v1": "fixture: 待真实数据覆盖",
+      "team_rule_v2": "fixture: 钥令系统下混域组队，待真实数据覆盖",
+      "realm_talent": {
+        "name": "fixture: 超维界域天赋",
+        "description": "fixture: 待真实游戏数据覆盖"
+      },
+      "pure_resonance": {
+        "name": "纯超维共鸣",
+        "description": "fixture: 超维空间卡牌复制相关，待真实游戏数据覆盖"
+      },
+      "co_resonance": [],
+      "core_mechanic": "超维空间卡牌复制；额外回合机制",
+      "starter_tip": "fixture: 待真实游戏数据覆盖"
+    }
+  ]
+}

--- a/projects/wiki/scripts/generate_pages.py
+++ b/projects/wiki/scripts/generate_pages.py
@@ -18,6 +18,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -114,21 +116,17 @@ def generate_character_page(char: dict, lang: str) -> str:
     title_name = name_en if lang == "en" else name
     title_val = f"{title_name} | {L['title_suffix']}"
 
-    # Quote YAML values containing colons (lessons-learned #6)
-    if ':' in title_val:
-        title_val = f'"{title_val}"'
-    if ':' in desc_text:
-        desc_text = f'"{desc_text}"'
+    frontmatter = {
+        "title": title_val,
+        "description": desc_text,
+        "portrait": f"/portraits/{slug}.png",
+        "pageClass": "character-page",
+    }
+    fm_block = yaml.safe_dump(
+        frontmatter, allow_unicode=True, default_flow_style=False, sort_keys=False
+    )
 
-    return f"""---
-title: {title_val}
-description: {desc_text}
-portrait: /portraits/{slug}.png
-pageClass: character-page
----
-
-<CharacterSheet characterId="{cid}" />
-"""
+    return f"---\n{fm_block}---\n\n<CharacterSheet characterId=\"{cid}\" />\n"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/knowledge_graph.py
+++ b/scripts/knowledge_graph.py
@@ -633,17 +633,58 @@ def load_graph() -> dict | None:
         return None
 
 
+def _build_name_index(graph: dict) -> None:
+    """Build an inverted name index on graph in-place (not persisted to disk).
+
+    graph["_name_index"]: {lowercased_name_or_alias -> [node_id, ...]}
+
+    Called lazily by find_node() on first access.  The index is stored as a
+    plain dict on the in-memory graph object; json.dumps/load round-trips
+    intentionally exclude it (no schema pollution, no stale-index risk after
+    incremental_update adds nodes).
+    """
+    index: dict[str, list[str]] = defaultdict(list)
+    for nid, node in graph["nodes"].items():
+        name_lower = node.get("name", "").lower()
+        if name_lower:
+            index[name_lower].append(nid)
+        for alias in node.get("properties", {}).get("aliases", []):
+            alias_lower = alias.lower()
+            if alias_lower:
+                index[alias_lower].append(nid)
+    graph["_name_index"] = dict(index)
+
+
 def find_node(graph: dict, query: str) -> list[dict]:
-    """Find nodes matching a query string."""
+    """Find nodes matching a query string.
+
+    Exact name/alias hits are resolved via an inverted index (O(1) per lookup).
+    Substring and node-ID matches fall back to linear scan, preserving the
+    original result set and sort order (exact > partial > id).
+    """
+    # Lazily build the name index on first call for this graph object.
+    if "_name_index" not in graph:
+        _build_name_index(graph)
+
     query_lower = query.lower()
     matches = []
+    exact_ids: set[str] = set()
+
+    # --- Fast path: exact name / alias match via index ---
+    for nid in graph["_name_index"].get(query_lower, []):
+        node = graph["nodes"].get(nid)
+        if node is not None:
+            matches.append({"node": node, "match": "exact"})
+            exact_ids.add(nid)
+
+    # --- Slow path: substring / id scan (skip already-exact nodes) ---
     for nid, node in graph["nodes"].items():
+        if nid in exact_ids:
+            continue
         name = node.get("name", "").lower()
         aliases = [a.lower() for a in node.get("properties", {}).get("aliases", [])]
 
-        if query_lower == name or query_lower in aliases:
-            matches.append({"node": node, "match": "exact"})
-        elif query_lower in name or any(query_lower in a for a in aliases):
+        if query_lower in name or any(query_lower in a for a in aliases):
             matches.append({"node": node, "match": "partial"})
         elif query_lower in nid.lower():
             matches.append({"node": node, "match": "id"})


### PR DESCRIPTION
## 概述

本 PR 已 rebase 至当前 main 并解决冲突。期间发现 main 已**独立**完成 aggregator.py 上帝模块拆分（`aggregator_base.py` + `aggregator_collectors.py`）并加了空跑非零退出——故艾瑞卡早前的 news ABC 重构（base_fetcher.py）与空跑退出已被取代、予以剔除，避免回退 main 更优结构。

## 已应用（7 项，均经核实相对当前 main 仍为新增）

| 项 | 改动 | 验证 |
|----|------|------|
| realms.json 创建 | 4 界域（chaos/aequor/caro/ultra）事实文件 | validate_data **ALL PASSED**，24 角色外键 SKIP → PASS |
| claude.yml 门控泛化 | `'lightproud'` → `github.repository_owner`，安全等价、去硬编码 | YAML 校验通过 |
| generate_pages YAML 库 | frontmatter 改 PyYAML safe_dump，替代脆弱手工冒号转义（lesson #6） | dry-run + 冒号场景验证通过 |
| fetch-wiki-data 补依赖 | `pip install pyyaml`（generate_pages 现依赖 yaml） | YAML 校验通过 |
| validate-data 权限 | 钉 `permissions: contents: read`（最小权限） | YAML 校验通过 |
| dream 权限收窄 | 去多余 `pull-requests: write`（仅 issue/OIDC 操作，无 PR 操作） | YAML 校验通过 |
| knowledge_graph 索引 | find_node 加名称倒排索引（O(1) 精确命中，模糊回退保留，惰性重建不持久化，CONCEPT_DICT 重构未触碰） | py_compile + 13 例等价性自检通过 |

净 diff：7 文件（+154 / -20），mergeable_state: clean。

## 已剔除（被 main 取代）
- base_fetcher.py（main 已有 aggregator_base.py）
- aggregator.py 的 ABC 包装 + 空跑退出（main 已拆分并实现）

## realms.json 字段采信纪律
id / name / name_en / color / core_mechanic 为公开可查阅事实（morimens-context.md + schema enum）；icon / difficulty / team_rule / realm_talent / co_resonance / starter_tip 为 fixture 占位（root description 已显式标注），遵循 characters.json 同款约定，不可当正典引用。

## 范围外发现（既有问题，未触碰）
- test-collectors.yml import 了 `fetch_twitter` / `fetch_fandom_wiki`，二者在当前 aggregator 结构中不存在——既有缺陷。

https://claude.ai/code/session_01VtJYkY3Qw6XfhzApQX1i91