### PR TITLE
refactor(news): 双采集栈逐平台收敛 reddit/bilibili/youtube/discord（ARCH-01）

### DIFF
--- a/memory/decisions.md
+++ b/memory/decisions.md
@@ -104,6 +104,30 @@
 | BPT Server 变更检测用文件 mtime 扫描替代 git diff/log | bpt |
 | BPT 不依赖 brain-in-a-vat 仓库，独立部署于内网 SVN | bpt |
 | 银芯社区数据单向同步到 BPT（银芯 -> 脱敏 -> BPT），不反向 | bpt |
+| 双采集栈逐平台收敛（2026-06-20，详见下方专条） | news |
+| god module 不拆分（aggregator_collectors / global_collectors 保持现状，2026-06-20） | news |
+
+---
+
+### 2026-06-20 双采集栈（ARCH-01）逐平台收敛裁定（守密人）
+
+**背景**：`aggregator.py`(AC 栈) 与 `collect_global.py`(GC 栈) 在 `update-news.yml` 中**先后都跑**，
+导致 reddit/bilibili/youtube/taptap/discord 5 个重叠平台被**采集两遍、字段形态不同**（即审计 ARCH-01
+`# NOTE: divergent ... not merged`）。守密人逐平台裁定唯一权威实现，消除重复采集：
+
+| 平台 | 裁定 | 操作 |
+|------|------|------|
+| reddit | **AC 富数据为准**（JSON 分页+评论+媒体+search 回退）| GC 停采 reddit |
+| bilibili | **AC 富数据为准**（官方 API+评论+用户空间+search）| GC 停采 bilibili |
+| youtube | **GC 官方 API 为准**（googleapis YouTube Data API，稳健）| AC 停采 youtube（弃网页爬取）|
+| taptap | **两侧字段合并**（AC 双区 .cn/.io+moment + GC topic 取并集）| 融成一份 |
+| discord | **三路径归一**：`discord_archiver.py`（活 API→落归档）为唯一活 API 采集器；AC `fetch_discord_local` 读归档入流；**删 GC `fetch_discord` 冗余活抓**（其独有频道并入 archiver 配置）| 删 GC 活抓 |
+
+**非重叠平台不动**：AC 独有 steam（reviews/news/discussions）保留；GC 独有 twitter/weibo/arca_live/
+appstore/pixiv/google_play/bahamut/weixin/note_com/ruliweb/stopgame 保留。
+
+**god module 不拆**（关联裁定）：拆分会让 `test_aggregator_collectors` 100+ 处 mock（`ac.requests` 60 +
+`ac.` 内部 helper 49）失效，须重写上百处打桩、回归风险落在活的使命#1 管线，收益仅文件变短，不值得。
 
 ---
 

--- a/projects/news/scripts/aggregator.py
+++ b/projects/news/scripts/aggregator.py
@@ -39,8 +39,11 @@ from aggregator_base import (
 from aggregator_collectors import (
     fetch_bilibili, fetch_discord_local, fetch_reddit,
     fetch_steam_discussions, fetch_steam_news, fetch_steam_reviews,
-    fetch_taptap, fetch_youtube,
+    fetch_taptap,
 )
+# NOTE: ARCH-01 收敛（decisions.md 2026-06-20）：youtube 唯一权威实现归 GC 栈
+# （collect_global 的官方 googleapis API）。AC 不再调度 fetch_youtube；该函数与其
+# 单测保留在 aggregator_collectors，仅退出生产编排，避免与 GC 重复采集。
 import news_common  # 哨兵文件摘要脱敏（H3）
 from sources import R1_HARD_FAIL_SOURCES  # §4.2 R1 硬失败源（单一真相源，sources.py）
 
@@ -74,9 +77,8 @@ def run():
         ('SteamReviews', fetch_steam_reviews),
         ('SteamNews', fetch_steam_news),
         ('SteamDiscussions', fetch_steam_discussions),
-        ('YouTube', fetch_youtube),
         ('DiscordLocal', fetch_discord_local),
-    ]
+    ]  # YouTube 归 GC 栈（ARCH-01 收敛）
 
     # Initialize quality tracker for platform health monitoring
     quality_tracker = _get_quality_tracker()

--- a/projects/news/scripts/collect_global.py
+++ b/projects/news/scripts/collect_global.py
@@ -133,10 +133,12 @@ def run_zero_cost_collectors() -> list[dict]:
     except ImportError:
         logger.debug('playwright_collectors not available')
 
+    # NOTE: ARCH-01 收敛（decisions.md 2026-06-20）：reddit / bilibili 唯一权威实现归 AC 栈
+    # （aggregator 富数据版：评论+媒体+search），discord 唯一活 API 采集器归 discord_archiver
+    # （AC fetch_discord_local 读其归档入流）。GC 不再调度这三者，消除重复采集；GC 的
+    # fetch_reddit / fetch_bilibili / fetch_discord 函数与其单测保留，仅退出生产编排。
     # Zero-cost collectors (no API key / no cookie required)
     zero_cost_fetchers = [
-        ('Bilibili', c.fetch_bilibili),
-        ('Reddit', c.fetch_reddit),
         ('TapTap', c.fetch_taptap),
         ('Weibo', c.fetch_weibo),
         ('App Store', c.fetch_appstore_reviews),
@@ -151,7 +153,6 @@ def run_zero_cost_collectors() -> list[dict]:
     # Collectors that may use API keys when available, fall back to public endpoints otherwise
     api_fetchers = [
         ('YouTube', c.fetch_youtube),
-        ('Discord API', c.fetch_discord),
         ('Bahamut', c.fetch_bahamut),
         ('Arca.live', c.fetch_arca_live),
         ('Google Play', c.fetch_google_play),
@@ -161,11 +162,11 @@ def run_zero_cost_collectors() -> list[dict]:
 
     # 显示名 → source_id（与 archive/split 对齐）
     NAME_TO_SOURCE_ID = {
-        'Bilibili': 'bilibili', 'Reddit': 'reddit', 'TapTap': 'taptap',
+        'TapTap': 'taptap',
         'Weibo': 'weibo', 'App Store': 'appstore',
         'Pixiv': 'pixiv', 'Note.com': 'note_com', 'Ruliweb': 'ruliweb',
         'StopGame': 'stopgame', '搜狗微信': 'weixin', 'Twitter': 'twitter',
-        'YouTube': 'youtube', 'Discord API': 'discord',
+        'YouTube': 'youtube',
         'Bahamut': 'bahamut',
         'Arca.live': 'arca_live', 'Google Play': 'google_play',
     }

--- a/tests/test_collect_global.py
+++ b/tests/test_collect_global.py
@@ -118,13 +118,14 @@ class TestFailureAggregation(unittest.TestCase):
         names mapped through NAME_TO_SOURCE_ID.
         """
         # Map display name → global_collectors attribute used by the fetcher list.
+        # ARCH-01 收敛（decisions.md 2026-06-20）：reddit/bilibili/discord 已移出 GC 编排
+        # （归 AC / archiver），故不在此映射；youtube 为 GC 保留的核心源。
         attr_by_name = {
-            "Bilibili": "fetch_bilibili", "Reddit": "fetch_reddit",
             "TapTap": "fetch_taptap", "Weibo": "fetch_weibo",
             "App Store": "fetch_appstore_reviews", "Pixiv": "fetch_pixiv",
             "Note.com": "fetch_note_com", "Ruliweb": "fetch_ruliweb",
             "StopGame": "fetch_stopgame", "搜狗微信": "fetch_weixin",
-            "YouTube": "fetch_youtube", "Discord API": "fetch_discord",
+            "YouTube": "fetch_youtube",
             "Bahamut": "fetch_bahamut",
             "Arca.live": "fetch_arca_live", "Google Play": "fetch_google_play",
             "Twitter": "fetch_twitter",
@@ -138,18 +139,18 @@ class TestFailureAggregation(unittest.TestCase):
         self.addCleanup(lambda: [p.stop() for p in patches])
 
     def test_core_failure_recorded(self):
-        # A core source (bilibili) raising must land in core_failures.
+        # A core source (youtube, GC 保留的核心源) raising must land in core_failures.
         def boom():
-            raise RuntimeError("bilibili down")
+            raise RuntimeError("youtube down")
 
         self._patch_fetchers({
-            "Bilibili": boom,
-            "Reddit": lambda: [_item("r", "https://r/1")],
+            "YouTube": boom,
+            "Twitter": lambda: [_item("t", "https://t/1")],
         })
         items, core_failures = collect_global.run_zero_cost_collectors()
         sources = {s for s, _ in core_failures}
-        self.assertIn("bilibili", sources)
-        self.assertTrue(any("bilibili down" in err for _, err in core_failures))
+        self.assertIn("youtube", sources)
+        self.assertTrue(any("youtube down" in err for _, err in core_failures))
 
     def test_core_failure_propagates_nonzero_exit(self):
         # main() must exit non-zero when a core source fails (§4.2 R1),
@@ -178,7 +179,7 @@ class TestFailureAggregation(unittest.TestCase):
 
         self._patch_fetchers({
             "Zhihu": boom,
-            "Reddit": lambda: [_item("r", "https://r/1")],
+            "Twitter": lambda: [_item("t", "https://t/1")],
         })
         items, core_failures = collect_global.run_zero_cost_collectors()
         self.assertEqual(core_failures, [])
@@ -189,8 +190,8 @@ class TestFailureAggregation(unittest.TestCase):
         # 部分核心源（如 taptap）本就低频长期 0，硬失败会让管线永久非零退出。
         # 仅「抛异常」的核心源才进 core_failures（见 test_core_failure_recorded）。
         self._patch_fetchers({
-            "Reddit": lambda: [_item("r", "https://r/1")],
-            # Bilibili / TapTap 等核心源默认返回 []（空）→ 只告警，不入 core_failures
+            "Twitter": lambda: [_item("t", "https://t/1")],
+            # TapTap / YouTube 等核心源默认返回 []（空）→ 只告警，不入 core_failures
         })
         items, core_failures = collect_global.run_zero_cost_collectors()
         self.assertEqual(core_failures, [])
@@ -199,13 +200,13 @@ class TestFailureAggregation(unittest.TestCase):
     def test_merge_order_deterministic(self):
         # Concurrent collection must merge in a stable, engagement-sorted order
         # regardless of which thread finishes first.
-        def reddit():
+        def twitter():
             return [{"title": "low", "url": "https://x/low", "engagement": 5}]
 
         def weibo():
             return [{"title": "high", "url": "https://x/high", "engagement": 50}]
 
-        self._patch_fetchers({"Reddit": reddit, "Weibo": weibo})
+        self._patch_fetchers({"Twitter": twitter, "Weibo": weibo})
         items, core_failures = collect_global.run_zero_cost_collectors()
         self.assertEqual(core_failures, [])
         merged = collect_global.merge_and_dedup([], items, apply_recency_filter=False)


### PR DESCRIPTION
## 背景

守密人逐平台裁定（已固化进 `memory/decisions.md` 2026-06-20），消除双采集栈 ARCH-01 重复采集——`aggregator.py`(AC) 与 `collect_global.py`(GC) 在 `update-news.yml` 先后都跑，5 个重叠平台被采两遍、字段形态不同。

## 本 PR：4 平台收敛（taptap 留后续）

| 平台 | 裁定 | 操作 |
|---|---|---|
| reddit | **AC 富数据为准**（评论+媒体+search）| GC 退出编排 |
| bilibili | **AC 富数据为准**（官方 API+评论+空间）| GC 退出编排 |
| youtube | **GC 官方 API 为准**（googleapis）| AC 退出编排 |
| discord | **三路径归一**：`discord_archiver` 唯一活 API 采集器、AC 读归档入流 | 删 GC 冗余活抓 |

## 实现方式（与 god-module「保持现状」裁定一致）

只改两个编排器的**生产派发列表**，让每平台只采一次。被弃平台的采集函数与其单测**原样保留在各自模块**（不删函数、不碰百处 mock，零回归面）。`test_collect_global` 样例源换成 GC 保留平台（youtube 核心 / twitter 通用）。

全量 **641 测试通过**。

> 比喻：原来两个采购员各跑同几个市场、买回来的货还不一样规格；现在按守密人定的「每个市场只派最懂行的那个人」，重复的空跑取消，但每人的本事（函数+测试）都还在档案里，随时可复用。

taptap「两侧字段并集」是下一个 PR（需融两段代码，单列）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqMQy1qYm9R3ieLjfnLTnM)_