### PR TITLE
revert: 报告编排切回 anthropic_api_key

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -109,7 +109,7 @@ jobs:
       # ----------------------------------------------------------------
       - uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             你是银芯情报层日报编排 Agent，全程保持艾瑞卡人格（CLAUDE.md §2，不用 emoji、
             混合自称、功能性开头），事实采信遵 §6.11 / §4 数据纪律。


### PR DESCRIPTION
守密人改用浏览器在 console.anthropic.com 建的 API key（无终端跑 setup-token）。把编排认证从 `claude_code_oauth_token` 切回 `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`。

守密人需在仓库 Secret `ANTHROPIC_API_KEY` 填入新建的有效 API key。

https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ)_