### PR TITLE
暂停志愿者 Discord 归档定时（待 bot 接入修复）

### DIFF
--- a/.github/workflows/discord-archive-volunteer.yml
+++ b/.github/workflows/discord-archive-volunteer.yml
@@ -5,9 +5,11 @@ name: Discord Archive (Volunteer)
 #   - 复用同一 bot（DISCORD_BOT_TOKEN），仅 guild_id 不同
 #   - 频繁运行以快速回填历史；不触碰 Global 数据
 on:
-  schedule:
-    # 每小时一次，offset :15 错开 Global（:00 增量 / :30 历史回填）
-    - cron: '15 * * * *'
+  # 定时暂停：bot 对该 guild 返回 403（未入驻/缺 View Channels），
+  # 接入修复并手动验证成功后再恢复下面的 schedule。
+  # schedule:
+  #   # 每小时一次，offset :15 错开 Global（:00 增量 / :30 历史回填）
+  #   - cron: '15 * * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## 背景
志愿者归档 workflow 首跑（[run #1](https://github.com/lightproud/brain-in-a-vat/actions/runs/27623170979)）在 `fetch_guild_meta` 即返回 **403 Forbidden** —— bot 尚未真正入驻志愿者 guild（或缺 View Channels 权限）。代码侧正常（正确以 volunteer guild 启动、token 已注入、分层逻辑走到真实 API 调用），问题在 Discord 接入端。

## 改动
暂停志愿者 workflow 的每小时 `schedule`（注释保留），止住 bot 接入修复前每小时一次的 403 失败通知噪音。保留 `workflow_dispatch`，bot 重邀请后可手动重新触发验证；验证成功后再恢复 schedule。

不影响 Global 采集，不触碰任何数据。

https://claude.ai/code/session_011sGv6KLzLhbbLJisoVpnn9

---
_Generated by [Claude Code](https://claude.ai/code/session_011sGv6KLzLhbbLJisoVpnn9)_