### PR TITLE
feat(ci): delete-release 支持清理悬空 git tag

### DIFF
--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -55,24 +55,41 @@ jobs:
           TAG: ${{ github.event.inputs.tag }}
         run: |
           echo "===== Release to be deleted: $TAG ====="
-          if ! gh release view "$TAG"; then
-            echo "ERROR: release '$TAG' 不存在（可能已删）。无需操作。"
-            exit 1
+          if gh release view "$TAG"; then
+            echo "release_exists=true" >> "$GITHUB_ENV"
+          else
+            echo "release '$TAG' 不存在（可能已删）；若 cleanup_tag=true 将仅清理悬空 git tag。"
+            echo "release_exists=false" >> "$GITHUB_ENV"
           fi
 
-      - name: Delete release
+      - name: Delete release and/or dangling git tag
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ github.event.inputs.tag }}
           CLEANUP_TAG: ${{ github.event.inputs.cleanup_tag }}
         run: |
-          if [ "$CLEANUP_TAG" = "true" ]; then
-            echo "删除 release 并连带删除 git tag '$TAG'..."
-            gh release delete "$TAG" --yes --cleanup-tag
+          if [ "$release_exists" = "true" ]; then
+            if [ "$CLEANUP_TAG" = "true" ]; then
+              echo "删除 release 并连带删除 git tag '$TAG'..."
+              gh release delete "$TAG" --yes --cleanup-tag
+            else
+              echo "删除 release '$TAG'（保留 git tag）..."
+              gh release delete "$TAG" --yes
+            fi
           else
-            echo "删除 release '$TAG'（保留 git tag）..."
-            gh release delete "$TAG" --yes
+            if [ "$CLEANUP_TAG" = "true" ]; then
+              echo "无 release，直接删除悬空 git tag '$TAG'..."
+              if gh api -X DELETE "repos/$GH_REPO/git/refs/tags/$TAG"; then
+                echo "悬空 tag '$TAG' 已删除。"
+              else
+                echo "ERROR: 删除 git tag '$TAG' 失败（可能 tag 也不存在）。"
+                exit 1
+              fi
+            else
+              echo "ERROR: release '$TAG' 不存在且 cleanup_tag=false，无可删对象。"
+              exit 1
+            fi
           fi
 
       - name: Verify deletion (expect 404)
@@ -80,10 +97,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ github.event.inputs.tag }}
+          CLEANUP_TAG: ${{ github.event.inputs.cleanup_tag }}
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "ERROR: release '$TAG' 删除后仍可访问，校验失败。"
             exit 1
           fi
-          echo "校验通过：release '$TAG' 已不存在（404）。"
+          if [ "$CLEANUP_TAG" = "true" ] && gh api "repos/$GH_REPO/git/refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "ERROR: git tag '$TAG' 删除后仍存在，校验失败。"
+            exit 1
+          fi
+          echo "校验通过：release '$TAG' 已不存在（404），git tag 亦已清理。"
           echo "提醒：删除后请把 RELEASES.md 中该行从藏宝图移除。"


### PR DESCRIPTION
## 背景

四分类整理「清理」项：`art-assets-v1` 的 release 已于 2026-06-21 删除，但 git tag 仍悬空指向 `3c4ae7d`。云容器 `git push --delete` 删 tag 被 403 拒（无 ref 写权限），原 `delete-release.yml` 又在「release 不存在」时直接报错退出，无法清理纯悬空 tag。

## 改动

`delete-release.yml` 增强：
- 元数据步骤不再因 release 缺失而硬退出，改记 `release_exists` 标志。
- 删除步骤：release 存在走原 `gh release delete`；release 不存在但 `cleanup_tag=true` 时，直接 `gh api -X DELETE git/refs/tags/<tag>` 删悬空 tag。
- 校验步骤额外确认 tag ref 已消失。

向后兼容：原「删 release + 连带 tag」路径不变。

## 用途

合并后触发该 workflow（tag=`art-assets-v1`, confirm=`art-assets-v1`, cleanup_tag=true）清掉悬空 tag。也可复用于未来任何「网页删了 release 但 tag 残留」的情况。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nDtfQT5VHH3faWPyxDy11

---
_Generated by [Claude Code](https://claude.ai/code/session_013nDtfQT5VHH3faWPyxDy11)_