### PR TITLE
feat(news): 日服 Discord 接入归档计划

### DIFF
--- a/.github/workflows/discord-archive-jp.yml
+++ b/.github/workflows/discord-archive-jp.yml
@@ -1,0 +1,83 @@
+name: Discord Archive (JP)
+
+# 日服服务器采集，与 Global 完全隔离（数据落 guilds/{JP_GUILD_ID}/），复用同一 bot。
+#
+# 启用步骤（守密人 / 艾瑞卡）：
+#   1. 运行 'Discord Discover Guilds' workflow，从 guilds_seen.json 取得日服 guild ID
+#   2. 把该 ID 填入下方 env.JP_GUILD_ID
+#   3. 取消 schedule 区块注释以开启定时采集（保留 :45 错峰，避开 Global 与志愿者）
+#
+# 安全保证：ID 未配置前，本 workflow 手动触发会经 Guard 步骤安全跳过（绿色通过、
+# 不会因空 ID 回落到 Global guild）。schedule 默认注释，未启用前不会定时空跑。
+on:
+  # schedule:
+  #   # 每小时一次，offset :45 错开 Global（每日 18:00）与志愿者（:15）
+  #   - cron: '45 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: discord-archive-jp-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  # 日服 guild ID —— 待 'Discord Discover Guilds' 探测后填入。留空时本 workflow 安全跳过。
+  JP_GUILD_ID: ''
+
+jobs:
+  archive:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    steps:
+      - name: Guard — require JP guild id
+        id: guard
+        run: |
+          if [ -z "$JP_GUILD_ID" ]; then
+            echo "::notice::JP_GUILD_ID 未配置 —— 安全跳过。请先运行 'Discord Discover Guilds'，从 projects/news/data/discord/guilds_seen.json 取得日服 guild ID 填入 env.JP_GUILD_ID，并取消 schedule 注释。"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.guard.outputs.skip == 'false'
+
+      - uses: actions/setup-python@v5
+        if: steps.guard.outputs.skip == 'false'
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        if: steps.guard.outputs.skip == 'false'
+        run: pip install -r projects/news/requirements.txt
+
+      - name: Run Discord archiver for JP guild
+        if: steps.guard.outputs.skip == 'false'
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ env.JP_GUILD_ID }}
+        # 默认 run()：增量 + 多月历史回填。首跑会全量回溯日服建服至今的历史。
+        # 数据根由 archiver 自动分层到 guilds/{guild_id}/（非 Global guild）。
+        run: python projects/news/scripts/discord_archiver.py
+
+      - name: Commit and push if changed
+        if: steps.guard.outputs.skip == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add projects/news/data/discord/guilds/
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: archive JP Discord data [skip ci]"
+            for i in 1 2 3 4; do
+              git pull --rebase origin main && git push origin main && exit 0
+              echo "Push attempt $i failed, retrying in $((i * 2))s..."
+              sleep $((i * 2))
+            done
+            echo "All push attempts failed"
+            exit 1
+          fi

--- a/.github/workflows/discord-discover-guilds.yml
+++ b/.github/workflows/discord-discover-guilds.yml
@@ -1,0 +1,52 @@
+name: Discord Discover Guilds
+
+# 一次性发现工具：列出 bot 当前加入的所有服务器，对照已登记清单（Global / 志愿者）
+# 高亮「未登记」服务器，把快照写入 projects/news/data/discord/guilds_seen.json 并提交。
+# 用于新服务器（如日服）接入归档计划前取得其 guild ID。只读 API，不抓消息。
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: discord-discover-guilds-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  discover:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r projects/news/requirements.txt
+
+      - name: List bot guilds
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+        run: python projects/news/scripts/discord_list_guilds.py
+
+      - name: Commit snapshot if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add projects/news/data/discord/guilds_seen.json
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: snapshot Discord guild list [skip ci]"
+            for i in 1 2 3 4; do
+              git pull --rebase origin main && git push origin main && exit 0
+              echo "Push attempt $i failed, retrying in $((i * 2))s..."
+              sleep $((i * 2))
+            done
+            echo "All push attempts failed"
+            exit 1
+          fi

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -52,7 +52,7 @@
   - [ ] Twitter/X — 需 TWITTER_BEARER_TOKEN
   - [ ] NGA — 需 NGA_FORUM_ID
   - [ ] TapTap — 需 TAPTAP_APP_ID
-  - [x] Discord — 已实现（Bot 已配置，全量归档 + 聚合器双通道）
+  - [x] Discord — 已实现（Bot 已配置，全量归档 + 聚合器双通道）；多 guild 分层归档：Global（data/discord/ 根）/ 志愿者（guilds/）/ 日服（接入中，2026-06-17，guilds/）
   - [x] YouTube — 代码就绪，需配置 API 密钥
 
 ### 报告系统（新增，来自 new-session-7Plu3）
@@ -142,12 +142,14 @@
 Phase 0/1 已验收归档（2026-04-04）：Phase 0 止血完成、Stage 1 日报 14 天验证
 通过、记忆系统 9 模块 + 做梦 Agent 三层上线。详见 `memory/strategic-plan-2026.md`。
 
-## Workflow 触发方式（2026-06-09 按 yml 实测 cron 核验）
+## Workflow 触发方式（2026-06-09 按 yml 实测 cron 核验；2026-06-17 补日服 Discord 接入）
 
 | Workflow | 触发 | 状态 |
 |----------|------|------|
 | update-news.yml | 每小时（`0 * * * *`） | 运行中 |
-| discord-archive.yml | 每日 18:00 UTC + 每月 1 日月度归档 | 运行中 |
+| discord-archive.yml | 每日 18:00 UTC + 每月 1 日月度归档（Global 服） | 运行中 |
+| discord-archive-jp.yml | 手动 dispatch；填 `JP_GUILD_ID` 后开 `:45` cron | 待启用（2026-06-17 新增，日服 guild，Guard 保护空 ID 安全跳过） |
+| discord-discover-guilds.yml | 手动 dispatch | 可用（2026-06-17 新增，列 bot 所在 guild 以发现日服 ID） |
 | collect-comments.yml | 每日 02:00 UTC | 运行中（2026-06-05 新增） |
 | recover-fanart.yml | 手动 dispatch | 可用（2026-06-05 新增） |
 | daily-report.yml | 手动 dispatch（定时已停用，报告改会话内订阅生成） | 备用 |

--- a/projects/news/CONTEXT.md
+++ b/projects/news/CONTEXT.md
@@ -1,7 +1,7 @@
 # News 聚合器 — 会话上下文
 
 > 启动时请先阅读根目录 `CLAUDE.md` 了解全局。
-> 最后更新：2026-06-09 by 主控台（艾瑞卡会话，状态核验刷新；实时进度权威在 `memory/project-status.md`）
+> 最后更新：2026-06-17 by 艾瑞卡会话（新增日服 Discord 归档接入：探测 + 分层 workflow；上次 2026-06-09 主控台状态核验。实时进度权威在 `memory/project-status.md`）
 
 ## v2.0 新使命定位（2026-04-26 起）
 
@@ -49,9 +49,27 @@
 
 ### 注意事项
 - update-news.yml 每小时运行一次（cron: '0 * * * *'）
-- discord-archive.yml 已从每小时降到每日 1 次（18:00 UTC）+ 每月 1 日月度归档
+- discord-archive.yml 已从每小时降到每日 1 次（18:00 UTC）+ 每月 1 日月度归档（Global 官方服，数据落 data/discord/ 根）
+- discord-archive-volunteer.yml 每小时 :15（志愿者服务器 guild，数据落 guilds/{id}/）
+- discord-archive-jp.yml 日服服务器归档（数据落 guilds/{id}/）：待填 JP_GUILD_ID 并启用 :45 错峰 cron，详见下「日服 Discord 接入」
+- discord-discover-guilds.yml 手动触发：列出 bot 所在全部服务器，发现待接入 guild ID
 - collect-comments.yml 每日 02:00 UTC（2026-06-05 新增）；recover-fanart.yml 手动触发（同日新增）
 - daily-report.yml 定时已停用，仅手动备用（报告改会话内订阅生成）
+
+### 日服 Discord 接入（2026-06-17）
+bot 已接入日服 Discord，纳入归档计划。归档器（`discord_archiver.py`）按 guild_id 自动分层，
+无需改采集代码，复用同一 `DISCORD_BOT_TOKEN`（与志愿者服务器同模式）。两步启用：
+
+1. **发现 guild ID**：在 Actions 运行 `Discord Discover Guilds`（`discord-discover-guilds.yml`，
+   仅手动触发）。脚本 `discord_list_guilds.py` 调 `/users/@me/guilds` 列出 bot 所在全部服务器，
+   对照已登记清单（Global / 志愿者）高亮「未登记」者，快照写入
+   `projects/news/data/discord/guilds_seen.json` 并提交回仓库。日服 ID 即在该快照中。
+2. **启用归档**：把日服 ID 填入 `discord-archive-jp.yml` 的 `env.JP_GUILD_ID`，取消其
+   `schedule` 区块注释（保留 `:45` 错峰，避开 Global 与志愿者）。在 ID 配置前，该 workflow
+   经 Guard 步骤安全跳过——绝不因空 ID 回落到 Global guild。
+
+首跑会全量回溯日服建服至今的历史（归档器对新 guild 的 cold-start 行为），数据隔离落
+`data/discord/guilds/{JP_GUILD_ID}/`，与 Global / 志愿者互不污染。
 
 ## 已完成
 - [x] aggregator.py 基础架构（Reddit/Bilibili/Twitter/NGA/TapTap/Steam）

--- a/projects/news/scripts/discord_list_guilds.py
+++ b/projects/news/scripts/discord_list_guilds.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Discord 服务器清单探测 — 列出 bot 当前加入的所有服务器（guild）
+
+用途：新服务器接入归档计划前的「发现」步骤。bot 接入新服务器（如日服）后运行本
+脚本，即可列出 bot 所在的全部 guild，对照已登记清单（Global / 志愿者）高亮
+「未登记」服务器，并把快照写入 data/discord/guilds_seen.json，供配置归档
+workflow 时取用 guild ID。
+
+只读：仅调用 GET /users/@me/guilds，不抓消息、不碰 channels 数据、不改 state。
+
+用法:
+  DISCORD_BOT_TOKEN=xxx python projects/news/scripts/discord_list_guilds.py
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# 复用归档器的 Global guild 常量作为单一权威来源。
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from discord_archiver import GLOBAL_GUILD_ID  # noqa: E402
+
+API_BASE = 'https://discord.com/api/v10'
+
+# 已登记服务器（归档计划已覆盖）。不在此表的 guild = 待接入候选（如新接入的日服）。
+VOLUNTEER_GUILD_ID = '1402537664619479100'
+KNOWN_GUILDS = {
+    GLOBAL_GUILD_ID: 'global · 官方/Global，归档至 data/discord/ 根目录',
+    VOLUNTEER_GUILD_ID: 'volunteer · 志愿者服务器，归档至 guilds/{id}/',
+}
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SEEN_PATH = _REPO_ROOT / 'projects' / 'news' / 'data' / 'discord' / 'guilds_seen.json'
+
+
+def classify_guilds(guilds: list, known: dict) -> tuple[list, list]:
+    """对照已登记清单给每个 guild 打标。纯函数，无 IO。
+
+    返回 (rows, unregistered)：
+      rows         —— 全部 guild，含 registered/role 标注，未登记者排在前
+      unregistered —— 未登记的 guild（待接入归档计划的候选，如新接入的日服）
+    """
+    rows = []
+    unregistered = []
+    for g in guilds:
+        gid = str(g.get('id', ''))
+        name = g.get('name', '')
+        role = known.get(gid)
+        registered = role is not None
+        rows.append({'id': gid, 'name': name, 'registered': registered, 'role': role})
+        if not registered:
+            unregistered.append({'id': gid, 'name': name})
+    # 未登记(False)排前，便于日志一眼定位候选；同组按名称升序。
+    rows.sort(key=lambda r: (r['registered'], r['name']))
+    return rows, unregistered
+
+
+def _get(path, headers, **params):
+    import requests
+
+    url = f'{API_BASE}{path}'
+    resp = None
+    for _ in range(4):
+        resp = requests.get(url, headers=headers, params=params, timeout=15)
+        if resp.status_code == 429:
+            wait = max(resp.json().get('retry_after', 2), 2)
+            time.sleep(wait)
+            continue
+        return resp
+    return resp
+
+
+def main() -> int:
+    token = os.environ.get('DISCORD_BOT_TOKEN', '')
+    if not token:
+        print('FAIL: DISCORD_BOT_TOKEN 未设置')
+        return 1
+
+    headers = {'Authorization': f'Bot {token}', 'Content-Type': 'application/json'}
+    resp = _get('/users/@me/guilds', headers, limit=200)
+    if resp is None:
+        print('FAIL: 请求服务器清单失败（无响应）')
+        return 1
+    if resp.status_code == 401:
+        print('FAIL: token 无效（401 Unauthorized）')
+        return 1
+    if resp.status_code != 200:
+        print(f'FAIL: 获取服务器清单失败 HTTP {resp.status_code}: {resp.text[:200]}')
+        return 1
+
+    guilds = resp.json()
+    if not isinstance(guilds, list):
+        print(f'FAIL: 响应格式异常: {str(guilds)[:200]}')
+        return 1
+
+    rows, unregistered = classify_guilds(guilds, KNOWN_GUILDS)
+
+    print(f'bot 当前加入 {len(rows)} 个服务器：')
+    for r in rows:
+        mark = r['role'] if r['registered'] else '★ 未登记（待接入候选）'
+        print(f"  - {r['id']}  {r['name']}  [{mark}]")
+
+    snapshot = {
+        'probed_at': datetime.now(timezone.utc).isoformat(),
+        'bot_guild_count': len(rows),
+        'guilds': rows,
+        'unregistered': unregistered,
+    }
+    SEEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SEEN_PATH.write_text(
+        json.dumps(snapshot, ensure_ascii=False, indent=2) + '\n', encoding='utf-8'
+    )
+    print(f'\n快照已写入 {SEEN_PATH.relative_to(_REPO_ROOT)}')
+
+    print('---')
+    if not unregistered:
+        print('结论: 未发现未登记服务器。bot 所在服务器均已纳入归档计划。')
+    elif len(unregistered) == 1:
+        u = unregistered[0]
+        print(f"结论: 发现 1 个未登记服务器 →「{u['name']}」(ID {u['id']})。")
+        print("      下一步: 将此 ID 填入 .github/workflows/discord-archive-jp.yml 的")
+        print("      env.JP_GUILD_ID，并取消该 workflow 的 schedule 注释以启用日服归档。")
+    else:
+        print(f'结论: 发现 {len(unregistered)} 个未登记服务器，请确认哪个是日服后填入归档 workflow：')
+        for u in unregistered:
+            print(f"      - {u['id']}  {u['name']}")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_discord_list_guilds.py
+++ b/tests/test_discord_list_guilds.py
@@ -1,0 +1,59 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "projects" / "news" / "scripts"))
+
+from discord_archiver import GLOBAL_GUILD_ID
+from discord_list_guilds import KNOWN_GUILDS, VOLUNTEER_GUILD_ID, classify_guilds
+
+
+class TestClassifyGuilds(unittest.TestCase):
+    """guild 分类纯函数：把 bot 加入的服务器对照已登记清单打标，
+    高亮未登记者（新接入的日服走这条路被发现）。"""
+
+    def test_flags_unregistered_guild(self):
+        guilds = [
+            {"id": GLOBAL_GUILD_ID, "name": "Official"},
+            {"id": VOLUNTEER_GUILD_ID, "name": "Volunteer"},
+            {"id": "9999999999", "name": "Morimens 日本"},
+        ]
+        rows, unregistered = classify_guilds(guilds, KNOWN_GUILDS)
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(len(unregistered), 1)
+        self.assertEqual(unregistered[0]["id"], "9999999999")
+        self.assertEqual(unregistered[0]["name"], "Morimens 日本")
+
+    def test_registered_guilds_have_role(self):
+        guilds = [{"id": GLOBAL_GUILD_ID, "name": "Official"}]
+        rows, unregistered = classify_guilds(guilds, KNOWN_GUILDS)
+        self.assertTrue(rows[0]["registered"])
+        self.assertIsNotNone(rows[0]["role"])
+        self.assertEqual(unregistered, [])
+
+    def test_unregistered_sorted_first(self):
+        # 未登记排在前，便于在 workflow 日志里一眼定位候选。
+        guilds = [
+            {"id": GLOBAL_GUILD_ID, "name": "ZZZ Official"},
+            {"id": "9999999999", "name": "AAA New"},
+        ]
+        rows, _ = classify_guilds(guilds, KNOWN_GUILDS)
+        self.assertFalse(rows[0]["registered"])
+        self.assertEqual(rows[0]["id"], "9999999999")
+
+    def test_int_ids_are_stringified(self):
+        # Discord API 可能回数值型 id；分类后应统一为字符串以便和已登记清单比对。
+        guilds = [{"id": int(GLOBAL_GUILD_ID), "name": "Official"}]
+        rows, unregistered = classify_guilds(guilds, KNOWN_GUILDS)
+        self.assertEqual(rows[0]["id"], GLOBAL_GUILD_ID)
+        self.assertTrue(rows[0]["registered"])
+        self.assertEqual(unregistered, [])
+
+    def test_empty(self):
+        rows, unregistered = classify_guilds([], KNOWN_GUILDS)
+        self.assertEqual(rows, [])
+        self.assertEqual(unregistered, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景
bot 已接入日服 Discord 服务器，纳入归档计划。

## 改动
归档器 `discord_archiver.py` 按 `DISCORD_GUILD_ID` 自动把数据分层到 `data/discord/guilds/{id}/`，**无需改采集代码**。本 PR 增加「发现 + 分层归档」脚手架，复用同一 `DISCORD_BOT_TOKEN`（与志愿者服务器同模式）。

- **`projects/news/scripts/discord_list_guilds.py`**（新）：调 `/users/@me/guilds` 列出 bot 所在全部服务器，对照已登记清单（Global / 志愿者）高亮「未登记」者，快照写入 `data/discord/guilds_seen.json`。纯函数 `classify_guilds()` 便于测试。
- **`.github/workflows/discord-discover-guilds.yml`**（新，仅手动触发）：运行上述脚本并提交快照，日服 ID 自动回流仓库，无需手抄。
- **`.github/workflows/discord-archive-jp.yml`**（新）：日服归档，镜像志愿者模式。`JP_GUILD_ID` 占位 + Guard 守卫（空 ID 安全跳过，绝不回落 Global），`schedule` 暂注释。
- **`tests/test_discord_list_guilds.py`**（新）：guild 分类纯函数单测。
- 文档：`projects/news/CONTEXT.md`（接入两步流程）+ `memory/project-status.md`（workflow 表）。

## 两步启用（守密人）
1. 在 Actions 运行 `Discord Discover Guilds` → 从 `guilds_seen.json` 取得日服 guild ID。
2. 把该 ID 填入 `discord-archive-jp.yml` 的 `env.JP_GUILD_ID`，取消 `schedule` 注释（保留 `:45` 错峰，避开 Global 与志愿者）。

## 安全保证
ID 配置前，jp workflow 经 Guard 步骤安全跳过。比喻：像装好但没插电的电器，没插上 `JP_GUILD_ID` 这根电线时按开关只亮个提示灯、绝不乱跑，更不会因空 ID 冒充官方服去重复抓数据。

## 验证
- `test_discord_list_guilds.py` 5/5 通过；`test_discord_archiver.py` 20/20 回归通过。
- 探测脚本无 token 时优雅退出（exit 1）。
- 两个 workflow YAML 语法校验通过。

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184kenmSwE6y4mh2riDLhut

---
_Generated by [Claude Code](https://claude.ai/code/session_0184kenmSwE6y4mh2riDLhut)_