### PR TITLE
feat: 银芯功能目录（自动生成 + 人工补注）

### DIFF
--- a/.github/workflows/build-capability-registry.yml
+++ b/.github/workflows/build-capability-registry.yml
@@ -1,0 +1,50 @@
+name: Build Capability Registry
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/**'
+      - 'projects/news/scripts/**'
+      - 'projects/*/CONTEXT.md'
+      - '.claude/commands/**'
+      - '.claude/skills/**'
+      - 'memory/capability-annotations.json'
+  workflow_dispatch:
+
+concurrency:
+  group: capability-registry-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Regenerate capability directory
+        run: python scripts/build_capability_registry.py
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add memory/capability-registry.json memory/capability-index.md
+          if git diff --staged --quiet; then
+            echo "Capability directory already up to date"
+          else
+            git commit -m "chore: rebuild capability registry [skip ci]"
+            for i in 1 2 3 4; do
+              git pull --rebase origin main && git push origin main && exit 0
+              echo "Push attempt $i failed, retrying in ${i}s..."
+              sleep $i
+            done
+            echo "All push attempts failed"
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ git commit = 数据归档提交 / git push = 同步至远端存储 /
 | `memory/lessons-learned.md` | 踩坑记录（持续追加编号，条数以文件最新为准）|
 | `memory/contribution-protocol.md` | 贡献协议 v1.0 |
 | `memory/style-guide.md` | 视觉规范 |
+| `memory/capability-index.md` | 银芯全功能目录（七层 109 项，CI 自动生成；人工用途补注在 `memory/capability-annotations.json`，机器权威数据在 `memory/capability-registry.json`）|
 | `assets/data/VERSION.md` | 事实圣经版本 |
 
 跨档案检索：`python scripts/memory_search.py "<关键词>"`。

--- a/memory/capability-annotations.json
+++ b/memory/capability-annotations.json
@@ -1,0 +1,54 @@
+{
+  "_meta": {
+    "purpose": "银芯功能目录的人工中文用途补注。本文件是七层功能目录中唯一手维护的部分。",
+    "how_to": "按 category -> id -> 中文用途说明 填写。id 与扫描器产出的 id 一致（工作流用文件名、脚本用文件名、MCP 用函数名、命令/技能/子项目用其名）。补注会被 build_capability_registry.py 合并进 registry 与 index。留空的条目自动回退到代码内 docstring/description。",
+    "categories": [
+      "workflows",
+      "scripts_top",
+      "scripts_news",
+      "mcp_tools",
+      "commands",
+      "skills",
+      "projects"
+    ]
+  },
+  "workflows": {
+    "backfill-gap.yml": "手动回填指定时间段的数据缺口。",
+    "backfill-media.yml": "定时回填并归档媒体文件（同人图等）。",
+    "backfill-news.yml": "定时回填历史社区新闻。",
+    "check-version.yml": "定时检测 Morimens 客户端版本更新。",
+    "claude.yml": "Claude Code GitHub 协作入口（@claude 触发）。",
+    "cleanup-stale-branches.yml": "定时清理过期分支。",
+    "collect-comments.yml": "定时采集视频评论。",
+    "collect-fanart.yml": "定时采集同人图。",
+    "deploy-site.yml": "push 触发部署 site 静态站。",
+    "discord-archive-jp.yml": "定时归档日服 Discord 数据。",
+    "discord-archive-volunteer.yml": "定时归档志愿者 Discord 数据。",
+    "discord-archive.yml": "定时归档主 Discord 数据。",
+    "discord-discover-guilds.yml": "定时发现新的 Discord 服务器。",
+    "discord-history-backfill.yml": "定时回填 Discord 历史消息。",
+    "extract-game-data.yml": "解包提取客户端游戏数据（wiki 数据源）。",
+    "fetch-wiki-data.yml": "定时抓取 wiki 数据。",
+    "recover-fanart.yml": "恢复丢失的同人图。",
+    "test-collectors.yml": "运行采集器单元测试。",
+    "test.yml": "运行全量 pytest 单元测试。",
+    "update-news.yml": "每小时采集社区新闻并更新输出层。",
+    "validate-data.yml": "校验 wiki JSON 数据（push/PR 触发）。",
+    "build-capability-registry.yml": "功能源变动时自动重生成银芯功能目录。"
+  },
+  "projects": {
+    "news": "使命#1 黑池信息入口：采集器 + 全量档案层 + 输出展示层，单向送黑池。",
+    "wiki": "使命#2 社区知识底座：VitePress 站点 + 72 角色数据库（客户端解包自举）。",
+    "site": "使命#3 对外门户：静态站 public/ + 设计令牌 design/。",
+    "game": "衍生游戏，退出主线，守密人个人兴趣，不主线派发。"
+  },
+  "skills": {
+    "anysearch": "实时网络检索（多区社区情报 CN/JP/TW），AnySearch API 封装，失败回退内置 WebSearch。"
+  },
+  "commands": {
+    "biav-report": "产出银芯社区情报深度报告（角色推荐 / bug 修复优先级等）。",
+    "daily-news": "运行 news 采集器并校验输出，非空才提交。",
+    "sync-memory": "核对各子项目实际文件状态，同步共享记忆文件。",
+    "validate-data": "校验 wiki 数据库全部 JSON 数据文件。"
+  }
+}

--- a/memory/capability-index.md
+++ b/memory/capability-index.md
@@ -1,0 +1,260 @@
+# 银芯功能目录（capability-index）
+
+> 本文件由 `scripts/build_capability_registry.py` 自动生成，**请勿手改**。
+> 中文用途补注请改 `memory/capability-annotations.json`；机器权威数据见 `memory/capability-registry.json`。
+
+- 生成日期：2026-06-20
+- 功能总数：**110**
+
+## 总览
+
+| 功能层 | 数量 |
+|------|------|
+| CI 自动化工作流 | 22 |
+| 顶层脚本（记忆 / 做梦 / 解包 / 运营） | 37 |
+| news 采集器脚本 | 26 |
+| MCP 知识层工具 | 16 |
+| Slash 命令 | 4 |
+| 仓内技能 | 1 |
+| 子项目 | 4 |
+
+## CI 自动化工作流（22）
+
+- **`Backfill Data Gap`** _[manual]_ — 手动回填指定时间段的数据缺口。  
+  `.github/workflows/backfill-gap.yml`
+- **`Backfill & Archive Media`** _[schedule/manual]_ — 定时回填并归档媒体文件（同人图等）。  
+  `.github/workflows/backfill-media.yml`
+- **`Backfill Historical News`** _[schedule/manual]_ — 定时回填历史社区新闻。  
+  `.github/workflows/backfill-news.yml`
+- **`Build Capability Registry`** _[push/manual]_ — 功能源变动时自动重生成银芯功能目录。  
+  `.github/workflows/build-capability-registry.yml`
+- **`Check Morimens Version Updates`** _[schedule/manual]_ — 定时检测 Morimens 客户端版本更新。  
+  `.github/workflows/check-version.yml`
+- **`Claude Code`** — Claude Code GitHub 协作入口（@claude 触发）。  
+  `.github/workflows/claude.yml`
+- **`Cleanup Stale Branches`** _[schedule/manual]_ — 定时清理过期分支。  
+  `.github/workflows/cleanup-stale-branches.yml`
+- **`Collect Video Comments`** _[schedule/manual]_ — 定时采集视频评论。  
+  `.github/workflows/collect-comments.yml`
+- **`Collect Fan Art`** _[schedule/manual]_ — 定时采集同人图。  
+  `.github/workflows/collect-fanart.yml`
+- **`Deploy Site`** _[push/manual]_ — push 触发部署 site 静态站。  
+  `.github/workflows/deploy-site.yml`
+- **`Discord Archive (JP)`** _[schedule/manual]_ — 定时归档日服 Discord 数据。  
+  `.github/workflows/discord-archive-jp.yml`
+- **`Discord Archive (Volunteer)`** _[schedule/manual]_ — 定时归档志愿者 Discord 数据。  
+  `.github/workflows/discord-archive-volunteer.yml`
+- **`Discord Archive`** _[schedule/manual]_ — 定时归档主 Discord 数据。  
+  `.github/workflows/discord-archive.yml`
+- **`Discord Discover Guilds`** _[manual]_ — 定时发现新的 Discord 服务器。  
+  `.github/workflows/discord-discover-guilds.yml`
+- **`Discord History Backfill`** _[schedule/manual]_ — 定时回填 Discord 历史消息。  
+  `.github/workflows/discord-history-backfill.yml`
+- **`Extract Game Data from Client`** _[push/manual]_ — 解包提取客户端游戏数据（wiki 数据源）。  
+  `.github/workflows/extract-game-data.yml`
+- **`Fetch Wiki Data`** _[schedule/push/manual]_ — 定时抓取 wiki 数据。  
+  `.github/workflows/fetch-wiki-data.yml`
+- **`Recover Fan Art`** _[manual]_ — 恢复丢失的同人图。  
+  `.github/workflows/recover-fanart.yml`
+- **`Test All Data Collectors`** _[manual]_ — 运行采集器单元测试。  
+  `.github/workflows/test-collectors.yml`
+- **`Run Tests`** _[push/pull_request/manual]_ — 运行全量 pytest 单元测试。  
+  `.github/workflows/test.yml`
+- **`Update Community News`** _[schedule/manual]_ — 每小时采集社区新闻并更新输出层。  
+  `.github/workflows/update-news.yml`
+- **`Validate Wiki Data`** _[push/pull_request/manual]_ — 校验 wiki JSON 数据（push/PR 触发）。  
+  `.github/workflows/validate-data.yml`
+
+## 顶层脚本（记忆 / 做梦 / 解包 / 运营）（37）
+
+- **`boot_snapshot.py`** — boot_snapshot.py — 银芯启动快照生成器  
+  `scripts/boot_snapshot.py`
+- **`build_capability_registry.py`** — build_capability_registry.py — 银芯功能目录自动扫描器  
+  `scripts/build_capability_registry.py`
+- **`character_persona.py`** — character_persona.py — Character Persona Prompt Generator  
+  `scripts/character_persona.py`
+- **`context_manager.py`** — context_manager.py — Virtual Context Manager (MemGPT-style)  
+  `scripts/context_manager.py`
+- **`dream.py`** — dream.py — 4-Phase AutoDream Memory Consolidation System  
+  `scripts/dream.py`
+- **`dream_ai.py`** — AI-powered consolidation + sleep-time precompute cache.  
+  `scripts/dream_ai.py`
+- **`dream_archive.py`** — Archive integrity scan — detect broken path references in repo docs.  
+  `scripts/dream_archive.py`
+- **`dream_config.py`** — Shared configuration constants for the dream.py memory-consolidation system.  
+  `scripts/dream_config.py`
+- **`dream_health.py`** — Memory hygiene checks — staleness, broken refs, duplicate decisions, etc.  
+  `scripts/dream_health.py`
+- **`dream_io.py`** — Dream persistence — journal, insights and access-log read/write.  
+  `scripts/dream_io.py`
+- **`dream_rem.py`** — REM phase — weekly deep reflection: cross-session pattern analysis,  
+  `scripts/dream_rem.py`
+- **`dream_sentinel.py`** — Sentinel layer — proactive anomaly detection over news data sources.  
+  `scripts/dream_sentinel.py`
+- **`extract_art.py`** — Batch extract art assets from Morimens encrypted AssetBundles.  
+  `scripts/extract_art.py`
+- **`fact_store.py`** — fact_store.py — AI-driven Fact Storage with Semantic Deduplication  
+  `scripts/fact_store.py`
+- **`generate_wiki_pages.py`** — Generate VitePress Markdown pages from processed JSON data.  
+  `scripts/generate_wiki_pages.py`
+- **`io_utils.py`** — io_utils.py — shared atomic file write helper.  
+  `scripts/io_utils.py`
+- **`knowledge_graph.py`** — knowledge_graph.py — Knowledge Graph Builder & Query Engine  
+  `scripts/knowledge_graph.py`
+- **`lua_parse.py`** — Shared parser for runtime-extracted Lua table dumps.  
+  `scripts/lua_parse.py`
+- **`mcp_server.py`** — mcp_server.py — BIAV-SC Memory MCP Server  
+  `scripts/mcp_server.py`
+- **`memory_search.py`** — memory_search.py — Semantic Memory Search with TF-IDF Vectors + Reranker  
+  `scripts/memory_search.py`
+- **`memory_writeback.py`** — memory_writeback.py — Long-term Memory Write-back Loop  
+  `scripts/memory_writeback.py`
+- **`memrl.py`** — memrl.py — MemRL-lite: Memory Utility Tracking & Adaptive Reranking  
+  `scripts/memrl.py`
+- **`parse_awaker_config.py`** — Parse AwakerConfig.lua into structured character profiles JSON.  
+  `scripts/parse_awaker_config.py`
+- **`parse_cg_gallery.py`** — Parse art_assets manifest.json to extract CG gallery data grouped by chapter.  
+  `scripts/parse_cg_gallery.py`
+- **`parse_collection_hall.py`** — Parse CollectionHall.lua into structured JSON for world lore encyclopedia.  
+  `scripts/parse_collection_hall.py`
+- **`parse_item_stories.py`** — Parse Item.lua to extract items with background stories (StoryDesc field).  
+  `scripts/parse_item_stories.py`
+- **`parse_voice_lines.py`** — Parse Voice.lua into structured JSON for wiki voice lines page.  
+  `scripts/parse_voice_lines.py`
+- **`reflexion.py`** — reflexion.py — Reflexion: Automatic Failure Learning  
+  `scripts/reflexion.py`
+- **`report_render.py`** — 银芯报告渲染器 — 结构化 markdown → 统一视觉风格的 PDF + HTML。  
+  `scripts/report_render.py`
+- **`send_report_email.py`** — 银芯日报投递器 — 把渲染好的 PDF 报告通过 SMTP 发送到指定邮箱。  
+  `scripts/send_report_email.py`
+- **`session_briefing.py`** — session_briefing.py — Smart Session Briefing Generator  
+  `scripts/session_briefing.py`
+- **`session_distiller.py`** — session_distiller.py — Claude Code SessionEnd transcript distiller (v0.4 md+meta).  
+  `scripts/session_distiller.py`
+- **`session_inject.py`** — session_inject.py —— UserPromptSubmit hook：每次用户输入前注入历史会话上下文。  
+  `scripts/session_inject.py`
+- **`session_reflexion.py`** — session_reflexion.py — Session-end reflexion hook  
+  `scripts/session_reflexion.py`
+- **`session_watch.py`** — session_watch.py —— PostToolUse hook：实时追加会话工具调用事件到 progress.jsonl。  
+  `scripts/session_watch.py`
+- **`silver_memory_tools.py`** — silver_memory_tools.py —— 银芯记忆增强工具集  
+  `scripts/silver_memory_tools.py`
+- **`text_utils.py`** — Shared text tokenization for the memory system.  
+  `scripts/text_utils.py`
+
+## news 采集器脚本（26）
+
+- **`aggregator.py`** — 忘却前夜 Morimens - 社区热点聚合器  
+  `projects/news/scripts/aggregator.py`
+- **`aggregator_base.py`** — Shared base for the news aggregator: HTTP/logging setup, config  
+  `projects/news/scripts/aggregator_base.py`
+- **`aggregator_collectors.py`** — Per-platform news collectors (Reddit, Bilibili, NGA, TapTap, Steam,  
+  `projects/news/scripts/aggregator_collectors.py`
+- **`archive_discord.py`** — Discord 月度归档脚本 — 打包超 60 天 JSONL → GitHub Releases → 从 git 删除  
+  `projects/news/scripts/archive_discord.py`
+- **`archive_platforms.py`** — 多平台按日归档脚本 — 将 news.json（merged 全量层）按每条目真实日期存入 data/platforms/  
+  `projects/news/scripts/archive_platforms.py`
+- **`backfill_forum_starters.py`** — backfill_forum_starters.py — 一次性回填所有 forum thread 的 starter 消息  
+  `projects/news/scripts/backfill_forum_starters.py`
+- **`backfill_gap.py`** — backfill_gap.py — One-time script to backfill the Apr 13-25 data gap.  
+  `projects/news/scripts/backfill_gap.py`
+- **`backfill_media.py`** — 媒体补录器 — 扫全量归档，把仍存活的图片全部下载归档，二进制走 Releases（决策 038/059）。  
+  `projects/news/scripts/backfill_media.py`
+- **`backfill_platforms.py`** — backfill_platforms.py — 多平台历史数据回溯采集  
+  `projects/news/scripts/backfill_platforms.py`
+- **`collect_fanart.py`** — 同人图采集器 — 把某日各信息源的玩家二创图抓到本地，供日报附录嵌图。  
+  `projects/news/scripts/collect_fanart.py`
+- **`collect_global.py`** — collect_global.py — 全球社区采集桥接脚本  
+  `projects/news/scripts/collect_global.py`
+- **`collect_video_comments.py`** — YouTube 视频评论采集器（累积归档版）。  
+  `projects/news/scripts/collect_video_comments.py`
+- **`collection_state.py`** — collection_state.py — Adaptive time window for news collection pipeline.  
+  `projects/news/scripts/collection_state.py`
+- **`data_quality.py`** — 数据质量增强模块  
+  `projects/news/scripts/data_quality.py`
+- **`discord_archiver.py`** — Discord 全量数据归档器 v2 — 双轨并行 + 断点续传 + JSONL 去重  
+  `projects/news/scripts/discord_archiver.py`
+- **`discord_list_guilds.py`** — Discord 服务器清单探测 — 列出 bot 当前加入的所有服务器（guild）  
+  `projects/news/scripts/discord_list_guilds.py`
+- **`discord_probe.py`** — Discord 只读连通性探针 — 验证 bot 在指定服务器的接入状态  
+  `projects/news/scripts/discord_probe.py`
+- **`download_media.py`** — download_media.py — 全平台媒体资源下载器  
+  `projects/news/scripts/download_media.py`
+- **`global_collectors.py`** — 忘却前夜 Morimens - 全球信息收集器  
+  `projects/news/scripts/global_collectors.py`
+- **`news_common.py`** — news_common.py — 采集层共享工具（ARCH-01/02 收敛单一归属）  
+  `projects/news/scripts/news_common.py`
+- **`playwright_collectors.py`** — Playwright-based collectors for Morimens community news.  
+  `projects/news/scripts/playwright_collectors.py`
+- **`repair_gaps.py`** — repair_gaps.py — Detect and report date gaps in platform archives.  
+  `projects/news/scripts/repair_gaps.py`
+- **`silent_sources_audit.py`** — silent_sources_audit.py — 沉默源审计（基于归档历史）  
+  `projects/news/scripts/silent_sources_audit.py`
+- **`sources.py`** — sources.py — 采集源单一真相源（single source of truth）  
+  `projects/news/scripts/sources.py`
+- **`split_output.py`** — split_output.py — 按数据源分割 projects/news/output/news.json  
+  `projects/news/scripts/split_output.py`
+- **`taptap_collector.py`** — TapTap 社区采集器 - Playwright 无头浏览器方案  
+  `projects/news/scripts/taptap_collector.py`
+
+## MCP 知识层工具（16）
+
+- **`memory_search`** — 搜索银芯知识库，返回最相关的知识块。  
+  `scripts/mcp_server.py`
+- **`graph_query`** — 查询知识图谱中的实体及其关联。  
+  `scripts/mcp_server.py`
+- **`graph_related_files`** — 查找与实体相关的文件，按图谱距离排序。  
+  `scripts/mcp_server.py`
+- **`memory_utility`** — 查看记忆文件效用排名。  
+  `scripts/mcp_server.py`
+- **`check_cache`** — 查询 Sleep-Time Compute 预计算缓存。  
+  `scripts/mcp_server.py`
+- **`recommend_context`** — 根据当前话题推荐应加载的知识文件（虚拟上下文管理）。  
+  `scripts/mcp_server.py`
+- **`rebuild_indexes`** — 重建所有索引（向量索引 + 知识图谱 + 效用分数）。  
+  `scripts/mcp_server.py`
+- **`store_facts`** — 存储本次对话中发现的重要知识事实。  
+  `scripts/mcp_server.py`
+- **`memory_writeback`** — 将当前会话产生的新知识写回知识库。  
+  `scripts/mcp_server.py`
+- **`session_briefing`** — 新会话启动时调用，获取智能 briefing。  
+  `scripts/mcp_server.py`
+- **`character_persona`** — 激活角色人格模式，让AI以游戏角色的语气进行对话。  
+  `scripts/mcp_server.py`
+- **`recall_session`** — 在历史 session digest 中语义搜索相关 session（TF-IDF + 4 维重排）。  
+  `scripts/mcp_server.py`
+- **`current_continuity`** — 读取 session 连续性链（上次 session 快照 + topics_hint）。  
+  `scripts/mcp_server.py`
+- **`record_decision`** — 追加决策条目到 memory/decisions.md 的当前有效决策表格末尾。  
+  `scripts/mcp_server.py`
+- **`record_lesson`** — 追加教训条目到 memory/lessons-learned.md 末尾。  
+  `scripts/mcp_server.py`
+- **`session_progress`** — 读取指定 session 的 progress.jsonl 增量事件列表（由 session_watch hook 记录）。  
+  `scripts/mcp_server.py`
+
+## Slash 命令（4）
+
+- **`biav-report`** — 产出银芯社区情报深度报告（角色推荐 / bug 修复优先级等）。  
+  `.claude/commands/biav-report.md`
+- **`daily-news`** — 运行 news 采集器并校验输出，非空才提交。  
+  `.claude/commands/daily-news.md`
+- **`sync-memory`** — 核对各子项目实际文件状态，同步共享记忆文件。  
+  `.claude/commands/sync-memory.md`
+- **`validate-data`** — 校验 wiki 数据库全部 JSON 数据文件。  
+  `.claude/commands/validate-data.md`
+
+## 仓内技能（1）
+
+- **`anysearch`** — 实时网络检索（多区社区情报 CN/JP/TW），AnySearch API 封装，失败回退内置 WebSearch。  
+  `.claude/skills/anysearch/SKILL.md`
+
+## 子项目（4）
+
+- **`game`** — 衍生游戏，退出主线，守密人个人兴趣，不主线派发。  
+  `projects/game/`
+- **`news`** — 使命#1 黑池信息入口：采集器 + 全量档案层 + 输出展示层，单向送黑池。  
+  `projects/news/`
+- **`site`** — 使命#3 对外门户：静态站 public/ + 设计令牌 design/。  
+  `projects/site/`
+- **`wiki`** — 使命#2 社区知识底座：VitePress 站点 + 72 角色数据库（客户端解包自举）。  
+  `projects/wiki/`

--- a/memory/capability-registry.json
+++ b/memory/capability-registry.json
@@ -1,100 +1,698 @@
 {
   "meta": {
-    "generated_at": "2026-04-14",
-    "generated_by": "Code-主控台 subagent (艾瑞卡扫描任务)",
-    "scope": "BIAV Studio team-internal (silver side inventory)",
-    "note": "v1 初版能力清单，对应黑池架构需求 5（团队共享技能/代理/MCP）。后续由艾瑞卡 review 扩展。扫描范围：.claude/commands, .claude/skills, .claude/agents, scripts/mcp_server.py, assets/data/character-personas/",
-    "source_paths_scanned": [
-      ".claude/commands/",
-      ".claude/skills/ (不存在)",
-      ".claude/agents/ (不存在)",
-      "scripts/mcp_server.py",
-      "assets/data/character-personas/"
-    ]
+    "generated_at": "2026-06-20",
+    "generated_by": "scripts/build_capability_registry.py (自动扫描)",
+    "do_not_hand_edit": "本文件由 CI 自动重生成；人工中文用途请改 memory/capability-annotations.json",
+    "scope": "BIAV-SC 银芯受限层全功能盘点（七层）",
+    "counts": {
+      "workflows": 22,
+      "scripts_top": 37,
+      "scripts_news": 26,
+      "mcp_tools": 16,
+      "commands": 4,
+      "skills": 1,
+      "projects": 4,
+      "total": 110
+    }
   },
-  "skills": [
+  "workflows": [
     {
-      "name": "daily-news",
-      "path": ".claude/commands/daily-news.md",
-      "summary": "Run the news aggregator and verify output"
+      "id": "backfill-gap.yml",
+      "name": "Backfill Data Gap",
+      "path": ".github/workflows/backfill-gap.yml",
+      "triggers": [
+        "manual"
+      ],
+      "note_zh": "手动回填指定时间段的数据缺口。"
     },
     {
-      "name": "sync-memory",
-      "path": ".claude/commands/sync-memory.md",
-      "summary": "Check all sub-project actual file states and sync shared memory files"
+      "id": "backfill-media.yml",
+      "name": "Backfill & Archive Media",
+      "path": ".github/workflows/backfill-media.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时回填并归档媒体文件（同人图等）。"
     },
     {
-      "name": "validate-data",
-      "path": ".claude/commands/validate-data.md",
-      "summary": "Validate all JSON data files in the wiki database"
+      "id": "backfill-news.yml",
+      "name": "Backfill Historical News",
+      "path": ".github/workflows/backfill-news.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时回填历史社区新闻。"
+    },
+    {
+      "id": "build-capability-registry.yml",
+      "name": "Build Capability Registry",
+      "path": ".github/workflows/build-capability-registry.yml",
+      "triggers": [
+        "push",
+        "manual"
+      ],
+      "note_zh": "功能源变动时自动重生成银芯功能目录。"
+    },
+    {
+      "id": "check-version.yml",
+      "name": "Check Morimens Version Updates",
+      "path": ".github/workflows/check-version.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时检测 Morimens 客户端版本更新。"
+    },
+    {
+      "id": "claude.yml",
+      "name": "Claude Code",
+      "path": ".github/workflows/claude.yml",
+      "triggers": [],
+      "note_zh": "Claude Code GitHub 协作入口（@claude 触发）。"
+    },
+    {
+      "id": "cleanup-stale-branches.yml",
+      "name": "Cleanup Stale Branches",
+      "path": ".github/workflows/cleanup-stale-branches.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时清理过期分支。"
+    },
+    {
+      "id": "collect-comments.yml",
+      "name": "Collect Video Comments",
+      "path": ".github/workflows/collect-comments.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时采集视频评论。"
+    },
+    {
+      "id": "collect-fanart.yml",
+      "name": "Collect Fan Art",
+      "path": ".github/workflows/collect-fanart.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时采集同人图。"
+    },
+    {
+      "id": "deploy-site.yml",
+      "name": "Deploy Site",
+      "path": ".github/workflows/deploy-site.yml",
+      "triggers": [
+        "push",
+        "manual"
+      ],
+      "note_zh": "push 触发部署 site 静态站。"
+    },
+    {
+      "id": "discord-archive-jp.yml",
+      "name": "Discord Archive (JP)",
+      "path": ".github/workflows/discord-archive-jp.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时归档日服 Discord 数据。"
+    },
+    {
+      "id": "discord-archive-volunteer.yml",
+      "name": "Discord Archive (Volunteer)",
+      "path": ".github/workflows/discord-archive-volunteer.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时归档志愿者 Discord 数据。"
+    },
+    {
+      "id": "discord-archive.yml",
+      "name": "Discord Archive",
+      "path": ".github/workflows/discord-archive.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时归档主 Discord 数据。"
+    },
+    {
+      "id": "discord-discover-guilds.yml",
+      "name": "Discord Discover Guilds",
+      "path": ".github/workflows/discord-discover-guilds.yml",
+      "triggers": [
+        "manual"
+      ],
+      "note_zh": "定时发现新的 Discord 服务器。"
+    },
+    {
+      "id": "discord-history-backfill.yml",
+      "name": "Discord History Backfill",
+      "path": ".github/workflows/discord-history-backfill.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "定时回填 Discord 历史消息。"
+    },
+    {
+      "id": "extract-game-data.yml",
+      "name": "Extract Game Data from Client",
+      "path": ".github/workflows/extract-game-data.yml",
+      "triggers": [
+        "push",
+        "manual"
+      ],
+      "note_zh": "解包提取客户端游戏数据（wiki 数据源）。"
+    },
+    {
+      "id": "fetch-wiki-data.yml",
+      "name": "Fetch Wiki Data",
+      "path": ".github/workflows/fetch-wiki-data.yml",
+      "triggers": [
+        "schedule",
+        "push",
+        "manual"
+      ],
+      "note_zh": "定时抓取 wiki 数据。"
+    },
+    {
+      "id": "recover-fanart.yml",
+      "name": "Recover Fan Art",
+      "path": ".github/workflows/recover-fanart.yml",
+      "triggers": [
+        "manual"
+      ],
+      "note_zh": "恢复丢失的同人图。"
+    },
+    {
+      "id": "test-collectors.yml",
+      "name": "Test All Data Collectors",
+      "path": ".github/workflows/test-collectors.yml",
+      "triggers": [
+        "manual"
+      ],
+      "note_zh": "运行采集器单元测试。"
+    },
+    {
+      "id": "test.yml",
+      "name": "Run Tests",
+      "path": ".github/workflows/test.yml",
+      "triggers": [
+        "push",
+        "pull_request",
+        "manual"
+      ],
+      "note_zh": "运行全量 pytest 单元测试。"
+    },
+    {
+      "id": "update-news.yml",
+      "name": "Update Community News",
+      "path": ".github/workflows/update-news.yml",
+      "triggers": [
+        "schedule",
+        "manual"
+      ],
+      "note_zh": "每小时采集社区新闻并更新输出层。"
+    },
+    {
+      "id": "validate-data.yml",
+      "name": "Validate Wiki Data",
+      "path": ".github/workflows/validate-data.yml",
+      "triggers": [
+        "push",
+        "pull_request",
+        "manual"
+      ],
+      "note_zh": "校验 wiki JSON 数据（push/PR 触发）。"
     }
   ],
-  "agents": [],
+  "scripts_top": [
+    {
+      "id": "boot_snapshot.py",
+      "path": "scripts/boot_snapshot.py",
+      "summary": "boot_snapshot.py — 银芯启动快照生成器"
+    },
+    {
+      "id": "build_capability_registry.py",
+      "path": "scripts/build_capability_registry.py",
+      "summary": "build_capability_registry.py — 银芯功能目录自动扫描器"
+    },
+    {
+      "id": "character_persona.py",
+      "path": "scripts/character_persona.py",
+      "summary": "character_persona.py — Character Persona Prompt Generator"
+    },
+    {
+      "id": "context_manager.py",
+      "path": "scripts/context_manager.py",
+      "summary": "context_manager.py — Virtual Context Manager (MemGPT-style)"
+    },
+    {
+      "id": "dream.py",
+      "path": "scripts/dream.py",
+      "summary": "dream.py — 4-Phase AutoDream Memory Consolidation System"
+    },
+    {
+      "id": "dream_ai.py",
+      "path": "scripts/dream_ai.py",
+      "summary": "AI-powered consolidation + sleep-time precompute cache."
+    },
+    {
+      "id": "dream_archive.py",
+      "path": "scripts/dream_archive.py",
+      "summary": "Archive integrity scan — detect broken path references in repo docs."
+    },
+    {
+      "id": "dream_config.py",
+      "path": "scripts/dream_config.py",
+      "summary": "Shared configuration constants for the dream.py memory-consolidation system."
+    },
+    {
+      "id": "dream_health.py",
+      "path": "scripts/dream_health.py",
+      "summary": "Memory hygiene checks — staleness, broken refs, duplicate decisions, etc."
+    },
+    {
+      "id": "dream_io.py",
+      "path": "scripts/dream_io.py",
+      "summary": "Dream persistence — journal, insights and access-log read/write."
+    },
+    {
+      "id": "dream_rem.py",
+      "path": "scripts/dream_rem.py",
+      "summary": "REM phase — weekly deep reflection: cross-session pattern analysis,"
+    },
+    {
+      "id": "dream_sentinel.py",
+      "path": "scripts/dream_sentinel.py",
+      "summary": "Sentinel layer — proactive anomaly detection over news data sources."
+    },
+    {
+      "id": "extract_art.py",
+      "path": "scripts/extract_art.py",
+      "summary": "Batch extract art assets from Morimens encrypted AssetBundles."
+    },
+    {
+      "id": "fact_store.py",
+      "path": "scripts/fact_store.py",
+      "summary": "fact_store.py — AI-driven Fact Storage with Semantic Deduplication"
+    },
+    {
+      "id": "generate_wiki_pages.py",
+      "path": "scripts/generate_wiki_pages.py",
+      "summary": "Generate VitePress Markdown pages from processed JSON data."
+    },
+    {
+      "id": "io_utils.py",
+      "path": "scripts/io_utils.py",
+      "summary": "io_utils.py — shared atomic file write helper."
+    },
+    {
+      "id": "knowledge_graph.py",
+      "path": "scripts/knowledge_graph.py",
+      "summary": "knowledge_graph.py — Knowledge Graph Builder & Query Engine"
+    },
+    {
+      "id": "lua_parse.py",
+      "path": "scripts/lua_parse.py",
+      "summary": "Shared parser for runtime-extracted Lua table dumps."
+    },
+    {
+      "id": "mcp_server.py",
+      "path": "scripts/mcp_server.py",
+      "summary": "mcp_server.py — BIAV-SC Memory MCP Server"
+    },
+    {
+      "id": "memory_search.py",
+      "path": "scripts/memory_search.py",
+      "summary": "memory_search.py — Semantic Memory Search with TF-IDF Vectors + Reranker"
+    },
+    {
+      "id": "memory_writeback.py",
+      "path": "scripts/memory_writeback.py",
+      "summary": "memory_writeback.py — Long-term Memory Write-back Loop"
+    },
+    {
+      "id": "memrl.py",
+      "path": "scripts/memrl.py",
+      "summary": "memrl.py — MemRL-lite: Memory Utility Tracking & Adaptive Reranking"
+    },
+    {
+      "id": "parse_awaker_config.py",
+      "path": "scripts/parse_awaker_config.py",
+      "summary": "Parse AwakerConfig.lua into structured character profiles JSON."
+    },
+    {
+      "id": "parse_cg_gallery.py",
+      "path": "scripts/parse_cg_gallery.py",
+      "summary": "Parse art_assets manifest.json to extract CG gallery data grouped by chapter."
+    },
+    {
+      "id": "parse_collection_hall.py",
+      "path": "scripts/parse_collection_hall.py",
+      "summary": "Parse CollectionHall.lua into structured JSON for world lore encyclopedia."
+    },
+    {
+      "id": "parse_item_stories.py",
+      "path": "scripts/parse_item_stories.py",
+      "summary": "Parse Item.lua to extract items with background stories (StoryDesc field)."
+    },
+    {
+      "id": "parse_voice_lines.py",
+      "path": "scripts/parse_voice_lines.py",
+      "summary": "Parse Voice.lua into structured JSON for wiki voice lines page."
+    },
+    {
+      "id": "reflexion.py",
+      "path": "scripts/reflexion.py",
+      "summary": "reflexion.py — Reflexion: Automatic Failure Learning"
+    },
+    {
+      "id": "report_render.py",
+      "path": "scripts/report_render.py",
+      "summary": "银芯报告渲染器 — 结构化 markdown → 统一视觉风格的 PDF + HTML。"
+    },
+    {
+      "id": "send_report_email.py",
+      "path": "scripts/send_report_email.py",
+      "summary": "银芯日报投递器 — 把渲染好的 PDF 报告通过 SMTP 发送到指定邮箱。"
+    },
+    {
+      "id": "session_briefing.py",
+      "path": "scripts/session_briefing.py",
+      "summary": "session_briefing.py — Smart Session Briefing Generator"
+    },
+    {
+      "id": "session_distiller.py",
+      "path": "scripts/session_distiller.py",
+      "summary": "session_distiller.py — Claude Code SessionEnd transcript distiller (v0.4 md+meta)."
+    },
+    {
+      "id": "session_inject.py",
+      "path": "scripts/session_inject.py",
+      "summary": "session_inject.py —— UserPromptSubmit hook：每次用户输入前注入历史会话上下文。"
+    },
+    {
+      "id": "session_reflexion.py",
+      "path": "scripts/session_reflexion.py",
+      "summary": "session_reflexion.py — Session-end reflexion hook"
+    },
+    {
+      "id": "session_watch.py",
+      "path": "scripts/session_watch.py",
+      "summary": "session_watch.py —— PostToolUse hook：实时追加会话工具调用事件到 progress.jsonl。"
+    },
+    {
+      "id": "silver_memory_tools.py",
+      "path": "scripts/silver_memory_tools.py",
+      "summary": "silver_memory_tools.py —— 银芯记忆增强工具集"
+    },
+    {
+      "id": "text_utils.py",
+      "path": "scripts/text_utils.py",
+      "summary": "Shared text tokenization for the memory system."
+    }
+  ],
+  "scripts_news": [
+    {
+      "id": "aggregator.py",
+      "path": "projects/news/scripts/aggregator.py",
+      "summary": "忘却前夜 Morimens - 社区热点聚合器"
+    },
+    {
+      "id": "aggregator_base.py",
+      "path": "projects/news/scripts/aggregator_base.py",
+      "summary": "Shared base for the news aggregator: HTTP/logging setup, config"
+    },
+    {
+      "id": "aggregator_collectors.py",
+      "path": "projects/news/scripts/aggregator_collectors.py",
+      "summary": "Per-platform news collectors (Reddit, Bilibili, NGA, TapTap, Steam,"
+    },
+    {
+      "id": "archive_discord.py",
+      "path": "projects/news/scripts/archive_discord.py",
+      "summary": "Discord 月度归档脚本 — 打包超 60 天 JSONL → GitHub Releases → 从 git 删除"
+    },
+    {
+      "id": "archive_platforms.py",
+      "path": "projects/news/scripts/archive_platforms.py",
+      "summary": "多平台按日归档脚本 — 将 news.json（merged 全量层）按每条目真实日期存入 data/platforms/"
+    },
+    {
+      "id": "backfill_forum_starters.py",
+      "path": "projects/news/scripts/backfill_forum_starters.py",
+      "summary": "backfill_forum_starters.py — 一次性回填所有 forum thread 的 starter 消息"
+    },
+    {
+      "id": "backfill_gap.py",
+      "path": "projects/news/scripts/backfill_gap.py",
+      "summary": "backfill_gap.py — One-time script to backfill the Apr 13-25 data gap."
+    },
+    {
+      "id": "backfill_media.py",
+      "path": "projects/news/scripts/backfill_media.py",
+      "summary": "媒体补录器 — 扫全量归档，把仍存活的图片全部下载归档，二进制走 Releases（决策 038/059）。"
+    },
+    {
+      "id": "backfill_platforms.py",
+      "path": "projects/news/scripts/backfill_platforms.py",
+      "summary": "backfill_platforms.py — 多平台历史数据回溯采集"
+    },
+    {
+      "id": "collect_fanart.py",
+      "path": "projects/news/scripts/collect_fanart.py",
+      "summary": "同人图采集器 — 把某日各信息源的玩家二创图抓到本地，供日报附录嵌图。"
+    },
+    {
+      "id": "collect_global.py",
+      "path": "projects/news/scripts/collect_global.py",
+      "summary": "collect_global.py — 全球社区采集桥接脚本"
+    },
+    {
+      "id": "collect_video_comments.py",
+      "path": "projects/news/scripts/collect_video_comments.py",
+      "summary": "YouTube 视频评论采集器（累积归档版）。"
+    },
+    {
+      "id": "collection_state.py",
+      "path": "projects/news/scripts/collection_state.py",
+      "summary": "collection_state.py — Adaptive time window for news collection pipeline."
+    },
+    {
+      "id": "data_quality.py",
+      "path": "projects/news/scripts/data_quality.py",
+      "summary": "数据质量增强模块"
+    },
+    {
+      "id": "discord_archiver.py",
+      "path": "projects/news/scripts/discord_archiver.py",
+      "summary": "Discord 全量数据归档器 v2 — 双轨并行 + 断点续传 + JSONL 去重"
+    },
+    {
+      "id": "discord_list_guilds.py",
+      "path": "projects/news/scripts/discord_list_guilds.py",
+      "summary": "Discord 服务器清单探测 — 列出 bot 当前加入的所有服务器（guild）"
+    },
+    {
+      "id": "discord_probe.py",
+      "path": "projects/news/scripts/discord_probe.py",
+      "summary": "Discord 只读连通性探针 — 验证 bot 在指定服务器的接入状态"
+    },
+    {
+      "id": "download_media.py",
+      "path": "projects/news/scripts/download_media.py",
+      "summary": "download_media.py — 全平台媒体资源下载器"
+    },
+    {
+      "id": "global_collectors.py",
+      "path": "projects/news/scripts/global_collectors.py",
+      "summary": "忘却前夜 Morimens - 全球信息收集器"
+    },
+    {
+      "id": "news_common.py",
+      "path": "projects/news/scripts/news_common.py",
+      "summary": "news_common.py — 采集层共享工具（ARCH-01/02 收敛单一归属）"
+    },
+    {
+      "id": "playwright_collectors.py",
+      "path": "projects/news/scripts/playwright_collectors.py",
+      "summary": "Playwright-based collectors for Morimens community news."
+    },
+    {
+      "id": "repair_gaps.py",
+      "path": "projects/news/scripts/repair_gaps.py",
+      "summary": "repair_gaps.py — Detect and report date gaps in platform archives."
+    },
+    {
+      "id": "silent_sources_audit.py",
+      "path": "projects/news/scripts/silent_sources_audit.py",
+      "summary": "silent_sources_audit.py — 沉默源审计（基于归档历史）"
+    },
+    {
+      "id": "sources.py",
+      "path": "projects/news/scripts/sources.py",
+      "summary": "sources.py — 采集源单一真相源（single source of truth）"
+    },
+    {
+      "id": "split_output.py",
+      "path": "projects/news/scripts/split_output.py",
+      "summary": "split_output.py — 按数据源分割 projects/news/output/news.json"
+    },
+    {
+      "id": "taptap_collector.py",
+      "path": "projects/news/scripts/taptap_collector.py",
+      "summary": "TapTap 社区采集器 - Playwright 无头浏览器方案"
+    }
+  ],
   "mcp_tools": [
     {
-      "name": "memory_search",
+      "id": "memory_search",
       "module": "scripts/mcp_server.py",
-      "summary": "搜索银芯知识库，基于 TF-IDF 向量检索 + 4 维重排序（语义/新鲜度/访问频率/图谱距离），返回最相关的知识块"
+      "summary": "搜索银芯知识库，返回最相关的知识块。"
     },
     {
-      "name": "graph_query",
+      "id": "graph_query",
       "module": "scripts/mcp_server.py",
-      "summary": "查询知识图谱中的实体及其关联，支持角色名、系统名、概念名"
+      "summary": "查询知识图谱中的实体及其关联。"
     },
     {
-      "name": "graph_related_files",
+      "id": "graph_related_files",
       "module": "scripts/mcp_server.py",
-      "summary": "查找与实体相关的文件，按图谱距离排序"
+      "summary": "查找与实体相关的文件，按图谱距离排序。"
     },
     {
-      "name": "memory_utility",
+      "id": "memory_utility",
       "module": "scripts/mcp_server.py",
-      "summary": "查看记忆文件效用排名（MemRL-lite EMA 追踪），识别高价值/待归档文件"
+      "summary": "查看记忆文件效用排名。"
     },
     {
-      "name": "check_cache",
+      "id": "check_cache",
       "module": "scripts/mcp_server.py",
-      "summary": "查询 Sleep-Time Compute 预计算缓存（深睡时预生成的常见问题答案）"
+      "summary": "查询 Sleep-Time Compute 预计算缓存。"
     },
     {
-      "name": "recommend_context",
+      "id": "recommend_context",
       "module": "scripts/mcp_server.py",
-      "summary": "根据当前话题推荐应加载的知识文件（向量检索 + 图谱 + 效用综合）"
+      "summary": "根据当前话题推荐应加载的知识文件（虚拟上下文管理）。"
     },
     {
-      "name": "rebuild_indexes",
+      "id": "rebuild_indexes",
       "module": "scripts/mcp_server.py",
-      "summary": "重建所有索引：向量索引 + 知识图谱 + 效用分数"
+      "summary": "重建所有索引（向量索引 + 知识图谱 + 效用分数）。"
     },
     {
-      "name": "store_facts",
+      "id": "store_facts",
       "module": "scripts/mcp_server.py",
-      "summary": "存储本次对话中发现的重要知识事实，支持自动去重（相似度 >75% 合并）"
+      "summary": "存储本次对话中发现的重要知识事实。"
     },
     {
-      "name": "memory_writeback",
+      "id": "memory_writeback",
       "module": "scripts/mcp_server.py",
-      "summary": "将当前会话产生的新知识写回知识库，自动检测 git 变更并增量重索引"
+      "summary": "将当前会话产生的新知识写回知识库。"
     },
     {
-      "name": "session_briefing",
+      "id": "session_briefing",
       "module": "scripts/mcp_server.py",
-      "summary": "新会话启动智能简报，综合 6 个数据源（上次回顾/git 变更/做梦发现/话题动量/效用趋势/推荐上下文）"
+      "summary": "新会话启动时调用，获取智能 briefing。"
     },
     {
-      "name": "character_persona",
+      "id": "character_persona",
       "module": "scripts/mcp_server.py",
-      "summary": "激活角色人格模式，让 AI 以游戏角色语气进行对话，跨平台支持银芯/黑池终端/黑池系统"
+      "summary": "激活角色人格模式，让AI以游戏角色的语气进行对话。"
+    },
+    {
+      "id": "recall_session",
+      "module": "scripts/mcp_server.py",
+      "summary": "在历史 session digest 中语义搜索相关 session（TF-IDF + 4 维重排）。"
+    },
+    {
+      "id": "current_continuity",
+      "module": "scripts/mcp_server.py",
+      "summary": "读取 session 连续性链（上次 session 快照 + topics_hint）。"
+    },
+    {
+      "id": "record_decision",
+      "module": "scripts/mcp_server.py",
+      "summary": "追加决策条目到 memory/decisions.md 的当前有效决策表格末尾。"
+    },
+    {
+      "id": "record_lesson",
+      "module": "scripts/mcp_server.py",
+      "summary": "追加教训条目到 memory/lessons-learned.md 末尾。"
+    },
+    {
+      "id": "session_progress",
+      "module": "scripts/mcp_server.py",
+      "summary": "读取指定 session 的 progress.jsonl 增量事件列表（由 session_watch hook 记录）。"
     }
   ],
-  "character_personas": [
+  "commands": [
     {
-      "name": "erica",
-      "display_name": "艾瑞卡",
-      "display_name_en": "Erica",
-      "path": "assets/data/character-personas/erica.json",
-      "affiliation": "弥萨格大学",
-      "role_in_silver_core": "数据库终端 / 自动人偶，默认会话角色人格"
+      "id": "biav-report",
+      "path": ".claude/commands/biav-report.md",
+      "summary": "Produce a silver-core community intelligence report (deep analysis / role recommendations / bug-fault list / weekly digest) from the full-archive layer, render it to a styled PDF + HTML, commit, push, and report back with hyperlinks. Use when the Keeper asks for a report, analysis, recommendation deck, or defect list built from community data.",
+      "note_zh": "产出银芯社区情报深度报告（角色推荐 / bug 修复优先级等）。"
+    },
+    {
+      "id": "daily-news",
+      "path": ".claude/commands/daily-news.md",
+      "summary": "Run the news aggregator and verify output",
+      "note_zh": "运行 news 采集器并校验输出，非空才提交。"
+    },
+    {
+      "id": "sync-memory",
+      "path": ".claude/commands/sync-memory.md",
+      "summary": "Check all sub-project actual file states and sync shared memory files",
+      "note_zh": "核对各子项目实际文件状态，同步共享记忆文件。"
+    },
+    {
+      "id": "validate-data",
+      "path": ".claude/commands/validate-data.md",
+      "summary": "Validate all JSON data files in the wiki database",
+      "note_zh": "校验 wiki 数据库全部 JSON 数据文件。"
+    }
+  ],
+  "skills": [
+    {
+      "id": "anysearch",
+      "path": ".claude/skills/anysearch/SKILL.md",
+      "name": "anysearch",
+      "summary": "Live web search via the AnySearch API for current or external information — community discussion, news, cross-region (CN/JP/TW) sources, and full-page content extraction. Use when a query needs up-to-date web results or sources beyond the local repo and the news pipeline. Falls back to the built-in WebSearch tool when AnySearch is unavailable.",
+      "note_zh": "实时网络检索（多区社区情报 CN/JP/TW），AnySearch API 封装，失败回退内置 WebSearch。"
+    }
+  ],
+  "projects": [
+    {
+      "id": "game",
+      "path": "projects/game/",
+      "summary": "> 最后更新：2026-04-26 by 主控台（艾瑞卡会话，写入 4-26 银芯重新定位 v2.0 game 重定位 — **退主线**）",
+      "note_zh": "衍生游戏，退出主线，守密人个人兴趣，不主线派发。"
+    },
+    {
+      "id": "news",
+      "path": "projects/news/",
+      "summary": "> 启动时请先阅读根目录 `CLAUDE.md` 了解全局。",
+      "note_zh": "使命#1 黑池信息入口：采集器 + 全量档案层 + 输出展示层，单向送黑池。"
+    },
+    {
+      "id": "site",
+      "path": "projects/site/",
+      "summary": "> 最后更新：2026-04-26 by 艾瑞卡（Code-site 维护会话，D-fix + D-mission + 自审清理 + D-biav 落地后状态同步）",
+      "note_zh": "使命#3 对外门户：静态站 public/ + 设计令牌 design/。"
+    },
+    {
+      "id": "wiki",
+      "path": "projects/wiki/",
+      "summary": "> 最后更新：2026-06-09 by 主控台（艾瑞卡会话，状态核验刷新；实时进度权威在 `memory/project-status.md`）",
+      "note_zh": "使命#2 社区知识底座：VitePress 站点 + 72 角色数据库（客户端解包自举）。"
     }
   ]
 }

--- a/scripts/build_capability_registry.py
+++ b/scripts/build_capability_registry.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""build_capability_registry.py — 银芯功能目录自动扫描器
+
+扫描全仓库七层功能源，产出机器权威的功能目录（capability registry）。
+人工只维护一个旁挂文件 memory/capability-annotations.json（中文用途补注），
+本脚本每次重生成时把补注合并回来，绝不覆盖人工注释。
+
+扫描范围：
+  1. .github/workflows/*.yml      CI 自动化工作流
+  2. scripts/*.py                 顶层脚本
+  3. projects/news/scripts/*.py   news 采集器脚本
+  4. scripts/mcp_server.py        MCP 知识层工具（@mcp.tool）
+  5. .claude/commands/*.md        Slash 命令
+  6. .claude/skills/*/SKILL.md    仓内技能
+  7. projects/*/                  子项目
+
+输出：
+  memory/capability-registry.json  机器权威 JSON（含合并后的人工补注）
+  memory/capability-index.md       人类可读 Markdown 总览
+
+用法：
+  python scripts/build_capability_registry.py            # 重生成
+  python scripts/build_capability_registry.py --check    # 仅校验是否过期（CI 用，非零退出=过期）
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = ROOT / "memory" / "capability-registry.json"
+ANNOTATIONS = ROOT / "memory" / "capability-annotations.json"
+INDEX_MD = ROOT / "memory" / "capability-index.md"
+
+
+_EMOJI_RE = re.compile(
+    "[\U0001F000-\U0001FAFF\U00002600-\U000027BF\U0001F1E6-\U0001F1FF\U0000FE00-\U0000FE0F\U00002190-\U000021FF\U00002B00-\U00002BFF]+"
+)
+
+
+def strip_emoji(s: str) -> str:
+    """清除 emoji 与杂项符号（§2.4 交付物禁 emoji）。"""
+    return _EMOJI_RE.sub("", s).strip()
+
+
+def first_doc_line(text: str) -> str:
+    """提取模块/函数 docstring 的第一行非空内容。"""
+    m = re.search(r'"""(.*?)"""', text, re.DOTALL)
+    if not m:
+        return ""
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def scan_workflows() -> list[dict]:
+    out = []
+    wf_dir = ROOT / ".github" / "workflows"
+    for p in sorted(wf_dir.glob("*.yml")):
+        text = p.read_text(encoding="utf-8", errors="ignore")
+        name_m = re.search(r"^name:\s*(.+)$", text, re.MULTILINE)
+        name = name_m.group(1).strip().strip("\"'") if name_m else p.stem
+        name = strip_emoji(name) or p.stem
+        triggers = []
+        if re.search(r"^\s*schedule:", text, re.MULTILINE) or "cron:" in text:
+            triggers.append("schedule")
+        if re.search(r"^\s*push:", text, re.MULTILINE):
+            triggers.append("push")
+        if re.search(r"^\s*pull_request:", text, re.MULTILINE):
+            triggers.append("pull_request")
+        if re.search(r"^\s*workflow_dispatch:", text, re.MULTILINE):
+            triggers.append("manual")
+        out.append({
+            "id": p.name,
+            "name": name,
+            "path": f".github/workflows/{p.name}",
+            "triggers": triggers,
+        })
+    return out
+
+
+def scan_python_dir(rel_dir: str) -> list[dict]:
+    out = []
+    d = ROOT / rel_dir
+    for p in sorted(d.glob("*.py")):
+        if p.name == "__init__.py":
+            continue
+        summary = first_doc_line(p.read_text(encoding="utf-8", errors="ignore"))
+        out.append({
+            "id": p.name,
+            "path": f"{rel_dir}/{p.name}",
+            "summary": summary,
+        })
+    return out
+
+
+def scan_mcp_tools() -> list[dict]:
+    out = []
+    p = ROOT / "scripts" / "mcp_server.py"
+    text = p.read_text(encoding="utf-8", errors="ignore")
+    # 匹配 @mcp.tool() 紧跟的 def name( ... ): """summary
+    pattern = re.compile(
+        r"@mcp\.tool\(\)\s*\n\s*def\s+(\w+)\s*\([^)]*\)[^:]*:\s*\n\s*\"\"\"(.*?)(?:\n|\"\"\")",
+        re.DOTALL,
+    )
+    for m in pattern.finditer(text):
+        out.append({
+            "id": m.group(1),
+            "module": "scripts/mcp_server.py",
+            "summary": m.group(2).strip(),
+        })
+    return out
+
+
+def scan_commands() -> list[dict]:
+    out = []
+    d = ROOT / ".claude" / "commands"
+    for p in sorted(d.glob("*.md")):
+        summary = ""
+        for line in p.read_text(encoding="utf-8", errors="ignore").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                summary = line.rstrip(":")
+                break
+        out.append({
+            "id": p.stem,
+            "path": f".claude/commands/{p.name}",
+            "summary": summary,
+        })
+    return out
+
+
+def scan_skills() -> list[dict]:
+    out = []
+    d = ROOT / ".claude" / "skills"
+    if not d.exists():
+        return out
+    for sp in sorted(d.iterdir()):
+        skill_md = sp / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        text = skill_md.read_text(encoding="utf-8", errors="ignore")
+        name_m = re.search(r"^name:\s*(.+)$", text, re.MULTILINE)
+        desc_m = re.search(r"^description:\s*(.+)$", text, re.MULTILINE)
+        out.append({
+            "id": sp.name,
+            "path": f".claude/skills/{sp.name}/SKILL.md",
+            "name": name_m.group(1).strip() if name_m else sp.name,
+            "summary": desc_m.group(1).strip() if desc_m else "",
+        })
+    return out
+
+
+def scan_projects() -> list[dict]:
+    out = []
+    d = ROOT / "projects"
+    for sp in sorted(d.iterdir()):
+        if not sp.is_dir():
+            continue
+        ctx = sp / "CONTEXT.md"
+        summary = ""
+        if ctx.exists():
+            for line in ctx.read_text(encoding="utf-8", errors="ignore").splitlines():
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    summary = line
+                    break
+        out.append({
+            "id": sp.name,
+            "path": f"projects/{sp.name}/",
+            "summary": summary,
+        })
+    return out
+
+
+def merge_annotations(registry: dict, annotations: dict) -> dict:
+    """把人工补注 note_zh 合并进每条目（按 category + id）。"""
+    for category, entries in registry.items():
+        if category == "meta" or not isinstance(entries, list):
+            continue
+        notes = annotations.get(category, {})
+        for entry in entries:
+            note = notes.get(entry.get("id"))
+            if note:
+                entry["note_zh"] = note
+    return registry
+
+
+def build() -> dict:
+    registry = {
+        "meta": {
+            "generated_at": date.today().isoformat(),
+            "generated_by": "scripts/build_capability_registry.py (自动扫描)",
+            "do_not_hand_edit": "本文件由 CI 自动重生成；人工中文用途请改 memory/capability-annotations.json",
+            "scope": "BIAV-SC 银芯受限层全功能盘点（七层）",
+        },
+        "workflows": scan_workflows(),
+        "scripts_top": scan_python_dir("scripts"),
+        "scripts_news": scan_python_dir("projects/news/scripts"),
+        "mcp_tools": scan_mcp_tools(),
+        "commands": scan_commands(),
+        "skills": scan_skills(),
+        "projects": scan_projects(),
+    }
+    counts = {k: len(v) for k, v in registry.items() if isinstance(v, list)}
+    counts["total"] = sum(counts.values())
+    registry["meta"]["counts"] = counts
+
+    annotations = {}
+    if ANNOTATIONS.exists():
+        annotations = json.loads(ANNOTATIONS.read_text(encoding="utf-8"))
+    registry = merge_annotations(registry, annotations)
+    return registry
+
+
+CATEGORY_TITLES = {
+    "workflows": "CI 自动化工作流",
+    "scripts_top": "顶层脚本（记忆 / 做梦 / 解包 / 运营）",
+    "scripts_news": "news 采集器脚本",
+    "mcp_tools": "MCP 知识层工具",
+    "commands": "Slash 命令",
+    "skills": "仓内技能",
+    "projects": "子项目",
+}
+
+
+def render_markdown(registry: dict) -> str:
+    meta = registry["meta"]
+    counts = meta["counts"]
+    lines = [
+        "# 银芯功能目录（capability-index）",
+        "",
+        "> 本文件由 `scripts/build_capability_registry.py` 自动生成，**请勿手改**。",
+        "> 中文用途补注请改 `memory/capability-annotations.json`；机器权威数据见 `memory/capability-registry.json`。",
+        "",
+        f"- 生成日期：{meta['generated_at']}",
+        f"- 功能总数：**{counts['total']}**",
+        "",
+        "## 总览",
+        "",
+        "| 功能层 | 数量 |",
+        "|------|------|",
+    ]
+    for cat, title in CATEGORY_TITLES.items():
+        lines.append(f"| {title} | {counts.get(cat, 0)} |")
+    lines.append("")
+
+    for cat, title in CATEGORY_TITLES.items():
+        entries = registry.get(cat, [])
+        if not entries:
+            continue
+        lines.append(f"## {title}（{len(entries)}）")
+        lines.append("")
+        for e in entries:
+            label = e.get("name") or e.get("id")
+            desc = e.get("note_zh") or e.get("summary") or ""
+            extra = ""
+            if cat == "workflows" and e.get("triggers"):
+                extra = f" _[{'/'.join(e['triggers'])}]_"
+            path = e.get("path") or e.get("module") or ""
+            if path:
+                lines.append(f"- **`{label}`**{extra} — {desc}  \n  `{path}`")
+            else:
+                lines.append(f"- **`{label}`**{extra} — {desc}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    registry = build()
+    new_json = json.dumps(registry, ensure_ascii=False, indent=2) + "\n"
+    new_md = render_markdown(registry)
+
+    if "--check" in sys.argv:
+        stale = False
+        if not REGISTRY.exists() or REGISTRY.read_text(encoding="utf-8") != new_json:
+            stale = True
+        if not INDEX_MD.exists() or INDEX_MD.read_text(encoding="utf-8") != new_md:
+            stale = True
+        if stale:
+            print("功能目录已过期，请运行 python scripts/build_capability_registry.py")
+            return 1
+        print("功能目录与代码一致。")
+        return 0
+
+    REGISTRY.write_text(new_json, encoding="utf-8")
+    INDEX_MD.write_text(new_md, encoding="utf-8")
+    counts = registry["meta"]["counts"]
+    print(f"功能目录已重生成：共 {counts['total']} 项")
+    for cat, title in CATEGORY_TITLES.items():
+        print(f"  {title}: {counts.get(cat, 0)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景

守密人问「银芯到底有多少功能，能维护一个目录吗」。盘点后发现仓内已有 `memory/capability-registry.json`，但生成于 2026-04-14，自述「`.claude/skills/` 不存在」「仅 3 个命令」，且只覆盖 skills/agents/mcp_tools 三类——21 个工作流、60 个脚本、4 个子项目全部缺席。本 PR 按守密人选定的「CI 自动生成 + 人工补注」方案重建。

## 改动

- **`scripts/build_capability_registry.py`** — 扫描器：扫描七层功能源（workflows / 顶层脚本 / news 采集器 / MCP 工具 / slash 命令 / 仓内技能 / 子项目），合并人工中文补注，清洗 emoji，支持 `--check`（过期即非零退出，供 CI 用）。
- **`memory/capability-annotations.json`** — 唯一手维护文件：每条功能的中文用途补注。
- **`memory/capability-registry.json`** — 机器权威 JSON（自动生成，含合并后补注）。
- **`memory/capability-index.md`** — 人类可读 Markdown 总览。
- **`.github/workflows/build-capability-registry.yml`** — 功能源变动时自动重生成目录，提交带 `[skip ci]`。
- **`CLAUDE.md` §5.3** — 登记功能目录，供未来会话发现。

## 当前盘点结果

共 **110 项**功能：CI 工作流 22 / 顶层脚本 37 / news 采集器 26 / MCP 工具 16 / slash 命令 4 / 仓内技能 1 / 子项目 4。

## 维护方式

人工只改 `capability-annotations.json`（补中文用途），其余由 CI 在功能文件变动时自动重生成——这正是上一版目录两个月就过期的根治办法。

## 验证

- `python scripts/build_capability_registry.py --check` → 目录与代码一致。
- `python -m py_compile scripts/build_capability_registry.py` → 通过。
- 全部 110 项均有描述，零 emoji。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqMQy1qYm9R3ieLjfnLTnM)_