### PR TITLE
fix(wiki): enforce required 'effect' field in trinkets schema

### DIFF
--- a/projects/wiki/data/schemas/trinkets.schema.json
+++ b/projects/wiki/data/schemas/trinkets.schema.json
@@ -50,6 +50,7 @@
         "id",
         "name",
         "rarity",
+        "effect",
         "obtain",
         "icon_url",
         "last_verified"


### PR DESCRIPTION
## Summary

A repo-wide scan for TODO markers found exactly one literal TODO in the active code/data layer: `projects/wiki/data/schemas/trinkets.schema.json` line 85, where the `effect` field description states it is a *"required field even if data is currently TODO (use 'pending' literal until populated)"* — yet the trinket `required` array omitted `effect`, so the schema never enforced its own documented contract.

## Change

- Add `"effect"` to the `required` array of the `trinket` definition (1 line).

## Safety

- `trinkets.json` is currently an empty stub (`"trinkets": []`), so no existing data is affected by the stricter constraint.
- When the 29 trinket entries are populated (Phase 3), missing effects must use the documented `"pending"` literal instead of being silently omitted.

## Verification

- `projects/wiki/scripts/validate_data.py`: ALL PASSED — 6 files checked, 6 schemas validated (including `trinkets.json` against the updated schema).
- `pytest tests/`: 40 passed (excluding `test_collect_global.py`, whose collection fails in this container because the isolated pytest tool env lacks `requests` — unrelated to this change).

https://claude.ai/code/session_01CkTqGPyuptTEUHPdaYZHLh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkTqGPyuptTEUHPdaYZHLh)_