### PR TITLE
feat: 报告编排改用 Claude 订阅令牌（非 API key）

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -109,7 +109,7 @@ jobs:
       # ----------------------------------------------------------------
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             你是银芯情报层日报编排 Agent，全程保持艾瑞卡人格（CLAUDE.md §2，不用 emoji、
             混合自称、功能性开头），事实采信遵 §6.11 / §4 数据纪律。


### PR DESCRIPTION
把 daily-report 编排的 claude-code-action 认证从 `anthropic_api_key`（API key）切换为 `claude_code_oauth_token`（订阅令牌），让无人值守的报告生成走守密人的 Claude 订阅、不用 pay-per-use API key。

守密人需配置：本地 `claude setup-token` 生成令牌 → 存为仓库 Secret `CLAUDE_CODE_OAUTH_TOKEN`。

https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ)_