### PR TITLE
test: 修复 test_collect_global 写穿真实 output/ 的隔离债

### DIFF
--- a/tests/test_collect_global.py
+++ b/tests/test_collect_global.py
@@ -161,9 +161,11 @@ class TestFailureAggregation(unittest.TestCase):
             "TapTap": boom,
             "Reddit": lambda: [_item("r", "https://r/1")],
         })
+        # Isolate all output writes: main() now persists via news_common.dump_json_atomic
+        # (temp file + os.replace), which bypasses builtins.open — so stub it out to a
+        # no-op, otherwise the test would clobber the real projects/news/output/*.json.
         with mock.patch.object(collect_global, "load_existing_news", return_value=[]), \
-                mock.patch("builtins.open", mock.mock_open()), \
-                mock.patch.object(collect_global.Path, "mkdir", lambda *a, **k: None):
+                mock.patch.object(news_common, "dump_json_atomic", lambda *a, **k: None):
             with self.assertRaises(SystemExit) as cm:
                 collect_global.main()
         self.assertEqual(cm.exception.code, 1)


### PR DESCRIPTION
## 背景

「全面修复」第二批——修 #6 测试隔离债（审视中代理标的「测试隔离 2/5」，且为 #1 原子写改动的连带回归）。

## 问题

`test_collect_global` 的 R1 非零退出测试，原靠 `mock.patch("builtins.open")` 拦截 `collect_global.main()` 的文件写入实现隔离。#1 原子写把写入改走 `news_common.dump_json_atomic`（`tempfile` + `os.replace`，**不经 builtins.open**）→ mock 失效 → 每次跑测试都**写穿真实 `projects/news/output/*.json`**（无网络时截空真数据）。

## 修复

改用 `mock.patch.object(news_common, "dump_json_atomic", no-op)` 隔离，不再依赖 builtins.open 实现细节。

## 验证

- 跑 `test_collect_global` 后 `output/` 改动文件数 = 0。
- 全量 **845 测试通过**，且全量跑完 `output/` 零污染（此前会被改 2 个文件）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqMQy1qYm9R3ieLjfnLTnM)_