### PR TITLE
恢复志愿者 Discord 归档每小时定时（首跑已成功）

### DIFF
--- a/.github/workflows/discord-archive-volunteer.yml
+++ b/.github/workflows/discord-archive-volunteer.yml
@@ -5,11 +5,9 @@ name: Discord Archive (Volunteer)
 #   - 复用同一 bot（DISCORD_BOT_TOKEN），仅 guild_id 不同
 #   - 频繁运行以快速回填历史；不触碰 Global 数据
 on:
-  # 定时暂停：bot 对该 guild 返回 403（未入驻/缺 View Channels），
-  # 接入修复并手动验证成功后再恢复下面的 schedule。
-  # schedule:
-  #   # 每小时一次，offset :15 错开 Global（:00 增量 / :30 历史回填）
-  #   - cron: '15 * * * *'
+  schedule:
+    # 每小时一次，offset :15 错开 Global（:00 增量 / :30 历史回填）
+    - cron: '15 * * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## 背景
志愿者归档手动首跑（[run #2](https://github.com/lightproud/brain-in-a-vat/actions/runs/27626642343)）142 秒绿灯完成，接入与归档验证全部通过：
- bot 连通志愿者 guild `1402537664619479100` 成功（403 已解除）
- 发现 31 个频道，本跑入库 1701 条消息（246 个日 JSONL 文件）
- 抽样消息正文非空（453 字样本），Message Content Intent 生效
- 历史回填游标在 `2026-05`，将随定时逐月向前补齐

## 改动
恢复 #226 中暂停的每小时 `schedule`（`:15` 错开 Global），让志愿者频繁归档与历史回填持续推进。不影响 Global，数据仍隔离在 `data/discord/guilds/1402537664619479100/`。

https://claude.ai/code/session_011sGv6KLzLhbbLJisoVpnn9

---
_Generated by [Claude Code](https://claude.ai/code/session_011sGv6KLzLhbbLJisoVpnn9)_