### PR TITLE
feat: 报告编排固定 Opus 4.8 + 1M 上下文

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   daily-report:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
@@ -117,6 +117,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Opus 4.8 + 1M 上下文（守密人定：分析质量优先；1M 窗口可一趟读完单日全量）
+          claude_args: "--model claude-opus-4-8[1m]"
           prompt: |
             你是银芯情报层日报编排 Agent，全程保持艾瑞卡人格（CLAUDE.md §2，不用 emoji、
             混合自称、功能性开头），事实采信遵 §6.11 / §4 数据纪律。


### PR DESCRIPTION
守密人定：分析质量优先，用 **Opus 4.8 + 1M 上下文**。

- 通过 `claude_args: --model claude-opus-4-8[1m]` 显式固定（之前失败日志里运行时已显示此模型，现锁死防漂移）。
- 1M 窗口让单日全量（~25–30 万 token）可一趟读完，正好化解「单次自动跑上下文有限」的顾虑。
- job 超时 30→60 分钟（Opus 深读较慢，避免被掐断）。

代价：Opus 1M 最贵，但符合「要质量」的取舍。

https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ)_