### PR TITLE
chore: 停掉每晚 API 计费自动跑，报告改会话内订阅生成

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -16,9 +16,8 @@ name: "📰 Daily Community Report"
 #   SMTP_HOST SMTP_PORT SMTP_USER SMTP_PASS [SMTP_FROM]  邮件投递凭据
 
 on:
-  schedule:
-    # 每日 01:30 UTC（北京时间 09:30），留足前一日采集与归档窗口
-    - cron: '30 1 * * *'
+  # 定时自动跑已停用——报告改在 Claude Code 会话里用订阅生成（零 API 费）。
+  # 此工作流仅保留手动触发，作为「需要无人值守 + 愿意走 API 计费」时的备用。
   workflow_dispatch:
     inputs:
       end_date:


### PR DESCRIPTION
守密人：报告以后在 Claude Code 会话里用**订阅**生成（零 API 费），不走 GitHub Actions 的 claude-code-action（那个按 token 计 Anthropic API 费）。

移除每日 `schedule` cron，**停掉每晚自动的 API 计费跑**；仅保留 `workflow_dispatch` 手动触发作为「确实需要无人值守且愿走 API」时的备用。

数据采集（归档/同人图/评论，不耗 ANTHROPIC API）仍可在 CI 跑；报告生成交给会话。

https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ)_