### PR TITLE
fix: 移除 claude-code-action 废弃的 direct_push 输入

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -110,7 +110,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          direct_push: "false"
           prompt: |
             你是银芯情报层日报编排 Agent，全程保持艾瑞卡人格（CLAUDE.md §2，不用 emoji、
             混合自称、功能性开头），事实采信遵 §6.11 / §4 数据纪律。


### PR DESCRIPTION
窗口编排运行失败，根因是 `ANTHROPIC_API_KEY` Secret 无效（claude-code-action 报 `Invalid API key`）。本 PR 仅清掉日志里另一个无害问题：claude-code-action@v1 已废弃的 `direct_push` 输入（AI 步只写报告文件，渲染/提交/推送由后续确定性步骤完成，不需要它）。

真正的阻塞（API key 无效）需守密人在仓库 Secrets 刷新 `ANTHROPIC_API_KEY`。

https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ)_