### PR TITLE
归档引擎补 month_from_parent_dir 分桶（fanart 可纯配置接入）

### DIFF
--- a/projects/news/scripts/archive_engine.py
+++ b/projects/news/scripts/archive_engine.py
@@ -19,7 +19,8 @@
 统一索引: projects/news/data/releases-index.json（自动生成，治「Release 好难认」）
 
 来源配置字段: base_dir(来源根目录) / glob(文件匹配) / group_by(分桶:
-month_from_stem 按文件名 YYYY-MM-DD 取 YYYY-MM | single) / group_label(single 桶名) /
+month_from_stem 按文件名 YYYY-MM-DD 取 YYYY-MM | month_from_parent_dir 按父目录名
+YYYY-MM-DD 取 YYYY-MM（日期在目录名，如 fanart）| single) / group_label(single 桶名) /
 cutoff_days(仅归档早于 N 天; null=不限龄) / tag_template/title_template/notes_template
 (Release 模板, 占位 {group}/{filename}/{size_kb}/{files}) / after_archive(git_rm|keep) /
 clean_empty_dirs(归档后清理空目录)。
@@ -56,6 +57,8 @@ def group_of(path: Path, group_by: str, group_label: str) -> str:
     """文件归属哪个桶。"""
     if group_by == 'month_from_stem':
         return path.stem[:7]  # YYYY-MM-DD -> YYYY-MM
+    if group_by == 'month_from_parent_dir':
+        return path.parent.name[:7]  # 父目录 YYYY-MM-DD -> YYYY-MM（日期在目录名，如 fanart）
     if group_by == 'single':
         return group_label
     raise ValueError(f'unknown group_by: {group_by}')
@@ -67,6 +70,8 @@ def is_eligible(path: Path, group_by: str, cutoff_date: str | None) -> bool:
         return True
     if group_by == 'month_from_stem':
         return path.stem < cutoff_date  # 与原 archive_discord 逐字节等价
+    if group_by == 'month_from_parent_dir':
+        return path.parent.name < cutoff_date  # 父目录 YYYY-MM-DD 逐字节比较
     # 无日期语义的来源不应配 cutoff_days；保守判为可归档
     return True
 
@@ -82,6 +87,8 @@ def discover(cfg: dict, base_dir: Path, force_groups: list[str]) -> dict[str, li
     if force_groups:
         wanted = set(force_groups)
         for f in base_dir.glob(cfg['glob']):
+            if not f.is_file():  # glob 可能命中目录（如 fanart 的 thumbs/），只归档文件
+                continue
             g = group_of(f, group_by, group_label)
             if g in wanted:
                 groups[g].append(f)
@@ -93,6 +100,8 @@ def discover(cfg: dict, base_dir: Path, force_groups: list[str]) -> dict[str, li
             cutoff_date = cutoff.strftime('%Y-%m-%d')
             logger.info(f'Cutoff date: {cutoff_date} ({cutoff_days} days ago)')
         for f in base_dir.glob(cfg['glob']):
+            if not f.is_file():  # glob 可能命中目录（如 fanart 的 thumbs/），只归档文件
+                continue
             if is_eligible(f, group_by, cutoff_date):
                 groups[group_of(f, group_by, group_label)].append(f)
     return dict(sorted(groups.items()))

--- a/tests/test_archive_engine.py
+++ b/tests/test_archive_engine.py
@@ -50,6 +50,17 @@ class GroupingAndCutoff(unittest.TestCase):
     def test_is_eligible_no_cutoff(self):
         self.assertTrue(ae.is_eligible(Path("a/whatever.jsonl"), "month_from_stem", None))
 
+    def test_group_of_month_from_parent_dir(self):
+        # 日期在父目录名（如 fanart：2026-05-29/pixiv_x.jpg），文件名 stem 无日期
+        p = Path("fanart/2026-05-29/pixiv_efad328a8f.jpg")
+        self.assertEqual(ae.group_of(p, "month_from_parent_dir", "all"), "2026-05")
+
+    def test_is_eligible_parent_dir_cutoff(self):
+        old = Path("fanart/2026-03-01/x.jpg")
+        new = Path("fanart/2026-06-10/x.jpg")
+        self.assertTrue(ae.is_eligible(old, "month_from_parent_dir", "2026-04-22"))
+        self.assertFalse(ae.is_eligible(new, "month_from_parent_dir", "2026-04-22"))
+
 
 class Discover(unittest.TestCase):
     def setUp(self):
@@ -81,6 +92,49 @@ class Discover(unittest.TestCase):
 
     def test_missing_base_dir_returns_empty(self):
         self.assertEqual(ae.discover(self._cfg(), self.base / "nope", []), {})
+
+
+class ParentDirLayoutAndFileGuard(unittest.TestCase):
+    """fanart 式布局：日期在目录名 + thumbs/ 子目录须被 is_file 护栏滤掉。"""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmp.name)
+        for day in ("2026-05-12", "2026-06-01"):
+            _touch(self.base / day / "pixiv_a.jpg")
+            _touch(self.base / day / "discord_b.png")
+            _touch(self.base / day / "thumbs" / "pixiv_a.jpg")  # 缩略图不该被归档
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _cfg(self, **over):
+        cfg = {"glob": "20*/*", "group_by": "month_from_parent_dir", "cutoff_days": None}
+        cfg.update(over)
+        return cfg
+
+    def test_groups_by_parent_dir_and_excludes_thumbs(self):
+        groups = ae.discover(self._cfg(), self.base, [])
+        self.assertEqual(set(groups), {"2026-05", "2026-06"})
+        # 每月仅 2 个顶层图；thumbs/ 子目录文件深一层不被 glob 命中
+        self.assertEqual(len(groups["2026-05"]), 2)
+        self.assertEqual({p.name for p in groups["2026-05"]}, {"pixiv_a.jpg", "discord_b.png"})
+
+    def test_glob_yielding_dir_is_skipped(self):
+        # glob '20*/*' 会命中 thumbs 目录本身，is_file 护栏须跳过它
+        self.assertTrue(any(p.is_dir() for p in self.base.glob("20*/*")))
+        groups = ae.discover(self._cfg(), self.base, [])
+        self.assertTrue(all(p.is_file() for ps in groups.values() for p in ps))
+
+    def test_parent_dir_cutoff_filters_recent(self):
+        # cutoff 仅留早于阈值的目录（2026-06-01 比 2026-05-12 新，被滤）
+        groups = ae.discover(self._cfg(cutoff_days=None), self.base, [])
+        self.assertEqual(set(groups), {"2026-05", "2026-06"})
+        # 用 is_eligible 直接验证父目录比较
+        f_old = self.base / "2026-05-12" / "pixiv_a.jpg"
+        f_new = self.base / "2026-06-01" / "pixiv_a.jpg"
+        self.assertTrue(ae.is_eligible(f_old, "month_from_parent_dir", "2026-05-30"))
+        self.assertFalse(ae.is_eligible(f_new, "month_from_parent_dir", "2026-05-30"))
 
 
 class Tarball(unittest.TestCase):


### PR DESCRIPTION
## 概要

补完归档引擎「零代码加来源」的能力缺口：让**日期写在父目录名**的来源（如 fanart：`2026-05-29/pixiv_x.jpg`，文件名 stem 无日期）也能纯配置接入。上轮测试发现的边界1。

## 改动（仅 2 文件，engine +11 行 / test +54 行）

- `group_of` / `is_eligible`：加 `month_from_parent_dir` 分支——按 `path.parent.name` 取 `YYYY-MM`，cutoff 逐字节比较父目录日期。
- `discover`：加 `is_file()` 护栏——glob 命中目录（如 fanart 的 `thumbs/` 缩略图子目录）时跳过，只归档文件。
- 5 个新单测：父目录分桶 / 父目录 cutoff / thumbs 排除 / glob 命中目录被跳过。

## 不做的事（留守密人裁定）

`archive_sources.json` **未加 fanart 条目**——fanart 的 cutoff 天数、归档后是否 `git_rm` 删原图，属运营决策。本 PR 只补**能力**，注册策略待守密人定。

## 验证

- `pytest` = **41 passed**（原 36 + 新 5），discord 回归零破坏。
- 真实 fanart 临时注册 dry-run（验毕已还原）：**596** 文件 / 2 组（2026-05: 430 / 2026-06: 166），与独立统计的「顶层非 thumbs 文件数 596」逐一吻合——证明父目录分桶正确、thumbs 被护栏干净排除。
- 2 文件经 blob SHA 校验逐字节落地；注册表 blob 与 main 一致（确认未动）。

本环境 git push 被代理 HTTP 413 封死（lesson #28），经 GitHub API 落地。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqMQy1qYm9R3ieLjfnLTnM)_