### PR TITLE
fix: 日报默认回到单日（昨日），多日仅作手动例外

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -22,13 +22,13 @@ on:
   workflow_dispatch:
     inputs:
       end_date:
-        description: '窗口结束日 YYYY-MM-DD（默认=北京今日）'
+        description: '结束日 YYYY-MM-DD（默认=北京昨日；定时每日跑覆盖昨日单日）'
         required: false
         default: ''
       window_days:
-        description: '窗口天数（含结束日，默认 4，即覆盖近 4 天）'
+        description: '窗口天数（含结束日，默认 1=单日日报；手动可填 N 拉多日例外）'
         required: false
-        default: '4'
+        default: '1'
 
 concurrency:
   group: daily-report
@@ -65,8 +65,9 @@ jobs:
         id: dates
         run: |
           END="${{ github.event.inputs.end_date }}"
-          [ -n "$END" ] || END=$(TZ=Asia/Shanghai date +%Y-%m-%d)
-          WIN="${{ github.event.inputs.window_days }}"; WIN=${WIN:-4}
+          # 默认=北京昨日（定时每日跑覆盖昨日完整一天；当日数据尚未采全）
+          [ -n "$END" ] || END=$(TZ=Asia/Shanghai date -d 'yesterday' +%Y-%m-%d)
+          WIN="${{ github.event.inputs.window_days }}"; WIN=${WIN:-1}
           START=$(date -d "$END -$((WIN-1)) day" +%Y-%m-%d)
           # 窗口内所有日期（空格分隔），供逐日同人图采集与 prompt 读取
           DATES=""
@@ -75,13 +76,19 @@ jobs:
           done
           MONTH=$(date -d "$END" +%Y-%m)
           STAMP=$(date -d "$END" +%Y%m%d)
+          # 单日时只显一个日期，多日才显区间；文件名单日用 daily、多日用 window
+          if [ "$START" = "$END" ]; then
+            DISP="$(date -d "$END" +%Y.%m.%d)"; KIND="daily"
+          else
+            DISP="$(date -d "$START" +%Y.%m.%d) ~ $(date -d "$END" +%Y.%m.%d)"; KIND="window"
+          fi
           {
             echo "START_DATE=$START"
             echo "END_DATE=$END"
             echo "WINDOW_DATES=$DATES"
-            echo "DISP_WINDOW=$(date -d "$START" +%Y.%m.%d) ~ $(date -d "$END" +%Y.%m.%d)"
-            echo "REPORT_MD=deliverables/$MONTH/morimens_window_$STAMP.md"
-            echo "REPORT_PDF=deliverables/$MONTH/morimens_window_$STAMP.pdf"
+            echo "DISP_WINDOW=$DISP"
+            echo "REPORT_MD=deliverables/$MONTH/morimens_${KIND}_$STAMP.md"
+            echo "REPORT_PDF=deliverables/$MONTH/morimens_${KIND}_$STAMP.pdf"
             echo "FANART_ROOT=projects/news/data/fanart"
           } >> "$GITHUB_ENV"
           mkdir -p "deliverables/$MONTH"


### PR DESCRIPTION
守密人澄清：最终落地是**每天触发、报昨日的日报**；4 天窗口只是一次性例外。

把默认改回单日：`window_days` 4→1、`end_date` 默认 今日→昨日（定时每日跑覆盖昨日完整一天）。单日时副标题只显一个日期、文件名用 `daily`；多日仍可手动用 inputs 拉「例外」窗口（文件名用 `window`）。

https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ)_