### PR TITLE
移植 grill 技能谱系（最小高价值）+ 技能写作审计标尺

### DIFF
--- a/.claude/skills/domain-modeling/SKILL.md
+++ b/.claude/skills/domain-modeling/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: domain-modeling
+description: Build and sharpen 银芯's shared language, and record decisions as they crystallise. Use when the keeper wants to pin down terminology, resolve a fuzzy term, capture an architectural decision, or when another skill (e.g. /grilling) needs to maintain the model.
+---
+
+# Domain Modeling — 术语锐化与决策落档
+
+Actively sharpen the project's shared language *as you design*, and write
+terminology and decisions down the moment they crystallise. This is the *active*
+discipline — challenging terms, inventing edge-case scenarios, recording outcomes —
+not merely *reading* a glossary for vocabulary (any skill can do that in one line).
+
+## Where things land (银芯 targets)
+
+银芯 has no generic `CONTEXT.md` glossary or `docs/adr/` tree. Map the upstream
+"glossary + ADR" idea onto the existing knowledge layer:
+
+- **术语 (glossary)** → `memory/morimens-context.md` 「核心术语」table for
+  worldview/game terms; the term tables in `CLAUDE.md §5` for system/architecture
+  terms. A sub-project's own jargon goes in its `projects/<x>/CONTEXT.md`.
+- **决策 (decisions, the ADR equivalent)** → `memory/decisions.md`「当前有效决策」table.
+
+## During the session
+
+### Challenge against the glossary
+When the keeper uses a term that conflicts with the existing language, call it out
+immediately. "morimens-context 把『X』定义为 A，但守密人此处似乎指 B —— 哪个为准？"
+
+### Sharpen fuzzy language
+When a term is vague or overloaded, propose a precise canonical 银芯 term, listing
+the words to avoid. "守密人说『数据层』—— 指全量档案层（`projects/news/data/`）还是
+输出展示层（`projects/news/output/`）？二者语义不可互换（§4.1）。"
+
+### Stress-test with scenarios
+When relationships are discussed, invent concrete edge-case scenarios that force the
+boundaries between concepts to be made precise.
+
+### Cross-reference with the archive
+When the keeper states how something works, check whether the repository agrees
+(`assets/data/*`, `memory/decisions.md`, `memory/project-status.md`). Surface any
+contradiction at once — never let a claim past that the archive refutes.
+
+### Update the glossary inline
+When a term resolves, record it right there in the appropriate glossary file (format
+above) — don't batch. A glossary entry is a tight one-or-two-sentence definition of
+what the term **is**, plus the words to `_Avoid_`. No implementation detail.
+
+### Offer to record a decision — sparingly, and gated
+Only propose a `memory/decisions.md` entry when **all three** are true:
+
+1. **Hard to reverse** — changing your mind later has a meaningful cost.
+2. **Surprising without context** — a future session will wonder "为什么这么做？".
+3. **The result of a real trade-off** — there were genuine alternatives.
+
+If any is missing, skip it. When all three hold, **draft** the entry in the existing
+decision-table format and present it for the keeper to ratify — **do not write to
+`memory/decisions.md` directly**. Per `CLAUDE.md §3.1`, the decision archive is
+守密人 / 主控台 authority only; Erica drafts and flags, the keeper commits.
+
+---
+
+Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) `domain-modeling`
+(MIT, © 2026 Matt Pocock); retargeted onto 银芯's glossary files and the §3.1-gated
+decision log.

--- a/.claude/skills/grill/SKILL.md
+++ b/.claude/skills/grill/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: grill
+description: 拷问对齐 + 落档。守密人手动召唤，对一个计划/设计展开关系式逼问，并把结晶出的术语与决策实时落档。
+disable-model-invocation: true
+---
+
+# Grill — 拷问对齐并落档
+
+Run a `/grilling` session, using the `/domain-modeling` skill.
+
+That is the whole skill: `/grilling` drives the relentless one-question-at-a-time
+interview; `/domain-modeling` captures the terminology and decisions it crystallises
+into the 银芯 knowledge layer as they happen.
+
+Use this before building anything non-trivial — a new mechanism, a sub-project
+milestone, a data-pipeline change — when the keeper has a codebase/archive to align
+against. For a stateless plan with nothing to record, the bare `/grilling` loop is
+enough on its own.
+
+---
+
+Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) `grill-with-docs`
+(MIT, © 2026 Matt Pocock); rewritten for the 银芯 persona and knowledge layer.

--- a/.claude/skills/grilling/SKILL.md
+++ b/.claude/skills/grilling/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: grilling
+description: Interview the keeper relentlessly about a plan or design before building. Use when the keeper wants to stress-test a plan, sharpen a vague idea, or uses any 'grill' / 拷问 / 质询 / 对齐 trigger phrase.
+---
+
+# Grilling — 拷问对齐
+
+Interview the keeper relentlessly about every aspect of this plan until you reach a
+shared understanding. Walk down each branch of the design tree, resolving
+dependencies between decisions one-by-one. For each question, provide your
+recommended answer.
+
+Ask the questions **one at a time**, waiting for feedback on each before
+continuing. Asking multiple questions at once is bewildering.
+
+If a question can be answered by exploring the repository (`assets/`, `projects/`,
+`memory/`) instead of asking, explore it — never ask the keeper what the archive
+already knows.
+
+## 银芯 adaptations (hard constraints)
+
+- Conduct the entire interview **in Erica's persona and in Chinese** (CLAUDE.md §2):
+  functional openers, system-term phrasing, no emoji, mixed self-reference. The
+  rules below describe the *process*; the *voice* is always Erica's.
+- Ground every challenge in 银芯 facts. Cross-check claims against the fact-bible
+  layer (`assets/data/*`), the decision log (`memory/decisions.md`), and the
+  唯一权威 status file (`memory/project-status.md`) before accepting them.
+- When the plan touches terminology or a decision worth recording, hand off to the
+  `/domain-modeling` skill — it owns the glossary and decision-log discipline
+  (including the §3.1 authority gate on `memory/decisions.md`).
+
+---
+
+Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) `grilling`
+(MIT, © 2026 Matt Pocock); rewritten for the 银芯 persona and knowledge layer.

--- a/memory/skill-authoring-standard.md
+++ b/memory/skill-authoring-standard.md
@@ -1,0 +1,52 @@
+# 技能写作审计标尺
+
+> 提炼自 [mattpocock/skills](https://github.com/mattpocock/skills) `writing-great-skills`
+> （MIT，© 2026 Matt Pocock），改写适配银芯。用于审计 `.claude/skills/` 与
+> `.claude/commands/` 的质量。
+>
+> 最后更新：2026-06-20 by 艾瑞卡会话（grill 谱系移植配套落档）
+
+## 0. 第一性原理
+
+技能存在的唯一目的：**从随机的 AI 里榨出确定性（predictability）——同样的「过程」，而非同样的「输出」**。下文每条杠杆都服务于此。
+
+## 1. 召唤轴（invocation，结构公理）
+
+每个 SKILL.md 二选一，按「谁能召唤它」分类：
+
+| 类型 | frontmatter | 谁能调 | 代价 |
+|------|-------------|--------|------|
+| **model-invoked**（模型召唤）| 不写 `disable-model-invocation` | 人 + AI 自动 + 其他技能 | 占上下文窗口（每轮常驻 description）|
+| **user-invoked**（用户召唤）| `disable-model-invocation: true` | 仅人类敲名字 | 占人脑记忆（人是索引）|
+
+铁律：user-invoked 可调 model-invoked，**但永不能调另一个 user-invoked**（后者无 description，无人能自动够到）。
+判据：「AI 需要自主够到它吗？」是 → model-invoked；只手动触发 → user-invoked，省上下文。
+
+## 2. 四个杠杆
+
+1. **信息阶梯**：内容按「立刻要看 → 按需查」三档排——① 步骤（在 SKILL.md 内，主层）② 引用（在文件内，次层）③ 外置引用（指针外链，用到才加载）。用「渐进披露」把次要引用推下去，保持顶部清爽。
+2. **领头词（leading word）**：借模型预训练已有的强概念当锚（如 *lesson* / *tracer bullet* / *拷问* / *红绿*），一个词顶一段定义。自造词不推荐——招不来先验，得自付定义 token。
+3. **两种负载平衡**：model-invoked 费上下文、user-invoked 费人脑。切太细两头亏；只在「独立触发」真值得时才拆。
+4. **完成判据（completion criterion）**：每个步骤须以「可检验 + 该穷尽处穷尽」的条件收尾（如「每个改动模型都已交代」而非「产出一份变更清单」），否则诱发虎头蛇尾。
+
+## 3. 五大病症诊断表（审计清单）
+
+逐条扫描每个技能，命中即修：
+
+| 病症 | 含义 | 小学生比喻 |
+|------|------|-----------|
+| **premature completion** | 没真干完就宣布完成，注意力滑向「完事」| 虎头蛇尾，作业写一半就交 |
+| **duplication** | 一个意思写两遍以上 | 复读机，啰嗦 |
+| **sediment** | 陈年废话沉积，没人敢删 | 老垃圾堆着没清 |
+| **sprawl** | 纯粹太长（即便每行都有效）| 裹脚布太长 |
+| **no-op** | 说了等于没说（模型默认就会）| 废话，「记得呼吸」|
+
+修法优先级：完成判据先收紧（便宜、局部）→ 仍虎头蛇尾再拆步骤；no-op 的修法是换更强的领头词（*relentless* 替 *be thorough*），不是换技术。
+
+## 4. 银芯落地校验
+
+新增/修改技能后，对照本标尺自审，并确认：
+- frontmatter 召唤轴选择与用途匹配（§1）
+- 无 §3 五病症
+- 引用上游须保留 MIT 署名（见各文件页脚）
+- 涉术语/决策落档的技能须走 `/domain-modeling`，且 `memory/decisions.md` 写入受 CLAUDE.md §3.1 守密人/主控台权限门控


### PR DESCRIPTION
## 背景

守密人要求研究并移植 mattpocock/skills 的 `/grill` 技能。经整仓研究（53 档案）+ 契合度评估，裁定**最小高价值移植**——只搬高契合的 grill 谱系，放弃 issue 流 / TS 工具等水土不服的部分。

## 本次落盘

| 文件 | 类型 | 作用 |
|------|------|------|
| `.claude/skills/grilling/SKILL.md` | model-invoked | 核心拷问循环：一次一问、附推荐答案、沿设计树解依赖、能查档案就别问。改写为艾瑞卡中文人格、对接银芯事实层 |
| `.claude/skills/grill/SKILL.md` | user-invoked | 守密人手动入口（对应上游 grill-with-docs）：跑 `/grilling` + `/domain-modeling` |
| `.claude/skills/domain-modeling/SKILL.md` | model-invoked | 术语锐化 + 决策落档。重定向到银芯 `memory/morimens-context.md` / CLAUDE.md §5 术语表与 `memory/decisions.md`（决策写入受 §3.1 守密人/主控台权限门控，仅起草不直写）|
| `memory/skill-authoring-standard.md` | 记忆层 | `writing-great-skills` 提炼为技能写作审计标尺（召唤轴 / 四杠杆 / 五病症诊断表）|

## 设计要点

- **召唤轴二分**：`grill` 为 user-invoked（无 description，仅守密人召唤），`grilling` / `domain-modeling` 为 model-invoked（可自动触发或被其他技能调用）。
- **银芯纪律对齐**：决策落档不直写 `decisions.md`，遵 CLAUDE.md §3.1 权限门控，起草后交守密人裁定。
- **许可合规**：上游 MIT（© 2026 Matt Pocock），所有移植件页脚保留署名。

## 未移植（评估后放弃）

issue 流（triage / to-issues / to-prd / implement）、架构治理（codebase-design / improve-codebase-architecture）、TS/JS 专用工具（migrate-to-shoehorn / setup-pre-commit）等——与银芯「知识层 + 数据采集」定位水土不服或与既有纪律冲突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vb7WdL6TSBkVx5qiVxma6V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vb7WdL6TSBkVx5qiVxma6V)_