### PR TITLE
feat: 功能目录升级为动态编排可达性分析器

### DIFF
--- a/memory/capability-annotations.json
+++ b/memory/capability-annotations.json
@@ -6,11 +6,38 @@
       "workflows",
       "scripts_top",
       "scripts_news",
+      "scripts_wiki",
       "mcp_tools",
       "commands",
       "skills",
       "projects"
     ]
+  },
+  "scripts_top": {
+    "extract_art.py": "从加密 AssetBundle 批量解包美术资源（手动运行，无定时入口）。",
+    "session_inject.py": "[退役钩子·孤儿] 原 UserPromptSubmit 钩子，会话注入历史上下文，2026-06-14 退役。",
+    "session_watch.py": "[退役钩子·孤儿] 原 PostToolUse 钩子，记录工具调用到 progress.jsonl，2026-06-14 退役。",
+    "session_distiller.py": "[退役钩子·孤儿] 原 SessionEnd 钩子，会话蒸馏，2026-06-14 退役。",
+    "session_reflexion.py": "[退役钩子·孤儿] 原会话末 reflexion 钩子，2026-06-14 退役。"
+  },
+  "scripts_wiki": {
+    "wiki_sources.py": "wiki 数据源单一真相源（角色/卡牌/技能等抓取配置）。",
+    "fetch_cards.py": "抓取卡牌数据。",
+    "fetch_skills.py": "抓取技能数据。",
+    "fetch_portraits.py": "抓取立绘数据。",
+    "fetch_stats.py": "抓取数值数据。",
+    "fetch_stages.py": "抓取关卡数据。",
+    "fetch_wheels.py": "抓取命轮数据。",
+    "fetch_lore.py": "抓取世界观/剧情文本。",
+    "generate_pages.py": "由抓取的 JSON 生成 VitePress 角色页。",
+    "generate_rss.py": "生成 wiki 更新 RSS。",
+    "validate_data.py": "校验 wiki 数据库全部 JSON。",
+    "check_version.py": "检测 Morimens 客户端版本更新。",
+    "extract_client_data.py": "从客户端解包提取结构化游戏数据。",
+    "decrypt_and_extract.py": "客户端解密 + 解包流水线（经子进程/手动调用）。",
+    "build_drop_index.py": "构建掉落物索引。",
+    "build_banner_character_index.py": "构建卡池角色索引。",
+    "build_notion_voice_enrichment.py": "[一次性·孤儿] 从 Notion 富化语音数据，无活入口。"
   },
   "workflows": {
     "backfill-gap.yml": "手动回填指定时间段的数据缺口。",

--- a/memory/capability-index.md
+++ b/memory/capability-index.md
@@ -4,21 +4,57 @@
 > 中文用途补注请改 `memory/capability-annotations.json`；机器权威数据见 `memory/capability-registry.json`。
 
 - 生成日期：2026-06-20
-- 功能总数：**110**
+- 功能总数：**125**
+- 脚本可达性：活 63 / 仅测试 9 / 孤儿 6
 
 ## 总览
 
 | 功能层 | 数量 |
 |------|------|
-| CI 自动化工作流 | 22 |
-| 顶层脚本（记忆 / 做梦 / 解包 / 运营） | 37 |
-| news 采集器脚本 | 26 |
-| MCP 知识层工具 | 16 |
-| Slash 命令 | 4 |
+| CI 自动化工作流（编排入口·定时/事件平面） | 22 |
+| 顶层脚本（记忆 / 做梦 / 解包 / 运营） | 36 |
+| news 采集器脚本 | 25 |
+| wiki 数据脚本 | 17 |
+| MCP 知识层工具（编排入口·AI 动态平面） | 16 |
+| Slash 命令（编排入口·人工平面） | 4 |
 | 仓内技能 | 1 |
 | 子项目 | 4 |
 
-## CI 自动化工作流（22）
+## 动态编排与可达性
+
+银芯只有四个编排平面，其中只有 MCP 是运行时真动态：
+
+| 编排平面 | 触发 | 动态 |
+|------|------|------|
+| 定时/事件（工作流）| cron + push | 否（静态调度）|
+| AI 动态（MCP 工具）| 艾瑞卡运行时自选 | 是 |
+| 人工（slash 命令 / 技能）| 守密人下达 | 半动态 |
+| 会话钩子 | 钩子自动 | 已退役（settings.json 无钩子）|
+
+可达性 = 从活编排入口沿 Python import 图传递闭包。`孤儿` = 无任何活入口可达，建议隔离待裁（§3.1 裁撤属守密人决策，工具只检测不删除）。
+
+### 孤儿脚本（6）— 无活编排入口可达，建议隔离待裁
+
+- `projects/wiki/scripts/build_notion_voice_enrichment.py` — [一次性·孤儿] 从 Notion 富化语音数据，无活入口。
+- `scripts/extract_art.py` — 从加密 AssetBundle 批量解包美术资源（手动运行，无定时入口）。
+- `scripts/session_distiller.py` — [退役钩子·孤儿] 原 SessionEnd 钩子，会话蒸馏，2026-06-14 退役。
+- `scripts/session_inject.py` — [退役钩子·孤儿] 原 UserPromptSubmit 钩子，会话注入历史上下文，2026-06-14 退役。
+- `scripts/session_reflexion.py` — [退役钩子·孤儿] 原会话末 reflexion 钩子，2026-06-14 退役。
+- `scripts/session_watch.py` — [退役钩子·孤儿] 原 PostToolUse 钩子，记录工具调用到 progress.jsonl，2026-06-14 退役。
+
+### 仅测试可达脚本（9）
+
+- `projects/wiki/scripts/build_banner_character_index.py`
+- `projects/wiki/scripts/build_drop_index.py`
+- `projects/wiki/scripts/decrypt_and_extract.py`
+- `scripts/lua_parse.py`
+- `scripts/parse_awaker_config.py`
+- `scripts/parse_cg_gallery.py`
+- `scripts/parse_collection_hall.py`
+- `scripts/parse_item_stories.py`
+- `scripts/parse_voice_lines.py`
+
+## CI 自动化工作流（编排入口·定时/事件平面）（22）
 
 - **`Backfill Data Gap`** _[manual]_ — 手动回填指定时间段的数据缺口。  
   `.github/workflows/backfill-gap.yml`
@@ -65,139 +101,172 @@
 - **`Validate Wiki Data`** _[push/pull_request/manual]_ — 校验 wiki JSON 数据（push/PR 触发）。  
   `.github/workflows/validate-data.yml`
 
-## 顶层脚本（记忆 / 做梦 / 解包 / 运营）（37）
+## 顶层脚本（记忆 / 做梦 / 解包 / 运营）（36）
 
-- **`boot_snapshot.py`** — boot_snapshot.py — 银芯启动快照生成器  
+- **`boot_snapshot.py`** _[活:import]_ — boot_snapshot.py — 银芯启动快照生成器  
   `scripts/boot_snapshot.py`
-- **`build_capability_registry.py`** — build_capability_registry.py — 银芯功能目录自动扫描器  
+- **`build_capability_registry.py`** _[活:workflow]_ — build_capability_registry.py — 银芯功能目录 + 动态编排可达性分析器  
   `scripts/build_capability_registry.py`
-- **`character_persona.py`** — character_persona.py — Character Persona Prompt Generator  
+- **`character_persona.py`** _[活:mcp]_ — character_persona.py — Character Persona Prompt Generator  
   `scripts/character_persona.py`
-- **`context_manager.py`** — context_manager.py — Virtual Context Manager (MemGPT-style)  
+- **`context_manager.py`** _[活:mcp]_ — context_manager.py — Virtual Context Manager (MemGPT-style)  
   `scripts/context_manager.py`
-- **`dream.py`** — dream.py — 4-Phase AutoDream Memory Consolidation System  
+- **`dream.py`** _[活:mcp]_ — dream.py — 4-Phase AutoDream Memory Consolidation System  
   `scripts/dream.py`
-- **`dream_ai.py`** — AI-powered consolidation + sleep-time precompute cache.  
+- **`dream_ai.py`** _[活:import]_ — AI-powered consolidation + sleep-time precompute cache.  
   `scripts/dream_ai.py`
-- **`dream_archive.py`** — Archive integrity scan — detect broken path references in repo docs.  
+- **`dream_archive.py`** _[活:import]_ — Archive integrity scan — detect broken path references in repo docs.  
   `scripts/dream_archive.py`
-- **`dream_config.py`** — Shared configuration constants for the dream.py memory-consolidation system.  
+- **`dream_config.py`** _[活:import]_ — Shared configuration constants for the dream.py memory-consolidation system.  
   `scripts/dream_config.py`
-- **`dream_health.py`** — Memory hygiene checks — staleness, broken refs, duplicate decisions, etc.  
+- **`dream_health.py`** _[活:import]_ — Memory hygiene checks — staleness, broken refs, duplicate decisions, etc.  
   `scripts/dream_health.py`
-- **`dream_io.py`** — Dream persistence — journal, insights and access-log read/write.  
+- **`dream_io.py`** _[活:import]_ — Dream persistence — journal, insights and access-log read/write.  
   `scripts/dream_io.py`
-- **`dream_rem.py`** — REM phase — weekly deep reflection: cross-session pattern analysis,  
+- **`dream_rem.py`** _[活:import]_ — REM phase — weekly deep reflection: cross-session pattern analysis,  
   `scripts/dream_rem.py`
-- **`dream_sentinel.py`** — Sentinel layer — proactive anomaly detection over news data sources.  
+- **`dream_sentinel.py`** _[活:import]_ — Sentinel layer — proactive anomaly detection over news data sources.  
   `scripts/dream_sentinel.py`
-- **`extract_art.py`** — Batch extract art assets from Morimens encrypted AssetBundles.  
+- **`extract_art.py`** _[孤儿:—]_ — 从加密 AssetBundle 批量解包美术资源（手动运行，无定时入口）。  
   `scripts/extract_art.py`
-- **`fact_store.py`** — fact_store.py — AI-driven Fact Storage with Semantic Deduplication  
+- **`fact_store.py`** _[活:mcp]_ — fact_store.py — AI-driven Fact Storage with Semantic Deduplication  
   `scripts/fact_store.py`
-- **`generate_wiki_pages.py`** — Generate VitePress Markdown pages from processed JSON data.  
+- **`generate_wiki_pages.py`** _[活:workflow]_ — Generate VitePress Markdown pages from processed JSON data.  
   `scripts/generate_wiki_pages.py`
-- **`io_utils.py`** — io_utils.py — shared atomic file write helper.  
+- **`io_utils.py`** _[活:import]_ — io_utils.py — shared atomic file write helper.  
   `scripts/io_utils.py`
-- **`knowledge_graph.py`** — knowledge_graph.py — Knowledge Graph Builder & Query Engine  
+- **`knowledge_graph.py`** _[活:mcp]_ — knowledge_graph.py — Knowledge Graph Builder & Query Engine  
   `scripts/knowledge_graph.py`
-- **`lua_parse.py`** — Shared parser for runtime-extracted Lua table dumps.  
+- **`lua_parse.py`** _[仅测试:test]_ — Shared parser for runtime-extracted Lua table dumps.  
   `scripts/lua_parse.py`
-- **`mcp_server.py`** — mcp_server.py — BIAV-SC Memory MCP Server  
+- **`mcp_server.py`** _[活:mcp]_ — mcp_server.py — BIAV-SC Memory MCP Server  
   `scripts/mcp_server.py`
-- **`memory_search.py`** — memory_search.py — Semantic Memory Search with TF-IDF Vectors + Reranker  
+- **`memory_search.py`** _[活:mcp]_ — memory_search.py — Semantic Memory Search with TF-IDF Vectors + Reranker  
   `scripts/memory_search.py`
-- **`memory_writeback.py`** — memory_writeback.py — Long-term Memory Write-back Loop  
+- **`memory_writeback.py`** _[活:mcp]_ — memory_writeback.py — Long-term Memory Write-back Loop  
   `scripts/memory_writeback.py`
-- **`memrl.py`** — memrl.py — MemRL-lite: Memory Utility Tracking & Adaptive Reranking  
+- **`memrl.py`** _[活:mcp]_ — memrl.py — MemRL-lite: Memory Utility Tracking & Adaptive Reranking  
   `scripts/memrl.py`
-- **`parse_awaker_config.py`** — Parse AwakerConfig.lua into structured character profiles JSON.  
+- **`parse_awaker_config.py`** _[仅测试:test]_ — Parse AwakerConfig.lua into structured character profiles JSON.  
   `scripts/parse_awaker_config.py`
-- **`parse_cg_gallery.py`** — Parse art_assets manifest.json to extract CG gallery data grouped by chapter.  
+- **`parse_cg_gallery.py`** _[仅测试:test]_ — Parse art_assets manifest.json to extract CG gallery data grouped by chapter.  
   `scripts/parse_cg_gallery.py`
-- **`parse_collection_hall.py`** — Parse CollectionHall.lua into structured JSON for world lore encyclopedia.  
+- **`parse_collection_hall.py`** _[仅测试:test]_ — Parse CollectionHall.lua into structured JSON for world lore encyclopedia.  
   `scripts/parse_collection_hall.py`
-- **`parse_item_stories.py`** — Parse Item.lua to extract items with background stories (StoryDesc field).  
+- **`parse_item_stories.py`** _[仅测试:test]_ — Parse Item.lua to extract items with background stories (StoryDesc field).  
   `scripts/parse_item_stories.py`
-- **`parse_voice_lines.py`** — Parse Voice.lua into structured JSON for wiki voice lines page.  
+- **`parse_voice_lines.py`** _[仅测试:test]_ — Parse Voice.lua into structured JSON for wiki voice lines page.  
   `scripts/parse_voice_lines.py`
-- **`reflexion.py`** — reflexion.py — Reflexion: Automatic Failure Learning  
+- **`reflexion.py`** _[活:import]_ — reflexion.py — Reflexion: Automatic Failure Learning  
   `scripts/reflexion.py`
-- **`report_render.py`** — 银芯报告渲染器 — 结构化 markdown → 统一视觉风格的 PDF + HTML。  
+- **`report_render.py`** _[活:command]_ — 银芯报告渲染器 — 结构化 markdown → 统一视觉风格的 PDF + HTML。  
   `scripts/report_render.py`
-- **`send_report_email.py`** — 银芯日报投递器 — 把渲染好的 PDF 报告通过 SMTP 发送到指定邮箱。  
-  `scripts/send_report_email.py`
-- **`session_briefing.py`** — session_briefing.py — Smart Session Briefing Generator  
+- **`session_briefing.py`** _[活:mcp]_ — session_briefing.py — Smart Session Briefing Generator  
   `scripts/session_briefing.py`
-- **`session_distiller.py`** — session_distiller.py — Claude Code SessionEnd transcript distiller (v0.4 md+meta).  
+- **`session_distiller.py`** _[孤儿:—]_ — [退役钩子·孤儿] 原 SessionEnd 钩子，会话蒸馏，2026-06-14 退役。  
   `scripts/session_distiller.py`
-- **`session_inject.py`** — session_inject.py —— UserPromptSubmit hook：每次用户输入前注入历史会话上下文。  
+- **`session_inject.py`** _[孤儿:—]_ — [退役钩子·孤儿] 原 UserPromptSubmit 钩子，会话注入历史上下文，2026-06-14 退役。  
   `scripts/session_inject.py`
-- **`session_reflexion.py`** — session_reflexion.py — Session-end reflexion hook  
+- **`session_reflexion.py`** _[孤儿:—]_ — [退役钩子·孤儿] 原会话末 reflexion 钩子，2026-06-14 退役。  
   `scripts/session_reflexion.py`
-- **`session_watch.py`** — session_watch.py —— PostToolUse hook：实时追加会话工具调用事件到 progress.jsonl。  
+- **`session_watch.py`** _[孤儿:—]_ — [退役钩子·孤儿] 原 PostToolUse 钩子，记录工具调用到 progress.jsonl，2026-06-14 退役。  
   `scripts/session_watch.py`
-- **`silver_memory_tools.py`** — silver_memory_tools.py —— 银芯记忆增强工具集  
+- **`silver_memory_tools.py`** _[活:mcp]_ — silver_memory_tools.py —— 银芯记忆增强工具集  
   `scripts/silver_memory_tools.py`
-- **`text_utils.py`** — Shared text tokenization for the memory system.  
+- **`text_utils.py`** _[活:import]_ — Shared text tokenization for the memory system.  
   `scripts/text_utils.py`
 
-## news 采集器脚本（26）
+## news 采集器脚本（25）
 
-- **`aggregator.py`** — 忘却前夜 Morimens - 社区热点聚合器  
+- **`aggregator.py`** _[活:command+workflow]_ — 忘却前夜 Morimens - 社区热点聚合器  
   `projects/news/scripts/aggregator.py`
-- **`aggregator_base.py`** — Shared base for the news aggregator: HTTP/logging setup, config  
+- **`aggregator_base.py`** _[活:import]_ — Shared base for the news aggregator: HTTP/logging setup, config  
   `projects/news/scripts/aggregator_base.py`
-- **`aggregator_collectors.py`** — Per-platform news collectors (Reddit, Bilibili, NGA, TapTap, Steam,  
+- **`aggregator_collectors.py`** _[活:import]_ — Per-platform news collectors (Reddit, Bilibili, NGA, TapTap, Steam,  
   `projects/news/scripts/aggregator_collectors.py`
-- **`archive_discord.py`** — Discord 月度归档脚本 — 打包超 60 天 JSONL → GitHub Releases → 从 git 删除  
+- **`archive_discord.py`** _[活:workflow]_ — Discord 月度归档脚本 — 打包超 60 天 JSONL → GitHub Releases → 从 git 删除  
   `projects/news/scripts/archive_discord.py`
-- **`archive_platforms.py`** — 多平台按日归档脚本 — 将 news.json（merged 全量层）按每条目真实日期存入 data/platforms/  
+- **`archive_platforms.py`** _[活:workflow]_ — 多平台按日归档脚本 — 将 news.json（merged 全量层）按每条目真实日期存入 data/platforms/  
   `projects/news/scripts/archive_platforms.py`
-- **`backfill_forum_starters.py`** — backfill_forum_starters.py — 一次性回填所有 forum thread 的 starter 消息  
+- **`backfill_forum_starters.py`** _[活:workflow]_ — backfill_forum_starters.py — 一次性回填所有 forum thread 的 starter 消息  
   `projects/news/scripts/backfill_forum_starters.py`
-- **`backfill_gap.py`** — backfill_gap.py — One-time script to backfill the Apr 13-25 data gap.  
+- **`backfill_gap.py`** _[活:workflow]_ — backfill_gap.py — One-time script to backfill the Apr 13-25 data gap.  
   `projects/news/scripts/backfill_gap.py`
-- **`backfill_media.py`** — 媒体补录器 — 扫全量归档，把仍存活的图片全部下载归档，二进制走 Releases（决策 038/059）。  
+- **`backfill_media.py`** _[活:workflow]_ — 媒体补录器 — 扫全量归档，把仍存活的图片全部下载归档，二进制走 Releases（决策 038/059）。  
   `projects/news/scripts/backfill_media.py`
-- **`backfill_platforms.py`** — backfill_platforms.py — 多平台历史数据回溯采集  
+- **`backfill_platforms.py`** _[活:workflow]_ — backfill_platforms.py — 多平台历史数据回溯采集  
   `projects/news/scripts/backfill_platforms.py`
-- **`collect_fanart.py`** — 同人图采集器 — 把某日各信息源的玩家二创图抓到本地，供日报附录嵌图。  
+- **`collect_fanart.py`** _[活:workflow]_ — 同人图采集器 — 把某日各信息源的玩家二创图抓到本地，供日报附录嵌图。  
   `projects/news/scripts/collect_fanart.py`
-- **`collect_global.py`** — collect_global.py — 全球社区采集桥接脚本  
+- **`collect_global.py`** _[活:workflow]_ — collect_global.py — 全球社区采集桥接脚本  
   `projects/news/scripts/collect_global.py`
-- **`collect_video_comments.py`** — YouTube 视频评论采集器（累积归档版）。  
+- **`collect_video_comments.py`** _[活:workflow]_ — YouTube 视频评论采集器（累积归档版）。  
   `projects/news/scripts/collect_video_comments.py`
-- **`collection_state.py`** — collection_state.py — Adaptive time window for news collection pipeline.  
+- **`collection_state.py`** _[活:import]_ — collection_state.py — Adaptive time window for news collection pipeline.  
   `projects/news/scripts/collection_state.py`
-- **`data_quality.py`** — 数据质量增强模块  
+- **`data_quality.py`** _[活:import]_ — 数据质量增强模块  
   `projects/news/scripts/data_quality.py`
-- **`discord_archiver.py`** — Discord 全量数据归档器 v2 — 双轨并行 + 断点续传 + JSONL 去重  
+- **`discord_archiver.py`** _[活:workflow]_ — Discord 全量数据归档器 v2 — 双轨并行 + 断点续传 + JSONL 去重  
   `projects/news/scripts/discord_archiver.py`
-- **`discord_list_guilds.py`** — Discord 服务器清单探测 — 列出 bot 当前加入的所有服务器（guild）  
+- **`discord_list_guilds.py`** _[活:workflow]_ — Discord 服务器清单探测 — 列出 bot 当前加入的所有服务器（guild）  
   `projects/news/scripts/discord_list_guilds.py`
-- **`discord_probe.py`** — Discord 只读连通性探针 — 验证 bot 在指定服务器的接入状态  
-  `projects/news/scripts/discord_probe.py`
-- **`download_media.py`** — download_media.py — 全平台媒体资源下载器  
+- **`download_media.py`** _[活:workflow]_ — download_media.py — 全平台媒体资源下载器  
   `projects/news/scripts/download_media.py`
-- **`global_collectors.py`** — 忘却前夜 Morimens - 全球信息收集器  
+- **`global_collectors.py`** _[活:import]_ — 忘却前夜 Morimens - 全球信息收集器  
   `projects/news/scripts/global_collectors.py`
-- **`news_common.py`** — news_common.py — 采集层共享工具（ARCH-01/02 收敛单一归属）  
+- **`news_common.py`** _[活:import]_ — news_common.py — 采集层共享工具（ARCH-01/02 收敛单一归属）  
   `projects/news/scripts/news_common.py`
-- **`playwright_collectors.py`** — Playwright-based collectors for Morimens community news.  
+- **`playwright_collectors.py`** _[活:import]_ — Playwright-based collectors for Morimens community news.  
   `projects/news/scripts/playwright_collectors.py`
-- **`repair_gaps.py`** — repair_gaps.py — Detect and report date gaps in platform archives.  
+- **`repair_gaps.py`** _[活:workflow]_ — repair_gaps.py — Detect and report date gaps in platform archives.  
   `projects/news/scripts/repair_gaps.py`
-- **`silent_sources_audit.py`** — silent_sources_audit.py — 沉默源审计（基于归档历史）  
+- **`silent_sources_audit.py`** _[活:workflow]_ — silent_sources_audit.py — 沉默源审计（基于归档历史）  
   `projects/news/scripts/silent_sources_audit.py`
-- **`sources.py`** — sources.py — 采集源单一真相源（single source of truth）  
+- **`sources.py`** _[活:workflow]_ — sources.py — 采集源单一真相源（single source of truth）  
   `projects/news/scripts/sources.py`
-- **`split_output.py`** — split_output.py — 按数据源分割 projects/news/output/news.json  
+- **`split_output.py`** _[活:workflow]_ — split_output.py — 按数据源分割 projects/news/output/news.json  
   `projects/news/scripts/split_output.py`
-- **`taptap_collector.py`** — TapTap 社区采集器 - Playwright 无头浏览器方案  
+- **`taptap_collector.py`** _[活:import]_ — TapTap 社区采集器 - Playwright 无头浏览器方案  
   `projects/news/scripts/taptap_collector.py`
 
-## MCP 知识层工具（16）
+## wiki 数据脚本（17）
+
+- **`build_banner_character_index.py`** _[仅测试:test]_ — 构建卡池角色索引。  
+  `projects/wiki/scripts/build_banner_character_index.py`
+- **`build_drop_index.py`** _[仅测试:test]_ — 构建掉落物索引。  
+  `projects/wiki/scripts/build_drop_index.py`
+- **`build_notion_voice_enrichment.py`** _[孤儿:—]_ — [一次性·孤儿] 从 Notion 富化语音数据，无活入口。  
+  `projects/wiki/scripts/build_notion_voice_enrichment.py`
+- **`check_version.py`** _[活:workflow]_ — 检测 Morimens 客户端版本更新。  
+  `projects/wiki/scripts/check_version.py`
+- **`decrypt_and_extract.py`** _[仅测试:test]_ — 客户端解密 + 解包流水线（经子进程/手动调用）。  
+  `projects/wiki/scripts/decrypt_and_extract.py`
+- **`extract_client_data.py`** _[活:workflow]_ — 从客户端解包提取结构化游戏数据。  
+  `projects/wiki/scripts/extract_client_data.py`
+- **`fetch_cards.py`** _[活:workflow]_ — 抓取卡牌数据。  
+  `projects/wiki/scripts/fetch_cards.py`
+- **`fetch_lore.py`** _[活:workflow]_ — 抓取世界观/剧情文本。  
+  `projects/wiki/scripts/fetch_lore.py`
+- **`fetch_portraits.py`** _[活:workflow]_ — 抓取立绘数据。  
+  `projects/wiki/scripts/fetch_portraits.py`
+- **`fetch_skills.py`** _[活:workflow]_ — 抓取技能数据。  
+  `projects/wiki/scripts/fetch_skills.py`
+- **`fetch_stages.py`** _[活:workflow]_ — 抓取关卡数据。  
+  `projects/wiki/scripts/fetch_stages.py`
+- **`fetch_stats.py`** _[活:workflow]_ — 抓取数值数据。  
+  `projects/wiki/scripts/fetch_stats.py`
+- **`fetch_wheels.py`** _[活:workflow]_ — 抓取命轮数据。  
+  `projects/wiki/scripts/fetch_wheels.py`
+- **`generate_pages.py`** _[活:workflow]_ — 由抓取的 JSON 生成 VitePress 角色页。  
+  `projects/wiki/scripts/generate_pages.py`
+- **`generate_rss.py`** _[活:workflow]_ — 生成 wiki 更新 RSS。  
+  `projects/wiki/scripts/generate_rss.py`
+- **`validate_data.py`** _[活:workflow]_ — 校验 wiki 数据库全部 JSON。  
+  `projects/wiki/scripts/validate_data.py`
+- **`wiki_sources.py`** _[活:import]_ — wiki 数据源单一真相源（角色/卡牌/技能等抓取配置）。  
+  `projects/wiki/scripts/wiki_sources.py`
+
+## MCP 知识层工具（编排入口·AI 动态平面）（16）
 
 - **`memory_search`** — 搜索银芯知识库，返回最相关的知识块。  
   `scripts/mcp_server.py`
@@ -232,7 +301,7 @@
 - **`session_progress`** — 读取指定 session 的 progress.jsonl 增量事件列表（由 session_watch hook 记录）。  
   `scripts/mcp_server.py`
 
-## Slash 命令（4）
+## Slash 命令（编排入口·人工平面）（4）
 
 - **`biav-report`** — 产出银芯社区情报深度报告（角色推荐 / bug 修复优先级等）。  
   `.claude/commands/biav-report.md`

--- a/memory/capability-registry.json
+++ b/memory/capability-registry.json
@@ -1,18 +1,25 @@
 {
   "meta": {
     "generated_at": "2026-06-20",
-    "generated_by": "scripts/build_capability_registry.py (自动扫描)",
+    "generated_by": "scripts/build_capability_registry.py (自动扫描 + 可达性分析)",
     "do_not_hand_edit": "本文件由 CI 自动重生成；人工中文用途请改 memory/capability-annotations.json",
-    "scope": "BIAV-SC 银芯受限层全功能盘点（七层）",
+    "scope": "BIAV-SC 银芯受限层全功能盘点 + 动态编排可达性",
+    "reachability_method": "从活编排入口（工作流/MCP/命令/钩子）沿 Python 模块级 import 图做传递闭包；status=orphaned 表示无任何活入口可达，建议隔离待裁，非自动删除。",
     "counts": {
       "workflows": 22,
-      "scripts_top": 37,
-      "scripts_news": 26,
+      "scripts_top": 36,
+      "scripts_news": 25,
+      "scripts_wiki": 17,
       "mcp_tools": 16,
       "commands": 4,
       "skills": 1,
       "projects": 4,
-      "total": 110
+      "total": 125
+    },
+    "reachability": {
+      "live": 63,
+      "test-only": 9,
+      "orphaned": 6
     }
   },
   "workflows": [
@@ -237,319 +244,719 @@
     {
       "id": "boot_snapshot.py",
       "path": "scripts/boot_snapshot.py",
-      "summary": "boot_snapshot.py — 银芯启动快照生成器"
+      "summary": "boot_snapshot.py — 银芯启动快照生成器",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "build_capability_registry.py",
       "path": "scripts/build_capability_registry.py",
-      "summary": "build_capability_registry.py — 银芯功能目录自动扫描器"
+      "summary": "build_capability_registry.py — 银芯功能目录 + 动态编排可达性分析器",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "character_persona.py",
       "path": "scripts/character_persona.py",
-      "summary": "character_persona.py — Character Persona Prompt Generator"
+      "summary": "character_persona.py — Character Persona Prompt Generator",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "context_manager.py",
       "path": "scripts/context_manager.py",
-      "summary": "context_manager.py — Virtual Context Manager (MemGPT-style)"
+      "summary": "context_manager.py — Virtual Context Manager (MemGPT-style)",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "dream.py",
       "path": "scripts/dream.py",
-      "summary": "dream.py — 4-Phase AutoDream Memory Consolidation System"
+      "summary": "dream.py — 4-Phase AutoDream Memory Consolidation System",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "dream_ai.py",
       "path": "scripts/dream_ai.py",
-      "summary": "AI-powered consolidation + sleep-time precompute cache."
+      "summary": "AI-powered consolidation + sleep-time precompute cache.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "dream_archive.py",
       "path": "scripts/dream_archive.py",
-      "summary": "Archive integrity scan — detect broken path references in repo docs."
+      "summary": "Archive integrity scan — detect broken path references in repo docs.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "dream_config.py",
       "path": "scripts/dream_config.py",
-      "summary": "Shared configuration constants for the dream.py memory-consolidation system."
+      "summary": "Shared configuration constants for the dream.py memory-consolidation system.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "dream_health.py",
       "path": "scripts/dream_health.py",
-      "summary": "Memory hygiene checks — staleness, broken refs, duplicate decisions, etc."
+      "summary": "Memory hygiene checks — staleness, broken refs, duplicate decisions, etc.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "dream_io.py",
       "path": "scripts/dream_io.py",
-      "summary": "Dream persistence — journal, insights and access-log read/write."
+      "summary": "Dream persistence — journal, insights and access-log read/write.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "dream_rem.py",
       "path": "scripts/dream_rem.py",
-      "summary": "REM phase — weekly deep reflection: cross-session pattern analysis,"
+      "summary": "REM phase — weekly deep reflection: cross-session pattern analysis,",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "dream_sentinel.py",
       "path": "scripts/dream_sentinel.py",
-      "summary": "Sentinel layer — proactive anomaly detection over news data sources."
+      "summary": "Sentinel layer — proactive anomaly detection over news data sources.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "extract_art.py",
       "path": "scripts/extract_art.py",
-      "summary": "Batch extract art assets from Morimens encrypted AssetBundles."
+      "summary": "Batch extract art assets from Morimens encrypted AssetBundles.",
+      "planes": [],
+      "status": "orphaned",
+      "note_zh": "从加密 AssetBundle 批量解包美术资源（手动运行，无定时入口）。"
     },
     {
       "id": "fact_store.py",
       "path": "scripts/fact_store.py",
-      "summary": "fact_store.py — AI-driven Fact Storage with Semantic Deduplication"
+      "summary": "fact_store.py — AI-driven Fact Storage with Semantic Deduplication",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "generate_wiki_pages.py",
       "path": "scripts/generate_wiki_pages.py",
-      "summary": "Generate VitePress Markdown pages from processed JSON data."
+      "summary": "Generate VitePress Markdown pages from processed JSON data.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "io_utils.py",
       "path": "scripts/io_utils.py",
-      "summary": "io_utils.py — shared atomic file write helper."
+      "summary": "io_utils.py — shared atomic file write helper.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "knowledge_graph.py",
       "path": "scripts/knowledge_graph.py",
-      "summary": "knowledge_graph.py — Knowledge Graph Builder & Query Engine"
+      "summary": "knowledge_graph.py — Knowledge Graph Builder & Query Engine",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "lua_parse.py",
       "path": "scripts/lua_parse.py",
-      "summary": "Shared parser for runtime-extracted Lua table dumps."
+      "summary": "Shared parser for runtime-extracted Lua table dumps.",
+      "planes": [
+        "test"
+      ],
+      "status": "test-only"
     },
     {
       "id": "mcp_server.py",
       "path": "scripts/mcp_server.py",
-      "summary": "mcp_server.py — BIAV-SC Memory MCP Server"
+      "summary": "mcp_server.py — BIAV-SC Memory MCP Server",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "memory_search.py",
       "path": "scripts/memory_search.py",
-      "summary": "memory_search.py — Semantic Memory Search with TF-IDF Vectors + Reranker"
+      "summary": "memory_search.py — Semantic Memory Search with TF-IDF Vectors + Reranker",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "memory_writeback.py",
       "path": "scripts/memory_writeback.py",
-      "summary": "memory_writeback.py — Long-term Memory Write-back Loop"
+      "summary": "memory_writeback.py — Long-term Memory Write-back Loop",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "memrl.py",
       "path": "scripts/memrl.py",
-      "summary": "memrl.py — MemRL-lite: Memory Utility Tracking & Adaptive Reranking"
+      "summary": "memrl.py — MemRL-lite: Memory Utility Tracking & Adaptive Reranking",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "parse_awaker_config.py",
       "path": "scripts/parse_awaker_config.py",
-      "summary": "Parse AwakerConfig.lua into structured character profiles JSON."
+      "summary": "Parse AwakerConfig.lua into structured character profiles JSON.",
+      "planes": [
+        "test"
+      ],
+      "status": "test-only"
     },
     {
       "id": "parse_cg_gallery.py",
       "path": "scripts/parse_cg_gallery.py",
-      "summary": "Parse art_assets manifest.json to extract CG gallery data grouped by chapter."
+      "summary": "Parse art_assets manifest.json to extract CG gallery data grouped by chapter.",
+      "planes": [
+        "test"
+      ],
+      "status": "test-only"
     },
     {
       "id": "parse_collection_hall.py",
       "path": "scripts/parse_collection_hall.py",
-      "summary": "Parse CollectionHall.lua into structured JSON for world lore encyclopedia."
+      "summary": "Parse CollectionHall.lua into structured JSON for world lore encyclopedia.",
+      "planes": [
+        "test"
+      ],
+      "status": "test-only"
     },
     {
       "id": "parse_item_stories.py",
       "path": "scripts/parse_item_stories.py",
-      "summary": "Parse Item.lua to extract items with background stories (StoryDesc field)."
+      "summary": "Parse Item.lua to extract items with background stories (StoryDesc field).",
+      "planes": [
+        "test"
+      ],
+      "status": "test-only"
     },
     {
       "id": "parse_voice_lines.py",
       "path": "scripts/parse_voice_lines.py",
-      "summary": "Parse Voice.lua into structured JSON for wiki voice lines page."
+      "summary": "Parse Voice.lua into structured JSON for wiki voice lines page.",
+      "planes": [
+        "test"
+      ],
+      "status": "test-only"
     },
     {
       "id": "reflexion.py",
       "path": "scripts/reflexion.py",
-      "summary": "reflexion.py — Reflexion: Automatic Failure Learning"
+      "summary": "reflexion.py — Reflexion: Automatic Failure Learning",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "report_render.py",
       "path": "scripts/report_render.py",
-      "summary": "银芯报告渲染器 — 结构化 markdown → 统一视觉风格的 PDF + HTML。"
-    },
-    {
-      "id": "send_report_email.py",
-      "path": "scripts/send_report_email.py",
-      "summary": "银芯日报投递器 — 把渲染好的 PDF 报告通过 SMTP 发送到指定邮箱。"
+      "summary": "银芯报告渲染器 — 结构化 markdown → 统一视觉风格的 PDF + HTML。",
+      "planes": [
+        "command"
+      ],
+      "status": "live"
     },
     {
       "id": "session_briefing.py",
       "path": "scripts/session_briefing.py",
-      "summary": "session_briefing.py — Smart Session Briefing Generator"
+      "summary": "session_briefing.py — Smart Session Briefing Generator",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "session_distiller.py",
       "path": "scripts/session_distiller.py",
-      "summary": "session_distiller.py — Claude Code SessionEnd transcript distiller (v0.4 md+meta)."
+      "summary": "session_distiller.py — Claude Code SessionEnd transcript distiller (v0.4 md+meta).",
+      "planes": [],
+      "status": "orphaned",
+      "note_zh": "[退役钩子·孤儿] 原 SessionEnd 钩子，会话蒸馏，2026-06-14 退役。"
     },
     {
       "id": "session_inject.py",
       "path": "scripts/session_inject.py",
-      "summary": "session_inject.py —— UserPromptSubmit hook：每次用户输入前注入历史会话上下文。"
+      "summary": "session_inject.py —— UserPromptSubmit hook：每次用户输入前注入历史会话上下文。",
+      "planes": [],
+      "status": "orphaned",
+      "note_zh": "[退役钩子·孤儿] 原 UserPromptSubmit 钩子，会话注入历史上下文，2026-06-14 退役。"
     },
     {
       "id": "session_reflexion.py",
       "path": "scripts/session_reflexion.py",
-      "summary": "session_reflexion.py — Session-end reflexion hook"
+      "summary": "session_reflexion.py — Session-end reflexion hook",
+      "planes": [],
+      "status": "orphaned",
+      "note_zh": "[退役钩子·孤儿] 原会话末 reflexion 钩子，2026-06-14 退役。"
     },
     {
       "id": "session_watch.py",
       "path": "scripts/session_watch.py",
-      "summary": "session_watch.py —— PostToolUse hook：实时追加会话工具调用事件到 progress.jsonl。"
+      "summary": "session_watch.py —— PostToolUse hook：实时追加会话工具调用事件到 progress.jsonl。",
+      "planes": [],
+      "status": "orphaned",
+      "note_zh": "[退役钩子·孤儿] 原 PostToolUse 钩子，记录工具调用到 progress.jsonl，2026-06-14 退役。"
     },
     {
       "id": "silver_memory_tools.py",
       "path": "scripts/silver_memory_tools.py",
-      "summary": "silver_memory_tools.py —— 银芯记忆增强工具集"
+      "summary": "silver_memory_tools.py —— 银芯记忆增强工具集",
+      "planes": [
+        "mcp"
+      ],
+      "status": "live"
     },
     {
       "id": "text_utils.py",
       "path": "scripts/text_utils.py",
-      "summary": "Shared text tokenization for the memory system."
+      "summary": "Shared text tokenization for the memory system.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     }
   ],
   "scripts_news": [
     {
       "id": "aggregator.py",
       "path": "projects/news/scripts/aggregator.py",
-      "summary": "忘却前夜 Morimens - 社区热点聚合器"
+      "summary": "忘却前夜 Morimens - 社区热点聚合器",
+      "planes": [
+        "command",
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "aggregator_base.py",
       "path": "projects/news/scripts/aggregator_base.py",
-      "summary": "Shared base for the news aggregator: HTTP/logging setup, config"
+      "summary": "Shared base for the news aggregator: HTTP/logging setup, config",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "aggregator_collectors.py",
       "path": "projects/news/scripts/aggregator_collectors.py",
-      "summary": "Per-platform news collectors (Reddit, Bilibili, NGA, TapTap, Steam,"
+      "summary": "Per-platform news collectors (Reddit, Bilibili, NGA, TapTap, Steam,",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "archive_discord.py",
       "path": "projects/news/scripts/archive_discord.py",
-      "summary": "Discord 月度归档脚本 — 打包超 60 天 JSONL → GitHub Releases → 从 git 删除"
+      "summary": "Discord 月度归档脚本 — 打包超 60 天 JSONL → GitHub Releases → 从 git 删除",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "archive_platforms.py",
       "path": "projects/news/scripts/archive_platforms.py",
-      "summary": "多平台按日归档脚本 — 将 news.json（merged 全量层）按每条目真实日期存入 data/platforms/"
+      "summary": "多平台按日归档脚本 — 将 news.json（merged 全量层）按每条目真实日期存入 data/platforms/",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "backfill_forum_starters.py",
       "path": "projects/news/scripts/backfill_forum_starters.py",
-      "summary": "backfill_forum_starters.py — 一次性回填所有 forum thread 的 starter 消息"
+      "summary": "backfill_forum_starters.py — 一次性回填所有 forum thread 的 starter 消息",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "backfill_gap.py",
       "path": "projects/news/scripts/backfill_gap.py",
-      "summary": "backfill_gap.py — One-time script to backfill the Apr 13-25 data gap."
+      "summary": "backfill_gap.py — One-time script to backfill the Apr 13-25 data gap.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "backfill_media.py",
       "path": "projects/news/scripts/backfill_media.py",
-      "summary": "媒体补录器 — 扫全量归档，把仍存活的图片全部下载归档，二进制走 Releases（决策 038/059）。"
+      "summary": "媒体补录器 — 扫全量归档，把仍存活的图片全部下载归档，二进制走 Releases（决策 038/059）。",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "backfill_platforms.py",
       "path": "projects/news/scripts/backfill_platforms.py",
-      "summary": "backfill_platforms.py — 多平台历史数据回溯采集"
+      "summary": "backfill_platforms.py — 多平台历史数据回溯采集",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "collect_fanart.py",
       "path": "projects/news/scripts/collect_fanart.py",
-      "summary": "同人图采集器 — 把某日各信息源的玩家二创图抓到本地，供日报附录嵌图。"
+      "summary": "同人图采集器 — 把某日各信息源的玩家二创图抓到本地，供日报附录嵌图。",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "collect_global.py",
       "path": "projects/news/scripts/collect_global.py",
-      "summary": "collect_global.py — 全球社区采集桥接脚本"
+      "summary": "collect_global.py — 全球社区采集桥接脚本",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "collect_video_comments.py",
       "path": "projects/news/scripts/collect_video_comments.py",
-      "summary": "YouTube 视频评论采集器（累积归档版）。"
+      "summary": "YouTube 视频评论采集器（累积归档版）。",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "collection_state.py",
       "path": "projects/news/scripts/collection_state.py",
-      "summary": "collection_state.py — Adaptive time window for news collection pipeline."
+      "summary": "collection_state.py — Adaptive time window for news collection pipeline.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "data_quality.py",
       "path": "projects/news/scripts/data_quality.py",
-      "summary": "数据质量增强模块"
+      "summary": "数据质量增强模块",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "discord_archiver.py",
       "path": "projects/news/scripts/discord_archiver.py",
-      "summary": "Discord 全量数据归档器 v2 — 双轨并行 + 断点续传 + JSONL 去重"
+      "summary": "Discord 全量数据归档器 v2 — 双轨并行 + 断点续传 + JSONL 去重",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "discord_list_guilds.py",
       "path": "projects/news/scripts/discord_list_guilds.py",
-      "summary": "Discord 服务器清单探测 — 列出 bot 当前加入的所有服务器（guild）"
-    },
-    {
-      "id": "discord_probe.py",
-      "path": "projects/news/scripts/discord_probe.py",
-      "summary": "Discord 只读连通性探针 — 验证 bot 在指定服务器的接入状态"
+      "summary": "Discord 服务器清单探测 — 列出 bot 当前加入的所有服务器（guild）",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "download_media.py",
       "path": "projects/news/scripts/download_media.py",
-      "summary": "download_media.py — 全平台媒体资源下载器"
+      "summary": "download_media.py — 全平台媒体资源下载器",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "global_collectors.py",
       "path": "projects/news/scripts/global_collectors.py",
-      "summary": "忘却前夜 Morimens - 全球信息收集器"
+      "summary": "忘却前夜 Morimens - 全球信息收集器",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "news_common.py",
       "path": "projects/news/scripts/news_common.py",
-      "summary": "news_common.py — 采集层共享工具（ARCH-01/02 收敛单一归属）"
+      "summary": "news_common.py — 采集层共享工具（ARCH-01/02 收敛单一归属）",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "playwright_collectors.py",
       "path": "projects/news/scripts/playwright_collectors.py",
-      "summary": "Playwright-based collectors for Morimens community news."
+      "summary": "Playwright-based collectors for Morimens community news.",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
     },
     {
       "id": "repair_gaps.py",
       "path": "projects/news/scripts/repair_gaps.py",
-      "summary": "repair_gaps.py — Detect and report date gaps in platform archives."
+      "summary": "repair_gaps.py — Detect and report date gaps in platform archives.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "silent_sources_audit.py",
       "path": "projects/news/scripts/silent_sources_audit.py",
-      "summary": "silent_sources_audit.py — 沉默源审计（基于归档历史）"
+      "summary": "silent_sources_audit.py — 沉默源审计（基于归档历史）",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "sources.py",
       "path": "projects/news/scripts/sources.py",
-      "summary": "sources.py — 采集源单一真相源（single source of truth）"
+      "summary": "sources.py — 采集源单一真相源（single source of truth）",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "split_output.py",
       "path": "projects/news/scripts/split_output.py",
-      "summary": "split_output.py — 按数据源分割 projects/news/output/news.json"
+      "summary": "split_output.py — 按数据源分割 projects/news/output/news.json",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live"
     },
     {
       "id": "taptap_collector.py",
       "path": "projects/news/scripts/taptap_collector.py",
-      "summary": "TapTap 社区采集器 - Playwright 无头浏览器方案"
+      "summary": "TapTap 社区采集器 - Playwright 无头浏览器方案",
+      "planes": [
+        "import"
+      ],
+      "status": "live"
+    }
+  ],
+  "scripts_wiki": [
+    {
+      "id": "build_banner_character_index.py",
+      "path": "projects/wiki/scripts/build_banner_character_index.py",
+      "summary": "Build a banner <-> character cross-index for Morimens summon banners.",
+      "planes": [
+        "test"
+      ],
+      "status": "test-only",
+      "note_zh": "构建卡池角色索引。"
+    },
+    {
+      "id": "build_drop_index.py",
+      "path": "projects/wiki/scripts/build_drop_index.py",
+      "summary": "Build a reverse drop index for Morimens stages.",
+      "planes": [
+        "test"
+      ],
+      "status": "test-only",
+      "note_zh": "构建掉落物索引。"
+    },
+    {
+      "id": "build_notion_voice_enrichment.py",
+      "path": "projects/wiki/scripts/build_notion_voice_enrichment.py",
+      "summary": "Build per-character voice-line enrichment for the Notion character database.",
+      "planes": [],
+      "status": "orphaned",
+      "note_zh": "[一次性·孤儿] 从 Notion 富化语音数据，无活入口。"
+    },
+    {
+      "id": "check_version.py",
+      "path": "projects/wiki/scripts/check_version.py",
+      "summary": "check_version.py - Automated version update tracker for Morimens wiki.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "检测 Morimens 客户端版本更新。"
+    },
+    {
+      "id": "decrypt_and_extract.py",
+      "path": "projects/wiki/scripts/decrypt_and_extract.py",
+      "summary": "Decrypt and extract Morimens encrypted AssetBundles.",
+      "planes": [
+        "test"
+      ],
+      "status": "test-only",
+      "note_zh": "客户端解密 + 解包流水线（经子进程/手动调用）。"
+    },
+    {
+      "id": "extract_client_data.py",
+      "path": "projects/wiki/scripts/extract_client_data.py",
+      "summary": "Extract game data from Morimens Unity client using UnityPy.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "从客户端解包提取结构化游戏数据。"
+    },
+    {
+      "id": "fetch_cards.py",
+      "path": "projects/wiki/scripts/fetch_cards.py",
+      "summary": "Fetch and enrich card data for all characters from Fandom wiki.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "抓取卡牌数据。"
+    },
+    {
+      "id": "fetch_lore.py",
+      "path": "projects/wiki/scripts/fetch_lore.py",
+      "summary": "Fetch detailed story/lore data from wiki sources and update lore.json.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "抓取世界观/剧情文本。"
+    },
+    {
+      "id": "fetch_portraits.py",
+      "path": "projects/wiki/scripts/fetch_portraits.py",
+      "summary": "Fetch character portrait images from wiki sources.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "抓取立绘数据。"
+    },
+    {
+      "id": "fetch_skills.py",
+      "path": "projects/wiki/scripts/fetch_skills.py",
+      "summary": "Fetch character skill data from Fandom MediaWiki API and update characters.json.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "抓取技能数据。"
+    },
+    {
+      "id": "fetch_stages.py",
+      "path": "projects/wiki/scripts/fetch_stages.py",
+      "summary": "Fetch and enrich stage/level data with drop tables and recommended levels.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "抓取关卡数据。"
+    },
+    {
+      "id": "fetch_stats.py",
+      "path": "projects/wiki/scripts/fetch_stats.py",
+      "summary": "Fetch character base stats (HP/ATK/DEF) from Fandom wiki sources.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "抓取数值数据。"
+    },
+    {
+      "id": "fetch_wheels.py",
+      "path": "projects/wiki/scripts/fetch_wheels.py",
+      "summary": "Fetch Wheel of Destiny effect data from Fandom MediaWiki API.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "抓取命轮数据。"
+    },
+    {
+      "id": "generate_pages.py",
+      "path": "projects/wiki/scripts/generate_pages.py",
+      "summary": "Auto-generate VitePress character detail pages from characters.json + equipment.json.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "由抓取的 JSON 生成 VitePress 角色页。"
+    },
+    {
+      "id": "generate_rss.py",
+      "path": "projects/wiki/scripts/generate_rss.py",
+      "summary": "generate_rss.py - Generate RSS and Atom feeds for the Morimens wiki.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "生成 wiki 更新 RSS。"
+    },
+    {
+      "id": "validate_data.py",
+      "path": "projects/wiki/scripts/validate_data.py",
+      "summary": "Validate all wiki JSON data files against schemas and cross-references.",
+      "planes": [
+        "workflow"
+      ],
+      "status": "live",
+      "note_zh": "校验 wiki 数据库全部 JSON。"
+    },
+    {
+      "id": "wiki_sources.py",
+      "path": "projects/wiki/scripts/wiki_sources.py",
+      "summary": "Shared Fandom / Bilibili wiki source constants for the fetch_*.py scripts.",
+      "planes": [
+        "import"
+      ],
+      "status": "live",
+      "note_zh": "wiki 数据源单一真相源（角色/卡牌/技能等抓取配置）。"
     }
   ],
   "mcp_tools": [

--- a/scripts/build_capability_registry.py
+++ b/scripts/build_capability_registry.py
@@ -1,26 +1,34 @@
 #!/usr/bin/env python3
-"""build_capability_registry.py — 银芯功能目录自动扫描器
+"""build_capability_registry.py — 银芯功能目录 + 动态编排可达性分析器
 
-扫描全仓库七层功能源，产出机器权威的功能目录（capability registry）。
-人工只维护一个旁挂文件 memory/capability-annotations.json（中文用途补注），
-本脚本每次重生成时把补注合并回来，绝不覆盖人工注释。
+扫描全仓库功能源，产出机器权威的功能目录，并对每个脚本做**静态可达性分析**：
+从「活编排入口」（工作流 / MCP 服务端 / slash 命令 / 会话钩子）出发，沿 Python
+模块级 import 图做传递闭包，判定每个脚本属于哪个编排平面、是否可达。这样「必要性」
+不再靠人工估算（易错），而是每次重生成时由工具算出来。
 
-扫描范围：
-  1. .github/workflows/*.yml      CI 自动化工作流
+人工只维护旁挂文件 memory/capability-annotations.json（中文用途补注）。
+
+功能源（七层）：
+  1. .github/workflows/*.yml      CI 工作流（编排入口·定时/事件平面）
   2. scripts/*.py                 顶层脚本
   3. projects/news/scripts/*.py   news 采集器脚本
-  4. scripts/mcp_server.py        MCP 知识层工具（@mcp.tool）
-  5. .claude/commands/*.md        Slash 命令
-  6. .claude/skills/*/SKILL.md    仓内技能
-  7. projects/*/                  子项目
+  4. projects/wiki/scripts/*.py   wiki 数据脚本
+  5. scripts/mcp_server.py        MCP 工具（编排入口·AI 动态平面）
+  6. .claude/commands/*.md        slash 命令（编排入口·人工平面）
+  7. .claude/skills/*/SKILL.md    仓内技能
+  8. projects/*/                  子项目
+
+编排可达性（每个脚本附 planes + status）：
+  - planes: workflow / mcp / command / hook（直接被某入口引用）或 import（仅经 import 间接可达）
+  - status: live（可达活件）/ test-only（仅被测试引用）/ orphaned（无任何活入口可达，建议隔离待裁）
 
 输出：
-  memory/capability-registry.json  机器权威 JSON（含合并后的人工补注）
-  memory/capability-index.md       人类可读 Markdown 总览
+  memory/capability-registry.json  机器权威 JSON（含可达性字段）
+  memory/capability-index.md       人类可读 Markdown（含编排与可达性专章）
 
 用法：
   python scripts/build_capability_registry.py            # 重生成
-  python scripts/build_capability_registry.py --check    # 仅校验是否过期（CI 用，非零退出=过期）
+  python scripts/build_capability_registry.py --check    # 校验是否过期（CI 用，非零退出=过期）
 """
 from __future__ import annotations
 
@@ -35,10 +43,14 @@ REGISTRY = ROOT / "memory" / "capability-registry.json"
 ANNOTATIONS = ROOT / "memory" / "capability-annotations.json"
 INDEX_MD = ROOT / "memory" / "capability-index.md"
 
+# 三个被纳入可达性分析的脚本层（运行时均以扁平 basename 互相 import）
+SCRIPT_DIRS = ["scripts", "projects/news/scripts", "projects/wiki/scripts"]
 
 _EMOJI_RE = re.compile(
     "[\U0001F000-\U0001FAFF\U00002600-\U000027BF\U0001F1E6-\U0001F1FF\U0000FE00-\U0000FE0F\U00002190-\U000021FF\U00002B00-\U00002BFF]+"
 )
+_PY_REF_RE = re.compile(r"\b([A-Za-z0-9_]+)\.py\b")
+_IMPORT_RE = re.compile(r"^[ \t]*(?:from|import)[ \t]+([A-Za-z_][\w]*)", re.MULTILINE)
 
 
 def strip_emoji(s: str) -> str:
@@ -58,10 +70,140 @@ def first_doc_line(text: str) -> str:
     return ""
 
 
+# ---------------------------------------------------------------------------
+# 静态可达性分析
+# ---------------------------------------------------------------------------
+
+def index_scripts() -> tuple[dict[str, str], dict[str, str]]:
+    """返回 (basename -> 相对路径)、(basename -> 源码文本)。"""
+    paths: dict[str, str] = {}
+    texts: dict[str, str] = {}
+    for rel_dir in SCRIPT_DIRS:
+        d = ROOT / rel_dir
+        if not d.exists():
+            continue
+        for p in sorted(d.glob("*.py")):
+            if p.name == "__init__.py":
+                continue
+            base = p.stem
+            paths[base] = f"{rel_dir}/{p.name}"
+            texts[base] = p.read_text(encoding="utf-8", errors="ignore")
+    return paths, texts
+
+
+def py_refs(text: str, known: set[str]) -> set[str]:
+    """文本里出现的 `<name>.py` 中属于已知脚本的 basename（工作流/命令用）。"""
+    return {m for m in _PY_REF_RE.findall(text) if m in known}
+
+
+def import_refs(text: str, known: set[str]) -> set[str]:
+    """文本里模块级/函数级 import 的首段 token 中属于已知脚本的 basename。"""
+    return {m for m in _IMPORT_RE.findall(text) if m in known}
+
+
+def collect_roots(known: set[str]) -> dict[str, set[str]]:
+    """收集被「活编排入口」直接引用的脚本 basename -> 平面集合。"""
+    roots: dict[str, set[str]] = {}
+
+    def add(base: str, plane: str) -> None:
+        roots.setdefault(base, set()).add(plane)
+
+    # 工作流：run: python X.py
+    for p in (ROOT / ".github" / "workflows").glob("*.yml"):
+        for b in py_refs(p.read_text(encoding="utf-8", errors="ignore"), known):
+            add(b, "workflow")
+
+    # MCP 服务端：.mcp.json 指向 mcp_server.py，mcp_server.py 内 import 的模块
+    mcp_cfg = ROOT / ".mcp.json"
+    if mcp_cfg.exists():
+        for b in py_refs(mcp_cfg.read_text(encoding="utf-8", errors="ignore"), known):
+            add(b, "mcp")
+    mcp_server = ROOT / "scripts" / "mcp_server.py"
+    if mcp_server.exists():
+        for b in import_refs(mcp_server.read_text(encoding="utf-8", errors="ignore"), known):
+            add(b, "mcp")
+
+    # slash 命令：mention 的 X.py
+    for p in (ROOT / ".claude" / "commands").glob("*.md"):
+        for b in py_refs(p.read_text(encoding="utf-8", errors="ignore"), known):
+            add(b, "command")
+
+    # 会话钩子：settings.json 里引用的脚本（当前为空）
+    settings = ROOT / ".claude" / "settings.json"
+    if settings.exists():
+        for b in py_refs(settings.read_text(encoding="utf-8", errors="ignore"), known):
+            add(b, "hook")
+
+    return roots
+
+
+def build_import_graph(texts: dict[str, str], known: set[str]) -> dict[str, set[str]]:
+    """脚本 import 图：basename -> 它 import 的已知脚本 basename 集合。"""
+    graph: dict[str, set[str]] = {}
+    for base, text in texts.items():
+        deps = import_refs(text, known)
+        deps.discard(base)
+        graph[base] = deps
+    return graph
+
+
+def reachable_from(roots: set[str], graph: dict[str, set[str]]) -> set[str]:
+    """从入口集合沿 import 图做传递闭包。"""
+    seen: set[str] = set()
+    stack = list(roots)
+    while stack:
+        cur = stack.pop()
+        if cur in seen:
+            continue
+        seen.add(cur)
+        stack.extend(graph.get(cur, ()))
+    return seen
+
+
+def test_refs(known: set[str]) -> set[str]:
+    """tests/ 目录里被 import 的脚本 basename。"""
+    refs: set[str] = set()
+    tdir = ROOT / "tests"
+    if tdir.exists():
+        for p in tdir.rglob("*.py"):
+            refs |= import_refs(p.read_text(encoding="utf-8", errors="ignore"), known)
+    return refs
+
+
+def analyze_orchestration() -> tuple[dict[str, dict], dict[str, str]]:
+    """返回 (basename -> {planes, status})、(basename -> 相对路径)。"""
+    paths, texts = index_scripts()
+    known = set(paths)
+    roots = collect_roots(known)
+    graph = build_import_graph(texts, known)
+    reachable = reachable_from(set(roots), graph)
+    tests = test_refs(known)
+
+    result: dict[str, dict] = {}
+    for base in known:
+        if base in roots:
+            planes = sorted(roots[base])
+            status = "live"
+        elif base in reachable:
+            planes = ["import"]
+            status = "live"
+        elif base in tests:
+            planes = ["test"]
+            status = "test-only"
+        else:
+            planes = []
+            status = "orphaned"
+        result[base] = {"planes": planes, "status": status}
+    return result, paths
+
+
+# ---------------------------------------------------------------------------
+# 各功能层扫描
+# ---------------------------------------------------------------------------
+
 def scan_workflows() -> list[dict]:
     out = []
-    wf_dir = ROOT / ".github" / "workflows"
-    for p in sorted(wf_dir.glob("*.yml")):
+    for p in sorted((ROOT / ".github" / "workflows").glob("*.yml")):
         text = p.read_text(encoding="utf-8", errors="ignore")
         name_m = re.search(r"^name:\s*(.+)$", text, re.MULTILINE)
         name = name_m.group(1).strip().strip("\"'") if name_m else p.stem
@@ -84,26 +226,28 @@ def scan_workflows() -> list[dict]:
     return out
 
 
-def scan_python_dir(rel_dir: str) -> list[dict]:
+def scan_python_dir(rel_dir: str, orch: dict[str, dict]) -> list[dict]:
     out = []
     d = ROOT / rel_dir
+    if not d.exists():
+        return out
     for p in sorted(d.glob("*.py")):
         if p.name == "__init__.py":
             continue
-        summary = first_doc_line(p.read_text(encoding="utf-8", errors="ignore"))
+        info = orch.get(p.stem, {})
         out.append({
             "id": p.name,
             "path": f"{rel_dir}/{p.name}",
-            "summary": summary,
+            "summary": first_doc_line(p.read_text(encoding="utf-8", errors="ignore")),
+            "planes": info.get("planes", []),
+            "status": info.get("status", "orphaned"),
         })
     return out
 
 
 def scan_mcp_tools() -> list[dict]:
     out = []
-    p = ROOT / "scripts" / "mcp_server.py"
-    text = p.read_text(encoding="utf-8", errors="ignore")
-    # 匹配 @mcp.tool() 紧跟的 def name( ... ): """summary
+    text = (ROOT / "scripts" / "mcp_server.py").read_text(encoding="utf-8", errors="ignore")
     pattern = re.compile(
         r"@mcp\.tool\(\)\s*\n\s*def\s+(\w+)\s*\([^)]*\)[^:]*:\s*\n\s*\"\"\"(.*?)(?:\n|\"\"\")",
         re.DOTALL,
@@ -119,19 +263,14 @@ def scan_mcp_tools() -> list[dict]:
 
 def scan_commands() -> list[dict]:
     out = []
-    d = ROOT / ".claude" / "commands"
-    for p in sorted(d.glob("*.md")):
+    for p in sorted((ROOT / ".claude" / "commands").glob("*.md")):
         summary = ""
         for line in p.read_text(encoding="utf-8", errors="ignore").splitlines():
             line = line.strip()
             if line and not line.startswith("#"):
                 summary = line.rstrip(":")
                 break
-        out.append({
-            "id": p.stem,
-            "path": f".claude/commands/{p.name}",
-            "summary": summary,
-        })
+        out.append({"id": p.stem, "path": f".claude/commands/{p.name}", "summary": summary})
     return out
 
 
@@ -158,8 +297,7 @@ def scan_skills() -> list[dict]:
 
 def scan_projects() -> list[dict]:
     out = []
-    d = ROOT / "projects"
-    for sp in sorted(d.iterdir()):
+    for sp in sorted((ROOT / "projects").iterdir()):
         if not sp.is_dir():
             continue
         ctx = sp / "CONTEXT.md"
@@ -170,16 +308,11 @@ def scan_projects() -> list[dict]:
                 if line and not line.startswith("#"):
                     summary = line
                     break
-        out.append({
-            "id": sp.name,
-            "path": f"projects/{sp.name}/",
-            "summary": summary,
-        })
+        out.append({"id": sp.name, "path": f"projects/{sp.name}/", "summary": summary})
     return out
 
 
 def merge_annotations(registry: dict, annotations: dict) -> dict:
-    """把人工补注 note_zh 合并进每条目（按 category + id）。"""
     for category, entries in registry.items():
         if category == "meta" or not isinstance(entries, list):
             continue
@@ -192,16 +325,19 @@ def merge_annotations(registry: dict, annotations: dict) -> dict:
 
 
 def build() -> dict:
+    orch, _ = analyze_orchestration()
     registry = {
         "meta": {
             "generated_at": date.today().isoformat(),
-            "generated_by": "scripts/build_capability_registry.py (自动扫描)",
+            "generated_by": "scripts/build_capability_registry.py (自动扫描 + 可达性分析)",
             "do_not_hand_edit": "本文件由 CI 自动重生成；人工中文用途请改 memory/capability-annotations.json",
-            "scope": "BIAV-SC 银芯受限层全功能盘点（七层）",
+            "scope": "BIAV-SC 银芯受限层全功能盘点 + 动态编排可达性",
+            "reachability_method": "从活编排入口（工作流/MCP/命令/钩子）沿 Python 模块级 import 图做传递闭包；status=orphaned 表示无任何活入口可达，建议隔离待裁，非自动删除。",
         },
         "workflows": scan_workflows(),
-        "scripts_top": scan_python_dir("scripts"),
-        "scripts_news": scan_python_dir("projects/news/scripts"),
+        "scripts_top": scan_python_dir("scripts", orch),
+        "scripts_news": scan_python_dir("projects/news/scripts", orch),
+        "scripts_wiki": scan_python_dir("projects/wiki/scripts", orch),
         "mcp_tools": scan_mcp_tools(),
         "commands": scan_commands(),
         "skills": scan_skills(),
@@ -211,27 +347,37 @@ def build() -> dict:
     counts["total"] = sum(counts.values())
     registry["meta"]["counts"] = counts
 
+    # 可达性汇总（仅统计三个脚本层）
+    reach = {"live": 0, "test-only": 0, "orphaned": 0}
+    for cat in ("scripts_top", "scripts_news", "scripts_wiki"):
+        for e in registry[cat]:
+            reach[e.get("status", "orphaned")] = reach.get(e.get("status", "orphaned"), 0) + 1
+    registry["meta"]["reachability"] = reach
+
     annotations = {}
     if ANNOTATIONS.exists():
         annotations = json.loads(ANNOTATIONS.read_text(encoding="utf-8"))
-    registry = merge_annotations(registry, annotations)
-    return registry
+    return merge_annotations(registry, annotations)
 
 
 CATEGORY_TITLES = {
-    "workflows": "CI 自动化工作流",
+    "workflows": "CI 自动化工作流（编排入口·定时/事件平面）",
     "scripts_top": "顶层脚本（记忆 / 做梦 / 解包 / 运营）",
     "scripts_news": "news 采集器脚本",
-    "mcp_tools": "MCP 知识层工具",
-    "commands": "Slash 命令",
+    "scripts_wiki": "wiki 数据脚本",
+    "mcp_tools": "MCP 知识层工具（编排入口·AI 动态平面）",
+    "commands": "Slash 命令（编排入口·人工平面）",
     "skills": "仓内技能",
     "projects": "子项目",
 }
+
+STATUS_TAG = {"live": "活", "test-only": "仅测试", "orphaned": "孤儿"}
 
 
 def render_markdown(registry: dict) -> str:
     meta = registry["meta"]
     counts = meta["counts"]
+    reach = meta["reachability"]
     lines = [
         "# 银芯功能目录（capability-index）",
         "",
@@ -240,6 +386,7 @@ def render_markdown(registry: dict) -> str:
         "",
         f"- 生成日期：{meta['generated_at']}",
         f"- 功能总数：**{counts['total']}**",
+        f"- 脚本可达性：活 {reach['live']} / 仅测试 {reach['test-only']} / 孤儿 {reach['orphaned']}",
         "",
         "## 总览",
         "",
@@ -250,6 +397,45 @@ def render_markdown(registry: dict) -> str:
         lines.append(f"| {title} | {counts.get(cat, 0)} |")
     lines.append("")
 
+    # 编排与可达性专章
+    lines += [
+        "## 动态编排与可达性",
+        "",
+        "银芯只有四个编排平面，其中只有 MCP 是运行时真动态：",
+        "",
+        "| 编排平面 | 触发 | 动态 |",
+        "|------|------|------|",
+        "| 定时/事件（工作流）| cron + push | 否（静态调度）|",
+        "| AI 动态（MCP 工具）| 艾瑞卡运行时自选 | 是 |",
+        "| 人工（slash 命令 / 技能）| 守密人下达 | 半动态 |",
+        "| 会话钩子 | 钩子自动 | 已退役（settings.json 无钩子）|",
+        "",
+        "可达性 = 从活编排入口沿 Python import 图传递闭包。`孤儿` = 无任何活入口可达，"
+        "建议隔离待裁（§3.1 裁撤属守密人决策，工具只检测不删除）。",
+        "",
+    ]
+    orphans = []
+    test_only = []
+    for cat in ("scripts_top", "scripts_news", "scripts_wiki"):
+        for e in registry[cat]:
+            if e["status"] == "orphaned":
+                orphans.append(e)
+            elif e["status"] == "test-only":
+                test_only.append(e)
+    if orphans:
+        lines.append(f"### 孤儿脚本（{len(orphans)}）— 无活编排入口可达，建议隔离待裁")
+        lines.append("")
+        for e in sorted(orphans, key=lambda x: x["path"]):
+            desc = e.get("note_zh") or e.get("summary") or ""
+            lines.append(f"- `{e['path']}` — {desc}")
+        lines.append("")
+    if test_only:
+        lines.append(f"### 仅测试可达脚本（{len(test_only)}）")
+        lines.append("")
+        for e in sorted(test_only, key=lambda x: x["path"]):
+            lines.append(f"- `{e['path']}`")
+        lines.append("")
+
     for cat, title in CATEGORY_TITLES.items():
         entries = registry.get(cat, [])
         if not entries:
@@ -259,14 +445,18 @@ def render_markdown(registry: dict) -> str:
         for e in entries:
             label = e.get("name") or e.get("id")
             desc = e.get("note_zh") or e.get("summary") or ""
-            extra = ""
+            tags = []
             if cat == "workflows" and e.get("triggers"):
-                extra = f" _[{'/'.join(e['triggers'])}]_"
+                tags.append("/".join(e["triggers"]))
+            if e.get("status"):
+                planes = "+".join(e.get("planes", [])) or "—"
+                tags.append(f"{STATUS_TAG.get(e['status'], e['status'])}:{planes}")
+            tag = f" _[{' | '.join(tags)}]_" if tags else ""
             path = e.get("path") or e.get("module") or ""
             if path:
-                lines.append(f"- **`{label}`**{extra} — {desc}  \n  `{path}`")
+                lines.append(f"- **`{label}`**{tag} — {desc}  \n  `{path}`")
             else:
-                lines.append(f"- **`{label}`**{extra} — {desc}")
+                lines.append(f"- **`{label}`**{tag} — {desc}")
         lines.append("")
     return "\n".join(lines)
 
@@ -277,11 +467,8 @@ def main() -> int:
     new_md = render_markdown(registry)
 
     if "--check" in sys.argv:
-        stale = False
-        if not REGISTRY.exists() or REGISTRY.read_text(encoding="utf-8") != new_json:
-            stale = True
-        if not INDEX_MD.exists() or INDEX_MD.read_text(encoding="utf-8") != new_md:
-            stale = True
+        stale = (not REGISTRY.exists() or REGISTRY.read_text(encoding="utf-8") != new_json
+                 or not INDEX_MD.exists() or INDEX_MD.read_text(encoding="utf-8") != new_md)
         if stale:
             print("功能目录已过期，请运行 python scripts/build_capability_registry.py")
             return 1
@@ -291,9 +478,11 @@ def main() -> int:
     REGISTRY.write_text(new_json, encoding="utf-8")
     INDEX_MD.write_text(new_md, encoding="utf-8")
     counts = registry["meta"]["counts"]
+    reach = registry["meta"]["reachability"]
     print(f"功能目录已重生成：共 {counts['total']} 项")
     for cat, title in CATEGORY_TITLES.items():
         print(f"  {title}: {counts.get(cat, 0)}")
+    print(f"  脚本可达性: 活 {reach['live']} / 仅测试 {reach['test-only']} / 孤儿 {reach['orphaned']}")
     return 0
 
 


### PR DESCRIPTION
## 背景

守密人「动态编排全部实现」。上一轮审视是**人工估算**，已被本工具证明会出错（例：我曾把做梦系 9 脚本估成孤儿，工具算出它们经 MCP `check_cache → dream → dream_*` 顶层 import 实为可达·活件）。本 PR 把「编排可达性」固化进扫描器，让必要性每次重生成时自动算出，而非靠会过期的人工报告。

## 改动

将功能扫描器从「静态清单」升级为「动态编排可达性分析器」：

1. **补 wiki 漏扫**：纳入 `projects/wiki/scripts/`（17 个脚本，含被工作流真实调度的 `fetch_*` / `generate_pages` 等最活脚本）。总量 110 → **125**。
2. **静态可达性分析**：从四个活编排入口（工作流 / MCP 服务端 / slash 命令 / 会话钩子）出发，沿 Python 模块级 import 图做传递闭包，给每个脚本打 `planes`（编排平面）+ `status`（live / test-only / orphaned）。
3. **自动暴露孤儿**：6 个孤儿（4 个 2026-06-14 退役的会话钩子 + `extract_art` + 一次性 Notion 富化脚本）、9 个仅测试可达脚本——全自动检出，无需人工盯。
4. **新增「动态编排与可达性」专章**：列出四个编排平面 + 不可达脚本清单（隔离候选）。

## 关键结论（工具实算，非估算）

- 脚本可达性：**活 63 / 仅测试 9 / 孤儿 6**。
- 四编排平面：定时/事件（工作流，静态调度）、AI 动态（MCP，唯一运行时真动态）、人工（命令/技能）、会话钩子（已退役，settings.json 无钩子）。
- 真孤儿是 4 个退役钩子脚本（`session_inject/watch/distiller/reflexion`）+ `extract_art`（手动运行）+ `build_notion_voice_enrichment`（一次性）。

## 边界（硬约束）

按 §3.1，**裁撤/删除属守密人决策**，工具只做**检测与标记**，绝不自动删档。孤儿标注为「建议隔离待裁」。桶2（MCP 记忆工具是否随自动环一并退役）属定位决策，留待守密人裁定。可达性基于模块级 import；子进程/手动调用（如 `extract_art`、`decrypt_and_extract`）无法被静态捕获，meta 已注明此局限。

## 验证

- `python scripts/build_capability_registry.py --check` → 目录与代码一致。
- `python -m py_compile` 通过；registry/annotations 两个 JSON 均合法。
- CI `build-capability-registry.yml` 会在合并后按新逻辑自动重生成目录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqMQy1qYm9R3ieLjfnLTnM)_