### PR TITLE
feat(archive): 滚动单 release 模式 + 合并 workflow（四分类整理 第一步）

### DIFF
--- a/.github/workflows/consolidate-releases.yml
+++ b/.github/workflows/consolidate-releases.yml
@@ -1,0 +1,134 @@
+name: Consolidate Releases
+
+# 把多个零散 release 合并归入一个目标 release（四分类整理：解包数据 / 解包资产 /
+# 社区归档数据 / 社区归档资产）。云容器无 release 写权限，故走此 workflow（Actions 内置令牌）。
+#
+# 安全设计：
+#   - 仅 workflow_dispatch 手动触发
+#   - confirm 必须等于 target_tag 才执行
+#   - 资产逐源下载到一个目录，整体上传到目标 release
+#   - 删源前先校验：目标 release 资产数 >= 下载到的资产数，不达标不删源（防丢数据）
+#   - delete_sources 显式开启才删，删除连带 git tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_tag:
+        description: '目标 release tag（如 unpacked-data / community-data / community-assets）'
+        required: true
+      target_title:
+        description: '目标 release 标题'
+        required: true
+      source_tags:
+        description: '并入的源 release tag，逗号分隔'
+        required: true
+      confirm:
+        description: '二次确认：重复键入 target_tag'
+        required: true
+      delete_sources:
+        description: '校验通过后删除源 release + git tag（true/false）'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: write
+
+jobs:
+  consolidate:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Verify confirmation matches target_tag
+        env:
+          T: ${{ github.event.inputs.target_tag }}
+          C: ${{ github.event.inputs.confirm }}
+        run: |
+          if [ "$T" != "$C" ]; then
+            echo "ERROR: confirm ('$C') 与 target_tag ('$T') 不一致，拒绝执行。"
+            exit 1
+          fi
+          echo "确认通过：合并到 '$T'。"
+
+      - uses: actions/checkout@v6
+
+      - name: Download all assets from source releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          SOURCES: ${{ github.event.inputs.source_tags }}
+        run: |
+          mkdir -p merge_assets
+          IFS=',' read -ra TAGS <<< "$SOURCES"
+          for t in "${TAGS[@]}"; do
+            tag="$(echo "$t" | tr -d '[:space:]')"
+            [ -z "$tag" ] && continue
+            echo "===== downloading assets from $tag ====="
+            if ! gh release view "$tag" >/dev/null 2>&1; then
+              echo "ERROR: 源 release '$tag' 不存在，中止。"
+              exit 1
+            fi
+            gh release download "$tag" --dir merge_assets || {
+              echo "ERROR: 下载 '$tag' 失败"; exit 1; }
+          done
+          echo "===== downloaded files ====="
+          ls -la merge_assets
+          count=$(find merge_assets -maxdepth 1 -type f | wc -l)
+          echo "downloaded_count=$count" >> "$GITHUB_ENV"
+          echo "total downloaded assets: $count"
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: 未下载到任何资产，中止。"
+            exit 1
+          fi
+
+      - name: Create or update target release and upload assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TARGET: ${{ github.event.inputs.target_tag }}
+          TITLE: ${{ github.event.inputs.target_title }}
+          SOURCES: ${{ github.event.inputs.source_tags }}
+        run: |
+          NOTES="Consolidated release. 合并自: $SOURCES. 由 consolidate-releases.yml 于 $(date -u +%Y-%m-%d) 生成。"
+          if gh release view "$TARGET" >/dev/null 2>&1; then
+            echo "目标 '$TARGET' 已存在，--clobber 追加资产..."
+            gh release upload "$TARGET" merge_assets/* --clobber
+          else
+            echo "创建目标 release '$TARGET'..."
+            gh release create "$TARGET" merge_assets/* --title "$TITLE" --notes "$NOTES"
+          fi
+
+      - name: Verify target asset count
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TARGET: ${{ github.event.inputs.target_tag }}
+        run: |
+          actual=$(gh release view "$TARGET" --json assets --jq '.assets | length')
+          echo "目标资产数=$actual，下载并入数=$downloaded_count"
+          if [ "$actual" -lt "$downloaded_count" ]; then
+            echo "ERROR: 目标资产数 ($actual) < 并入数 ($downloaded_count)，上传不完整，保留源 release 不删。"
+            exit 1
+          fi
+          echo "校验通过。"
+
+      - name: Delete source releases (only when requested and verification passed)
+        if: ${{ github.event.inputs.delete_sources == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          SOURCES: ${{ github.event.inputs.source_tags }}
+          TARGET: ${{ github.event.inputs.target_tag }}
+        run: |
+          IFS=',' read -ra TAGS <<< "$SOURCES"
+          for t in "${TAGS[@]}"; do
+            tag="$(echo "$t" | tr -d '[:space:]')"
+            [ -z "$tag" ] && continue
+            if [ "$tag" = "$TARGET" ]; then
+              echo "skip: 源与目标同名 ($tag)"
+              continue
+            fi
+            echo "删除源 release + git tag '$tag'..."
+            gh release delete "$tag" --yes --cleanup-tag
+          done
+          echo "源 release 清理完成。"

--- a/projects/news/scripts/archive_engine.py
+++ b/projects/news/scripts/archive_engine.py
@@ -21,9 +21,14 @@
 来源配置字段: base_dir(来源根目录) / glob(文件匹配) / group_by(分桶:
 month_from_stem 按文件名 YYYY-MM-DD 取 YYYY-MM | month_from_parent_dir 按父目录名
 YYYY-MM-DD 取 YYYY-MM（日期在目录名，如 fanart）| single) / group_label(single 桶名) /
-cutoff_days(仅归档早于 N 天; null=不限龄) / tag_template/title_template/notes_template
-(Release 模板, 占位 {group}/{filename}/{size_kb}/{files}) / after_archive(git_rm|keep) /
+cutoff_days(仅归档早于 N 天; null=不限龄) / after_archive(git_rm|keep) /
 clean_empty_dirs(归档后清理空目录)。
+上传两选一：
+  - 滚动单 release（推荐）: release_tag(固定 Release 标签) + asset_template(每桶资产文件名,
+    占位 {group}) + release_title/release_notes(Release 级文案)。所有桶归入同一 release，
+    每桶一资产，--clobber 仅替换本桶不动其它桶。
+  - 旧版每桶一 tag（向后兼容）: tag_template/title_template/notes_template
+    (占位 {group}/{filename}/{size_kb}/{files})。
 """
 
 import argparse
@@ -109,10 +114,16 @@ def discover(cfg: dict, base_dir: Path, force_groups: list[str]) -> dict[str, li
 
 # ---------- 打包 / 上传 / 删除 ----------
 
+def asset_name_of(cfg: dict, group: str) -> str:
+    """归档资产文件名。滚动模式用 asset_template；旧模式沿用 {tag}.tar.gz（向后兼容）。"""
+    if cfg.get('asset_template'):
+        return cfg['asset_template'].format(group=group)
+    return f"{cfg['tag_template'].format(group=group)}.tar.gz"
+
+
 def create_tarball(cfg: dict, base_dir: Path, group: str, files: list[Path]) -> tuple[Path, int]:
     """打 tar.gz；arcname 相对 base_dir（与原 archive_discord 等价）。"""
-    tag = cfg['tag_template'].format(group=group)
-    archive_path = base_dir / f'{tag}.tar.gz'
+    archive_path = base_dir / asset_name_of(cfg, group)
     with tarfile.open(archive_path, 'w:gz') as tar:
         for f in sorted(files):
             tar.add(f, arcname=str(f.relative_to(base_dir)))
@@ -122,12 +133,49 @@ def create_tarball(cfg: dict, base_dir: Path, group: str, files: list[Path]) -> 
 
 
 def upload_to_release(cfg: dict, archive_path: Path, group: str, file_count: int) -> bool:
-    """经 gh CLI 上传到 GitHub Releases。幂等：先删同名 release/tag。"""
+    """经 gh CLI 上传到 GitHub Releases。
+
+    两种模式：
+    - 滚动单 release（配 release_tag）：所有桶归入同一个 release，每桶一资产文件；
+      上传用 `--clobber` 仅替换本桶资产，不动同 release 内其它桶（修「每月一 tag」散乱）。
+    - 旧版每桶一 tag（配 tag_template）：幂等先删同名 release/tag 再 create（向后兼容）。
+    """
     repo = os.environ.get('GITHUB_REPOSITORY', '')
     if not repo:
         logger.error('GITHUB_REPOSITORY not set, cannot upload')
         return False
 
+    release_tag = cfg.get('release_tag')
+    if release_tag:
+        # 滚动模式：确保 release 存在，再以 --clobber 追加/替换本桶单资产。
+        exists = subprocess.run(
+            ['gh', 'release', 'view', release_tag, '--repo', repo],
+            cwd=REPO_ROOT, capture_output=True,
+        ).returncode == 0
+        if not exists:
+            title = cfg.get('release_title', release_tag)
+            notes = cfg.get(
+                'release_notes',
+                'Rolling archive release. Each asset is one bucket; auto-managed by archive_engine.py.',
+            )
+            created = subprocess.run([
+                'gh', 'release', 'create', release_tag,
+                '--title', title, '--notes', notes, '--repo', repo,
+            ], cwd=REPO_ROOT, capture_output=True, text=True)
+            if created.returncode != 0:
+                logger.error(f'Release create failed: {created.stderr}')
+                return False
+        uploaded = subprocess.run([
+            'gh', 'release', 'upload', release_tag, str(archive_path),
+            '--clobber', '--repo', repo,
+        ], cwd=REPO_ROOT, capture_output=True, text=True)
+        if uploaded.returncode == 0:
+            logger.info(f'Uploaded asset {archive_path.name} to rolling release {release_tag}')
+            return True
+        logger.error(f'Asset upload failed: {uploaded.stderr}')
+        return False
+
+    # 旧版每桶一 tag（向后兼容）
     tag = cfg['tag_template'].format(group=group)
     size_kb = archive_path.stat().st_size // 1024
     title = cfg['title_template'].format(group=group)
@@ -204,10 +252,14 @@ def rebuild_releases_index(registry: dict):
         log = load_log(base_dir / 'archive-log.json')
         for entry in log:
             group = entry.get('group') or entry.get('month', '')
+            default_tag = cfg.get('release_tag') or (
+                cfg['tag_template'].format(group=group) if cfg.get('tag_template') else group
+            )
             index.append({
                 'source': entry.get('source', source_id),
                 'group': group,
-                'tag': entry.get('tag', cfg['tag_template'].format(group=group)),
+                'tag': entry.get('tag') or default_tag,
+                'asset': entry.get('asset'),
                 'files': entry.get('files'),
                 'archive_size_bytes': entry.get('archive_size_bytes'),
                 'uploaded_to_releases': entry.get('uploaded_to_releases'),
@@ -265,7 +317,8 @@ def archive_source(source_id: str, cfg: dict, args) -> None:
         log.append({
             'source': source_id,
             'group': group,
-            'tag': cfg['tag_template'].format(group=group),
+            'tag': cfg.get('release_tag') or cfg['tag_template'].format(group=group),
+            'asset': archive_path.name,
             'files': len(files),
             'archive_size_bytes': archive_size,
             'uploaded_to_releases': uploaded,

--- a/projects/news/scripts/archive_sources.json
+++ b/projects/news/scripts/archive_sources.json
@@ -4,9 +4,10 @@
     "glob": "channels/*/*.jsonl",
     "group_by": "month_from_stem",
     "cutoff_days": 60,
-    "tag_template": "discord-archive-{group}",
-    "title_template": "Discord Archive {group}",
-    "notes_template": "Discord message archive for {group}.\n{filename}: {size_kb} KB compressed.",
+    "release_tag": "community-data",
+    "release_title": "Community Archive Data",
+    "release_notes": "社区归档数据滚动 release：每月一个 discord-archive-YYYY-MM.tar.gz 资产，由 archive_engine.py 自动追加（替代旧「每月一 tag」）。",
+    "asset_template": "discord-archive-{group}.tar.gz",
     "after_archive": "git_rm",
     "clean_empty_dirs": true
   }

--- a/tests/test_archive_engine.py
+++ b/tests/test_archive_engine.py
@@ -16,19 +16,23 @@ def _touch(p: Path, content: str = "{}\n"):
 
 
 class RegistryInvariants(unittest.TestCase):
-    """锁住向后兼容：Discord 标签/cutoff/删数据策略不得漂移。"""
+    """锁住 Discord 滚动单 release 设计 + 不漂移的 cutoff/删数据策略。"""
 
-    def test_discord_entry_backward_compatible(self):
+    def test_discord_entry_rolling_release(self):
         cfg = ae.load_registry()["discord"]
-        # 标签必须仍是 discord-archive-YYYY-MM，否则现存 20 个 Release 成孤儿
-        self.assertEqual(cfg["tag_template"], "discord-archive-{group}")
-        self.assertEqual(cfg["title_template"], "Discord Archive {group}")
+        # 滚动单 release：所有月份归入固定标签 community-data
+        self.assertEqual(cfg["release_tag"], "community-data")
+        self.assertEqual(cfg["release_title"], "Community Archive Data")
+        # 资产文件名仍按月，向后兼容旧 discord-archive-YYYY-MM.tar.gz（迁移来的资产同名）
+        self.assertEqual(cfg["asset_template"], "discord-archive-{group}.tar.gz")
+        self.assertEqual(
+            ae.asset_name_of(cfg, "2026-01"), "discord-archive-2026-01.tar.gz"
+        )
+        # 不漂移的策略
         self.assertEqual(cfg["cutoff_days"], 60)
         self.assertEqual(cfg["group_by"], "month_from_stem")
         self.assertEqual(cfg["after_archive"], "git_rm")
         self.assertEqual(cfg["base_dir"], "projects/news/data/discord")
-        # 标签实际渲染等价于原 archive_discord
-        self.assertEqual(cfg["tag_template"].format(group="2026-01"), "discord-archive-2026-01")
 
 
 class GroupingAndCutoff(unittest.TestCase):
@@ -151,6 +155,51 @@ class Tarball(unittest.TestCase):
             # tar 内路径相对 base_dir（与原 archive_discord 一致）
             with tarfile.open(path, "r:gz") as tar:
                 self.assertEqual(tar.getnames(), ["channels/xx/2026-01-01.jsonl"])
+
+
+class RollingUpload(unittest.TestCase):
+    """滚动单 release：不得删整个 release，只 --clobber 替换本桶资产。"""
+
+    def _run_upload(self, view_returncode):
+        cfg = {
+            "release_tag": "community-data",
+            "release_title": "Community Archive Data",
+            "asset_template": "discord-archive-{group}.tar.gz",
+        }
+        calls = []
+
+        def fake_run(cmd, *a, **k):
+            calls.append(cmd)
+            if cmd[:3] == ["gh", "release", "view"]:
+                return mock.Mock(returncode=view_returncode)
+            return mock.Mock(returncode=0, stderr="", stdout="")
+
+        with tempfile.TemporaryDirectory() as d:
+            archive = Path(d) / "discord-archive-2026-05.tar.gz"
+            archive.write_text("x")
+            with mock.patch.dict(ae.os.environ, {"GITHUB_REPOSITORY": "o/r"}), \
+                 mock.patch.object(ae.subprocess, "run", side_effect=fake_run):
+                ok = ae.upload_to_release(cfg, archive, "2026-05", 3)
+        return ok, calls
+
+    def test_existing_release_clobbers_asset_no_delete(self):
+        ok, calls = self._run_upload(view_returncode=0)  # release 已存在
+        self.assertTrue(ok)
+        verbs = [c[:3] for c in calls]
+        self.assertIn(["gh", "release", "view"], verbs)
+        self.assertIn(["gh", "release", "upload"], verbs)
+        # 关键：绝不删整个 release（否则会连带删掉其它月份资产）
+        self.assertNotIn(["gh", "release", "delete"], verbs)
+        upload_cmd = next(c for c in calls if c[:3] == ["gh", "release", "upload"])
+        self.assertIn("--clobber", upload_cmd)
+
+    def test_missing_release_is_created_then_uploaded(self):
+        ok, calls = self._run_upload(view_returncode=1)  # release 不存在
+        self.assertTrue(ok)
+        verbs = [c[:3] for c in calls]
+        self.assertIn(["gh", "release", "create"], verbs)
+        self.assertIn(["gh", "release", "upload"], verbs)
+        self.assertNotIn(["gh", "release", "delete"], verbs)
 
 
 class GitRm(unittest.TestCase):


### PR DESCRIPTION
## 背景

Releases 四分类整理（解包数据 / 解包资产 / 社区归档数据 / 社区归档资产）的**第一步：引擎改造 + 合并工具**。守密人裁定社区归档数据桶「改引擎为滚动单 release」。

## 为什么需要改引擎

排查发现：30 个 `discord-archive-YYYY-MM` 是**归档引擎按月自动新增**的（`tag_template: discord-archive-{group}`）。若只把它们硬合成一个 release，下月引擎照样冒出新月 tag，合并不「粘」。故先改引擎。

## 改动

**引擎（`archive_engine.py`）新增滚动单 release 模式**
- 源配置含 `release_tag` + `asset_template` 时：每个桶（如每月 Discord）作为**一个资产**上传进**同一个固定 release**，用 `gh release upload --clobber` 只替换本桶资产、不动同 release 内其它桶。
- 取代旧的「每月删整 release 再重建」——那会连带删掉其它月。旧版 `tag_template` 每桶一 tag 路径保留（向后兼容）。

**配置（`archive_sources.json`）**：discord 切到 `release_tag=community-data`，资产文件名仍为 `discord-archive-YYYY-MM.tar.gz`（迁移来的旧资产同名，无缝衔接）。

**合并 workflow（`consolidate-releases.yml`，新增）**：把多个源 release 并入一个目标——下载全部资产 → 上传目标 → 校验资产数 → **仅校验通过才删源（连带 git tag）**。带 typed-confirm 守卫。

## 验证

- `tests/test_archive_engine.py` 更新为滚动设计 + 新增覆盖：断言滚动上传用 `--clobber` 且**绝不删共享 release**、release 不存在时先 create 再 upload。
- 本地 `python3 -m unittest tests.test_archive_engine` 全绿（19 项）。全量 656 测试仅剩 2 处**预先存在**的失败（okf 路径，与本改动无关，clean tree 同样失败）。
- YAML / JSON / Python 语法校验通过。
- 解决了与 origin/main `month_from_parent_dir`（fanart）改动的一处文档串冲突，两者并存。

## 后续（合并到 main 后由艾瑞卡触发）

1. `community-data` ← 30 个 discord 月 tag（迁移 + 删旧月 tag）
2. `unpacked-data` ← `game-data-v1` + `lua-bytecode-v1`
3. `community-assets` ← `media-archive-v1`
4. 更新 RELEASES.md 为四分类结构

解包资产 ~10G 桶按守密人意「随后」处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nDtfQT5VHH3faWPyxDy11

---
_Generated by [Claude Code](https://claude.ai/code/session_013nDtfQT5VHH3faWPyxDy11)_