### PR TITLE
fix(news): 修复 403 私有频道导致 Discord 历史回填游标卡死

### DIFF
--- a/projects/news/scripts/discord_archiver.py
+++ b/projects/news/scripts/discord_archiver.py
@@ -113,6 +113,12 @@ def request_with_retry(method, url, max_retries=3, backoff_base=2, **kwargs):
     raise last_exc
 
 
+def _is_forbidden(exc) -> bool:
+    """True if the exception is a Discord 403 — bot lacks permission to read the channel."""
+    resp = getattr(exc, 'response', None)
+    return getattr(resp, 'status_code', None) == 403
+
+
 # ── Main class ───────────────────────────────────────────────────────────────
 
 class DiscordArchiver:
@@ -395,7 +401,13 @@ class DiscordArchiver:
             try:
                 messages = self._api(f'/channels/{channel_id}/messages', **params)
             except Exception as e:
-                logger.warning(f'Channel {channel_id} cold-start fetch failed: {e}')
+                if _is_forbidden(e):
+                    ch_st = self._ch_state(ch_key)
+                    ch_st['forbidden'] = True
+                    ch_st['name'] = channel_name
+                    logger.info(f'Channel {channel_name}({channel_id}) inaccessible (403) — marked forbidden')
+                else:
+                    logger.warning(f'Channel {channel_id} cold-start fetch failed: {e}')
                 break
             if not isinstance(messages, list) or not messages:
                 break
@@ -431,6 +443,8 @@ class DiscordArchiver:
         history, not just the latest 100 messages.
         """
         ch_key = str(channel_id)
+        if self._ch_state(ch_key).get('forbidden'):
+            return 0  # no read permission (403) — skip, don't burn requests each run
         last_id = self._ch_state(ch_key).get('last_message_id', '0')
         if last_id == '0':
             return self._cold_start_backfill(channel_id, channel_name)
@@ -446,7 +460,11 @@ class DiscordArchiver:
             try:
                 messages = self._api(f'/channels/{channel_id}/messages', **params)
             except Exception as e:
-                logger.warning(f'Channel {channel_id} incremental fetch failed: {e}')
+                if _is_forbidden(e):
+                    self._ch_state(ch_key)['forbidden'] = True
+                    logger.info(f'Channel {channel_name}({channel_id}) inaccessible (403) — marked forbidden')
+                else:
+                    logger.warning(f'Channel {channel_id} incremental fetch failed: {e}')
                 break
             if not isinstance(messages, list) or not messages:
                 break
@@ -504,6 +522,8 @@ class DiscordArchiver:
         Returns -1 if channel was skipped (created after target month).
         """
         ch_key = str(channel_id)
+        if self._ch_state(ch_key).get('forbidden'):
+            return -1  # no read permission (403) — skip, excluded from completion check
         month_str = _mstr(year, month)
         after_sf, before_sf = _month_bounds(year, month)
 
@@ -546,7 +566,11 @@ class DiscordArchiver:
             try:
                 messages = self._api(f'/channels/{channel_id}/messages', **params)
             except Exception as e:
-                logger.warning(f'Channel {channel_id} history {month_str} failed: {e}')
+                if _is_forbidden(e):
+                    self._ch_state(ch_key)['forbidden'] = True
+                    logger.info(f'Channel {channel_name}({channel_id}) inaccessible (403) — marked forbidden')
+                else:
+                    logger.warning(f'Channel {channel_id} history {month_str} failed: {e}')
                 break
 
             if not isinstance(messages, list) or not messages:
@@ -594,6 +618,8 @@ class DiscordArchiver:
         """Return True if every channel has fully processed the given historical month."""
         for ch_id in channel_ids:
             ch_st = self.state['channels'].get(str(ch_id), {})
+            if ch_st.get('forbidden'):
+                continue  # 无权限频道(403)永远抓不到，排除出完成判定，否则游标永久卡死
             if ch_st.get('last_historical_month') != month_str:
                 return False
             if int(ch_st.get('last_historical_message_id', '0')) < int(before_sf):

--- a/tests/test_discord_archiver.py
+++ b/tests/test_discord_archiver.py
@@ -14,6 +14,7 @@ from discord_archiver import (
     DISCORD_EPOCH_MS,
     DiscordArchiver,
     _dt_from_sf,
+    _is_forbidden,
     _mstr,
     _month_bounds,
     _prev_month,
@@ -172,6 +173,78 @@ class TestMstr(unittest.TestCase):
 
     def test_zero_pads_year_to_four_digits(self):
         self.assertEqual(_mstr(999, 7), "0999-07")
+
+
+class TestForbiddenChannelHandling(unittest.TestCase):
+    """403 (no-permission) channels must not block the historical backfill
+    cursor — regression guard for the JP-guild private-channel deadlock where
+    unreadable channels (mod-log, hidden channels, etc.) pinned the cursor
+    forever on the first historical month."""
+
+    def _make_archiver(self, tmpdir):
+        env = {
+            "DISCORD_BOT_TOKEN": "dummy",
+            "DISCORD_GUILD_ID": "999",
+            "DISCORD_DATA_ROOT": tmpdir,
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            return DiscordArchiver()
+
+    def test_is_forbidden_detects_403_only(self):
+        class _Resp:
+            def __init__(self, code):
+                self.status_code = code
+
+        class _Err(Exception):
+            def __init__(self, code):
+                self.response = _Resp(code)
+
+        self.assertTrue(_is_forbidden(_Err(403)))
+        self.assertFalse(_is_forbidden(_Err(500)))
+        self.assertFalse(_is_forbidden(Exception("no response attribute")))
+
+    def test_forbidden_channel_excluded_from_month_completion(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            arch = self._make_archiver(tmp)
+            month = "2026-05"
+            _, before_sf = _month_bounds(2026, 5)
+            arch.state["channels"]["readable"] = {
+                "last_historical_month": month,
+                "last_historical_message_id": before_sf,
+            }
+            arch.state["channels"]["locked"] = {"forbidden": True}
+            self.assertTrue(
+                arch._all_channels_done_for_month(["readable", "locked"], month, before_sf),
+                "forbidden channel must not block month completion",
+            )
+
+    def test_unreached_channel_still_blocks(self):
+        # 回归：非 forbidden 且未抓到月末的频道仍须阻止游标推进
+        with tempfile.TemporaryDirectory() as tmp:
+            arch = self._make_archiver(tmp)
+            month = "2026-05"
+            _, before_sf = _month_bounds(2026, 5)
+            arch.state["channels"]["readable"] = {
+                "last_historical_month": month,
+                "last_historical_message_id": before_sf,
+            }
+            arch.state["channels"]["lagging"] = {
+                "last_historical_month": month,
+                "last_historical_message_id": "0",
+            }
+            self.assertFalse(
+                arch._all_channels_done_for_month(["readable", "lagging"], month, before_sf)
+            )
+
+    def test_forbidden_channel_skips_history_fetch_without_api_call(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            arch = self._make_archiver(tmp)
+            arch.state["channels"]["locked"] = {"forbidden": True}
+            called = []
+            arch._api = lambda *a, **k: called.append(1) or []
+            result = arch.fetch_channel_history_month("locked", "locked-name", 2026, 5)
+            self.assertEqual(result, -1)
+            self.assertEqual(called, [], "forbidden channel must not trigger any API call")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 根因
归档器 [`_all_channels_done_for_month`](https://github.com/lightproud/brain-in-a-vat/blob/main/projects/news/scripts/discord_archiver.py#L591) 要求**每个**频道都抓完当月才推进历史回填游标。但服务器存在 bot 无读取权限的私有/管理频道（`mod-log`、`moderator-only`、各「非表示（隐藏）」频道、`sandbox` 等），它们请求返回 403、永远抓不到，于是该判定恒为 False，主循环 `else: break` 跳出，**历史游标永久卡在第一个历史月**。

日服实测确认：游标焊死在 `2026-05`，主力频道 `なんでも雑談` 在 2026-05 之前的历史从未回填，归档器每轮 13 秒空转。**所有共用此归档器的服务器（Global / 志愿者 / 日服）均受同一影响。**

## 修复
- `_is_forbidden()`：从抛出的 HTTPError 识别 Discord 403
- cold-start / 增量 / 历史三处抓取入口：遇 403 标记频道 `forbidden`
- forbidden 频道跳过抓取（不再每轮空耗请求），并在完成判定中排除 → 游标可正常逐月回溯到建服日
- 4 个单测：403 识别 / 完成判定排除 / 抓取跳过零请求 / 非 forbidden 未完成仍阻塞（回归保护）

## 验证
`test_discord_archiver.py` **24 测试全过**（20 回归 + 4 新）。

比喻：归档员原本死守「本月每个抽屉都登记完，才准翻上个月的柜子」，可有几个上锁的抽屉（403）他永远登记不了、被焊在原地；现在他认得这些锁、登记时直接跳过，就能继续往更早的柜子翻了。

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184kenmSwE6y4mh2riDLhut

---
_Generated by [Claude Code](https://claude.ai/code/session_0184kenmSwE6y4mh2riDLhut)_