### PR TITLE
wiki: 给 72 唤醒体打可召唤/非可召唤分类标签

### DIFF
--- a/memory/lessons-learned.md
+++ b/memory/lessons-learned.md
@@ -1,6 +1,6 @@
 # 踩坑记录
 
-> 最后更新：2026-04-28 by Code-BPT 会话（lesson #32 生成连贯性压倒数据完整性 + 事实采信纪律 3 条硬规则）
+> 最后更新：2026-06-16 by 艾瑞卡会话（lesson #34 push 413/502 真因=本地 origin/main 陈旧，push 前必先 fetch 对齐 + 诊断命令清单）
 >
 > 记录协作过程中犯过的错误，避免重犯。每条包含 Context、Problem、Fix、Impact。
 
@@ -322,6 +322,22 @@
   - 模拟失败路径：`git remote set-url origin http://nonexistent.local/fake` → 同上 → 验证 hook exit 0（非阻塞）+ log 含「push failed (non-fatal, will retry next session)」+ commit 仍落地（仅未 push）
 - **取舍**：放弃「绝对不做 git push」的简洁性，换取 untracked 自动归档；用「软失败 + log 留痕 + 自愈循环」三重保险压制沉默失败风险——push 失败不丢数据（commit 已落地），下次 SessionStart 同步带过去。
 - **Impact**：守密人会话体验、untracked 累积消除、stop-hook 报警频率下降；SessionEnd hook 与 SessionStart hook 自愈循环正式建立；为未来 hook 扩展（如 SessionEnd 触发 dream phase / index rebuild）提供 commit/push 模式参考。**相关教训**：参考实现给的逻辑要先用「我的边界条件能不能命中」校验一遍，brief 模板的 if 条件链不一定覆盖所有 use case（本次 untracked-only 场景被 `git diff --quiet` 误判跳过即典型例）。
+
+## 34. push 413/502 真因是本地 origin/main 指针陈旧，push 前必先 fetch 对齐
+
+- **Context**：2026-06-16 feature 分支 `claude/wangque-qianye-wiki-zbk125`（删 wiki 结构化层 db/）任务完成，`git push -u` 连续约 10 次失败，远端经本地 git 代理（`127.0.0.1:38095`）返回 **HTTP 413 / 502** 交替 + `send-pack: unexpected disconnect while reading sideband packet`。期间尝试 HTTP/1.1 + 增大 postBuffer + 多轮延时退避，**全部无效**。
+- **Problem（误诊与真因）**：第一反应误判为「Cloudflare 网关瞬时抖动，等自愈」——这是不查数据的空泛归因。硬数据复盘才定位真因：
+  1. 本地 `origin/main` 指针陈旧停在 `c798cf8`，而远端真实 main 早已推进到 `2a8e2e7`（`git ls-remote origin` 一眼看穿）。
+  2. `git rev-list --objects origin/main..HEAD | git pack-objects --stdout | wc -c` = **12,790 字节**（相对陈旧 main 极小）；但 `git rev-list --objects HEAD | git pack-objects` = **713 MB**（全 history，仓库 news 数据 + `update_notices.json` 累积巨大）。
+  3. push 走 smart-HTTP 与服务器实时 want/have 协商。本地 refs 陈旧时协商无法干净对齐共同基底，代理把请求按超大体量退件 → 413（payload too large）/ 502。**413 是真实的「包太大」，不是误报**——只是「大」来自协商失败回退到接近全 history，而非我这次 12.5 KB 的改动。
+- **Fix**：`git fetch origin main` 把远端跟踪指针刷新到最新 `2a8e2e7` **之后**，立即重 push → 一次 PUSH_SUCCEEDED。协商瞬间收敛到最小包（1 提交 / 12.5 KB）。
+- **诊断命令清单**（可重现，遇 push 413/502 先跑这套再下结论）：
+  - `git ls-remote origin | head` —— 看服务器真实 refs，与本地 `git rev-parse origin/main` 对比是否漂移
+  - `git rev-list --objects origin/main..HEAD | git pack-objects --stdout | wc -c` —— 量待推包真实字节数（极小却 413 = 协商/对齐问题，非内容问题）
+  - `git merge-base --is-ancestor <我的基底> origin/main` —— 确认基底是否仍在远端历史
+- **根因归属**：lesson #28（Cloudflare HTTP 413 推送堵塞）+ lesson #31（main 漂移）**同源复发**。原靠 `session-start-sync.sh` 钩子开工自动对齐 main 根治；该钩子 2026-06-14 退役后改「按需手动 `git fetch origin main`」，本次正是漏了开工对齐这一步 → 复发。
+- **硬规则**：**push 前先 `git fetch origin <base>` 对齐远端跟踪指针**；遇 push 413/502 不要空泛归因「网关抖动」或盲目退避重试，先跑上面三条诊断命令用字节数据定位，再处置。
+- **Impact**：消除「push 失败 = 等自愈」的误诊惯性；为所有银芯子会话（钩子退役后手动对齐时代）提供 push 故障的标准诊断路径；呼应 lesson #32 事实采信纪律——结论必须由直接产出该事实的工具（`ls-remote` / `pack-objects` / `merge-base`）支撑，禁止凭印象外推。
 
 ---
 

--- a/projects/wiki/data/processed/characters.json
+++ b/projects/wiki/data/processed/characters.json
@@ -2,7 +2,14 @@
   "_meta": {
     "source": "AwakerConfig.lua (runtime memory extraction)",
     "total_characters": 72,
-    "generated": "2026-04-25"
+    "generated": "2026-04-25",
+    "category_criterion": "依据源 AwakerConfig 是否含 SummonSlogan(召唤台词)区分:有=summonable(可召唤唤醒体),无=non_summonable(非可召唤单位,含 Boss/敌方/本源变体/彩蛋,缺叙事字段属预期而非数据缺失)",
+    "category_counts": {
+      "summonable": 54,
+      "non_summonable": 18
+    },
+    "subtype_note": "non_summonable 下 subtype:origin_variant 依名字「本源」前缀客观赋值;special 为其余非可召唤单位,Boss/敌方/彩蛋的精确细分需可验证来源,暂不臆断",
+    "categorized": "2026-06-16"
   },
   "characters": [
     {
@@ -19,7 +26,8 @@
       "characteristic": "反击敌人    多次伤害",
       "introduction": "鞭打对手的同时获得大量反击，让意欲还击的对手痛不欲生。",
       "gameplay_intro": "·通过灵知觉醒和指令卡可以快速堆叠反击，造成伤害越高，获得的反击越多。",
-      "summon_slogan": "不要盲信表象的甜蜜，热情的皮囊下，说不定藏匿着恶鬼。"
+      "summon_slogan": "不要盲信表象的甜蜜，热情的皮囊下，说不定藏匿着恶鬼。",
+      "category": "summonable"
     },
     {
       "id": 15561,
@@ -35,7 +43,9 @@
       "characteristic": "卡牌强化    力量夺取",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "origin_variant"
     },
     {
       "id": 15562,
@@ -51,7 +61,8 @@
       "characteristic": "中毒爆发    资源循环",
       "introduction": "在超维空间或手牌中不断成长翠色火焰，释放狂气爆发将其一并释放烧尽敌人。",
       "gameplay_intro": "·回合结束时「绿炎」若在手牌或超维空间中，将会升级为<DerivativeCardKeywords_19:「腐化绿炎」>，升级后可以造成更高的伤害和中毒。",
-      "summon_slogan": "旋转的足尖承载了她的梦想，她的追求，以及那一切破灭后，从痛恨与绝望中燃起的青色火焰。"
+      "summon_slogan": "旋转的足尖承载了她的梦想，她的追求，以及那一切破灭后，从痛恨与绝望中燃起的青色火焰。",
+      "category": "summonable"
     },
     {
       "id": 15563,
@@ -67,7 +78,8 @@
       "characteristic": "触腕爆发    触腕成长",
       "introduction": "以王者威压号令触腕制裁敌人，并以王的血脉迅速激发爆发性的触腕伤害潜力。",
       "gameplay_intro": "·使用卡牌和狂气爆发来使触腕获得爆发成长",
-      "summon_slogan": "与常规认知相悖的是，他讨厌水。"
+      "summon_slogan": "与常规认知相悖的是，他讨厌水。",
+      "category": "summonable"
     },
     {
       "id": 15564,
@@ -83,7 +95,8 @@
       "characteristic": "力量爆发    偷取力量",
       "introduction": "以巨刃之力挥动重刃斩杀敌人，触腕伤害和力量都使他变得更加强大。",
       "gameplay_intro": "·「巨刃之威」和「斩首重创」拥有高额伤害和多倍力量加成，可对单个和群体敌人造成大量伤害。",
-      "summon_slogan": "当他举起巨剑，带来的必然是鲜血与死亡。"
+      "summon_slogan": "当他举起巨剑，带来的必然是鲜血与死亡。",
+      "category": "summonable"
     },
     {
       "id": 15565,
@@ -99,7 +112,8 @@
       "characteristic": "防护爆发    回收弃牌",
       "introduction": "坚固的螺壳让队伍的防护更上一层楼，并用螺壳上的尖刺反击来犯的对手。",
       "gameplay_intro": "·拥有强大的防护和堆叠反击的能力，灵知觉醒后该能力还能更上一层。",
-      "summon_slogan": "只要还能够冒险，她就能笑着前进。"
+      "summon_slogan": "只要还能够冒险，她就能笑着前进。",
+      "category": "summonable"
     },
     {
       "id": 15566,
@@ -115,7 +129,8 @@
       "characteristic": "临时触腕    免疫死亡",
       "introduction": "庇佑航行，从死亡的危机中守护友方，并用梦境之力回复友方生命。",
       "gameplay_intro": "·拥有较全面的算力供应、生命回复、触腕伤害提升的辅助能力。",
-      "summon_slogan": "「那艘船，为什么会沉呢？」"
+      "summon_slogan": "「那艘船，为什么会沉呢？」",
+      "category": "summonable"
     },
     {
       "id": 15567,
@@ -131,7 +146,8 @@
       "characteristic": "连环打击    打击卡增幅",
       "introduction": "她会使用独特的技巧连击敌人，并用出血伤害终结对手。",
       "gameplay_intro": "·灵活的使用锁链打击敌人，能够在造成伤害的同时施加大量出血。",
-      "summon_slogan": "挣脱锁链之后，她向一切锁链的缔造者复仇。"
+      "summon_slogan": "挣脱锁链之后，她向一切锁链的缔造者复仇。",
+      "category": "summonable"
     },
     {
       "id": 15568,
@@ -147,7 +163,9 @@
       "characteristic": "检索卡牌    多次伤害",
       "introduction": "从过往的指令中获取力量为她所用，并以命定之剑造成高额单次伤害。",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 15569,
@@ -163,7 +181,8 @@
       "characteristic": "高额群攻    伤害成长",
       "introduction": "以连绵不断的「打击」造成多次伤害，并唤起终焉巨兽吞噬仇敌。",
       "gameplay_intro": "",
-      "summon_slogan": "星之巨兽如是说：掀起滔天巨浪吧！让敌人发出悲鸣吧！"
+      "summon_slogan": "星之巨兽如是说：掀起滔天巨浪吧！让敌人发出悲鸣吧！",
+      "category": "summonable"
     },
     {
       "id": 15570,
@@ -179,7 +198,8 @@
       "characteristic": "驱散虚弱    生命回复",
       "introduction": "以其完美的研究成果为其他唤醒体提供狂气，并回复大量生命。",
       "gameplay_intro": "",
-      "summon_slogan": "她所追寻的，乃是藏于天地间之奥秘。"
+      "summon_slogan": "她所追寻的，乃是藏于天地间之奥秘。",
+      "category": "summonable"
     },
     {
       "id": 15571,
@@ -195,7 +215,8 @@
       "characteristic": "补充算力    抵抗死亡",
       "introduction": "为你的队伍提供大量算力并用料理回复生命，同时用黑暗料理毒杀敌人。",
       "gameplay_intro": "·拥有强大的生命回复和灵活的算力供应能力。",
-      "summon_slogan": "无论是扫帚还是武器，她都能使得十分优雅。"
+      "summon_slogan": "无论是扫帚还是武器，她都能使得十分优雅。",
+      "category": "summonable"
     },
     {
       "id": 15572,
@@ -211,7 +232,8 @@
       "characteristic": "补充手牌    临时力量",
       "introduction": "能够像变魔术一样抽取或更换大量卡牌，并获得临时力量来增强伤害。",
       "gameplay_intro": "·狂气爆发可造成群体伤害和抽牌，抽到越多自身指令卡、状态或症状卡，造成的伤害次数越多。",
-      "summon_slogan": "变走有形的东西算什么把戏？她的演出可以窃取灵魂。"
+      "summon_slogan": "变走有形的东西算什么把戏？她的演出可以窃取灵魂。",
+      "category": "summonable"
     },
     {
       "id": 15573,
@@ -227,7 +249,8 @@
       "characteristic": "多次伤害    穿透防护",
       "introduction": "源源不断分裂腺体进行低算力消耗的攻击，必要时一气消耗所有腺体发动总攻。",
       "gameplay_intro": "",
-      "summon_slogan": "「嗯？水母？果冻？」"
+      "summon_slogan": "「嗯？水母？果冻？」",
+      "category": "summonable"
     },
     {
       "id": 15574,
@@ -243,7 +266,8 @@
       "characteristic": "力量夺取    消耗降低",
       "introduction": "使用超越时空的歌声来降低手中大量卡牌的算力消耗，并使队友的战斗意志高涨。",
       "gameplay_intro": "·灵知觉醒可赋予汀克特的所有指令卡随机效果，随机获得虚弱、易伤、抽牌、算力、狂气的能力。",
-      "summon_slogan": "在金丝的牢笼中，在无形的枷锁下，夜莺只是歌唱，只是歌唱。"
+      "summon_slogan": "在金丝的牢笼中，在无形的枷锁下，夜莺只是歌唱，只是歌唱。",
+      "category": "summonable"
     },
     {
       "id": 15575,
@@ -259,7 +283,8 @@
       "characteristic": "触腕生成    补充手牌",
       "introduction": "为触腕附上烈毒来折辱敌人，并以虔诚的信仰让队伍获取卡牌，指明前进道路。",
       "gameplay_intro": "·狂气爆发和灵知觉醒拥有强大的过牌能力，提高队伍容错率。",
-      "summon_slogan": "海底火山的呼吸不再低鸣耳畔，深海幻梦也已经是模糊的图像。"
+      "summon_slogan": "海底火山的呼吸不再低鸣耳畔，深海幻梦也已经是模糊的图像。",
+      "category": "summonable"
     },
     {
       "id": 15576,
@@ -275,7 +300,8 @@
       "characteristic": "触腕激发    补充算力",
       "introduction": "她能够承受献祭来抵抗敌方的高额伤害，并能够号令触腕展开总攻。",
       "gameplay_intro": "·拥有独特的防护能力，将敌人伤害转变为献祭",
-      "summon_slogan": "把蛋糕和柔软的床榻奉上，她说不定就能好好听人说话了。"
+      "summon_slogan": "把蛋糕和柔软的床榻奉上，她说不定就能好好听人说话了。",
+      "category": "summonable"
     },
     {
       "id": 15577,
@@ -291,7 +317,8 @@
       "characteristic": "死亡抵抗    夺取力量",
       "introduction": "能够附加高额的死亡抵抗，并吸食对手的力量来抵御攻击。",
       "gameplay_intro": "·狂气爆发可以为我方提供永久的死亡抵抗。",
-      "summon_slogan": "深爱着夜莺的劣等品，也会有绽放的一天。"
+      "summon_slogan": "深爱着夜莺的劣等品，也会有绽放的一天。",
+      "category": "summonable"
     },
     {
       "id": 15578,
@@ -307,7 +334,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "有着高额的暴击率和暴击伤害，布朗和鼠群会成为他对抗多名敌人的关键助力。",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 15579,
@@ -323,7 +352,8 @@
       "characteristic": "狂气供给    延迟抽牌",
       "introduction": "能够为其他友方提供狂气，同时也能够耗尽手牌凝聚高额护盾。",
       "gameplay_intro": "·拥有强大的防护和提供狂气的能力。",
-      "summon_slogan": "就连记忆中的黑暗，也会招来那可怖的诅咒。"
+      "summon_slogan": "就连记忆中的黑暗，也会招来那可怖的诅咒。",
+      "category": "summonable"
     },
     {
       "id": 15580,
@@ -339,7 +369,8 @@
       "characteristic": "触发中毒    虚弱敌方",
       "introduction": "结合海毒和虚弱，在确保自身生存的同时持续折磨对手。",
       "gameplay_intro": "·通过指令卡快速对敌人堆叠中毒，使用狂气爆发触发敌人的中毒效果，造成大量伤害。",
-      "summon_slogan": "未曾绽放的睡莲，回归了海的怀抱。"
+      "summon_slogan": "未曾绽放的睡莲，回归了海的怀抱。",
+      "category": "summonable"
     },
     {
       "id": 15581,
@@ -355,7 +386,8 @@
       "characteristic": "生命上限    受伤变强",
       "introduction": "将承受的痛苦转化为怒火消灭敌人，或是转化为生命来帮助友方。",
       "gameplay_intro": "·拥有强大的防护能力，生命越低防护越强。",
-      "summon_slogan": "「妈妈，在哪？」"
+      "summon_slogan": "「妈妈，在哪？」",
+      "category": "summonable"
     },
     {
       "id": 15582,
@@ -371,7 +403,8 @@
       "characteristic": "触腕生成    狂气支援",
       "introduction": "她既能够使用大祭司的权能号令更多触腕，也能以祭祀匕首来毒杀敌人。",
       "gameplay_intro": "·指令卡拥有独特的<O07CardKeyWord:祭仪>效果，将会转化<O07CardKeyWord2:「圣礼」>强化指令卡。",
-      "summon_slogan": "虔诚的信仰最终化作刺向自己的利刃。"
+      "summon_slogan": "虔诚的信仰最终化作刺向自己的利刃。",
+      "category": "summonable"
     },
     {
       "id": 15583,
@@ -387,7 +420,8 @@
       "characteristic": "延迟回复    削弱敌方",
       "introduction": "不同的情绪带来不同的强力增益，并变化其狂气爆发效果。",
       "gameplay_intro": "·拥有四种效果各异的诗篇，触发跃迁时将进入「喜、怒、哀、惧」四种之一的情绪状态中。",
-      "summon_slogan": "当心，她的悲伤可比玫瑰刺棘棘手得多。"
+      "summon_slogan": "当心，她的悲伤可比玫瑰刺棘棘手得多。",
+      "category": "summonable"
     },
     {
       "id": 15584,
@@ -403,7 +437,8 @@
       "characteristic": "多次伤害    生命回复",
       "introduction": "以华丽的轮舞造成高额次数的伤害，并以敌人鲜血治愈自身。",
       "gameplay_intro": "",
-      "summon_slogan": "端上来吧，那些绣金的华丽礼服；端上来吧，那些异国鸟羽制成的羽扇。端上来吧，只有这样，才能获得她的沙龙的邀请。"
+      "summon_slogan": "端上来吧，那些绣金的华丽礼服；端上来吧，那些异国鸟羽制成的羽扇。端上来吧，只有这样，才能获得她的沙龙的邀请。",
+      "category": "summonable"
     },
     {
       "id": 15585,
@@ -419,7 +454,8 @@
       "characteristic": "驱散脆弱    临时力量",
       "introduction": "以无形黏液凝结障壁，并举起长枪指引队友发起冲锋号角。",
       "gameplay_intro": "",
-      "summon_slogan": "「我不会再让任何人受伤。」"
+      "summon_slogan": "「我不会再让任何人受伤。」",
+      "category": "summonable"
     },
     {
       "id": 15586,
@@ -435,7 +471,8 @@
       "characteristic": "高额反击    触发跃迁",
       "introduction": "以周身棘刺叠加大量反击来击穿来犯敌人，并且将棘刺挥舞造成伤害。",
       "gameplay_intro": "·拥有强大的反击能力和额外触发跃迁的独特效果",
-      "summon_slogan": "盲眼奴从庄严宣誓，吟诵崇高的律令：靠近她、服从她……然后永远爱她。"
+      "summon_slogan": "盲眼奴从庄严宣誓，吟诵崇高的律令：靠近她、服从她……然后永远爱她。",
+      "category": "summonable"
     },
     {
       "id": 15587,
@@ -451,7 +488,8 @@
       "characteristic": "单段高伤    力量成长",
       "introduction": "不断隐忍继续力量，一击为敌人带来终结的复仇者。",
       "gameplay_intro": "·狂气爆发可以大幅提升本回合中「打击」造成的伤害。",
-      "summon_slogan": "她所渴求的，从来都不是鲜血。"
+      "summon_slogan": "她所渴求的，从来都不是鲜血。",
+      "category": "summonable"
     },
     {
       "id": 15588,
@@ -467,7 +505,8 @@
       "characteristic": "对抗塞卡    戒备提升",
       "introduction": "久经战场的战士擅长堆叠大量护盾，并将护盾转化为利刃进行攻击。",
       "gameplay_intro": "·拥有强大的防护和单体伤害能力，护盾越高，「心眼利刃」造成的伤害越高。",
-      "summon_slogan": "战场夺去了她的肢体，却永远不会磨灭她的灵魂。"
+      "summon_slogan": "战场夺去了她的肢体，却永远不会磨灭她的灵魂。",
+      "category": "summonable"
     },
     {
       "id": 15589,
@@ -483,7 +522,8 @@
       "characteristic": "触腕激发    补充算力",
       "introduction": "身为神母的她赐福与庇佑着臣民，无上的权力能够将敌人的生命转化为进献神明的祭品。",
       "gameplay_intro": "·身为蹈海者崇敬的神母，她制定新的秩序庇佑着所有臣民，大幅强化深海界域基础效果。",
-      "summon_slogan": "她献身于神明的诞礼，以骨血兑现永恒的虚妄。"
+      "summon_slogan": "她献身于神明的诞礼，以骨血兑现永恒的虚妄。",
+      "category": "summonable"
     },
     {
       "id": 15590,
@@ -499,7 +539,8 @@
       "characteristic": "万能创造    易伤敌人",
       "introduction": "能够自定义强力的千面幻象，并将其置入超维空间的魔女。",
       "gameplay_intro": "·拥有可成长的伤害手段和强大的组合爆发能力",
-      "summon_slogan": "她的小店什么都有，只是——小心她索取的报酬。"
+      "summon_slogan": "她的小店什么都有，只是——小心她索取的报酬。",
+      "category": "summonable"
     },
     {
       "id": 15591,
@@ -515,7 +556,8 @@
       "characteristic": "石化控制    易伤敌人",
       "introduction": "以凝结之眼石化敌人使其无法行动，并变得易碎。",
       "gameplay_intro": "",
-      "summon_slogan": "剥落的石屑，正是她守护珍爱之物的证明。"
+      "summon_slogan": "剥落的石屑，正是她守护珍爱之物的证明。",
+      "category": "summonable"
     },
     {
       "id": 15592,
@@ -531,7 +573,8 @@
       "characteristic": "持续防护    触腕成长",
       "introduction": "持续不断的雕刻石壁防御后续攻击，失落的艺术在护盾越高时伤害就越强。",
       "gameplay_intro": "·拥有强大的防护和永久生成触腕能力，触腕越多防护能力越强。",
-      "summon_slogan": "除了温和秀美，锐利而具有攻击性也是艺术的一部分。"
+      "summon_slogan": "除了温和秀美，锐利而具有攻击性也是艺术的一部分。",
+      "category": "summonable"
     },
     {
       "id": 15593,
@@ -547,7 +590,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "有着高额的暴击率和暴击伤害，布朗和鼠群会成为他对抗多名敌人的关键助力。",
       "gameplay_intro": "「集结鼠群」消耗算力生成<DerivativeCardKeywords_12:「鼠群冲击」>，消耗算力越多，伤害次数越高，可以通过积攒算力一次打出超高伤害。",
-      "summon_slogan": "小看老鼠可是要付出惨痛代价的哦！"
+      "summon_slogan": "小看老鼠可是要付出惨痛代价的哦！",
+      "category": "summonable"
     },
     {
       "id": 15594,
@@ -563,7 +607,8 @@
       "characteristic": "反击敌人    触腕伤害",
       "introduction": "张开全身鳞刺，反击来犯的敌人，并以血脉之力回复自身生命。",
       "gameplay_intro": "·拥有强大的生命回复和堆叠反击的能力，在面对多段伤害的敌人时表现出色。",
-      "summon_slogan": "鳃痕、鳞片……血脉的证明是他仅剩的信念。"
+      "summon_slogan": "鳃痕、鳞片……血脉的证明是他仅剩的信念。",
+      "category": "summonable"
     },
     {
       "id": 15595,
@@ -579,7 +624,8 @@
       "characteristic": "检索卡牌    多次伤害",
       "introduction": "为你的队伍提供最需要的卡牌支援，并以逐渐迅疾的剑术刺穿对手。",
       "gameplay_intro": "",
-      "summon_slogan": "观察，感受，思考。"
+      "summon_slogan": "观察，感受，思考。",
+      "category": "summonable"
     },
     {
       "id": 15596,
@@ -595,7 +641,8 @@
       "characteristic": "复制卡牌    狂气供给",
       "introduction": "孕育圣树之子使吞噬效果多次发动，并以丰穰之仪模仿友方技能。",
       "gameplay_intro": "·拥有独特的复制卡牌能力，复制后的卡牌算力消耗还会降低。",
-      "summon_slogan": "「成为我的仆从，我的战士，我的……孩子。」"
+      "summon_slogan": "「成为我的仆从，我的战士，我的……孩子。」",
+      "category": "summonable"
     },
     {
       "id": 15597,
@@ -611,7 +658,8 @@
       "characteristic": "生命回复    力量提升",
       "introduction": "将自身的痛楚转化为力量，在低生命时能够大量回复。",
       "gameplay_intro": "·狂气爆发可以回复较多生命，生命越低回复越多。",
-      "summon_slogan": "「啜饮吧，这甘美的死亡。」"
+      "summon_slogan": "「啜饮吧，这甘美的死亡。」",
+      "category": "summonable"
     },
     {
       "id": 15598,
@@ -627,7 +675,8 @@
       "characteristic": "狂气爆发    越战越勇",
       "introduction": "不停战斗并不断变得更强的狂战士，低生命的时候会更加强大。",
       "gameplay_intro": "·狂气爆发可以造成高额的群体伤害，同时享受高额的力量加成。",
-      "summon_slogan": "他不放过任何一个捣碎敌人的机会。"
+      "summon_slogan": "他不放过任何一个捣碎敌人的机会。",
+      "category": "summonable"
     },
     {
       "id": 15599,
@@ -643,7 +692,8 @@
       "characteristic": "算力支援    护盾转输出",
       "introduction": "无尽的仁爱能够积攒猩红熔炉，在受伤时给予应急支援。",
       "gameplay_intro": "·拥有独特的积攒猩红熔炉能力，能从指令卡、生命、甚至是敌人伤害中积攒猩红熔炉回复量。",
-      "summon_slogan": "「引领前路吧，神谕中的救世主，将我们带往那无苦的未来。」"
+      "summon_slogan": "「引领前路吧，神谕中的救世主，将我们带往那无苦的未来。」",
+      "category": "summonable"
     },
     {
       "id": 15600,
@@ -659,7 +709,8 @@
       "characteristic": "戒备成长    中毒连击",
       "introduction": "提供大量胚胎融合的同时，对敌人注入毒素来破坏其神志。",
       "gameplay_intro": "·拥有强大的防护和施加中毒的能力，触发吞噬可获得永久攻防成长的能力。",
-      "summon_slogan": "在她构筑的迷宫中，迷失的可不止是方向。"
+      "summon_slogan": "在她构筑的迷宫中，迷失的可不止是方向。",
+      "category": "summonable"
     },
     {
       "id": 15601,
@@ -675,7 +726,8 @@
       "characteristic": "单段高伤    狂气爆发增幅",
       "introduction": "以不同形态适应不同界域的队伍，在「抑郁」和「躁狂」人格之间不断切换的猎手。",
       "gameplay_intro": "·拥有抑郁和躁狂两种姿态，初始为抑郁姿态，释放狂气爆发会切换姿态，不同姿态下卡牌效果不同。",
-      "summon_slogan": "歇斯底里、癔症、神经衰弱、癫痫……总而言之，就是疯女人。"
+      "summon_slogan": "歇斯底里、癔症、神经衰弱、癫痫……总而言之，就是疯女人。",
+      "category": "summonable"
     },
     {
       "id": 15602,
@@ -691,7 +743,8 @@
       "characteristic": "生命回复    单段高伤",
       "introduction": "在平时能够为队伍提供回复和大量狂气，但首领战中将驱动毁灭的引擎终结敌人。",
       "gameplay_intro": "·平时是一名提供可靠支援能力的研究者，能够在提供大量狂气的同时强化友方或削弱敌人。",
-      "summon_slogan": "希望只会是让人更加痛苦的毒药。只有在彻底、迅速的毁灭中，所有人才能获得真正的解脱。"
+      "summon_slogan": "希望只会是让人更加痛苦的毒药。只有在彻底、迅速的毁灭中，所有人才能获得真正的解脱。",
+      "category": "summonable"
     },
     {
       "id": 15603,
@@ -707,7 +760,8 @@
       "characteristic": "攻防兼备    形态转换",
       "introduction": "能够短暂性提供爆发力量或戒备，无论是攻击还是防御都是好手。",
       "gameplay_intro": "",
-      "summon_slogan": "她是弥萨格最大的数据库，是最万能的检索机。"
+      "summon_slogan": "她是弥萨格最大的数据库，是最万能的检索机。",
+      "category": "summonable"
     },
     {
       "id": 15604,
@@ -723,7 +777,8 @@
       "characteristic": "补充手牌    黑印获取",
       "introduction": "抽取大量卡牌的同时，通过掉落黑印赢取混沌的遗赠造物，使莱克变得更强。",
       "gameplay_intro": "·狂气爆发和技能都具有随机性，运气越好收益越高。",
-      "summon_slogan": "「再赌最后一把如何？这一次，就赌上你我的未来。」"
+      "summon_slogan": "「再赌最后一把如何？这一次，就赌上你我的未来。」",
+      "category": "summonable"
     },
     {
       "id": 54116,
@@ -739,7 +794,8 @@
       "characteristic": "临时文本",
       "introduction": "塔薇通晓一切，能够将一切技能为她所用，并将银钥作为资源来进行攻击。",
       "gameplay_intro": "·全知的智者，拥有无穷的智慧，娴熟地掌握所有的技能，在无数种可能性中寻找最佳的道路。",
-      "summon_slogan": "穿越穷极之门，世界的终极奥秘将对你敞开。"
+      "summon_slogan": "穿越穷极之门，世界的终极奥秘将对你敞开。",
+      "category": "summonable"
     },
     {
       "id": 54117,
@@ -755,7 +811,8 @@
       "characteristic": "临时文本",
       "introduction": "用回环乐音造成伤害的同时让卡牌多次生效，连绵的乐音还能够创造大量「灵感」。",
       "gameplay_intro": "·优雅而灵活的操纵音符，既能够降低卡牌的算力消耗，也能使其额外触发多次效果。",
-      "summon_slogan": "所有的音符，都将随指挥棒的轨迹起舞。"
+      "summon_slogan": "所有的音符，都将随指挥棒的轨迹起舞。",
+      "category": "summonable"
     },
     {
       "id": 77911,
@@ -771,7 +828,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 77913,
@@ -787,7 +846,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "以炽热之火焚烧万物的烈阳，消耗更多算力可以大幅提升卡牌效果。",
       "gameplay_intro": "·焚尽一切的爆燃之主，漫天活焰裹噬所有试图阻挡她的敌人。",
-      "summon_slogan": "她是永不落下的太阳，祂将带来平等的死亡。"
+      "summon_slogan": "她是永不落下的太阳，祂将带来平等的死亡。",
+      "category": "summonable"
     },
     {
       "id": 77914,
@@ -803,7 +863,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 77917,
@@ -819,7 +881,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "运用圣辉之力周期性强化卡牌效果，运用圣子的权能裁决一切漆黑的罪恶。",
       "gameplay_intro": "·虔诚而尊贵的提灯圣子，纯洁的圣心永远追逐光明。",
-      "summon_slogan": "圣心照耀之下，没有罪人能逃离圣子的审判。"
+      "summon_slogan": "圣心照耀之下，没有罪人能逃离圣子的审判。",
+      "category": "summonable"
     },
     {
       "id": 77918,
@@ -835,7 +898,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 77921,
@@ -851,7 +916,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 77922,
@@ -867,7 +934,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "夜空中的冷光，能够在生成大量触腕的同时重新构筑手牌，配合「余波」效果发挥更大的潜力。",
       "gameplay_intro": "·坚毅的少女，视死如归的她在面对死亡的威胁时能够爆发无限的潜力。",
-      "summon_slogan": "她的责任、她的义务、她的生命都与船只绑定，除此之外，别无他物。"
+      "summon_slogan": "她的责任、她的义务、她的生命都与船只绑定，除此之外，别无他物。",
+      "category": "summonable"
     },
     {
       "id": 77923,
@@ -883,7 +951,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "以羽翼吹动狂风护佑我方，掉落的黑色羽翼能够施加致命的「侵蚀」使其承受伤害时失去大量生命。",
       "gameplay_intro": "·不屈的孤嚎鸟，以羽翼吹动狂风护佑我方。",
-      "summon_slogan": "他是倔强不屈的飞鸟，如无自由宁愿死亡。"
+      "summon_slogan": "他是倔强不屈的飞鸟，如无自由宁愿死亡。",
+      "category": "summonable"
     },
     {
       "id": 77924,
@@ -899,7 +968,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 77925,
@@ -915,7 +986,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "积累共感，催眠敌人降低其伤害，或是创伤敌人使敌人受伤提高。",
       "gameplay_intro": "·温和而优雅的心理医师，与患者交流的过程中，能够逐渐感知对方的情绪积攒「共感」。释放狂气爆发后，能够消耗「共感」操纵其精神状态，施加恐惧瓦解敌人的战斗意志，或植入创伤瞬间摧毁其心防。",
-      "summon_slogan": "她掌控着心理咨询的节奏，救赎或者毁灭，都在她的一念之间。"
+      "summon_slogan": "她掌控着心理咨询的节奏，救赎或者毁灭，都在她的一念之间。",
+      "category": "summonable"
     },
     {
       "id": 77926,
@@ -931,7 +1003,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "根据局势灵活的创造不同绘卷，大幅强化其它唤醒体的狂气爆发效果。",
       "gameplay_intro": "·热忱于创作的残骸绘者，其作品能够为己方队伍带来各种灵性的增益。",
-      "summon_slogan": "他将用他的画作，带你一同见证世界的真相。"
+      "summon_slogan": "他将用他的画作，带你一同见证世界的真相。",
+      "category": "summonable"
     },
     {
       "id": 77927,
@@ -947,7 +1020,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 77928,
@@ -963,7 +1038,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 78754,
@@ -979,7 +1056,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "origin_variant"
     },
     {
       "id": 78840,
@@ -995,7 +1074,9 @@
       "characteristic": "检索卡牌    多次伤害",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 78841,
@@ -1011,7 +1092,9 @@
       "characteristic": "检索卡牌    多次伤害",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 94450,
@@ -1027,7 +1110,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "手持巨斧的活泼少女，在战斗中则会化身为狂热的战士，并能够在逆境中爆发更强战斗力。",
       "gameplay_intro": "·手持战斧的活泼少女，在战斗中则会化身为狂热的战士，并能够在逆境中爆发更强的战斗力。",
-      "summon_slogan": "雾境中的来客，将于银与血中，在此世受洗重生。"
+      "summon_slogan": "雾境中的来客，将于银与血中，在此世受洗重生。",
+      "category": "summonable"
     },
     {
       "id": 94451,
@@ -1043,7 +1127,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "origin_variant"
     },
     {
       "id": 95786,
@@ -1059,7 +1145,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "优雅的食者，对剩余生命较低的敌人造成可观的伤害，享用亡者的残骸时能够强化自身并回复生命。",
       "gameplay_intro": "·优雅的食者，为痛苦挣扎的灵魂带来命定之死的解脱。",
-      "summon_slogan": "他已听见你的呼唤。他将邀请你，一同享用那魂灵的盛宴。"
+      "summon_slogan": "他已听见你的呼唤。他将邀请你，一同享用那魂灵的盛宴。",
+      "category": "summonable"
     },
     {
       "id": 122587,
@@ -1075,7 +1162,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "origin_variant"
     },
     {
       "id": 125346,
@@ -1091,7 +1180,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "令人痴醉的魅力能够瓦解敌人的斗志，渗入全身的蚀骨毒素将在其沉沦之时轰然迸发。",
       "gameplay_intro": "·优雅而妩媚的东方「神明」。当她挪开扇面时，众生都将痴醉于她致命的魅力。",
-      "summon_slogan": "注视着这令人战栗的美丽，她「爱」你，祂会永远、永远「陪伴」你。"
+      "summon_slogan": "注视着这令人战栗的美丽，她「爱」你，祂会永远、永远「陪伴」你。",
+      "category": "summonable"
     },
     {
       "id": 130226,
@@ -1107,7 +1197,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 130375,
@@ -1123,7 +1215,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 130384,
@@ -1139,7 +1233,9 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "",
       "gameplay_intro": "",
-      "summon_slogan": ""
+      "summon_slogan": "",
+      "category": "non_summonable",
+      "subtype": "special"
     },
     {
       "id": 130901,
@@ -1155,7 +1251,8 @@
       "characteristic": "多次伤害    暴击",
       "introduction": "开朗率直的野性少女，手中的重火器集聚涡流能量后能够造成巨大的破坏。",
       "gameplay_intro": "·向往友情的开朗少女，能够从伙伴的狂气爆发中得到鼓舞并释放攻击协同伙伴追击敌方。",
-      "summon_slogan": "拘束，引导，释放，毁灭。漩涡将听从她的指引，让一切坏人沉溺于深渊。"
+      "summon_slogan": "拘束，引导，释放，毁灭。漩涡将听从她的指引，让一切坏人沉溺于深渊。",
+      "category": "summonable"
     }
   ]
 }


### PR DESCRIPTION
## 背景

对解包 A 类数据(角色基线)做完整性体检后发现:`characters.json` 的叙事字段(`introduction` / `gameplay_intro` / `summon_slogan`)填充率仅 64–78%,看似数据缺失,实为**假性空缺**——18 个非可召唤单位(Boss/敌方/本源变体/彩蛋)在客户端源 `AwakerConfig` 里本就没有这些面向玩家的字段。

## 改动

给 `projects/wiki/data/processed/characters.json` 每个角色新增 `category` 字段,消除假性空缺误读:

- **判据(可验证、零臆断)**:依据源 `AwakerConfig` 是否含 `SummonSlogan`(召唤台词)区分。
- `summonable`(可召唤唤醒体):**54** 个,叙事字段完整。
- `non_summonable`(非可召唤单位):**18** 个,缺叙事字段属预期。
  - 其中 `subtype: origin_variant`(本源变体)**4** 个,依名字「本源」前缀客观赋值。
  - 其余 `subtype: special` **14** 个;Boss/敌方/彩蛋的精确细分需可验证来源,暂不臆断。
- 判据、计数、subtype 说明写入 `_meta`,供审计。

## 数据纪律说明

- 未引入任何无法从源数据验证的语义标签(刻意不直接打「Boss/彩蛋」)。
- 空字段经回源核对,确认是源头本无,清洗过程未丢数据。
- 该文件为中间提取产物,不受 `data/schemas/characters.schema.json` 约束(该 schema 面向尚未构建的 `data/db/` 规范库),本次改动不影响 `validate_data.py`。

https://claude.ai/code/session_01HwtYDRQVWT7h97EZUkLgnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwtYDRQVWT7h97EZUkLgnZ)_