### PR TITLE
续清诈尸：project-status Wiki 段整段失真 + 4 处 CONTEXT 死链

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -63,63 +63,36 @@
 ## Wiki 数据集 + 站点
 
 ### 游戏数据集（原 database）
-- **当前状态**（2026-04-20 B3 调研修正）：
-  - **`projects/wiki/data/db/characters.json` 基线尚未建立**（git 历史中无此文件），Phase 2 首要任务是自举基线
-  - 角色真实总数为 **72 角色**（含皮肤/联动/彩蛋），不是 63。来源：`projects/wiki/data/extracted/categorized/character_data.txt`（客户端逆向提取）
-  - 数据覆盖度**基线缺失，真实缺口详见 `memory/wiki-phase-2-gap-inventory.md`**
-  - 72/72 角色有元数据（EN/JA 描述、获取方式翻译完成），结构化卡牌/技能数据待 Phase 2 从 Fandom 抓取补充
-  - 47 个立绘 PNG 已下载到 `assets/images/portraits/`（蛇形命名，约 65% 覆盖，对 72 角色仍缺约 25 个）
-  - 命轮数据：29 条 Name（TrinketSuitEffect.lua），**全部缺 Effect/Condition 字段**，待 Phase 2 从 AwakerPotency.lua 或 Fandom 提取
-  - 命轮与密契装备体系
-  - 四大界域体系（Chaos、Aequor、Caro、Ultra）
-  - 版本线 v1.0→v2.5（含 3 个联动记录）
-  - 世界观设定（8 组织、12 关键角色、主线剧情详细摘要）
-  - 卡牌数据库 cards.json
-  - 关卡掉落表 stages.json
-  - 多语言术语翻译 translations.json（zh/en/ja）
-  - 角色语音框架 voice_lines.json（10 角色，待补充实际台词）
-  - content_database.json 技能数据已整合到 characters.json
-- **已删除**：tier 评级字段（非项目关注点）
-- **自动化抓取（外部合成数据旧链，2026-06 PR #253 整套退役删除）**：原 11 个外部抓取/生成脚本
-  （`fetch_portraits/skills/cards/stats/stages/wheels/lore/voice_lines/steam_assets.py`、
-  `extract_game_data.py`、`generate_pages.py`）+ `fetch-wiki-data.yml` workflow 已随
-  「退役外部合成数据旧链、wiki 改用客户端解包数据」一并删除。理由：Fandom/GameKee 等外部源
-  为合成/二手数据，与 W2「以 `data/extracted/` 一手解包字段为唯一数据源」纪律冲突。
-  - 现存留 `projects/wiki/scripts/`：解包链 `decrypt_and_extract.py` / `extract_client_data.py`、
-    索引构建 `build_banner_character_index.py` / `build_drop_index.py`、`generate_rss.py`、
-    `check_version.py`、`validate_data.py`（精确清单以 `ls projects/wiki/scripts/` 为准）
+
+> **重大状态变更（2026-06）**：原 `data/db/` 结构化层（characters.json 全 6 JSON + 派生页）
+> 已于 **2026-06-15 守密人裁定整层清空**（原 24/72 全为 partial/fixture 占位、长期误导）；
+> 外部合成数据抓取链（fetch_* 等）已于 **PR #253 整套退役删除**。本节下方凡涉及
+> `data/db/` 旧内容 / 24-72 自举进度 / Fandom 抓取的描述均为**清空前历史记录**，现行以本框为准。
+
+- **现行数据源（唯一）**：`projects/wiki/data/extracted/categorized/character_data.txt`
+  （客户端一手解包字段）；角色真实总数 **72**（含皮肤/联动/彩蛋）
+- **W2 任务**：以解包字段重建可信 `characters` 基线（**禁用合成占位**），再接回数据桥与生成页；
+  真实缺口见 `memory/wiki-phase-2-gap-inventory.md`，进度以本档「子项目状态」为准
+- **现存解包/索引脚本**（`projects/wiki/scripts/`）：`decrypt_and_extract.py` / `extract_client_data.py` /
+  `build_banner_character_index.py` / `build_drop_index.py` / `generate_rss.py` / `check_version.py` /
+  `validate_data.py`（精确清单以 `ls` 为准）
+- **已退役（PR #253）**：11 个外部抓取/生成脚本（`fetch_portraits/skills/cards/stats/stages/wheels/lore/voice_lines/steam_assets.py`、
+  `extract_game_data.py`、`generate_pages.py`）+ `fetch-wiki-data.yml` workflow，理由：外部源为合成/二手数据，与「一手解包为唯一源」纪律冲突
 
 ### Wiki 站点
-- **已完成**：
-  - VitePress 站点框架、三语言结构（ZH/EN/JA）
-  - 模板页面脚手架（数量随 Phase 2 基线自举后重新生成）
-  - 约 580+ 页 Markdown 内容（ZH 193 + EN 198 + JA 197 页，基于早期假数据生成，Phase 2 需重跑 generate_pages.py）
-  - 内容完成度：**基线缺失，真实缺口详见 `memory/wiki-phase-2-gap-inventory.md`**
-  - 加权总完成度原声称 83%，B3 调研（2026-04-20）揭露：characters.json 从未存在，该数据不可信
-  - Phase 2 达到 90% 需要：先自举 characters.json（72 角色最小骨架）→ 再触发 fetch-wiki-data workflow 抓取技能/命轮/立绘
-  - 11 个 Vue 交互组件（全部已注册到 theme）：
-    - CharacterGrid（角色筛选/排序）— 已嵌入唤醒体索引页
-    - CharacterCompare（角色对比）
-    - WheelList（命轮筛选列表）— 已嵌入命轮索引页
-    - GachaSimulator（抽卡模拟器）
-    - TeamBuilder（队伍搭配器）
-    - DamageCalculator（伤害计算器）
-    - FarmingPlanner（素材规划器）
-    - StaminaTracker（体力追踪器）
-    - UpdateTimeline（版本时间线）— 已嵌入更新记录页
-    - ChangelogFeed（最近变更）— 已嵌入更新记录页
-    - VoiceLines（语音台词展示）
-  - SEO 优化：Schema.org JSON-LD、OG 社交分享图、sitemap、robots.txt
-  - RSS/Atom 订阅源
-  - 贡献指南 contributing.md
-- **技术栈**：VitePress 1.6.4 + Vue 3.5.13
-- **部署**：由 Code-site 统一管理（deploy-site.yml），wiki 位于 /wiki/ 子路径
-- **已修复问题**（2026-03-30）：
-  - `cleanUrls: false` — GitHub Pages 不支持无扩展名 URL 重写
-  - 立绘路径用 `:src` 动态绑定避免 Vite import 错误
-  - YAML frontmatter 含冒号自动引号转义
-  - VoiceLines 组件已注册到 theme
-  - deploy-site.yml smoke test 适配 zh root locale 路径
+
+- **现状（2026-06-21 实测）**：VitePress 站点框架在；Markdown 页面 **约 86 个**（脚手架 + 索引页 +
+  1 个 Pandia fixture 角色页 `docs/zh/awakeners/pandia.md`）——原「约 580+ 页（ZH/EN/JA 三语全量）」
+  系清空前基于早期假数据生成，已随结构化层清空大幅缩减
+- **数据桥**：`docs/.vitepress/theme/data/characters.ts` 现导出空数组（保留类型/组件脚手架，
+  W2 重建基线后接回），VitePress 构建已验证通过（BUILD_OK）
+- **Vue 组件（约 12 个，2026-06 重建集，角色数据展示向）**：CharacterGrid / CharacterInfobox /
+  CharacterSheet / SkillTable / TrinketRecommendationCard / AscensionMaterialBlock / BondRewardList /
+  StatGrowthChart / AffinityTags / PortraitGallery / VoiceLineList / FixtureBadge（精确以
+  `ls docs/.vitepress/theme/components/` 为准）。**原列的 GachaSimulator/TeamBuilder/DamageCalculator
+  等计算器/模拟器组件已不在当前组件集**
+- **技术栈**：VitePress 1.6.4 + Vue 3.5.13；**部署**：Code-site 统一管理（`deploy-site.yml`），wiki 在 `/wiki/` 子路径
+- 详细开发上下文与 milestone 见 `projects/wiki/CONTEXT.md`
 
 ## Game 衍生游戏
 

--- a/projects/game/CONTEXT.md
+++ b/projects/game/CONTEXT.md
@@ -37,7 +37,7 @@
 - [ ] 后续：更多唤醒体 / 武器进化树 / 真实立绘接入 / 音效
 
 ## 依赖
-- `projects/wiki/data/db/characters.json` — 角色数据（已建立，当前 24/72 角色，Phase 2 补齐中。Phase 4 启动前应已齐 72）
+- 角色数据 — 现行源 `projects/wiki/data/extracted/categorized/character_data.txt`（一手解包，72 角色）。**原 `projects/wiki/data/db/characters.json` 结构化层 2026-06-15 已清空，W2 重建中**，Phase 4 启动前应已齐 72
 - `projects/game/config/game-config.json` — 游戏配置（本项目产出，待创建）
 - `assets/images/` — 图片素材
 

--- a/projects/news/CONTEXT.md
+++ b/projects/news/CONTEXT.md
@@ -37,7 +37,7 @@
 - [ ] Reddit 子版块名确认（r/Morimens 是否存在）
 - [ ] Twitter / NGA / TapTap 配置密钥（如 Phase 2 优先级允许）
 - [ ] 周报/月报机制（日报之上叠加趋势分析）
-- [ ] 黑池接口规范文档对齐（参考 `memory/silver-blackpool-interface.md`）
+- [ ] 黑池接口规范文档对齐（参考 `memory/active/silver-blackpool-interface.md`）
 
 ### M3 稳定化（6-11 → 7-10，30 天）
 - [ ] 自动化连续 30 天稳定运行验证

--- a/projects/site/CONTEXT.md
+++ b/projects/site/CONTEXT.md
@@ -29,7 +29,7 @@
 ## 职责范围
 
 Code-site 会话负责：
-- **主站导航页** (`site/index.html`)：项目入口，连接 Wiki / News / Game 三个子站
+- **主站导航页** (`projects/site/public/index.html`)：项目入口，连接 Wiki / News / Game 三个子站
 - **统一部署流水线** (`.github/workflows/deploy-site.yml`)：构建并发布整个 GitHub Pages 站点
 - **跨站视觉一致性**：确保各子站风格与 `memory/style-guide.md` 协调
 - **交互体验优化**：响应式布局、动画效果、用户体验


### PR DESCRIPTION
## 背景

守密人指示「继续」。本轮把审计延伸到**状态权威 Wiki 段** + **动手前必读的子项目 `CONTEXT.md`**，继续清「文档声称、实现层已删/已变」。

## project-status.md「Wiki 数据集 + 站点」整段失真（实测对照）

| 旧描述 | 实测真相（2026-06-21） |
|--------|------------------------|
| 约 580+ 页（ZH193+EN198+JA197）| **86 页**（脚手架 + 索引 + 1 个 Pandia fixture 角色页）|
| 11 Vue 交互组件：GachaSimulator / TeamBuilder / DamageCalculator / FarmingPlanner / StaminaTracker … | **全不存在**；实为 12 个角色数据展示组件的重建集（仅 CharacterGrid 重叠）|
| db/characters.json 24/72 自举 | 6-15 整层清空，现行源 `data/extracted` 一手解包 |

整段重写为「通栏免责声明 + 实测现状框」，旧进度明确标为清空前历史记录。

> 小学生比喻：宣传册印着「本馆 580 间展厅、配抽卡机/伤害计算器」，实地一看只有 86 间、且展品全换成了角色资料展板——把宣传册改成跟现场一致。

## CONTEXT.md 死链（按各档目录正确解析后核实）

| 档 | 死链 | 修正 |
|----|------|------|
| news | `memory/silver-blackpool-interface.md` | → `memory/active/`（文件已移位）|
| game | `db/characters.json`「已建立 24/72」| → 6-15 清空注 + 解包源 |
| site | `site/index.html` | → `projects/site/public/index.html`（精度）|

`wiki/CONTEXT.md` 死链最多，但已有通栏退役免责声明（L10/L18 明示「下文 db/ 自举 / generate_pages 描述均为退役旧链历史记录」），属诚实自标的历史层，**按标准保留不 churn**。

## 纪律

每处「已删/已变」前先核实存在性；Vue 组件清单与 `ls` 实测逐一核对一致。决策一致性 C1-C5 / `test_claude_md` 路径对账均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNakXvaGxHXTED12dJTghr)_