### PR TITLE
正式接入 fanart 归档（60天 cutoff + git_rm，滚动 community-assets）

### DIFF
--- a/.github/workflows/fanart-archive.yml
+++ b/.github/workflows/fanart-archive.yml
@@ -1,0 +1,70 @@
+name: Fanart Archive
+
+on:
+  schedule:
+    # Monthly cleanup: 1st of each month at 06:30 UTC
+    # (offset from Discord Archive's 06:00 to avoid concurrent push races on main)
+    - cron: '30 6 1 * *'
+  workflow_dispatch:
+    inputs:
+      force_group:
+        description: 'YYYY-MM to archive (bypasses 60-day cutoff). Comma-separated for multiple.'
+        required: false
+        default: ''
+
+concurrency:
+  group: fanart-archive-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  archive:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r projects/news/requirements.txt
+
+      - name: Archive fan-art to Releases (old originals → community-assets, git_rm)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          FORCE_GROUP_INPUT: ${{ github.event.inputs.force_group }}
+        run: |
+          FLAGS="--source fanart"
+          if [ -n "$FORCE_GROUP_INPUT" ]; then
+            IFS=',' read -ra GROUPS <<< "$FORCE_GROUP_INPUT"
+            for g in "${GROUPS[@]}"; do
+              g_trimmed="$(echo "$g" | tr -d '[:space:]')"
+              [ -n "$g_trimmed" ] && FLAGS="$FLAGS --force-group $g_trimmed"
+            done
+          fi
+          echo "Running: python projects/news/scripts/archive_engine.py $FLAGS"
+          python projects/news/scripts/archive_engine.py $FLAGS
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add projects/news/data/fanart/ projects/news/data/releases-index.json
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: monthly fan-art cleanup — old originals moved to Releases [skip ci]"
+            for i in 1 2 3 4; do
+              git pull --rebase origin main && git push origin main && exit 0
+              echo "Push attempt $i failed, retrying in ${i}s..."
+              sleep $i
+            done
+            echo "All push attempts failed"
+            exit 1
+          fi

--- a/projects/news/scripts/archive_sources.json
+++ b/projects/news/scripts/archive_sources.json
@@ -10,5 +10,17 @@
     "asset_template": "discord-archive-{group}.tar.gz",
     "after_archive": "git_rm",
     "clean_empty_dirs": true
+  },
+  "fanart": {
+    "base_dir": "projects/news/data/fanart",
+    "glob": "20*/*",
+    "group_by": "month_from_parent_dir",
+    "cutoff_days": 60,
+    "release_tag": "community-assets",
+    "release_title": "Community Archive Assets",
+    "release_notes": "社区归档资产滚动 release：每月一个 fanart-archive-YYYY-MM.tar.gz 资产（同人图原图 + 当日 gallery_manifest），由 archive_engine.py 自动追加。缩略图 thumbs/ 留 git 作轻量预览。",
+    "asset_template": "fanart-archive-{group}.tar.gz",
+    "after_archive": "git_rm",
+    "clean_empty_dirs": false
   }
 }

--- a/tests/test_archive_engine.py
+++ b/tests/test_archive_engine.py
@@ -34,6 +34,19 @@ class RegistryInvariants(unittest.TestCase):
         self.assertEqual(cfg["after_archive"], "git_rm")
         self.assertEqual(cfg["base_dir"], "projects/news/data/discord")
 
+    def test_fanart_entry_rolling_release(self):
+        cfg = ae.load_registry()["fanart"]
+        # 守密人 2026-06-21 裁定：60 天 cutoff + git_rm 删原图
+        self.assertEqual(cfg["base_dir"], "projects/news/data/fanart")
+        self.assertEqual(cfg["glob"], "20*/*")
+        self.assertEqual(cfg["group_by"], "month_from_parent_dir")
+        self.assertEqual(cfg["cutoff_days"], 60)
+        self.assertEqual(cfg["after_archive"], "git_rm")
+        # 图片资产归「社区归档资产」滚动 release（与 discord 文本数据的 community-data 分开）
+        self.assertEqual(cfg["release_tag"], "community-assets")
+        self.assertEqual(cfg["asset_template"], "fanart-archive-{group}.tar.gz")
+        self.assertEqual(ae.asset_name_of(cfg, "2026-05"), "fanart-archive-2026-05.tar.gz")
+
 
 class GroupingAndCutoff(unittest.TestCase):
     def test_group_of_month_from_stem(self):
@@ -199,30 +212,6 @@ class RollingUpload(unittest.TestCase):
         verbs = [c[:3] for c in calls]
         self.assertIn(["gh", "release", "create"], verbs)
         self.assertIn(["gh", "release", "upload"], verbs)
-        self.assertNotIn(["gh", "release", "delete"], verbs)
-
-
-class GitRm(unittest.TestCase):
-    def test_git_rm_called_per_file(self):
-        files = [Path("/repo/a.jsonl"), Path("/repo/b.jsonl")]
-        with mock.patch.object(ae.subprocess, "run") as run:
-            run.return_value = mock.Mock(returncode=0)
-            removed = ae.git_rm_files(files)
-        self.assertEqual(removed, 2)
-        self.assertEqual(run.call_count, 2)
-        # 确实调用的是 git rm -f
-        first = run.call_args_list[0].args[0]
-        self.assertEqual(first[:3], ["git", "rm", "-f"])
-
-    def test_git_rm_untracked_falls_back_to_unlink(self):
-        with tempfile.TemporaryDirectory() as d:
-            f = Path(d) / "x.jsonl"
-            f.write_text("x")
-            err = ae.subprocess.CalledProcessError(1, "git")
-            with mock.patch.object(ae.subprocess, "run", side_effect=err):
-                removed = ae.git_rm_files([f])
-            self.assertEqual(removed, 1)
-            self.assertFalse(f.exists())  # 已 unlink
 
 
 class DryRun(unittest.TestCase):

--- a/tests/test_archive_engine.py
+++ b/tests/test_archive_engine.py
@@ -212,6 +212,30 @@ class RollingUpload(unittest.TestCase):
         verbs = [c[:3] for c in calls]
         self.assertIn(["gh", "release", "create"], verbs)
         self.assertIn(["gh", "release", "upload"], verbs)
+        self.assertNotIn(["gh", "release", "delete"], verbs)
+
+
+class GitRm(unittest.TestCase):
+    def test_git_rm_called_per_file(self):
+        files = [Path("/repo/a.jsonl"), Path("/repo/b.jsonl")]
+        with mock.patch.object(ae.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0)
+            removed = ae.git_rm_files(files)
+        self.assertEqual(removed, 2)
+        self.assertEqual(run.call_count, 2)
+        # 确实调用的是 git rm -f
+        first = run.call_args_list[0].args[0]
+        self.assertEqual(first[:3], ["git", "rm", "-f"])
+
+    def test_git_rm_untracked_falls_back_to_unlink(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "x.jsonl"
+            f.write_text("x")
+            err = ae.subprocess.CalledProcessError(1, "git")
+            with mock.patch.object(ae.subprocess, "run", side_effect=err):
+                removed = ae.git_rm_files([f])
+            self.assertEqual(removed, 1)
+            self.assertFalse(f.exists())  # 已 unlink
 
 
 class DryRun(unittest.TestCase):


### PR DESCRIPTION
## 概要

守密人 2026-06-21 裁定**正式接入 fanart 归档**：60 天 cutoff + git_rm 删原图，腾出 **574MB** 工作树空间（11MB thumbs 缩略图留 git 作旧报告轻量预览）。

## 改动（3 文件，纯新增）

- `archive_sources.json`：加 `fanart` 条目（`month_from_parent_dir` 分桶 + `glob: 20*/*` 排除 thumbs/）。
- `.github/workflows/fanart-archive.yml`：月度归档工作流（仿 discord-archive，06:30 错峰避推送竞争 + `force_group` 手动派发）。CI 内跑引擎——云容器无 gh CLI 不能本地传 Release。
- `tests/test_archive_engine.py`：加 fanart 注册守护测试（锁运营参数 + `asset_name_of` 渲染）。

## ⚠ 需守密人复核的架构判断：release 归类

main 已被 #299 重构为**滚动单 release**。按 #299 consolidate-releases 的四分类（解包数据 / 解包资产 / **社区归档数据** / **社区归档资产**），fanart 是**图片资产** → 归 `community-assets`（与 discord 文本数据的 `community-data` 分开）。这是与 #299 taxonomy 一致的原则选择；若守密人想让 fanart 也并入 `community-data`，改一行 `release_tag` 即可。

## 当前不会立即归档（基础设施先就位）

fanart 数据只跨 40 天（2026-05-12 → 06-19），60 天 cutoff 下默认 dry-run = `nothing to archive`。待 2026-05 数据满 60 天（约 7 月中）自动生效。`force_group 2026-05` 可手动提前归档（验证得 430 文件/356MB）。

## 验证

- `pytest` = **20 passed**（原 19 + fanart 守护测试）。
- force-group 2026-05 dry-run：430 文件/356MB；默认 60 天 cutoff 暂不归档；`asset_name_of` → `fanart-archive-2026-05.tar.gz` @ `community-assets`。
- JSON/YAML 合法；3 文件经 blob SHA 校验逐字节落地（其中 test 文件首推转录漏 24 行被 blob 校验拦截、已补回 #299 既有 GitRm/clobber 断言）。

## 过程说明

沿用旧分支前发现 main 已被 #299 重构，旧版基于过时 `tag_template` schema，**已废弃旧改动、基于最新 main 按新滚动 schema 重做**，避免回退 #299。

本环境 git push 被代理 HTTP 413 封死（lesson #28），经 GitHub API 落地。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqMQy1qYm9R3ieLjfnLTnM)_