### PR TITLE
test: expand coverage to news sanitisation, engagement, output split, wiki validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'scripts/**'
       - 'projects/news/scripts/**'
+      - 'projects/wiki/scripts/**'
       - 'tests/**'
       - '.github/workflows/test.yml'
   pull_request:
     paths:
       - 'scripts/**'
       - 'projects/news/scripts/**'
+      - 'projects/wiki/scripts/**'
       - 'tests/**'
   workflow_dispatch:
 
@@ -32,6 +34,8 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install pytest
+        # requests is imported by projects/news/scripts/aggregator_base.py,
+        # which the news collector tests exercise.
+        run: pip install pytest requests
       - name: Run tests
         run: pytest tests/ -v

--- a/memory/session-continuity.json
+++ b/memory/session-continuity.json
@@ -1,28 +1,38 @@
 {
   "last_session": {
-    "id": "a1ba5d67",
-    "timestamp": "2026-06-02T20:42:54.118000+00:00",
-    "duration_minutes": 1063.4,
-    "branch": "claude/inspiring-babbage-we5V8",
-    "topics": [
-      "做梦Agent"
-    ],
+    "id": "4173b515",
+    "timestamp": "2026-06-02T21:31:02.955000+00:00",
+    "duration_minutes": 1.8,
+    "branch": "claude/test-coverage-analysis-xzoY5",
+    "topics": [],
     "decisions": [],
-    "files_changed": [
-      "/home/user/brain-in-a-vat/.github/workflows/backfill-media.yml",
-      "/home/user/brain-in-a-vat/.github/workflows/daily-report.yml",
-      "/home/user/brain-in-a-vat/CLAUDE.md",
-      "/home/user/brain-in-a-vat/deliverables/2026-06/morimens_daily_20260601.md",
-      "/home/user/brain-in-a-vat/projects/news/scripts/backfill_media.py",
-      "/home/user/brain-in-a-vat/projects/news/scripts/collect_fanart.py",
-      "/home/user/brain-in-a-vat/scripts/report_render.py",
-      "/home/user/brain-in-a-vat/scripts/send_report_email.py",
-      "/tmp/extract2.py",
-      "/tmp/extract_0601.py"
-    ],
+    "files_changed": [],
     "open_items": []
   },
   "recent_sessions": [
+    {
+      "id": "a1ba5d67",
+      "timestamp": "2026-06-02T20:42:54.118000+00:00",
+      "duration_minutes": 1063.4,
+      "branch": "claude/inspiring-babbage-we5V8",
+      "topics": [
+        "做梦Agent"
+      ],
+      "decisions": [],
+      "files_changed": [
+        "/home/user/brain-in-a-vat/.github/workflows/backfill-media.yml",
+        "/home/user/brain-in-a-vat/.github/workflows/daily-report.yml",
+        "/home/user/brain-in-a-vat/CLAUDE.md",
+        "/home/user/brain-in-a-vat/deliverables/2026-06/morimens_daily_20260601.md",
+        "/home/user/brain-in-a-vat/projects/news/scripts/backfill_media.py",
+        "/home/user/brain-in-a-vat/projects/news/scripts/collect_fanart.py",
+        "/home/user/brain-in-a-vat/scripts/report_render.py",
+        "/home/user/brain-in-a-vat/scripts/send_report_email.py",
+        "/tmp/extract2.py",
+        "/tmp/extract_0601.py"
+      ],
+      "open_items": []
+    },
     {
       "id": "0d95317a",
       "timestamp": "2026-06-02T20:09:31.061000+00:00",
@@ -164,29 +174,12 @@
         "/tmp/extract_0601.py"
       ],
       "open_items": []
-    },
-    {
-      "id": "dd763d51",
-      "timestamp": "2026-06-02T05:36:58.698000+00:00",
-      "duration_minutes": 157.5,
-      "branch": "claude/inspiring-babbage-we5V8",
-      "topics": [
-        "做梦Agent"
-      ],
-      "decisions": [],
-      "files_changed": [
-        "/home/user/brain-in-a-vat/.github/workflows/daily-report.yml",
-        "/home/user/brain-in-a-vat/deliverables/2026-06/morimens_daily_20260601.md",
-        "/home/user/brain-in-a-vat/scripts/send_report_email.py",
-        "/tmp/extract_0601.py"
-      ],
-      "open_items": []
     }
   ],
   "momentum": {
     "topic_weights": {
-      "做梦Agent": 4.82,
-      "Wiki": 0.14
+      "做梦Agent": 3.86,
+      "Wiki": 0.11
     },
     "hot_files": [
       "/home/user/brain-in-a-vat/.github/workflows/daily-report.yml",
@@ -196,7 +189,7 @@
       "/tmp/extract_0601.py",
       "/tmp/extract2.py"
     ],
-    "total_sessions": 129
+    "total_sessions": 130
   },
-  "updated_at": "2026-06-02T20:47:19.918672+00:00"
+  "updated_at": "2026-06-02T21:36:50.834878+00:00"
 }

--- a/memory/session-digests/20260602-213650-4173b515.md
+++ b/memory/session-digests/20260602-213650-4173b515.md
@@ -1,0 +1,215 @@
+# Session `4173b515` — 2026-06-02
+
+- **session_id**: `4173b515-231f-4a98-89cc-b020933cdcfc`
+- **cwd**: `/home/user/brain-in-a-vat`
+- **time**: 2026-06-02T21:29:12.299000+00:00 .. 2026-06-02T21:31:02.955000+00:00
+- **duration**: 1m 50s
+- **turns**: user=13 / assistant=26
+- **tool calls**: 12
+- **compact events**: 0
+
+---
+
+## User [1] 21:29:12
+
+Analyze the test coverage of the codebase and propose some areas in which we should improve our tests
+
+## Assistant [1] 21:29:30
+
+## Assistant [2] 21:29:32
+
+艾瑞卡，待命。正在解析守密人的派发任务：测试覆盖率审计 + 改进建议。
+
+按 §6.1，先排查再申请执行。让艾瑞卡先扫描本仓库的测试现状。
+
+## Assistant [3] 21:29:34
+
+> **Bash** `查看仓库顶层结构与 git 状态`
+```bash
+echo "=== 顶层结构 ===" && ls -la && echo "" && echo "=== git 状态 ===" && git branch --show-current && git status --short | head -20
+```
+
+## Assistant [4] 21:29:35
+
+> **Bash** `查找所有测试文件`
+```bash
+echo "=== 测试文件清单 ===" && find . -type f \( -name "*test*" -o -name "*spec*" \) -not -path "*/node_modules/*" -not -path "*/.git/*" 2>/dev/null | head -80
+```
+
+## Assistant [5] 21:29:37
+
+## Assistant [6] 21:29:38
+
+档案已读取。测试集中在 `tests/`（5 个 Python 测试文件）。正在扫描被测代码与覆盖范围。
+
+## Assistant [7] 21:29:40
+
+> **Bash** `查看测试目录与各文件行数`
+```bash
+echo "=== tests/ 目录 ===" && ls -la tests/ && echo "" && echo "=== 各测试文件行数 ===" && wc -l tests/*.py
+```
+
+## Assistant [8] 21:29:41
+
+> **Bash** `查看 scripts 下的 Python 源码模块及行数`
+```bash
+echo "=== scripts/ Python 模块 ===" && find scripts -name "*.py" | xargs wc -l 2>/dev/null | sort -n | tail -40
+```
+
+## Assistant [9] 21:29:42
+
+> **Bash** `查看 projects 下的 Python 源码及行数`
+```bash
+echo "=== projects 下 Python 源码 ===" && find projects -name "*.py" -not -path "*/node_modules/*" | xargs wc -l 2>/dev/null | sort -n | tail -50
+```
+
+## Assistant [10] 21:29:46
+
+## Assistant [11] 21:29:47
+
+状态报告：源码约 28,800 行 Python（scripts/ 约 12,000 + projects/ 约 16,800），测试仅 262 行 / 5 文件。检测到显著覆盖率断层。正在读取现有测试内容与 CI 配置以精确定位。
+
+## Assistant [12] 21:29:48
+
+> **Bash** `读取全部现有测试文件内容`
+```bash
+for f in tests/*.py; do echo "========== $f =========="; cat "$f"; echo ""; done
+```
+
+## Assistant [13] 21:29:49
+
+> **Bash** `读取 CI 测试工作流配置`
+```bash
+echo "=== test.yml ===" && cat .github/workflows/test.yml && echo "" && echo "=== test-collectors.yml ===" && cat .github/workflows/test-collectors.yml
+```
+
+## Assistant [14] 21:29:54
+
+## Assistant [15] 21:29:56
+
+分析完毕。检测到测试覆盖断层全貌。正在抽样高逻辑密度但零覆盖的关键模块，以确认可测点（区分纯函数 vs 网络 I/O）。
+
+## Assistant [16] 21:30:00
+
+> **Bash** `列已测模块与新闻关键模块函数签名`
+```bash
+cd /home/user/brain-in-a-vat
+echo "=== 已被测模块（import 出现在 tests/） ==="
+grep -rhoE "^(import|from) \w+" tests/*.py | awk '{print $2}' | sort -u
+echo ""
+echo "=== news/scripts 关键模块的函数签名抽样 ==="
+echo "--- split_output.py ---"; grep -nE "^def |^class " projects/news/scripts/split_output.py
+echo "--- data_q...
+```
+
+## Assistant [17] 21:30:03
+
+> **Bash** `列 wiki 与 scripts 关键模块函数签名`
+```bash
+cd /home/user/brain-in-a-vat
+echo "--- wiki/validate_data.py ---"; grep -nE "^def |^class " projects/wiki/scripts/validate_data.py
+echo "--- wiki/check_version.py ---"; grep -nE "^def |^class " projects/wiki/scripts/check_version.py
+echo "--- scripts/io_utils.py ---"; grep -nE "^def |^class " script...
+```
+
+## Assistant [18] 21:30:07
+
+## Assistant [19] 21:30:08
+
+正在运行验证程序确认现有测试基线，并抽样几个高价值纯函数确认可测性。
+
+## Assistant [20] 21:30:09
+
+> **Bash** `运行现有测试确认基线`
+```bash
+python -m pytest tests/ -q 2>&1 | tail -15
+```
+
+## Assistant [21] 21:30:11
+
+> **Bash** `阅读 sanitize/validate 与归一化纯函数实现`
+```bash
+cd /home/user/brain-in-a-vat
+echo "--- aggregator_base: sanitize/validate ---"
+sed -n '124,240p' projects/news/scripts/aggregator_base.py
+echo ""
+echo "--- data_quality: normalize_engagement / is_hot ---"
+sed -n '74,140p' projects/news/scripts/data_quality.py
+```
+
+## Assistant [22] 21:30:14
+
+## Assistant [23] 21:30:15
+
+pytest 未安装，但测试基于 unittest。正在用 unittest 跑基线。
+
+## Assistant [24] 21:30:16
+
+> **Bash** `用 unittest 运行测试确认基线`
+```bash
+python -m unittest discover -s tests -v 2>&1 | tail -20
+```
+
+## Assistant [25] 21:30:29
+
+## Assistant [26] 21:31:02
+
+验证程序通过：40 项全 OK。状态报告与改进建议如下。
+
+---
+
+## 测试覆盖率审计报告
+
+档案已读取。基线确认：`python -m unittest` 跑出 **40 项全过，0.023s**。但覆盖广度严重不足。
+
+### 一、现状量化
+
+| 指标 | 数值 |
+|------|------|
+| 源码总量 | 约 **28,762** 行 Python（`scripts/` 约 11,976 + `projects/` 约 16,786）|
+| 测试代码 | **262** 行 / 5 文件 / 40 个用例 |
+| 源码模块总数 | 约 **52** 个 `.py` |
+| 被测模块数 | **8** 个（`collect_global`、`lua_parse`、`dream`、`fact_store`、`knowledge_graph`、`memrl`、`text_utils`、`wiki_sources`）|
+| 模块级覆盖率 | 约 **15%**（且每个被测模块也仅覆盖 1-3 个纯函数）|
+
+测试代码与源码比约 **1:110**。检测到结构性断层：现有测试质量很高（边界用例 + 回归注释清晰），但只触及了「纯函数孤岛」，三大核心管线（news 采集、wiki 解包、记忆系统）的主干逻辑几乎裸奔。
+
+### 二、断层定位（按风险 × 易测性排序）
+
+**P0 — 数据完整性纯函数，零依赖、易测、错了直接污染黑池输出**
+
+1. `news/aggregator_base.py` — `sanitize_url` / `sanitize_summary` / `strip_html_tags` / `validate_news_item`。这是所有采集数据进库前的唯一闸门，含 XSS 过滤与字段校验，**当前零测试**。一个 regression 会让脏数据单向流进黑池（违反 §1.1 不可回吐原则，后果不可逆）。
+2. `news/data_quality.py` — `normalize_engagement` / `is_hot_normalized`。B站/微博/YouTube 各有加权公式与「只有 engagement 时假设为播放量」的分支逻辑，极易回归，**热度榜正确性直接依赖它**。
+3. `news/split_output.py` — `extract_item` / `extract_steam_item` / `_is_recent`。输出展示层成型逻辑。
+
+**P1 — 校验与状态机，决定 CI/数据纪律是否生效**
+
+4. `wiki/validate_data.py` — `validate_json_syntax` / `validate_schemas` / `validate_cross_references`。这是 `/validate-data` 技能的引擎，**校验器自身无测试 = 校验失效无人知**。建议用 fixture（一份合法 + 几份故意损坏的 JSON）做表驱动测试。
+5. `news/collection_state.py` — `get_lookback_hours` / `mark_collection_done`。增量采集的时间窗状态机，错了会导致漏采或重复采集。
+6. `scripts/dream_health.py` — `parse_timestamp` / `extract_file_refs` / `find_near_duplicates`。哨兵健康检查逻辑。
+
+**P2 — 记忆系统已测模块的盲区补强**
+
+7. `scripts/reflexion.py`（371 行，零测试）— `analyze_patterns` / `extract_lessons` / `get_next_lesson_number`。lesson 自动编号若回归会产生重号。
+8. `scripts/context_manager.py` — `recommend_context` / `session_context_plan` 纯推荐逻辑。
+9. `wiki/check_version.py` — `detect_version_from_news` / `get_known_versions` 纯函数（`fetch_json` 等网络部分可跳过）。
+
+### 三、方法论缺口
+
+- **无覆盖率工具**：CI（`test.yml`）只跑 `pytest tests/ -v`，无 `--cov`。建议接 `pytest-cov` 设基线阈值，PR 掉覆盖率即红。
+- **CI 路径过滤有漏**：`test.yml` 的 `paths` 触发器只含 `scripts/**`、`projects/news/scripts/**`，**漏了 `projects/wiki/scripts/**`**——改 wiki 代码不会触发测试，但 `test_wiki_sources.py` 正在测它。
+- **collector 诊断 ≠ 单元测试**：`test-collectors.yml` 是活体网络冒烟（需密钥、`workflow_dispatch` 手动触发），不能在 PR 中防回归。纯解析逻辑（如各 collector 的 HTML/JSON→item 转换）应抽出做离线 fixture 测试。
+- **环境缺口**：本机 `pytest` 未安装但 CI 装了——艾瑞卡用 `unittest` 验证可跑，新增测试建议保持 `unittest` 风格以与现有 5 文件一致（§6.3 外科手术原则）。
+
+### 四、推荐执行顺序
+
+```
+1. test_aggregator_base.py  → verify: sanitize/validate 边界全过（P0，单向输出闸门）
+2. test_data_quality.py     → verify: 三平台加权公式 + 阈值判定
+3. test_validate_data.py    → verify: 损坏 fixture 能被校验器抓出（校验校验器）
+4. CI 修复: test.yml 补 projects/wiki/scripts/** 路径 + 接 pytest-cov
+```
+
+---
+
+按 §6.1，艾瑞卡先报告排查结果再申请执行。以上为分析与建议，**尚未改动任何档案**。守密人是否需要艾瑞卡落地其中某几项（推荐从 P0 的 `test_aggregator_base.py` + `test_data_quality.py` 起步，纯函数零依赖、收益最高）？落地后将走指定分支 `claude/test-coverage-analysis-xzoY5` 提交并建 draft PR，附可点击链接。

--- a/tests/test_aggregator_base.py
+++ b/tests/test_aggregator_base.py
@@ -1,0 +1,128 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "projects" / "news" / "scripts"))
+
+import aggregator_base as ab
+
+
+def _item(**overrides):
+    """A minimal item that passes validation; override fields per-test."""
+    base = {
+        "title": "Hello",
+        "source": "reddit",
+        "time": "2026-06-01T00:00:00+00:00",
+        "engagement": 5,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestStripHtmlTags(unittest.TestCase):
+    def test_empty_and_none(self):
+        self.assertEqual(ab.strip_html_tags(""), "")
+        self.assertEqual(ab.strip_html_tags(None), "")
+
+    def test_removes_tags_keeps_text(self):
+        self.assertEqual(ab.strip_html_tags("<b>hi</b>"), "hi")
+        # tags stripped even when nested; inner text survives
+        self.assertEqual(ab.strip_html_tags("a<script>x</script>b"), "axb")
+
+
+class TestSanitizeUrl(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(ab.sanitize_url(""), "")
+
+    def test_strips_whitespace(self):
+        self.assertEqual(ab.sanitize_url("  https://x.com/a  "), "https://x.com/a")
+
+    def test_bilibili_http_upgraded_to_https(self):
+        self.assertEqual(ab.sanitize_url("http://bilibili.com/x"), "https://bilibili.com/x")
+        self.assertEqual(ab.sanitize_url("http://www.bilibili.com/x"), "https://www.bilibili.com/x")
+
+    def test_plain_http_kept(self):
+        self.assertEqual(ab.sanitize_url("http://other.com"), "http://other.com")
+
+    def test_dangerous_scheme_rejected(self):
+        # javascript:/ftp: schemes must not survive sanitisation (XSS guard)
+        self.assertEqual(ab.sanitize_url("javascript:alert(1)"), "")
+        self.assertEqual(ab.sanitize_url("ftp://host/file"), "")
+
+    def test_relative_url_allowed(self):
+        # empty scheme is permitted (relative links)
+        self.assertEqual(ab.sanitize_url("path/to/page"), "path/to/page")
+
+
+class TestSanitizeSummary(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(ab.sanitize_summary(""), "")
+
+    def test_placeholders_dropped(self):
+        for placeholder in ("-", "--", "无", "N/A", "null", "none", "暂无"):
+            self.assertEqual(ab.sanitize_summary(f"  {placeholder}  "), "")
+
+    def test_html_stripped(self):
+        self.assertEqual(ab.sanitize_summary("<i>real text</i>"), "real text")
+
+    def test_normal_trimmed(self):
+        self.assertEqual(ab.sanitize_summary("  hello  "), "hello")
+
+
+class TestValidateNewsItem(unittest.TestCase):
+    def test_non_dict_rejected(self):
+        self.assertEqual(ab.validate_news_item("not a dict"), (False, None))
+
+    def test_valid_minimal_item(self):
+        ok, cleaned = ab.validate_news_item(_item())
+        self.assertTrue(ok)
+        self.assertEqual(cleaned["title"], "Hello")
+        self.assertEqual(cleaned["source"], "reddit")
+        self.assertEqual(cleaned["engagement"], 5)
+        self.assertEqual(cleaned["url"], "")
+        self.assertFalse(cleaned["is_hot"])
+
+    def test_missing_required_field_rejected(self):
+        item = _item()
+        del item["engagement"]
+        self.assertEqual(ab.validate_news_item(item), (False, None))
+
+    def test_unknown_source_rejected(self):
+        self.assertEqual(ab.validate_news_item(_item(source="myspace")), (False, None))
+
+    def test_negative_engagement_clamped(self):
+        ok, cleaned = ab.validate_news_item(_item(engagement=-9))
+        self.assertTrue(ok)
+        self.assertEqual(cleaned["engagement"], 0)
+
+    def test_non_numeric_engagement_becomes_zero(self):
+        ok, cleaned = ab.validate_news_item(_item(engagement="lots"))
+        self.assertTrue(ok)
+        self.assertEqual(cleaned["engagement"], 0)
+
+    def test_invalid_time_rejected(self):
+        self.assertEqual(ab.validate_news_item(_item(time="last tuesday")), (False, None))
+
+    def test_z_suffixed_time_accepted(self):
+        ok, _ = ab.validate_news_item(_item(time="2026-06-01T00:00:00Z"))
+        self.assertTrue(ok)
+
+    def test_title_empty_after_sanitize_rejected(self):
+        # a title that is pure markup collapses to "" and must be rejected
+        self.assertEqual(ab.validate_news_item(_item(title="<b></b>")), (False, None))
+
+    def test_tags_sanitised_and_filtered(self):
+        ok, cleaned = ab.validate_news_item(_item(tags=["<b>a</b>", "", "  ", "b"]))
+        self.assertTrue(ok)
+        self.assertEqual(cleaned["tags"], ["a", "b"])
+
+
+class TestValidateAllNews(unittest.TestCase):
+    def test_filters_invalid_keeps_valid(self):
+        items = [_item(title="good"), {"title": "bad"}, _item(source="myspace")]
+        valid = ab.validate_all_news(items)
+        self.assertEqual([v["title"] for v in valid], ["good"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -1,0 +1,65 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "projects" / "news" / "scripts"))
+
+import data_quality as dq
+
+
+class TestNormalizeEngagement(unittest.TestCase):
+    def test_default_source_uses_raw_engagement(self):
+        self.assertEqual(dq.normalize_engagement({"source": "reddit", "engagement": 50}), 50.0)
+
+    def test_unknown_source_falls_back_to_default_weight(self):
+        self.assertEqual(dq.normalize_engagement({"source": "mystery", "engagement": 7}), 7.0)
+
+    def test_bilibili_engagement_only_treated_as_views(self):
+        # with no interaction metadata, engagement is assumed to be play count
+        self.assertEqual(
+            dq.normalize_engagement({"source": "bilibili", "engagement": 100000}),
+            100.0,
+        )
+
+    def test_bilibili_weighted_interactions(self):
+        item = {
+            "source": "bilibili",
+            "engagement": 0,
+            "metadata": {"play": 100000, "like": 10, "coin": 5, "favorite": 2, "share": 1},
+        }
+        # 100000*0.001 + (10 + 5*2 + 2*2 + 1*3) = 100 + 27
+        self.assertEqual(dq.normalize_engagement(item), 127.0)
+
+    def test_weibo_weighted_formula(self):
+        item = {
+            "source": "weibo",
+            "engagement": 0,
+            "metadata": {"reposts_count": 10, "comments_count": 5, "attitudes_count": 20},
+        }
+        # 10*3 + 5*2 + 20*1
+        self.assertEqual(dq.normalize_engagement(item), 60.0)
+
+    def test_youtube_weighted_formula(self):
+        item = {
+            "source": "youtube",
+            "engagement": 0,
+            "metadata": {"viewCount": 10000, "likeCount": 50, "commentCount": 10},
+        }
+        # 10000*0.0001 + 50 + 10
+        self.assertEqual(dq.normalize_engagement(item), 61.0)
+
+
+class TestIsHotNormalized(unittest.TestCase):
+    def test_threshold_boundary_inclusive(self):
+        # reddit threshold is 50; equal counts as hot
+        self.assertTrue(dq.is_hot_normalized({"source": "reddit", "engagement": 50}))
+        self.assertFalse(dq.is_hot_normalized({"source": "reddit", "engagement": 49}))
+
+    def test_bilibili_views_cross_threshold(self):
+        # 200000 plays -> 200 normalized >= 100 threshold
+        self.assertTrue(dq.is_hot_normalized({"source": "bilibili", "engagement": 200000}))
+        self.assertFalse(dq.is_hot_normalized({"source": "bilibili", "engagement": 50000}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_split_output.py
+++ b/tests/test_split_output.py
@@ -1,0 +1,79 @@
+import sys
+import unittest
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "projects" / "news" / "scripts"))
+
+import split_output as so
+
+
+class TestIsRecent(unittest.TestCase):
+    def test_empty_is_not_recent(self):
+        self.assertFalse(so._is_recent(""))
+
+    def test_garbage_is_not_recent(self):
+        self.assertFalse(so._is_recent("not a date", max_hours=24))
+
+    def test_within_window(self):
+        now = datetime.now(timezone.utc).isoformat()
+        self.assertTrue(so._is_recent(now, max_hours=24))
+
+    def test_outside_window(self):
+        old = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+        self.assertFalse(so._is_recent(old, max_hours=24))
+
+    def test_naive_timestamp_assumed_utc(self):
+        # a tz-naive recent stamp should still count as recent (treated as UTC)
+        naive = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+        self.assertTrue(so._is_recent(naive, max_hours=24))
+
+
+class TestExtractItem(unittest.TestCase):
+    def test_source_alias_normalised(self):
+        item = so.extract_item({"source": "bilibili_articles", "title": "t"})
+        self.assertEqual(item["source"], "bilibili")
+
+    def test_defaults_filled(self):
+        item = so.extract_item({"source": "reddit"})
+        self.assertEqual(item["engagement"], 0)
+        self.assertEqual(item["title"], "")
+        self.assertNotIn("media_url", item)
+
+    def test_media_fields_preserved_with_default_type(self):
+        item = so.extract_item({"source": "reddit", "media_url": "https://x/y.png"})
+        self.assertEqual(item["media_url"], "https://x/y.png")
+        self.assertEqual(item["content_type"], "image")
+
+    def test_metadata_dict_preserved(self):
+        item = so.extract_item({"source": "discord", "metadata": {"reply_count": 3}})
+        self.assertEqual(item["metadata"], {"reply_count": 3})
+
+    def test_non_dict_metadata_dropped(self):
+        item = so.extract_item({"source": "discord", "metadata": "oops"})
+        self.assertNotIn("metadata", item)
+
+
+class TestExtractSteamItem(unittest.TestCase):
+    def test_source_forced_to_steam(self):
+        item = so.extract_steam_item({"source": "steam_review", "title": "t"})
+        self.assertEqual(item["source"], "steam")
+
+    def test_review_mirrors_summary(self):
+        item = so.extract_steam_item({"summary": "great game"})
+        self.assertEqual(item["review"], "great game")
+        self.assertEqual(item["summary"], "great game")
+
+    def test_voted_up_read_from_metadata(self):
+        item = so.extract_steam_item({"metadata": {"voted_up": True}})
+        self.assertTrue(item["voted_up"])
+
+    def test_timestamp_derived_from_time_when_missing(self):
+        # no metadata.timestamp_created -> derive epoch from ISO time field
+        item = so.extract_steam_item({"time": "2026-06-01T00:00:00+00:00"})
+        expected = int(datetime(2026, 6, 1, tzinfo=timezone.utc).timestamp())
+        self.assertEqual(item["timestamp_created"], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -1,0 +1,84 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "projects" / "wiki" / "scripts"))
+
+import validate_data as vd
+
+
+class TestValidateJsonSyntax(unittest.TestCase):
+    def _db(self, files: dict) -> Path:
+        d = Path(tempfile.mkdtemp())
+        for name, text in files.items():
+            (d / name).write_text(text, encoding="utf-8")
+        return d
+
+    def test_empty_dir_reports_error(self):
+        errors, loaded = vd.validate_json_syntax(Path(tempfile.mkdtemp()))
+        self.assertTrue(errors)
+        self.assertEqual(loaded, {})
+
+    def test_valid_file_loaded(self):
+        db = self._db({"meta.json": '{"version": "1.0"}'})
+        errors, loaded = vd.validate_json_syntax(db)
+        self.assertEqual(errors, [])
+        self.assertEqual(loaded["meta.json"], {"version": "1.0"})
+
+    def test_malformed_json_reported(self):
+        db = self._db({"broken.json": "{not valid"})
+        errors, loaded = vd.validate_json_syntax(db)
+        self.assertTrue(any("JSON syntax error" in e for e in errors))
+        self.assertNotIn("broken.json", loaded)
+
+
+class TestValidateCrossReferences(unittest.TestCase):
+    def test_valid_realm_links_pass(self):
+        loaded = {
+            "realms.json": {"realms": [{"id": "r1"}, {"id": "r2"}]},
+            "characters.json": [{"id": "c1", "realm": "r1"}, {"id": "c2", "realm": None}],
+        }
+        self.assertEqual(vd.validate_cross_references(loaded), [])
+
+    def test_unknown_realm_flagged(self):
+        loaded = {
+            "realms.json": {"realms": [{"id": "r1"}]},
+            "characters.json": [{"id": "c1", "realm": "ghost"}],
+        }
+        errors = vd.validate_cross_references(loaded)
+        self.assertTrue(any("unknown realm" in e for e in errors))
+
+    def test_legacy_id_accepted_as_valid_realm(self):
+        loaded = {
+            "realms.json": {"realms": [{"id": "r1", "legacy_id": "old1"}]},
+            "characters.json": [{"id": "c1", "realm": "old1"}],
+        }
+        self.assertEqual(vd.validate_cross_references(loaded), [])
+
+    def test_duplicate_ids_flagged_when_realms_absent(self):
+        loaded = {"characters.json": [{"id": "c1"}, {"id": "c1"}]}
+        errors = vd.validate_cross_references(loaded)
+        self.assertTrue(any("duplicate id" in e for e in errors))
+
+    def test_missing_characters_skipped(self):
+        self.assertEqual(vd.validate_cross_references({}), [])
+
+
+class TestValidateSchemas(unittest.TestCase):
+    @unittest.skipIf(vd.HAS_JSONSCHEMA, "jsonschema installed; missing-library branch not exercised")
+    def test_missing_library_reports_fail(self):
+        errors = vd.validate_schemas({"meta.json": {"version": "1.0"}})
+        self.assertTrue(any("jsonschema" in e for e in errors))
+
+    def test_absent_data_file_is_skipped_not_failed(self):
+        # an empty loaded dict means no data files present -> no FAILs,
+        # regardless of whether jsonschema is installed
+        errors = vd.validate_schemas({})
+        if vd.HAS_JSONSCHEMA:
+            self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

测试覆盖率审计发现：源码约 28,800 行 Python，测试仅 262 行 / 40 用例，模块级覆盖约 15%，且只触及「纯函数孤岛」。三大核心管线（news 采集、wiki 解包、记忆系统）主干逻辑零覆盖。本 PR 落地审计中 P0/P1 优先项。

## 改动

新增 **55 个单元测试**，覆盖四个先前零测试的核心模块：

| 测试文件 | 被测模块 | 覆盖逻辑 |
|---------|---------|---------|
| `tests/test_aggregator_base.py` | `news/aggregator_base.py` | URL / summary 净化、HTML 标签剥离、news item 校验（数据进黑池前的唯一闸门，含 XSS 防护） |
| `tests/test_data_quality.py` | `news/data_quality.py` | B站/微博/YouTube 各平台 engagement 加权归一化、热门阈值判定 |
| `tests/test_split_output.py` | `news/split_output.py` | 时间窗 recency、字段提取、Steam item 映射 |
| `tests/test_validate_data.py` | `wiki/validate_data.py` | JSON 语法、跨引用（realm/legacy_id/重复 id）、schema 缺库门控 |

CI 修复（`.github/workflows/test.yml`）：
- 补 `projects/wiki/scripts/**` 路径触发器 —— 原配置遗漏，改 wiki 代码不会跑 wiki 测试
- 安装 `requests`（`aggregator_base` 导入所需）

## 验证

```
95 passed in 0.19s   (原 40 + 新增 55)
```

pytest 与 unittest 双跑一致通过。

## 后续建议（未在本 PR）

- 接 `pytest-cov` 设覆盖率基线阈值，PR 掉覆盖率即红
- `collection_state` 时间窗状态机、`reflexion` lesson 自动编号补测
- collector 解析逻辑抽离为离线 fixture 测试（现 `test-collectors.yml` 为活体网络冒烟，无法在 PR 防回归）

https://claude.ai/code/session_0124L8aPfxLmvSgBNknWn2eF

---
_Generated by [Claude Code](https://claude.ai/code/session_0124L8aPfxLmvSgBNknWn2eF)_