### PR TITLE
Discord 采集器：频道首次采集走冷启动全量回填

### DIFF
--- a/projects/news/scripts/discord_archiver.py
+++ b/projects/news/scripts/discord_archiver.py
@@ -372,10 +372,68 @@ class DiscordArchiver:
 
     # ── Track 1: Incremental (new messages since last run) ───────────────────
 
+    def _cold_start_backfill(self, channel_id, channel_name: str = '') -> int:
+        """First-ever pass for a channel: page BACKWARD (before cursor) from
+        newest to oldest, up to MAX_MESSAGES_PER_CHANNEL, so a freshly-added
+        guild/channel is archived in full on first run instead of only its
+        latest 100. Sets the incremental cursor to the newest message so
+        subsequent runs resume normal after-based incremental. Any messages
+        older than the cap fall to the historical backfill track.
+        """
+        ch_key = str(channel_id)
+        total = 0
+        before = None
+        newest_id = '0'
+
+        while total < MAX_MESSAGES_PER_CHANNEL:
+            if self._is_time_up():
+                logger.warning(f'Runtime limit during cold-start backfill: {channel_name}')
+                break
+            params = {'limit': 100}
+            if before:
+                params['before'] = before
+            try:
+                messages = self._api(f'/channels/{channel_id}/messages', **params)
+            except Exception as e:
+                logger.warning(f'Channel {channel_id} cold-start fetch failed: {e}')
+                break
+            if not isinstance(messages, list) or not messages:
+                break
+            messages.sort(key=lambda m: m['id'])  # ascending
+            if before is None:
+                # First batch (no cursor) holds the newest messages; the last
+                # after ascending sort is the channel's newest message overall.
+                newest_id = messages[-1]['id']
+            for msg in messages:
+                self._process_message(msg, channel_id, channel_name)
+                total += 1
+            before = messages[0]['id']  # page further back from the oldest in batch
+            time.sleep(REQUEST_DELAY)
+            if len(messages) < 100:
+                break
+
+        if newest_id != '0':
+            self._ch_state(ch_key)['last_message_id'] = newest_id
+            self._ch_state(ch_key)['name'] = channel_name
+            self._ch_state(ch_key)['cold_started'] = True
+
+        if total >= MAX_MESSAGES_PER_CHANNEL:
+            logger.info(f'Cold-start {channel_name}({channel_id}): hit cap {MAX_MESSAGES_PER_CHANNEL}, older history via backfill track')
+        else:
+            logger.info(f'Cold-start {channel_name}({channel_id}): {total} messages (full channel)')
+        return total
+
     def fetch_channel_incremental(self, channel_id, channel_name: str = '') -> int:
-        """Fetch all new messages since last archived message. Returns count."""
+        """Fetch all new messages since last archived message. Returns count.
+
+        On the very first pass for a channel (no stored cursor) this delegates
+        to a full backward backfill so freshly-added guilds capture their whole
+        history, not just the latest 100 messages.
+        """
         ch_key = str(channel_id)
         last_id = self._ch_state(ch_key).get('last_message_id', '0')
+        if last_id == '0':
+            return self._cold_start_backfill(channel_id, channel_name)
         total = 0
 
         while total < MAX_MESSAGES_PER_CHANNEL:

--- a/tests/test_discord_archiver.py
+++ b/tests/test_discord_archiver.py
@@ -1,7 +1,10 @@
+import os
 import sys
+import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "projects" / "news" / "scripts"))
 
@@ -9,12 +12,83 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "projects" / "ne
 # no network), so the module can be imported directly.
 from discord_archiver import (
     DISCORD_EPOCH_MS,
+    DiscordArchiver,
     _dt_from_sf,
     _mstr,
     _month_bounds,
     _prev_month,
     _sf_from_dt,
 )
+
+
+def _msg(mid: int) -> dict:
+    """Minimal raw Discord message with a numeric snowflake id."""
+    return {
+        "id": str(mid),
+        "channel_id": "chan",
+        "type": 0,
+        "author": {"id": "u1", "username": "tester", "bot": False},
+        "content": f"msg {mid}",
+        "timestamp": "2026-05-03T14:41:39.000000+00:00",
+    }
+
+
+class TestColdStartBackfill(unittest.TestCase):
+    """First-ever channel pass pages backward to capture full history, not
+    just the latest 100 (regression guard for the volunteer-guild fix)."""
+
+    def _make_archiver(self, tmpdir):
+        env = {
+            "DISCORD_BOT_TOKEN": "dummy",
+            "DISCORD_GUILD_ID": "999",
+            "DISCORD_DATA_ROOT": tmpdir,
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            return DiscordArchiver()
+
+    def test_cold_start_pages_backward_and_sets_cursor_to_newest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            arch = self._make_archiver(tmp)
+            # 250 messages: ids 1001..1250. Discord returns newest-first per page.
+            all_ids = list(range(1001, 1251))
+
+            def fake_api(path, **params):
+                before = params.get("before")
+                # newest-first ordering
+                pool = sorted(all_ids, reverse=True)
+                if before is not None:
+                    pool = [i for i in pool if i < int(before)]
+                return [_msg(i) for i in pool[:100]]
+
+            with mock.patch.object(arch, "_api", side_effect=fake_api), \
+                    mock.patch("discord_archiver.time.sleep"):
+                total = arch.fetch_channel_incremental("chan", "general")
+
+            self.assertEqual(total, 250)  # full channel, not just latest 100
+            st = arch.state["channels"]["chan"]
+            self.assertEqual(st["last_message_id"], "1250")  # cursor = newest
+            self.assertTrue(st["cold_started"])
+
+    def test_second_run_uses_incremental_after_not_cold_start(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            arch = self._make_archiver(tmp)
+            arch.state["channels"]["chan"] = {"last_message_id": "2000"}
+            seen_params = []
+
+            def fake_api(path, **params):
+                seen_params.append(params)
+                if "after" in params:  # only new messages after 2000
+                    return [_msg(2001), _msg(2002)]
+                return []
+
+            with mock.patch.object(arch, "_api", side_effect=fake_api), \
+                    mock.patch("discord_archiver.time.sleep"):
+                total = arch.fetch_channel_incremental("chan", "general")
+
+            self.assertEqual(total, 2)
+            # Existing channel must use after-based incremental, never before-paging
+            self.assertTrue(all("after" in p for p in seen_params))
+            self.assertFalse(any("before" in p for p in seen_params))
 
 
 class TestSnowflakeHelpers(unittest.TestCase):


### PR DESCRIPTION
## 背景（守密人提问触发）
增量轨在频道**首次采集**时，把游标锚定到「最新 100 条」（从 id=0 起用 after 游标），更早历史留给逐月回填轨。这对百万级的 Global 服务器是合理分工，但对**新接入的小服务器**（如志愿者服务器），会让活跃频道首跑只抓最新 100 条，体感「才这么点消息」。

## 改动
新增 `_cold_start_backfill`：当频道**无存储游标**（首次）时，用 `before` 游标**从最新往最旧翻页**，一次抓满整段历史（到 `MAX_MESSAGES_PER_CHANNEL` 上限），再把增量游标设到最新消息，之后照常走 after 增量。超过上限的更早消息仍由历史轨兜底。

- 小频道首跑即全量；大频道首跑吃满最近 5000，更早交历史轨。
- 对 Global 无副作用（它已采完、不会再冷启动）。
- 惠及将来任何新接入的服务器。

## 测试
新增 2 个回归用例（共 20 项 Discord 测试通过，全量 238 项通过）：
- 冷启动向后翻页抓全 250 条（非只 100），游标置为最新。
- 已有游标的频道仍走 after 增量，绝不退回 before 翻页。

*比喻：以前管理员第一趟只抄每间教室最近一页，旧页慢慢补；现在第一趟就从最新一页一路往回抄到开学第一天，小教室一趟抄完。*

https://claude.ai/code/session_011sGv6KLzLhbbLJisoVpnn9

---
_Generated by [Claude Code](https://claude.ai/code/session_011sGv6KLzLhbbLJisoVpnn9)_