### PR TITLE
feat: YouTube 评论累积采集（全量新+回填旧）

### DIFF
--- a/.github/workflows/collect-comments.yml
+++ b/.github/workflows/collect-comments.yml
@@ -1,0 +1,58 @@
+name: "💬 Collect Video Comments"
+
+# 独立采集忘却前夜相关 YouTube 视频（含官方 PV）的热门评论，归档到
+# projects/news/data/platforms/youtube_comments/{date}.json，供会话内报告引用。
+# 只用 YOUTUBE_API_KEY（Google，免费配额），不碰 Anthropic API、不花钱。
+
+on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: '归档日期标签 YYYY-MM-DD（默认=北京昨日）'
+        required: false
+        default: ''
+  schedule:
+    - cron: '0 2 * * *'   # 每日 02:00 UTC 自动采（与新闻管线同属免费数据层）
+
+concurrency:
+  group: collect-comments
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Collect video comments
+        env:
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+        run: |
+          D="${{ github.event.inputs.date }}"
+          [ -n "$D" ] || D=$(TZ=Asia/Shanghai date -d 'yesterday' +%Y-%m-%d)
+          python projects/news/scripts/collect_video_comments.py --date "$D" --top-videos 15 --per-video 25
+
+      - name: Commit comments archive
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add projects/news/data/platforms/youtube_comments/
+          if git diff --staged --quiet; then
+            echo "No new comments to commit"
+          else
+            git commit -m "chore: archive youtube video comments [skip ci]"
+            for i in 1 2 3 4; do
+              git pull --rebase origin main && git push origin main && exit 0
+              sleep $i
+            done
+            exit 1
+          fi

--- a/projects/news/scripts/collect_video_comments.py
+++ b/projects/news/scripts/collect_video_comments.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python3
-"""YouTube 视频评论采集器 — 抓忘却前夜相关视频（尤其官方 PV）下的热门评论。
+"""YouTube 视频评论采集器（累积归档版）。
 
-第 4 条需求：报告要呈现「官方动作下大家的 PV 视频评论」，但现有 youtube 源只存视频
-元数据、不存评论。本脚本用 YouTube Data API v3 的 commentThreads 拉取窗口内相关视频的
-热门评论，归档到 platforms/youtube_comments/{date}.json 供报告引用（含发言人+原文）。
+守密人要求：每天采集忘却前夜相关视频的**所有新评论**，并**归档旧评论**（不丢历史）。
+做法：维护一个去重累积库，每次运行增量补新 + 逐步回填旧。
 
-需 YOUTUBE_API_KEY（CI secrets 已有；本地通常无，故本地仅作 dry 校验）。
+存储（projects/news/data/platforms/youtube_comments/）：
+  comments.jsonl   累积库，一行一条评论，按 comment id 去重、只增不删
+  state.json       每视频分页状态 {video_id: {title, channel, exhausted, next_page}}
+  {date}.json      当次运行采到的评论快照（供当日报告引用「PV 视频评论」）
+
+候选视频来源：YouTube 搜索（Morimens/忘却前夜…）+ 复用已归档的 youtube 视频 ID
+（data/platforms/youtube/*.json）。每视频按 order=time 分页：
+  - 增量：翻到整页都已在库即停（已追上最新）。
+  - 回填：每视频每次最多翻 --max-pages 页，未尽则 state 标记 exhausted=false 下次续。
+
+需 YOUTUBE_API_KEY（Google Data API，免费配额：commentThreads 1 单位/100 条，
+每日 1 万单位足够）。无 key 时仍建目录并退出，便于工作流容错。
 
 用法：
-  YOUTUBE_API_KEY=xxx python projects/news/scripts/collect_video_comments.py --date 2026-06-02 \
-      --top-videos 12 --per-video 20
-输出：platforms/youtube_comments/{date}.json（每条含 video_title/video_url/author/text/likes/published）
+  YOUTUBE_API_KEY=xxx python projects/news/scripts/collect_video_comments.py --date 2026-06-03
 """
-import os, json, argparse, urllib.request, urllib.parse, urllib.error
+import os, json, glob, argparse, urllib.request, urllib.parse, urllib.error
 from datetime import datetime, timezone
 
 API = "https://www.googleapis.com/youtube/v3"
+DEST = "projects/news/data/platforms/youtube_comments"
+SEARCH_Q = ["Morimens", "忘却前夜", "Morimens Saya no Uta", "忘却前夜 沙耶"]
 
 
 def _get(path, params):
@@ -25,68 +35,115 @@ def _get(path, params):
         return json.load(r)
 
 
-def search_videos(key, n):
-    """搜索忘却前夜相关视频，按相关度取近窗口，返回 [(id,title,channel)]。"""
-    out = {}
-    for q in ["Morimens", "忘却前夜", "Morimens Saya"]:
+def discover_videos(key):
+    """搜索 + 复用归档的 youtube 视频 ID → {vid: (title, channel)}。"""
+    vids = {}
+    for q in SEARCH_Q:
         try:
-            data = _get("search", {"part": "snippet", "q": q, "type": "video",
-                                   "order": "relevance", "maxResults": 15, "key": key})
-            for it in data.get("items", []):
+            for it in _get("search", {"part": "snippet", "q": q, "type": "video",
+                                      "order": "date", "maxResults": 25, "key": key}).get("items", []):
                 vid = it.get("id", {}).get("videoId")
                 if vid:
                     sn = it.get("snippet", {})
-                    out[vid] = (sn.get("title", ""), sn.get("channelTitle", ""))
+                    vids[vid] = (sn.get("title", ""), sn.get("channelTitle", ""))
         except Exception as e:
             print(f"  search '{q}' 失败: {type(e).__name__}")
-    return list(out.items())[:n]
+    # 复用已归档 youtube 视频 URL 里的 video id
+    for fp in glob.glob("projects/news/data/platforms/youtube/*.json"):
+        try:
+            items = json.load(open(fp, encoding="utf-8"))
+        except Exception:
+            continue
+        for it in (items if isinstance(items, list) else []):
+            u = it.get("url", "")
+            if "watch?v=" in u:
+                vid = u.split("watch?v=")[1][:11]
+                vids.setdefault(vid, (it.get("title", ""), it.get("author", "")))
+    return vids
 
 
-def top_comments(key, vid, per):
-    try:
-        data = _get("commentThreads", {"part": "snippet", "videoId": vid,
-                                       "order": "relevance", "maxResults": per,
-                                       "textFormat": "plainText", "key": key})
-    except urllib.error.HTTPError as e:
-        # 评论关闭/视频不可用时跳过
-        print(f"  {vid} commentThreads HTTP {e.code}")
-        return []
-    rows = []
-    for t in data.get("items", []):
-        c = t.get("snippet", {}).get("topLevelComment", {}).get("snippet", {})
-        rows.append({"author": c.get("authorDisplayName", ""),
-                     "text": (c.get("textDisplay") or "")[:600],
-                     "likes": c.get("likeCount", 0),
-                     "published": c.get("publishedAt", "")})
-    return rows
+def fetch_video_comments(key, vid, known_ids, max_pages):
+    """按时间序分页拉评论；遇整页已知即停（增量）；返回 (new_rows, exhausted)。"""
+    new_rows, page, token = [], 0, None
+    while page < max_pages:
+        params = {"part": "snippet", "videoId": vid, "order": "time",
+                  "maxResults": 100, "textFormat": "plainText", "key": key}
+        if token:
+            params["pageToken"] = token
+        try:
+            data = _get("commentThreads", params)
+        except urllib.error.HTTPError as e:
+            return new_rows, True  # 评论关闭/不可用 → 视为已尽
+        page += 1
+        page_new = 0
+        for t in data.get("items", []):
+            cid = t.get("id")
+            c = t.get("snippet", {}).get("topLevelComment", {}).get("snippet", {})
+            if not cid or cid in known_ids:
+                continue
+            known_ids.add(cid)
+            page_new += 1
+            new_rows.append({"id": cid, "video_id": vid,
+                             "author": c.get("authorDisplayName", ""),
+                             "text": (c.get("textDisplay") or "")[:1000],
+                             "likes": c.get("likeCount", 0),
+                             "published": c.get("publishedAt", ""),
+                             "fetched_at": datetime.now(timezone.utc).isoformat()})
+        token = data.get("nextPageToken")
+        if page_new == 0:        # 整页都已知 → 已追上最新
+            return new_rows, True
+        if not token:            # 没有下一页 → 该视频评论已尽
+            return new_rows, True
+    return new_rows, False       # 还有更多，下次续（回填未尽）
 
 
 def main():
-    ap = argparse.ArgumentParser(description="YouTube 视频评论采集器")
-    ap.add_argument("--date", required=True, help="归档日期标签 YYYY-MM-DD")
-    ap.add_argument("--top-videos", type=int, default=12)
-    ap.add_argument("--per-video", type=int, default=20)
+    ap = argparse.ArgumentParser(description="YouTube 评论累积采集器")
+    ap.add_argument("--date", required=True, help="当次快照日期标签 YYYY-MM-DD")
+    ap.add_argument("--max-pages", type=int, default=8, help="每视频每次最多翻页数（回填节流）")
     a = ap.parse_args()
+    os.makedirs(DEST, exist_ok=True)   # 始终建目录，便于工作流容错
 
     key = os.environ.get("YOUTUBE_API_KEY")
     if not key:
-        print("YOUTUBE_API_KEY 未设置——跳过（本地无 key 属正常，CI 会跑）")
+        print("YOUTUBE_API_KEY 未设置——跳过（CI 须配此 Secret 方能采评论）")
         return
 
-    vids = search_videos(key, a.top_videos)
-    out = []
-    for vid, (title, ch) in vids:
-        for c in top_comments(key, vid, a.per_video):
-            c.update({"video_id": vid, "video_title": title, "channel": ch,
-                      "video_url": f"https://www.youtube.com/watch?v={vid}"})
-            out.append(c)
-    out.sort(key=lambda x: -x.get("likes", 0))
+    # 载入累积库 + 已知 id
+    store = f"{DEST}/comments.jsonl"
+    known = set();
+    if os.path.isfile(store):
+        for line in open(store, encoding="utf-8"):
+            try:
+                known.add(json.loads(line)["id"])
+            except Exception:
+                pass
+    state = {}
+    sp = f"{DEST}/state.json"
+    if os.path.isfile(sp):
+        state = json.load(open(sp, encoding="utf-8"))
 
-    dest_dir = "projects/news/data/platforms/youtube_comments"
-    os.makedirs(dest_dir, exist_ok=True)
-    dest = f"{dest_dir}/{a.date}.json"
-    json.dump(out, open(dest, "w", encoding="utf-8"), ensure_ascii=False, indent=1)
-    print(f"采集 {len(out)} 条评论（{len(vids)} 视频）→ {dest}")
+    videos = discover_videos(key)
+    print(f"候选视频 {len(videos)}；库内已有评论 {len(known)} 条")
+
+    run_new = []
+    with open(store, "a", encoding="utf-8") as f:
+        for vid, (title, ch) in videos.items():
+            rows, exhausted = fetch_video_comments(key, vid, known, a.max_pages)
+            for r in rows:
+                r["video_title"] = title; r["channel"] = ch
+                r["video_url"] = f"https://www.youtube.com/watch?v={vid}"
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+                run_new.append(r)
+            state[vid] = {"title": title, "channel": ch, "exhausted": exhausted,
+                          "last_run": a.date}
+    json.dump(state, open(sp, "w", encoding="utf-8"), ensure_ascii=False, indent=1)
+
+    # 当次快照（按 likes 排序，供报告引用）
+    run_new.sort(key=lambda x: -x.get("likes", 0))
+    json.dump(run_new, open(f"{DEST}/{a.date}.json", "w", encoding="utf-8"),
+              ensure_ascii=False, indent=1)
+    print(f"本次新增 {len(run_new)} 条；累积库共 {len(known)} 条 → {store}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
按守密人：每天采 Morimens 视频**所有新评论 + 归档旧评论**。

把 `collect_video_comments.py` 从「每日 top-N 快照」升级为**累积归档**：
- `comments.jsonl` 按 comment id 去重、只增不删的累积库；
- 每视频 `order=time` 分页：整页已知即停（增量补新）、每次每视频最多翻 N 页（回填旧、节流），`state.json` 记录是否翻尽、下次续；
- 候选视频 = YouTube 搜索 + 复用已归档 youtube 视频 ID；
- 始终建目录（修上次 git add 因无产出 exit 128 的崩溃）；保留 `{date}.json` 当次快照供报告引用。

**商店评测（Steam/AppStore/GooglePlay）经核查已是累积归档**（`backfill_platforms` + `global_collectors` + 619/204/56 天档），无需改动。

⚠️ 上次 CI 测试运行**无产出**——`YOUTUBE_API_KEY` 在该 workflow 里为空（采集器无 key 即跳过）。需守密人确认/配置 `YOUTUBE_API_KEY` Secret，评论采集方能工作。

https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012FCYoSt7QduU63sdokLGNQ)_