### PR TITLE
refactor(news): taptap 合并归 AC（topic 帖子 + 富评价），ARCH-01 收敛收尾

### DIFF
--- a/projects/news/scripts/aggregator_collectors.py
+++ b/projects/news/scripts/aggregator_collectors.py
@@ -607,7 +607,30 @@ def fetch_taptap():
         offset += 10
         time.sleep(0.5)
 
-    logger.info(f'TapTap: fetched {len(items)} reviews')
+    review_count = len(items)
+
+    # ARCH-01 收敛（decisions.md 2026-06-20，守密人「GC 功能合并到 AC」）：吸收 GC 栈
+    # 独有的 topic 帖子能力（AC 原本仅评价）。topic 经 taptap_collector（Playwright）抓取；
+    # 评价优先用上面 webapiv2 富字段版，仅当 webapiv2 空时回退取 collector 的评价。
+    # Playwright 不可用（如纯 CI/测试环境）时静默跳过 topic，不影响 webapiv2 评价。
+    try:
+        import asyncio
+        import taptap_collector as _tc
+        topic_items, pw_reviews = asyncio.run(_tc.collect(cutoff=cutoff))
+        items.extend(topic_items)
+        if review_count == 0:
+            items.extend(pw_reviews)
+        logger.info(
+            f'TapTap: + {len(topic_items)} topic posts'
+            + ('' if review_count else f' + {len(pw_reviews)} fallback reviews')
+            + ' (taptap_collector)'
+        )
+    except ImportError:
+        logger.info('TapTap: taptap_collector/playwright unavailable, topic posts skipped')
+    except Exception as e:
+        logger.warning(f'TapTap topic collect failed: {e}')
+
+    logger.info(f'TapTap: fetched {len(items)} items ({review_count} webapiv2 reviews)')
     return items
 
 

--- a/projects/news/scripts/collect_global.py
+++ b/projects/news/scripts/collect_global.py
@@ -122,7 +122,6 @@ def run_zero_cost_collectors() -> list[dict]:
         'Arca.live':   'fetch_arca_live_playwright',
         'Ruliweb':     'fetch_ruliweb_playwright',
         'Bahamut':     'fetch_bahamut_playwright',
-        'TapTap':      'fetch_taptap_playwright',
         'Weibo':       'fetch_weibo_playwright',
     }
 
@@ -135,11 +134,11 @@ def run_zero_cost_collectors() -> list[dict]:
 
     # NOTE: ARCH-01 收敛（decisions.md 2026-06-20）：reddit / bilibili 唯一权威实现归 AC 栈
     # （aggregator 富数据版：评论+媒体+search），discord 唯一活 API 采集器归 discord_archiver
-    # （AC fetch_discord_local 读其归档入流）。GC 不再调度这三者，消除重复采集；GC 的
-    # fetch_reddit / fetch_bilibili / fetch_discord 函数与其单测保留，仅退出生产编排。
+    # （AC fetch_discord_local 读其归档入流）。taptap 亦归 AC（守密人「GC 功能合并到 AC」：
+    # AC fetch_taptap 已吸收本栈 taptap_collector 的 topic 帖子能力 + 保留 webapiv2 富评价）。
+    # GC 不再调度这四者，消除重复采集；对应函数与其单测保留，仅退出生产编排。
     # Zero-cost collectors (no API key / no cookie required)
     zero_cost_fetchers = [
-        ('TapTap', c.fetch_taptap),
         ('Weibo', c.fetch_weibo),
         ('App Store', c.fetch_appstore_reviews),
         ('Pixiv', c.fetch_pixiv),
@@ -162,7 +161,6 @@ def run_zero_cost_collectors() -> list[dict]:
 
     # 显示名 → source_id（与 archive/split 对齐）
     NAME_TO_SOURCE_ID = {
-        'TapTap': 'taptap',
         'Weibo': 'weibo', 'App Store': 'appstore',
         'Pixiv': 'pixiv', 'Note.com': 'note_com', 'Ruliweb': 'ruliweb',
         'StopGame': 'stopgame', '搜狗微信': 'weixin', 'Twitter': 'twitter',

--- a/tests/test_collect_global.py
+++ b/tests/test_collect_global.py
@@ -118,10 +118,10 @@ class TestFailureAggregation(unittest.TestCase):
         names mapped through NAME_TO_SOURCE_ID.
         """
         # Map display name → global_collectors attribute used by the fetcher list.
-        # ARCH-01 收敛（decisions.md 2026-06-20）：reddit/bilibili/discord 已移出 GC 编排
-        # （归 AC / archiver），故不在此映射；youtube 为 GC 保留的核心源。
+        # ARCH-01 收敛（decisions.md 2026-06-20）：reddit/bilibili/discord/taptap 已移出 GC
+        # 编排（归 AC / archiver），故不在此映射；youtube 为 GC 保留的核心源。
         attr_by_name = {
-            "TapTap": "fetch_taptap", "Weibo": "fetch_weibo",
+            "Weibo": "fetch_weibo",
             "App Store": "fetch_appstore_reviews", "Pixiv": "fetch_pixiv",
             "Note.com": "fetch_note_com", "Ruliweb": "fetch_ruliweb",
             "StopGame": "fetch_stopgame", "搜狗微信": "fetch_weixin",
@@ -156,11 +156,11 @@ class TestFailureAggregation(unittest.TestCase):
         # main() must exit non-zero when a core source fails (§4.2 R1),
         # even though good items were collected and written.
         def boom():
-            raise RuntimeError("taptap down")
+            raise RuntimeError("youtube down")
 
         self._patch_fetchers({
-            "TapTap": boom,
-            "Reddit": lambda: [_item("r", "https://r/1")],
+            "YouTube": boom,
+            "Twitter": lambda: [_item("t", "https://t/1")],
         })
         # Isolate all output writes: main() now persists via news_common.dump_json_atomic
         # (temp file + os.replace), which bypasses builtins.open — so stub it out to a


### PR DESCRIPTION
## 背景

ARCH-01 收敛收尾。taptap 合并勘探出**传输冲突**：AC 走直连 webapiv2（仅评价、字段富：sentiment/author/engagement），GC 走 Playwright `taptap_collector`（帖子 topic + 评价、字段较薄），两侧对 webapiv2 是否还活判断相反。

守密人裁定：**GC 功能合并到 AC**。

## 改动

- **AC `fetch_taptap` 成为唯一权威**：保留 webapiv2 富评价 + 吸收 GC 独有的 **topic 帖子**能力（经 `taptap_collector` Playwright）。webapiv2 评价为空时回退取 collector 评价。Playwright 不可用（CI/测试）静默跳过 topic、不影响评价。
- **GC 撤 taptap 编排**：`zero_cost_fetchers` / `NAME_TO_SOURCE_ID` / `PW_FALLBACK` 三处移除；`fetch_taptap` 与 `taptap_collector` 函数保留、仅退出生产编排。
- 测试：`test_collect_global` 核心源样例从 taptap 换 youtube（GC 保留的核心源）。

全量 **641 测试通过**。playwright 未装时验证了 topic 静默跳过路径。

> 比喻：taptap 原来俩采购员，一个只收「评价」但记得最细（含好评差评/作者/热度），一个能多收「帖子」但记得粗。守密人说「把会收帖子那位的本事教给记得最细那位」——于是细心那位现在既收富评价、又会收帖子，另一位退场。

至此 ARCH-01 五平台（reddit/bilibili/youtube/discord/taptap）逐平台收敛全部落地，双栈重复采集消除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqMQy1qYm9R3ieLjfnLTnM)_