### PR TITLE
fix(news): 暴露核心源静默吐 0 + 待配 cookie 源优雅降级

### DIFF
--- a/projects/news/scripts/collect_global.py
+++ b/projects/news/scripts/collect_global.py
@@ -34,8 +34,9 @@ RAW_OUTPUT_PATH = _REPO_ROOT / 'projects' / 'news' / 'output' / 'news-raw.json'
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 
-# Core sources whose failure must surface a non-zero exit (§4.2 R1：任一核心源失败即整次失败)。
-CORE_SOURCES = {'bilibili', 'reddit', 'nga', 'taptap'}
+# 核心源 + 需 secret 的源元数据统一取自 sources.py（单一真相源，杜绝硬编码漂移）。
+# 核心源失败（含静默吐 0）须以非零退出暴露（§4.2 R1：任一核心源失败即整次失败）。
+from sources import CORE_SOURCES, AUTH_GATED
 
 
 # ── Source mapping: collector source names → aggregator source names ──
@@ -249,11 +250,27 @@ def run_zero_cost_collectors() -> list[dict]:
             items.extend(result)
             succeeded.append((name, len(result)))
             logger.info(f"  {name}: +{len(result)} items")
+            if tracker:
+                tracker.update_platform_status(source_id, len(result))
         else:
             empty.append(name)
-            logger.info(f"  · {name}: 0 items")
-        if tracker:
-            tracker.update_platform_status(source_id, len(result))
+            gate_env = AUTH_GATED.get(source_id)
+            if gate_env and not os.environ.get(gate_env):
+                # 优雅降级：需 cookie/key 的源未配置 secret → 预期 0 产出，标注待配，不计采集故障
+                logger.info(f"  · {name}: 0 items (待配 {gate_env}，已降级)")
+                if tracker:
+                    tracker.update_platform_status(source_id, 0, note=f"待配 {gate_env}")
+            else:
+                # 核心源静默吐 0：从 INFO 提升为 WARNING，不再悄悄溜过（§4.2 R1 告警）。
+                # 不做硬失败：部分核心源（如 taptap）本就低频，0 产出不应阻断管线；
+                # 持久信号交由健康层按 consecutive_silent_days 自动 degraded/dormant。
+                # 硬失败（非零退出）仍只保留给抛异常的核心源（见 core_failures 主路径）。
+                if source_id in CORE_SOURCES:
+                    logger.warning(f"  {name}: CORE source 0 items — 已告警，健康层据连续沉默天数降级 (§4.2 R1)")
+                else:
+                    logger.info(f"  · {name}: 0 items")
+                if tracker:
+                    tracker.update_platform_status(source_id, 0)
 
     # Diagnostic summary
     logger.info("=== 采集诊断 ===")

--- a/projects/news/scripts/data_quality.py
+++ b/projects/news/scripts/data_quality.py
@@ -174,7 +174,8 @@ class SilentPlatformTracker:
         with open(self.health_path, 'w', encoding='utf-8') as f:
             json.dump(self.health_data, f, ensure_ascii=False, indent=2)
 
-    def update_platform_status(self, platform: str, items_count: int, error: Optional[str] = None):
+    def update_platform_status(self, platform: str, items_count: int,
+                               error: Optional[str] = None, note: Optional[str] = None):
         """
         更新平台状态。
 
@@ -182,6 +183,7 @@ class SilentPlatformTracker:
             platform: 平台名称
             items_count: 本次采集到的条目数
             error: 如果失败，错误信息
+            note: 降级原因标注（如「待配 NGA_COOKIE」），恢复产出后自动清除
         """
         today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
 
@@ -214,6 +216,12 @@ class SilentPlatformTracker:
                 p['level'] = self.LEVEL_DORMANT
             elif p['consecutive_silent_days'] >= self.DEGRADED_THRESHOLD:
                 p['level'] = self.LEVEL_DEGRADED
+
+        # 降级原因标注：恢复产出后清除，否则记录调用方给的 note（如「待配 cookie」）
+        if items_count > 0:
+            p.pop('note', None)
+        elif note:
+            p['note'] = note
 
         if error:
             p['errors'].append({

--- a/projects/news/scripts/sources.py
+++ b/projects/news/scripts/sources.py
@@ -76,6 +76,18 @@ CORE_SOURCES = [
     'steam', 'official', 'youtube', 'discord',
 ]
 
+# 需登录态 cookie / API key 才能采集的源 → 所需环境变量名（单一真相源）。
+# 未配置对应 secret 时：该源 0 产出属预期降级（标注「待配」，不计采集故障）；
+# 已配置 secret 仍 0 产出：才视为真故障。collect_global 据此区分「待配 cookie」与「核心源静默失败」。
+AUTH_GATED = {
+    'nga': 'NGA_COOKIE',
+    'zhihu': 'ZHIHU_COOKIE',
+    'naver_cafe': 'NAVER_COOKIE',
+    'youtube': 'YOUTUBE_API_KEY',
+    'discord': 'DISCORD_BOT_TOKEN',
+    'telegram': 'TELEGRAM_CHANNELS',
+}
+
 # Discord 有独立归档器（discord_archiver.py），不走 archive_platforms 的按日归档
 ARCHIVE_PLATFORMS = [s for s in KNOWN_SOURCES if s != 'discord']
 

--- a/tests/test_collect_global.py
+++ b/tests/test_collect_global.py
@@ -182,6 +182,18 @@ class TestFailureAggregation(unittest.TestCase):
         self.assertEqual(core_failures, [])
         self.assertEqual(len(items), 1)
 
+    def test_core_empty_not_hard_failure(self):
+        # 设计决策：核心源「静默吐 0」只告警（WARNING）+ 健康层降级，不进 core_failures。
+        # 部分核心源（如 taptap）本就低频长期 0，硬失败会让管线永久非零退出。
+        # 仅「抛异常」的核心源才进 core_failures（见 test_core_failure_recorded）。
+        self._patch_fetchers({
+            "Reddit": lambda: [_item("r", "https://r/1")],
+            # Bilibili / TapTap / NGA 等核心源默认返回 []（空）→ 只告警，不入 core_failures
+        })
+        items, core_failures = collect_global.run_zero_cost_collectors()
+        self.assertEqual(core_failures, [])
+        self.assertEqual(len(items), 1)
+
     def test_merge_order_deterministic(self):
         # Concurrent collection must merge in a stable, engagement-sorted order
         # regardless of which thread finishes first.


### PR DESCRIPTION
## 背景

对新闻采集器二/三/四档异常源逐一**实跑取证**后的修复。一手诊断结论：

| 源 | 实测 | 真因 |
|----|------|------|
| nga（核心） | unparseable JS | 反爬，需 `NGA_COOKIE`；却因「只有抛异常才告警」**静默吐 0 溜过 §4.2 R1** |
| zhihu / naver_cafe | 403 | 需登录态 cookie（`ZHIHU_COOKIE` / `NAVER_COOKIE`） |
| note_com / google_play | 403 / 缺包 | cloudscraper、google-play-scraper **在 CI 已装**（沙箱才缺），note_com 真因是 Cloudflare |
| arca_live | **90 条** | 其实已恢复，health 标签滞后（下一轮自愈） |
| twitter / bahamut / official | 0 | 数据真空 / 低频，探头健康，非 bug |
| fivech / telegram | dormant | fivech 主端点 404；telegram 缺 `TELEGRAM_CHANNELS` |

## 改动

- **`sources.py`**：新增 `AUTH_GATED`（源 → 所需 secret 环境变量），作为「需 cookie/key 才能产出」的单一真相源。
- **`collect_global.py`**：
  - 从 `sources.py` 导入权威 `CORE_SOURCES`，**消除硬编码 4 元素漂移**（原为 `{bilibili,reddit,nga,taptap}`，与权威 8 源不一致）。
  - 空结果分支区分两种情况：
    - **待配 secret**（如 nga 未配 `NGA_COOKIE`）→ 优雅降级，日志 + health 标注 `待配 <ENV>`，**不计故障**；
    - **核心源其他情况吐 0** → INFO 提升为 **WARNING**（可见告警）+ 健康层按连续沉默天数降级。**不做硬失败**：taptap 等低频核心源本就长期 0，硬失败会让管线永久非零退出。
  - 硬失败（非零退出）仍只保留给**抛异常**的核心源（原 R1 契约不变）。
- **`data_quality.py`**：`update_platform_status` 新增可选 `note` 字段，写入 `source-health.json`，恢复产出后自动清除。
- **`tests/`**：钉死新契约（核心源静默吐 0 ≠ 硬失败，仅异常才进 `core_failures`）。

## 验证

- `pytest tests/` → **233 passed, 14 subtests passed**
- 六场景仿真：nga/zhihu 未配 → 待配降级；reddit 真 0 → 告警；youtube 已配密钥仍 0 → 告警；bahamut 非核心 0 → 容忍。
- `note` 字段实测：写入「待配 NGA_COOKIE」→ 恢复产出后自动清除。

## 后续（需守密人）

- 配置 `NGA_COOKIE` / `ZHIHU_COOKIE` / `NAVER_COOKIE` secret 即可激活对应源（代码侧已就绪）。
- fivech 主端点 `pug.5ch.io/applism` 已失效，需另寻端点（dormant 128 天，低 ROI）。

https://claude.ai/code/session_0192nifEuLyw2PBWiiebmvvD

---
_Generated by [Claude Code](https://claude.ai/code/session_0192nifEuLyw2PBWiiebmvvD)_