### PR TITLE
fix(docs): 修正 wiki 开发文档中不存在的 npm 脚本引用

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,7 +49,7 @@ AI 会话（C1）按既定政策直推 main，不走此模板。
 ## 验证清单
 
 - [ ] 本地跑通对应校验脚本（如 `python projects/wiki/scripts/validate_data.py` / `python assets/data/validate.py`）
-- [ ] 若涉及 site / wiki / news 视觉，已在本地预览（`npm run docs:dev` 或浏览器打开 HTML）
+- [ ] 若涉及 site / wiki / news 视觉，已在本地预览（`npm run dev` 或浏览器打开 HTML）
 - [ ] 不引入 emoji（按 `CLAUDE.md` 硬约束）
 - [ ] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案（这些归主控台）
 

--- a/memory/session-continuity.json
+++ b/memory/session-continuity.json
@@ -1,28 +1,46 @@
 {
   "last_session": {
-    "id": "a1ba5d67",
-    "timestamp": "2026-06-02T20:42:54.118000+00:00",
-    "duration_minutes": 1063.4,
-    "branch": "claude/inspiring-babbage-we5V8",
+    "id": "4b21de40",
+    "timestamp": "2026-06-02T21:34:28.471000+00:00",
+    "duration_minutes": 5.5,
+    "branch": "claude/todo-implementation-VrygM",
     "topics": [
-      "做梦Agent"
+      "Wiki"
     ],
     "decisions": [],
     "files_changed": [
-      "/home/user/brain-in-a-vat/.github/workflows/backfill-media.yml",
-      "/home/user/brain-in-a-vat/.github/workflows/daily-report.yml",
-      "/home/user/brain-in-a-vat/CLAUDE.md",
-      "/home/user/brain-in-a-vat/deliverables/2026-06/morimens_daily_20260601.md",
-      "/home/user/brain-in-a-vat/projects/news/scripts/backfill_media.py",
-      "/home/user/brain-in-a-vat/projects/news/scripts/collect_fanart.py",
-      "/home/user/brain-in-a-vat/scripts/report_render.py",
-      "/home/user/brain-in-a-vat/scripts/send_report_email.py",
-      "/tmp/extract2.py",
-      "/tmp/extract_0601.py"
+      "/home/user/brain-in-a-vat/.github/PULL_REQUEST_TEMPLATE.md",
+      "/home/user/brain-in-a-vat/projects/site/design/morimens-design-system-guide.html",
+      "/home/user/brain-in-a-vat/projects/wiki/CONTEXT.md"
     ],
-    "open_items": []
+    "open_items": [
+      "` / `# TODO` 注释**——grep 全仓（排除 `.git` 与历史会话摘要）零命中。多数审计点名项（`memory_search.py` 重复 import / 吞错 idiom、`dr"
+    ]
   },
   "recent_sessions": [
+    {
+      "id": "a1ba5d67",
+      "timestamp": "2026-06-02T20:42:54.118000+00:00",
+      "duration_minutes": 1063.4,
+      "branch": "claude/inspiring-babbage-we5V8",
+      "topics": [
+        "做梦Agent"
+      ],
+      "decisions": [],
+      "files_changed": [
+        "/home/user/brain-in-a-vat/.github/workflows/backfill-media.yml",
+        "/home/user/brain-in-a-vat/.github/workflows/daily-report.yml",
+        "/home/user/brain-in-a-vat/CLAUDE.md",
+        "/home/user/brain-in-a-vat/deliverables/2026-06/morimens_daily_20260601.md",
+        "/home/user/brain-in-a-vat/projects/news/scripts/backfill_media.py",
+        "/home/user/brain-in-a-vat/projects/news/scripts/collect_fanart.py",
+        "/home/user/brain-in-a-vat/scripts/report_render.py",
+        "/home/user/brain-in-a-vat/scripts/send_report_email.py",
+        "/tmp/extract2.py",
+        "/tmp/extract_0601.py"
+      ],
+      "open_items": []
+    },
     {
       "id": "0d95317a",
       "timestamp": "2026-06-02T20:09:31.061000+00:00",
@@ -164,29 +182,12 @@
         "/tmp/extract_0601.py"
       ],
       "open_items": []
-    },
-    {
-      "id": "dd763d51",
-      "timestamp": "2026-06-02T05:36:58.698000+00:00",
-      "duration_minutes": 157.5,
-      "branch": "claude/inspiring-babbage-we5V8",
-      "topics": [
-        "做梦Agent"
-      ],
-      "decisions": [],
-      "files_changed": [
-        "/home/user/brain-in-a-vat/.github/workflows/daily-report.yml",
-        "/home/user/brain-in-a-vat/deliverables/2026-06/morimens_daily_20260601.md",
-        "/home/user/brain-in-a-vat/scripts/send_report_email.py",
-        "/tmp/extract_0601.py"
-      ],
-      "open_items": []
     }
   ],
   "momentum": {
     "topic_weights": {
-      "做梦Agent": 4.82,
-      "Wiki": 0.14
+      "做梦Agent": 3.86,
+      "Wiki": 1.11
     },
     "hot_files": [
       "/home/user/brain-in-a-vat/.github/workflows/daily-report.yml",
@@ -196,7 +197,7 @@
       "/tmp/extract_0601.py",
       "/tmp/extract2.py"
     ],
-    "total_sessions": 129
+    "total_sessions": 130
   },
-  "updated_at": "2026-06-02T20:47:19.918672+00:00"
+  "updated_at": "2026-06-02T21:38:15.427861+00:00"
 }

--- a/memory/session-digests/20260602-213815-4b21de40.md
+++ b/memory/session-digests/20260602-213815-4b21de40.md
@@ -1,0 +1,361 @@
+# Session `4b21de40` — 2026-06-02
+
+- **session_id**: `4b21de40-5675-42cf-b79e-2b54af52c800`
+- **cwd**: `/home/user/brain-in-a-vat`
+- **time**: 2026-06-02T21:28:57.302000+00:00 .. 2026-06-02T21:34:28.471000+00:00
+- **duration**: 5m 31s
+- **turns**: user=38 / assistant=71
+- **tool calls**: 37
+- **compact events**: 0
+
+---
+
+## User [1] 21:28:57
+
+Search the codebase for TODO comments, select one that seems straightforward, and implement it.
+
+## Assistant [1] 21:29:16
+
+## Assistant [2] 21:29:16
+
+正在扫描仓库中的 TODO 标记......
+
+## Assistant [3] 21:29:18
+
+> **Bash** `Search for TODO comments`
+```bash
+grep -rn "TODO" --include="*.py" --include="*.js" --include="*.ts" --include="*.json" --include="*.md" --include="*.html" --include="*.css" . 2>/dev/null | grep -v node_modules | head -80
+```
+
+## Assistant [4] 21:29:22
+
+## Assistant [5] 21:29:22
+
+正在过滤历史日志，聚焦真实代码中的待办标记......
+
+## Assistant [6] 21:29:23
+
+> **Bash** `Search code files excluding digests`
+```bash
+grep -rn "TODO\|FIXME\|XXX" --include="*.py" --include="*.js" --include="*.ts" --include="*.html" --include="*.css" --include="*.vue" . 2>/dev/null | grep -v node_modules | grep -v "session-digests"
+```
+
+## Assistant [7] 21:29:31
+
+## Assistant [8] 21:29:31
+
+正在排查 checkbox 式待办与文档 TODO（排除历史摘要）......
+
+## Assistant [9] 21:29:32
+
+> **Bash** `Find markdown files with TODO markers`
+```bash
+grep -rln "TODO\|FIXME\|待实现\|待补充\|待填充" --include="*.md" . 2>/dev/null | grep -v "session-digests" | grep -v node_modules
+```
+
+## Assistant [10] 21:29:40
+
+> **Bash** `Inspect TODO mentions in docs`
+```bash
+grep -rn "TODO\|FIXME\|待实现\|待补充\|待填充" deliverables/2026-06/repo-health-assessment-2026-06-02.md memory/project-status.md 2>/dev/null | head -40
+```
+
+## Assistant [11] 21:29:46
+
+## Assistant [12] 21:29:49
+
+> **Bash** `Search shell/yaml and project scripts`
+```bash
+grep -rn "TODO\|FIXME" --include="*.sh" --include="*.yml" --include="*.yaml" --include="*.toml" --include="*.cfg" . 2>/dev/null | grep -v node_modules | grep -v session-digests; echo "---PY broader---"; grep -rn "TODO" projects/news/scripts projects/wiki/scripts scripts 2>/dev/null | grep -v "skip_m...
+```
+
+## Assistant [13] 21:29:53
+
+## Assistant [14] 21:29:55
+
+> **Bash** `Find comment-style TODO/FIXME everywhere`
+```bash
+grep -rEn "(#|//|<!--)\s*(TODO|FIXME)" . 2>/dev/null | grep -v node_modules | grep -v "memory/session-digests" | grep -v "\.git/"
+```
+
+## Assistant [15] 21:30:18
+
+## Assistant [16] 21:30:20
+
+> **Bash** `Search JSON data for TODO placeholders`
+```bash
+cd /home/user/brain-in-a-vat; grep -rn "TODO\|待补充\|待填充\|待实现\|placeholder\|PLACEHOLDER" --include="*.json" projects/ assets/ 2>/dev/null | grep -v node_modules | head -40
+```
+
+## Assistant [17] 21:30:25
+
+## Assistant [18] 21:30:26
+
+正在读取仓库健康评估档案，寻找可落地的小型待办......
+
+## Assistant [19] 21:30:26
+
+> **Read** `/home/user/brain-in-a-vat/deliverables/2026-06/repo-health-assessment-2026-06-02.md`
+
+## Assistant [20] 21:30:48
+
+## Assistant [21] 21:30:49
+
+正在定位语音框架档案，核实其待补充状态......
+
+## Assistant [22] 21:30:51
+
+> **Bash** `Locate voice_lines.json`
+```bash
+cd /home/user/brain-in-a-vat; find . -name "voice_lines.json" -not -path "*/node_modules/*" 2>/dev/null; echo "---"; grep -rn "TODO\|待补充\|待填\|pending\|placeholder\|待生成" $(find . -name "voice_lines.json" -not -path "*/node_modules/*" 2>/dev/null) 2>/dev/null | head
+```
+
+## Assistant [23] 21:30:54
+
+> **Bash** `Inspect voice_lines.json structure`
+```bash
+cd /home/user/brain-in-a-vat; python3 -c "import json;d=json.load(open('projects/wiki/data/processed/voice_lines.json'));print(type(d), len(d));import sys;print(json.dumps(d, ensure_ascii=False)[:1500])"
+```
+
+## Assistant [24] 21:31:04
+
+## Assistant [25] 21:31:04
+
+正在核验 `memory_search.py` 被反复点名却未修的两处代码异常......
+
+## Assistant [26] 21:31:04
+
+> **Bash** `View flagged lines in memory_search.py`
+```bash
+cd /home/user/brain-in-a-vat; sed -n '20,25p;660,675p;858,912p' scripts/memory_search.py | cat -n
+```
+
+## Assistant [27] 21:31:08
+
+## Assistant [28] 21:31:10
+
+> **Bash** `Find duplicate import and swallow idiom`
+```bash
+cd /home/user/brain-in-a-vat; echo "=== import re occurrences ==="; grep -n "import re" scripts/memory_search.py; echo "=== swallow-error idiom ==="; grep -n "except (ImportError, Exception)\|except (Exception" scripts/memory_search.py
+```
+
+## Assistant [29] 21:31:22
+
+## Assistant [30] 21:31:24
+
+两处被点名的 `memory_search.py` 异常已在历史中修正（当前无重复 import、无吞错 idiom）。正在核验评估报告里其余可落地的具体缺陷......
+
+## Assistant [31] 21:31:27
+
+> **Bash** `Check dream.yml and wiki page generator`
+```bash
+cd /home/user/brain-in-a-vat; echo "=== dream.yml around 100 ==="; grep -n "generate-report\|\.yml\|workflow" .github/workflows/dream.yml 2>/dev/null | head; echo "=== exists? ==="; ls .github/workflows/ | grep -i "generate-report\|report"; echo "=== lesson #7 leading slash in generate_wiki_pages ==...
+```
+
+## Assistant [32] 21:31:30
+
+> **Bash** `Read dream.yml workflow-check block`
+```bash
+cd /home/user/brain-in-a-vat; sed -n '90,135p' .github/workflows/dream.yml; echo "=== workflows present ==="; ls .github/workflows/
+```
+
+## Assistant [33] 21:31:44
+
+## Assistant [34] 21:31:46
+
+两处 `memory_search.py` 异常、`dream.yml` 虚假告警均已在历史中修正——评估报告记录的是更早状态。正在核验仍然存在的具体缺陷，挑选可干净落地的一项......
+
+## Assistant [35] 21:31:49
+
+> **Bash** `Verify README/lessons drift`
+```bash
+cd /home/user/brain-in-a-vat; echo "=== README docs:dev claim ==="; grep -rn "docs:dev\|踩坑\|lessons\|30 条\|32 条" README.md 2>/dev/null | head; echo "=== package.json scripts (wiki) ==="; cat projects/wiki/package.json 2>/dev/null | python3 -c "import json,sys;print(json.load(sys.stdin).get('scripts'...
+```
+
+## Assistant [36] 21:31:54
+
+## Assistant [37] 21:31:56
+
+> **Bash** `Count actual lessons`
+```bash
+cd /home/user/brain-in-a-vat; echo "=== lesson entry headings ==="; grep -nE "lesson #[0-9]+|#[0-9]+ |^### |^## [0-9]" memory/lessons-learned.md | grep -iE "#[0-9]+" | head -40; echo "=== max lesson number ==="; grep -oE "#[0-9]+" memory/lessons-learned.md | sort -t'#' -k2 -n | tail -3; echo "=== do...
+```
+
+## Assistant [38] 21:32:07
+
+## Assistant [39] 21:32:13
+
+排查完毕，状态报告：
+
+银芯当前活跃代码层**无任何字面 `// TODO` / `# TODO` 注释**——grep 全仓（排除 `.git` 与历史会话摘要）零命中。多数审计点名项（`memory_search.py` 重复 import / 吞错 idiom、`dream.yml` 虚假告警）已在历史中修正。
+
+但艾瑞卡定位到一条**仍然存在、且已被 2026-06-02 健康评估明确登记为待办**的缺陷——文档与实况对账项「`docs:dev` 脚本不存在」：
+
+- `projects/wiki/package.json` 的脚本实为 `dev`（`vitepress dev docs`），**不存在 `docs:dev`**
+- 但两处文档仍指引 `npm run docs:dev`，照抄会直接报错
+
+正在读取两处断裂引用的上下文以做外科手术式修正......
+
+## Assistant [40] 21:32:15
+
+> **Bash** `Read context around docs:dev references`
+```bash
+cd /home/user/brain-in-a-vat; echo "=== CONTEXT.md 85-100 ==="; sed -n '85,100p' projects/wiki/CONTEXT.md | cat -n; echo "=== PR template 48-55 ==="; sed -n '48,55p' .github/PULL_REQUEST_TEMPLATE.md | cat -n; echo "=== any other docs:dev refs in tracked non-digest files ==="; grep -rn "docs:dev" pro...
+```
+
+## Assistant [41] 21:32:20
+
+## Assistant [42] 21:32:21
+
+> **Bash** `Print exact wiki npm scripts`
+```bash
+cd /home/user/brain-in-a-vat; python3 -c "import json;s=json.load(open('projects/wiki/package.json'))['scripts'];[print(k,'->',v) for k,v in s.items()]"
+```
+
+## Assistant [43] 21:32:32
+
+## Assistant [44] 21:32:34
+
+确认：`package.json` 实有脚本为 `dev` / `docs:build` / `build` / `preview`。故 `docs:dev`（应为 `dev`）与 `docs:preview`（应为 `preview`）两个命令在文档中均为断裂引用，`docs:build` 正确。
+
+正在建立工作分支并做外科手术式修正（仅改这两个不存在的命令引用）......
+
+## Assistant [45] 21:32:36
+
+> **Bash** `Create branch and read HTML context`
+```bash
+cd /home/user/brain-in-a-vat; git checkout -b claude/todo-implementation-VrygM 2>&1 | tail -2; echo "=== HTML lines ==="; sed -n '190,194p;326,330p' projects/site/design/morimens-design-system-guide.html
+```
+
+## Assistant [46] 21:32:39
+
+> **Bash** `Switch to target branch`
+```bash
+cd /home/user/brain-in-a-vat; git checkout claude/todo-implementation-VrygM 2>&1 | tail -1; git log --oneline -1
+```
+
+## Assistant [47] 21:32:41
+
+Now applying the surgical fixes across the four affected docs:
+
+## Assistant [48] 21:32:43
+
+> **Edit** `/home/user/brain-in-a-vat/projects/wiki/CONTEXT.md`
+
+## Assistant [49] 21:32:45
+
+> **Read** `/home/user/brain-in-a-vat/projects/wiki/CONTEXT.md` (offset=88, limit=12)
+
+## Assistant [50] 21:32:49
+
+> **Edit** `/home/user/brain-in-a-vat/projects/wiki/CONTEXT.md`
+
+## Assistant [51] 21:32:53
+
+> **Read** `/home/user/brain-in-a-vat/.github/PULL_REQUEST_TEMPLATE.md` (offset=52, limit=1)
+
+## Assistant [52] 21:32:57
+
+> **Edit** `/home/user/brain-in-a-vat/.github/PULL_REQUEST_TEMPLATE.md`
+
+## Assistant [53] 21:33:04
+
+> **Read** `/home/user/brain-in-a-vat/projects/site/design/morimens-design-system-guide.html` (offset=191, limit=3)
+
+## Assistant [54] 21:33:08
+
+> **Edit** `/home/user/brain-in-a-vat/projects/site/design/morimens-design-system-guide.html`
+
+## Assistant [55] 21:33:11
+
+> **Edit** `/home/user/brain-in-a-vat/projects/site/design/morimens-design-system-guide.html`
+
+## Assistant [56] 21:33:14
+
+Running the verification program — confirming zero remaining broken command references in tracked, non-digest files:
+
+## Assistant [57] 21:33:17
+
+> **Bash** `Verify no broken refs remain and commands exist`
+```bash
+cd /home/user/brain-in-a-vat; echo "=== residual docs:dev / docs:preview (excl digests) ==="; grep -rn "docs:dev\|docs:preview" projects/wiki projects/site .github README.md 2>/dev/null | grep -v session-digests; echo "exit=$?"; echo "=== confirm replacements landed ==="; grep -rn "npm run dev\|npm ...
+```
+
+## Assistant [58] 21:33:21
+
+验证通过：`grep` 残留命中归零（exit=1），三处文档共五行命令引用全部对齐到 `package.json` 实有脚本（`dev` / `docs:build` / `preview`）。
+
+正在数据归档提交并同步至远端存储......
+
+## Assistant [59] 21:33:25
+
+> **Bash** `Commit the doc fixes`
+```bash
+cd /home/user/brain-in-a-vat; git add projects/wiki/CONTEXT.md .github/PULL_REQUEST_TEMPLATE.md projects/site/design/morimens-design-system-guide.html; git commit -q -m "fix(docs): correct non-existent npm scripts in wiki dev docs
+
+The package.json defines 'dev' and 'preview', not 'docs:dev'/'docs:p...
+```
+
+## Assistant [60] 21:33:28
+
+> **Bash** `Push branch to remote`
+```bash
+cd /home/user/brain-in-a-vat; git push -u origin claude/todo-implementation-VrygM 2>&1 | tail -8
+```
+
+## Assistant [61] 21:33:38
+
+同步完成。正在创建草稿 PR......
+
+## Assistant [62] 21:33:38
+
+> **ToolSearch** (query, max_results)
+
+## Assistant [63] 21:33:52
+
+> **mcp__github__create_pull_request** (owner, repo, title, head, base)
+
+## Assistant [64] 21:33:56
+
+## Assistant [65] 21:33:57
+
+任务交付完成。守密人已订阅 PR #165 活动，正在检查当前 CI 状态与未处理评审意见......
+
+## Assistant [66] 21:33:57
+
+> **ToolSearch** (query, max_results)
+
+## Assistant [67] 21:34:00
+
+> **mcp__github__pull_request_read** (method, owner, repo, pullNumber)
+
+## Assistant [68] 21:34:03
+
+> **mcp__github__pull_request_read** (method, owner, repo, pullNumber)
+
+## Assistant [69] 21:34:12
+
+> **mcp__github__pull_request_read** (method, owner, repo, pullNumber)
+
+## Assistant [70] 21:34:17
+
+## Assistant [71] 21:34:28
+
+状态报告——PR #165 检查完毕：
+
+- **CI 检查**：`check_runs` 总数 0；合并状态 `pending` 但关联上下文数为 0——说明仓库 workflow 未对该纯文档分支触发任何检查作业（采集/部署类 workflow 多走 path filter 或仅在 main 上跑）。无失败项。
+- **评审意见**：评审线程总数 0，无未处理评论。
+
+当前无需任何修正动作。艾瑞卡保持对 PR #165 的活动监听，CI 事件或新评审到达时会自动唤醒排查。
+
+---
+
+本次交付小结：
+- 分支 `claude/todo-implementation-VrygM` · 提交 [`b1b892da`](https://github.com/lightproud/brain-in-a-vat/commit/b1b892da8dedfb62641f63f3728512b91d2b86bc)
+- 草稿 PR：[#165](https://github.com/lightproud/brain-in-a-vat/pull/165)
+- 改动文件（修正后均与 `package.json` 实有脚本对齐）：
+  - [`projects/wiki/CONTEXT.md`](https://github.com/lightproud/brain-in-a-vat/blob/claude/todo-implementation-VrygM/projects/wiki/CONTEXT.md)
+  - [`.github/PULL_REQUEST_TEMPLATE.md`](https://github.com/lightproud/brain-in-a-vat/blob/claude/todo-implementation-VrygM/.github/PULL_REQUEST_TEMPLATE.md)
+  - [`projects/site/design/morimens-design-system-guide.html`](https://github.com/lightproud/brain-in-a-vat/blob/claude/todo-implementation-VrygM/projects/site/design/morimens-design-system-guide.html)
+
+补充说明：全仓并无字面 TODO 注释可实现，艾瑞卡据健康评估档案选取了一条仍存在、可验证、外科手术式的「文档与实况对账」待办落地——纠正了贡献者照抄即报错的 `npm run docs:dev`（应为 `dev`）与 `docs:preview`（应为 `preview`）。

--- a/projects/site/design/morimens-design-system-guide.html
+++ b/projects/site/design/morimens-design-system-guide.html
@@ -189,7 +189,7 @@ export default theme</code></pre>
 
   <p><strong>Step 3：验证构建</strong></p>
   <pre><code>cd projects/wiki
-npm run docs:dev
+npm run dev
 # 检查：深渊底色、金色链接、宋体标题、噪点纹理</code></pre>
 
   <h3>VitePress 变量映射关系</h3>
@@ -325,7 +325,7 @@ npm run docs:dev
     <tr><td>1</td><td>创建 <code>projects/site/design/morimens-design-tokens.css</code></td><td>仓库</td><td><span class="badge badge-keep">已落地</span></td></tr>
     <tr><td>2</td><td>替换 <code>custom.css</code> → <code>morimens-vitepress-theme.css</code></td><td>Wiki</td><td><span class="badge badge-keep">已落地</span></td></tr>
     <tr><td>3</td><td>修改 <code>index.ts</code> 引入新 CSS</td><td>Wiki</td><td><span class="badge badge-keep">已落地</span></td></tr>
-    <tr><td>4</td><td>本地 <code>npm run docs:dev</code> 验证</td><td>Wiki</td><td><span class="badge badge-keep">已落地</span></td></tr>
+    <tr><td>4</td><td>本地 <code>npm run dev</code> 验证</td><td>Wiki</td><td><span class="badge badge-keep">已落地</span></td></tr>
     <tr><td>5</td><td>主页 <code>index.html</code> 通过 deploy-site.yml 自动部署</td><td>主页</td><td><span class="badge badge-keep">已落地</span></td></tr>
     <tr><td>6</td><td>GitHub Pages Source = gh-pages</td><td>部署</td><td><span class="badge badge-keep">已落地</span></td></tr>
     <tr><td>7</td><td>主页社区链接真实化（D-fix）</td><td>主页</td><td><span class="badge badge-keep">已落地</span></td></tr>

--- a/projects/wiki/CONTEXT.md
+++ b/projects/wiki/CONTEXT.md
@@ -90,9 +90,9 @@ Code-wiki
 # Wiki 站点
 cd projects/wiki
 npm install
-npm run docs:dev    # 本地开发
+npm run dev         # 本地开发
 npm run docs:build  # 构建
-npm run docs:preview # 预览构建结果
+npm run preview     # 预览构建结果
 
 # 数据查询
 python scripts/content_db.py


### PR DESCRIPTION
## 背景

任务要求在代码库中检索 TODO 并实现一项。全仓扫描确认活跃代码层无字面 `// TODO` / `# TODO` 注释（仅历史会话摘要与 skip-marker 定义中出现）。多数审计点名项已在历史中修正。本 PR 落地的是 `deliverables/2026-06/repo-health-assessment-2026-06-02.md` 明确登记、且至今仍存在的待办项——「文档与实况对账：`docs:dev` 脚本不存在」。

## 问题

`projects/wiki/package.json` 实有脚本为 `dev` / `docs:build` / `build` / `preview`，**不存在** `docs:dev` 与 `docs:preview`。但三处文档仍指引贡献者执行 `npm run docs:dev`（及 `docs:preview`），照抄会直接报错。

## 改动（外科手术式，仅纠正断裂命令）

| 文件 | 原 | 改 |
|------|----|----|
| `projects/wiki/CONTEXT.md` | `npm run docs:dev` / `npm run docs:preview` | `npm run dev` / `npm run preview` |
| `.github/PULL_REQUEST_TEMPLATE.md` | `npm run docs:dev` | `npm run dev` |
| `projects/site/design/morimens-design-system-guide.html`（2 处） | `npm run docs:dev` | `npm run dev` |

`docs:build` 引用正确，未改动。

## 验证

- `grep -rn "docs:dev\|docs:preview"`（排除会话摘要）残留命中归零
- 改后全部命令与 `package.json` 脚本键 `['dev','docs:build','build','preview']` 对齐

https://claude.ai/code/session_01KSoKsDUwkGK2YyusYMHPWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSoKsDUwkGK2YyusYMHPWb)_