### PR TITLE
TapTap: deep-scroll collection + backfill registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,8 +160,7 @@ git commit = 数据归档提交 / git push = 同步至远端存储 /
 | `assets/data/narrative-structure.json` | 三部叙事结构、各章压缩细节、角色线 |
 | `assets/data/design-decisions.json` | 设计哲学、被砍机制、平衡理念 |
 | `assets/data/card-system.json` | 卡牌系统术语（指令卡等，解包字面验证） |
-| `projects/wiki/data/db/characters.json` | 72 角色基线（自举进度见 `memory/project-status.md`） |
-| `projects/wiki/data/extracted/categorized/character_data.txt` | 72 角色原始字段（客户端解包，自举数据源） |
+| `projects/wiki/data/extracted/categorized/character_data.txt` | 72 角色基线原始字段（客户端解包，自举数据源；原结构化角色数据层随 #221 退役、待 W2 重建，进度见 `memory/project-status.md`）|
 | `memory/morimens-context.md` | 世界观术语 + 历史时间线 |
 
 ### §5.2 社区情报（先读 §4 数据纪律）

--- a/projects/news/scripts/backfill_platforms.py
+++ b/projects/news/scripts/backfill_platforms.py
@@ -648,6 +648,40 @@ def backfill_weixin(state: dict, max_pages: int) -> int:
     return total
 
 
+def backfill_taptap(state: dict, max_pages: int) -> int:
+    """TapTap 帖子/评价历史回溯。
+
+    TapTap 无可用官方 API（webapiv2 端点全 404），复用 taptap_collector 的
+    Playwright 滚动深采：回溯模式下用深 cutoff（180 天）+ 放大滚动轮次
+    （max_pages*4），一次尽量多抓历史，并绕过增量短路（backfill=True）。
+    帖子归 taptap/、评价归 taptap_review/，与日常增量同目录、按 URL 去重合并。
+
+    注意：实际可补深度受 TapTap 懒加载放出的历史上限约束，无法保证补到任意
+    久远；浏览器采集需 CI 带 Chromium 环境，本地无浏览器时返回 0 不报错。
+    """
+    ps = _platform_state(state, 'taptap')
+    cutoff = datetime.now(timezone.utc) - timedelta(days=180)
+    try:
+        import asyncio
+        import taptap_collector
+        topics, reviews = asyncio.run(
+            taptap_collector.collect(
+                cutoff=cutoff, max_scrolls=max_pages * 4, backfill=True
+            )
+        )
+    except Exception as e:
+        logger.warning(f'TapTap backfill failed (browser env required): {e}')
+        return 0
+
+    _archive_items('taptap', topics)
+    _archive_items('taptap_review', reviews)
+    count = len(topics) + len(reviews)
+    ps['total'] = ps.get('total', 0) + count
+    ps['page'] = ps.get('page', 1) + 1
+    ps['last_run'] = datetime.now(timezone.utc).isoformat()
+    return count
+
+
 # ── Registry ──────────────────────────────────────────────────────────────
 
 BACKFILL_REGISTRY = {
@@ -658,6 +692,7 @@ BACKFILL_REGISTRY = {
     'pixiv': backfill_pixiv,
     'ruliweb': backfill_ruliweb,
     'weixin': backfill_weixin,
+    'taptap': backfill_taptap,
 }
 
 

--- a/projects/news/scripts/sources.py
+++ b/projects/news/scripts/sources.py
@@ -85,7 +85,7 @@ ARCHIVE_PLATFORMS = [s for s in KNOWN_SOURCES if s != 'discord']
 # backfill_platforms.py 的 PLATFORM_BACKFILLERS 实际支持的源（务必与之同步）
 BACKFILL_PLATFORMS = [
     'bilibili', 'appstore', 'steam_review', 'arca_live',
-    'pixiv', 'ruliweb', 'weixin',
+    'pixiv', 'ruliweb', 'weixin', 'taptap',
 ]
 
 # data/platforms/ 下仍有历史归档、但采集逻辑已移除的遗留源。

--- a/projects/news/scripts/taptap_collector.py
+++ b/projects/news/scripts/taptap_collector.py
@@ -80,6 +80,61 @@ def _parse_taptap_dom_time(time_str):
     return news_common.parse_relative_time(time_str)[0]
 
 
+# ─── 滚动深采（懒加载分页）─────────────────────────────────────
+
+async def _autoscroll_collect(page, parse_fn, captured, max_scrolls: int, cutoff) -> list[dict]:
+    """滚动页面触发懒加载，累积并合并所有捕获 API 响应中的条目（按 item_id/url 去重）。
+
+    TapTap 评价/帖子页是 Nuxt 客户端渲染、滚动到底懒加载下一批。原逻辑只取首屏
+    第一个有效响应（约十几条），此函数下滑 max_scrolls 次、把每次新触发的 XHR
+    响应一并解析合并，直到：连续两轮无新增（到底）或已捕获条目最早时间早于 cutoff
+    （回溯深度足够）。返回去重后的 raw 条目列表。
+    """
+    merged: dict[str, dict] = {}
+
+    def _merge() -> None:
+        # captured 由 page.on("response") 持续追加，每轮重新全量合并即可
+        for _url, body in list(captured):
+            for it in parse_fn(body):
+                key = it.get("item_id") or it.get("url") or it.get("title", "")[:60]
+                if key and key not in merged:
+                    merged[key] = it
+
+    def _reached_cutoff() -> bool:
+        if not cutoff or not merged:
+            return False
+        try:
+            earliest = min(
+                datetime.fromisoformat(it["created"])
+                for it in merged.values()
+                if it.get("created")
+            )
+            return earliest < cutoff
+        except Exception:
+            return False
+
+    _merge()  # 首屏已捕获的先并入
+    stale = 0
+    for _ in range(max(0, max_scrolls)):
+        if _reached_cutoff():
+            break
+        prev = len(merged)
+        try:
+            await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+        except Exception:
+            pass
+        await page.wait_for_timeout(1800)  # 等待懒加载 XHR 返回
+        _merge()
+        if len(merged) == prev:
+            stale += 1
+            if stale >= 2:  # 连续两轮无新增 = 已到底
+                break
+        else:
+            stale = 0
+
+    return list(merged.values())
+
+
 # ─── 帖子页 ───────────────────────────────────────────────────
 
 def _parse_topic_api_body(body: dict) -> list[dict]:
@@ -153,8 +208,8 @@ def _parse_topic_api_body(body: dict) -> list[dict]:
     return results
 
 
-async def _extract_topics(page) -> list[dict]:
-    """访问帖子页，优先拦截网络响应，fallback 到 DOM 提取。"""
+async def _extract_topics(page, max_scrolls: int = 5, cutoff=None) -> list[dict]:
+    """访问帖子页，滚动累积拦截的网络响应，fallback 到 DOM 提取。"""
     captured: list[tuple[str, dict]] = []
 
     async def handle_response(response):
@@ -183,14 +238,13 @@ async def _extract_topics(page) -> list[dict]:
     # 额外等待 JS 异步渲染
     await page.wait_for_timeout(3000)
 
-    # 1. 从拦截的 API 响应中提取
-    for api_url, body in captured:
-        items = _parse_topic_api_body(body)
-        if items:
-            logger.info(f"TapTap topics: {len(items)} from API {api_url}")
-            return items
+    # 1. 滚动累积所有拦截到的 API 响应（合并去重）
+    items = await _autoscroll_collect(page, _parse_topic_api_body, captured, max_scrolls, cutoff)
+    if items:
+        logger.info(f"TapTap topics: {len(items)} after {max_scrolls}-scroll API merge")
+        return items
 
-    # 2. Fallback: DOM 提取
+    # 2. Fallback: DOM 提取（此时页面已滚动到底，DOM 含更多条目）
     logger.info("TapTap: API interception yielded no topics, falling back to DOM")
     return await _extract_topics_dom(page)
 
@@ -222,7 +276,7 @@ async def _extract_topics_dom(page) -> list[dict]:
         for (const sel of candidateSelectors) {
             const els = document.querySelectorAll(sel);
             if (els.length >= 3) {  // 至少3条才认为找到了
-                postElements = Array.from(els).slice(0, 30);
+                postElements = Array.from(els).slice(0, 200);
                 break;
             }
         }
@@ -355,8 +409,8 @@ def _parse_review_api_body(body: dict) -> list[dict]:
     return results
 
 
-async def _extract_reviews(page) -> list[dict]:
-    """访问评价页，优先拦截网络响应，fallback 到 DOM 提取。"""
+async def _extract_reviews(page, max_scrolls: int = 5, cutoff=None) -> list[dict]:
+    """访问评价页，滚动累积拦截的网络响应，fallback 到 DOM 提取。"""
     captured: list[tuple[str, dict]] = []
 
     async def handle_response(response):
@@ -383,11 +437,11 @@ async def _extract_reviews(page) -> list[dict]:
 
     await page.wait_for_timeout(3000)
 
-    for api_url, body in captured:
-        items = _parse_review_api_body(body)
-        if items:
-            logger.info(f"TapTap reviews: {len(items)} from API {api_url}")
-            return items
+    # 滚动累积所有拦截到的评价 API 响应（合并去重）
+    items = await _autoscroll_collect(page, _parse_review_api_body, captured, max_scrolls, cutoff)
+    if items:
+        logger.info(f"TapTap reviews: {len(items)} after {max_scrolls}-scroll API merge")
+        return items
 
     logger.info("TapTap: API interception yielded no reviews, falling back to DOM")
     return await _extract_reviews_dom(page)
@@ -417,7 +471,7 @@ async def _extract_reviews_dom(page) -> list[dict]:
         for (const sel of candidateSelectors) {
             const found = document.querySelectorAll(sel);
             if (found.length >= 3) {
-                els = Array.from(found).slice(0, 30);
+                els = Array.from(found).slice(0, 200);
                 break;
             }
         }
@@ -474,9 +528,19 @@ async def _extract_reviews_dom(page) -> list[dict]:
 
 # ─── 主入口 ───────────────────────────────────────────────────
 
-async def collect(cutoff: datetime | None = None) -> tuple[list[dict], list[dict]]:
+async def collect(
+    cutoff: datetime | None = None,
+    max_scrolls: int = 5,
+    backfill: bool = False,
+) -> tuple[list[dict], list[dict]]:
     """
     启动 headless Chromium，采集帖子和评价。
+
+    参数:
+      cutoff:      只保留晚于此时刻的条目；None 时默认近 24 小时（日常增量）。
+      max_scrolls: 每页下滑触发懒加载的最大轮次；回溯时调大以抓取更深历史。
+      backfill:    回溯模式。绕过「遇到上次最新 ID 即停」的增量短路，
+                   仅用 cutoff 控制时间深度，便于一次性补齐历史。
 
     返回 (topic_items, review_items)，每条均为 collector._make_item() 兼容的字典。
     """
@@ -504,7 +568,7 @@ async def collect(cutoff: datetime | None = None) -> tuple[list[dict], list[dict
             # 帖子页
             page = await context.new_page()
             try:
-                topic_raw = await _extract_topics(page)
+                topic_raw = await _extract_topics(page, max_scrolls, cutoff)
             except Exception as e:
                 logger.warning(f"TapTap topics extraction failed: {e}")
             finally:
@@ -513,7 +577,7 @@ async def collect(cutoff: datetime | None = None) -> tuple[list[dict], list[dict
             # 评价页
             page2 = await context.new_page()
             try:
-                review_raw = await _extract_reviews(page2)
+                review_raw = await _extract_reviews(page2, max_scrolls, cutoff)
             except Exception as e:
                 logger.warning(f"TapTap reviews extraction failed: {e}")
             finally:
@@ -563,8 +627,8 @@ async def collect(cutoff: datetime | None = None) -> tuple[list[dict], list[dict
     topic_items: list[dict] = []
     for raw in topic_raw:
         item_id = raw.get("item_id", "")
-        if item_id and item_id == last_post_id:
-            break  # 已处理到上次位置
+        if not backfill and item_id and item_id == last_post_id:
+            break  # 增量模式：已处理到上次位置（回溯模式不短路，靠 cutoff 控深度）
         if item_id and not new_last_post_id:
             new_last_post_id = item_id  # 记录本次最新ID（第一条）
         item = _to_item(raw, "taptap_post")
@@ -574,7 +638,7 @@ async def collect(cutoff: datetime | None = None) -> tuple[list[dict], list[dict
     review_items: list[dict] = []
     for raw in review_raw:
         item_id = raw.get("item_id", "")
-        if item_id and item_id == last_review_id:
+        if not backfill and item_id and item_id == last_review_id:
             break
         if item_id and not new_last_review_id:
             new_last_review_id = item_id

--- a/tests/test_taptap_scroll.py
+++ b/tests/test_taptap_scroll.py
@@ -1,0 +1,89 @@
+"""taptap_collector 滚动深采（_autoscroll_collect）核心逻辑单测。
+
+不依赖真实浏览器：用 mock async page 模拟「每滚动一轮触发一批新 XHR 响应」，
+验证多响应合并去重、cutoff 深度停止、到底（连续无新增）停止三条行为。
+"""
+
+import asyncio
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "projects/news/scripts"))
+import taptap_collector  # noqa: E402
+
+
+def _parse(body):
+    """测试用 parse_fn：body['items'] 即原始条目列表。"""
+    return body.get("items", [])
+
+
+def _item(iid, days_ago=0):
+    t = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+    return {"item_id": iid, "url": f"https://t/{iid}", "title": f"t{iid}", "created": t}
+
+
+class _MockPage:
+    """每次 wait_for_timeout 往 captured 追加下一批响应，模拟滚动懒加载。"""
+
+    def __init__(self, batches, captured):
+        self._batches = batches
+        self._captured = captured
+        self._i = 0
+
+    async def evaluate(self, _js):
+        return None
+
+    async def wait_for_timeout(self, _ms):
+        if self._i < len(self._batches):
+            self._captured.append(("url", {"items": self._batches[self._i]}))
+            self._i += 1
+
+
+def test_autoscroll_merges_and_dedups():
+    captured = [("url", {"items": [_item("1")]})]  # 首屏
+    batches = [
+        [_item("2"), _item("1")],  # 第二批含重复 1
+        [_item("3")],
+    ]
+    page = _MockPage(batches, captured)
+    items = asyncio.run(
+        taptap_collector._autoscroll_collect(page, _parse, captured, max_scrolls=5, cutoff=None)
+    )
+    ids = sorted(i["item_id"] for i in items)
+    assert ids == ["1", "2", "3"], f"应合并去重为 1/2/3，实得 {ids}"
+
+
+def test_autoscroll_stops_at_cutoff_depth():
+    captured = [("url", {"items": [_item("a", days_ago=1)]})]
+    # 第二批引入 200 天前的老条目 → 触达 cutoff（180 天）应停止继续滚动
+    batches = [
+        [_item("b", days_ago=200)],
+        [_item("c", days_ago=1)],  # 不应被抓到（已在上一轮后 break）
+    ]
+    page = _MockPage(batches, captured)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=180)
+    items = asyncio.run(
+        taptap_collector._autoscroll_collect(page, _parse, captured, max_scrolls=10, cutoff=cutoff)
+    )
+    ids = {i["item_id"] for i in items}
+    assert "b" in ids, "应抓到触达 cutoff 的老条目 b"
+    assert "c" not in ids, "触达 cutoff 后应停止，不再抓 c"
+
+
+def test_autoscroll_stops_when_exhausted():
+    # 无新批次：连续无新增应在有限轮内停止（不空转满 max_scrolls）
+    captured = [("url", {"items": [_item("x")]})]
+    page = _MockPage([], captured)
+    items = asyncio.run(
+        taptap_collector._autoscroll_collect(page, _parse, captured, max_scrolls=100, cutoff=None)
+    )
+    assert len(items) == 1 and items[0]["item_id"] == "x"
+    assert page._i == 0  # 无批次可注入
+
+
+if __name__ == "__main__":
+    test_autoscroll_merges_and_dedups()
+    test_autoscroll_stops_at_cutoff_depth()
+    test_autoscroll_stops_when_exhausted()
+    print("all passed")


### PR DESCRIPTION
## 背景

守密人指出 TapTap 数据量异常（仅 51 条）。诊断确认根因：TapTap 无可用官方 API（webapiv2 端点全 404、Nuxt 客户端渲染），采集器只 `goto + 等3秒 + 返回首个捕获的 API 响应`（约十几条），**从不滚动触发懒加载分页**，DOM 兜底还硬截 `slice(0,30)`；且 taptap 不在回溯名单、采集器 2026-06-13 才接入——故只有 4 天首屏的累积。

守密人裁定：滚动分页深采 + 接入回溯。

## 改动

**采集器 `taptap_collector.py`**
- 新增 `_autoscroll_collect()`：下滑至页底最多 `max_scrolls` 轮，合并**所有**捕获的 XHR 响应条目（按 item_id/url 去重），并在「连续两轮无新增（到底）」或「最早条目早于 cutoff（深度够）」时提前停止。
- `_extract_topics`/`_extract_reviews` 改为跨滚动合并，不再「取首个响应即返回」。
- DOM 兜底上限 30 → 200（兜底执行时页面已滚动到底）。
- `collect()` 新增 `max_scrolls` + `backfill` 参数；回溯模式绕过「遇上次最新 ID 即停」的增量短路，仅靠 cutoff 控深度。

**回溯接入 `backfill_platforms.py` / `sources.py`**
- 新增 `backfill_taptap()`：深 cutoff（180 天）+ `max_pages*4` 滚动轮次，帖子归 `taptap/`、评价归 `taptap_review/`，按 URL 去重合并；无浏览器环境时返回 0 不报错。
- 注册进 `BACKFILL_REGISTRY` 与 `sources.BACKFILL_PLATFORMS`（两者一致性已断言）。

**测试 `test_taptap_scroll.py`**：mock async page 驱动 3 个用例——跨滚动合并去重、cutoff 深度停止、到底停止。

**连带修复**：`CLAUDE.md §5.1` 引用的 `db/characters.json` 已被 #221 删除，改指向现存 `extracted/` 数据源（原先在 main 上导致 `test_referenced_paths_exist` 失败）。

## 验证

- 全量 `pytest tests/`：**236 passed, 14 subtests passed**（含新增 3 项）。
- `BACKFILL_PLATFORMS` 与 `BACKFILL_REGISTRY` 一致性校验通过。

## 重要说明（诚实标注）

实际可补抓的历史深度，取决于 TapTap 懒加载放出多少历史，**须在带 Chromium 的 CI 环境实跑验证**——本开发环境无法对 taptap.cn 执行 Playwright（外网 + 浏览器二进制 + 反爬）。本 PR 保证逻辑正确、去重/停止/接入到位，实采增量待 CI 回溯任务运行后观察。

https://claude.ai/code/session_011sGv6KLzLhbbLJisoVpnn9

---
_Generated by [Claude Code](https://claude.ai/code/session_011sGv6KLzLhbbLJisoVpnn9)_