### PR TITLE
chore: 媒体补录改为每小时（清积压期）

### DIFF
--- a/.github/workflows/backfill-media.yml
+++ b/.github/workflows/backfill-media.yml
@@ -8,7 +8,7 @@ name: "🖼️ Backfill & Archive Media"
 
 on:
   schedule:
-    - cron: '0 3 * * *'   # 每日 03:00 UTC
+    - cron: '0 * * * *'   # 每小时（清积压期；积压补齐后可调回每日）
   workflow_dispatch:
     inputs:
       no_discord:
@@ -17,7 +17,7 @@ on:
         default: false
       budget:
         description: '运行预算秒数'
-        default: '3000'
+        default: '2400'
 
 concurrency:
   group: backfill-media


### PR DESCRIPTION
## 目标

按守密人要求，把媒体补录工作流从**每日**改为**每小时**，加快清理 ~51k Discord 图积压。

## 改动（仅 backfill-media.yml）

- `cron: '0 3 * * *'`（每日 03:00 UTC）→ `cron: '0 * * * *'`（每小时）
- 定时运行预算 fallback `3000`→`2400` 秒（<1h），配合 `concurrency`（cancel-in-progress:false 串行）避免堆积

补录脚本可续跑（清单中已 ok 的跳过），每小时增量补齐，积压收敛后可调回每日。

https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ)_