### PR TITLE
docs: 对冲缺口闭合记录（channels/ 3.3G→600M，缺口已诊断+排空）

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -64,7 +64,7 @@
 
 ### 2.3 社区归档数据（community-data，§4.1 全量保全）
 
-- 单个滚动 release `community-data`：**30 个月** `discord-archive-{YYYY-MM}.tar.gz`（2023-11 ~ 2026-04），共 ~6.6 MB。
+- 单个滚动 release `community-data`：**30 个月** `discord-archive-{YYYY-MM}.tar.gz`（2023-11 ~ 2026-04），共 ~287 MB（2026-06-21 排空时由 force-month 重归档为含回填补全的更全版本，较初版 6.6 MB 大幅充实）。
 - 由归档引擎 `archive_engine.py`（`archive_sources.json` 的 discord 条目，`release_tag: community-data`）**每月自动追加一个资产**（`gh release upload --clobber`，只替换当月不动其它月），取代旧「每月一 tag」。
 - github-actions[bot] 经 `discord-archive.yml` 触发。
 
@@ -83,10 +83,11 @@
   - `community-assets` ← media-archive-v1
 - **引擎改造**：discord / fanart 归档切换为滚动单 release 模式，未来周期自动并入对应桶，不再散落新 tag。
 - **完整性核对**：`community-data` 实测 30 资产（2023-11 → 2026-04 连续无断档）✓；`unpacked-assets` 实测 15 资产、约 10.7 GB ✓；所有旧源 tag + 悬空 tag `art-assets-v1` 均已删（404 核实）。
+- **对冲缺口闭合（repo-slimming-plan §4）**：历史回填曾每小时把已归档月 jsonl 拉回 git（与月清理对冲，致 channels/ 3.3G 虚胖）。根因修复（`discord_archiver.py` 加「已归档月跳过」守卫）已在 main 生效；2026-06-21 force-month 一次性排空 30 个已归档月，channels/ 12,803→1,882 文件、3.3G→600M，仅留近月 2026-05/06（未够龄）。
 
 ## 四、治理待办
 
-- **已知缺口（非 release 本身）**：归档标记成功但 git 主数据仍在（见 `memory/strategy/repo-slimming-plan.md` §4），待诊断。
+- **（已闭合 2026-06-21）** 归档标记成功但 git 主数据仍在的对冲缺口——根因（历史回填无「已归档月跳过」）已修复 + 30 月存量已排空，详见 §三 末条与 `memory/strategy/repo-slimming-plan.md` §4。当前无未决治理项。
 
 ## 五、如何取用
 

--- a/memory/strategy/repo-slimming-plan.md
+++ b/memory/strategy/repo-slimming-plan.md
@@ -37,13 +37,17 @@
 
 落实决策 179 的代码**早已写好并跑过**。初版方案「决策 179/199 从未写脚本」论断作废。
 
-## 4. 真实缺口（待诊断，非本次范围）
+## 4. 真实缺口（2026-06-21 已闭合）
 
-归档日志标记 2023-11~2026-04 已上传并应删 git，但 `channels/` 里这些月的 jsonl **仍在**（2023-12 至 2025-07+，每月百余文件，构成 3.1G）。
+归档日志标记 2023-11~2026-04 已上传并应删 git，但 `channels/` 里这些月的 jsonl **仍在**（每月百余文件，构成 3.3G）。
 
-疑似真因：`discord-history-backfill.yml` 历史回填把月清理删掉的老数据**又拉回 git**，与月清理形成对冲循环；或 `archive_discord.py` 删除步未生效。**需 diagnosing 确认**，守密人 2026-06-20 暂未派此诊断。
+**诊断结论（2026-06-21）**：真因 = `discord-history-backfill.yml`（每小时跑 `discord_archiver.py --history-only`）逐月回拉已归档月写回 git，与月清理（一月一次）形成对冲循环。git-log 铁证：样本 `channels/.../2024-01-18.jsonl` 仅由 `discord history backfill` 提交添加。`archive_discord.py` 删除步本身正常（workflow 有 commit+push）。
 
-> 比喻：一个人往外搬旧报纸，另一个人又从仓库搬回来，门口永远堆着。
+**修复**：
+1. **断环（根因）**：`discord_archiver.py` 历史回填两处循环加「已归档月跳过」守卫——`_archived_months()` 读 `archive-log.json`（`uploaded_to_releases` 为真的月，兼容 `month`/`group` 双 schema），命中即 `_advance_historical_month` 跳过、零 API 零写入。已在 main 生效（守密人/并行会话独立实现，本会话另写同款后按 lesson #35 弃用、采用 main 版）。
+2. **排空存量**：2026-06-21 经 `discord-archive.yml` force-month 对 30 个已归档月重归档（--clobber 把 `community-data` 更新为含回填补全的更全版本 6.6MB→287MB）+ git_rm + push。channels/ **12,803→1,882 文件、3.3G→600M**，仅留近月 2026-05/06（未够 60 天龄）。守卫已生效，回填不再填回。
+
+> 比喻：以前一个人往外搬旧报纸、另一个每小时从仓库搬回来；现在给搬回来那人立了规矩「已入库的别再搬」，并把门口堆积的旧报纸一次清走。
 
 ## 5. fanart 现状（待核）
 
@@ -56,6 +60,6 @@ fanart 有 `collect-fanart.yml` / `recover-fanart.yml` / `backfill-media.yml` + 
 
 ## 7. 后续（守密人择期）
 
-- **诊断**：归档标记成功但 git 数据仍在的对冲缺口（读 `archive_discord.py` 删除逻辑 + `discord-history-backfill.yml` 回填范围）。
-- **fanart 现状核实**后再定是否需补月归档。
+- ~~**诊断**：对冲缺口~~ **2026-06-21 已闭合**（见 §4：断环守卫 + 30 月排空，channels/ 3.3G→600M）。
+- ~~**fanart 现状核实**~~ 已落地：fanart 归档进 `community-assets` 滚动 release（`archive_sources.json` fanart 条目，见 RELEASES.md §2.4）。
 - 所有「上传 / 删 git」执行走 workflow，非云容器手动。


### PR DESCRIPTION
## 完成

诊断并闭合「归档标记成功但 git 主数据仍在」的对冲缺口（repo-slimming-plan §4，最后一项治理待办）。

## 诊断

`discord-history-backfill.yml`（每小时跑 `discord_archiver.py --history-only`）逐月回拉**已归档月**写回 `channels/`，与月清理（一月一次）对冲——删一次、填回 24 次，致 channels/ 虚胖 3.3G。git-log 铁证：样本 `2024-01-18.jsonl` 仅由 `discord history backfill` 提交添加。

## 修复（两层）

1. **断环（根因）**：历史回填加「已归档月跳过」守卫（`_archived_months()` 读 archive-log、命中即跳过、零 API 零写入）。**已在 main 生效**——守密人/并行会话已独立实现；本会话另写同款后按 **lesson #35** 弃用、采用 main 版（两份逻辑等价、互为印证）。
2. **排空存量**：force-month 对 30 个已归档月重归档 + git_rm + push。

## 核验

| 指标 | 前 | 后 |
|------|----|----|
| channels/ 文件 | 12,803 | **1,882** |
| channels/ 体量 | 3.3G | **600M** |
| 已归档月（2024-01/2025-06/2026-04）| 198/442/… | **0/0/0** |
| 近月 2026-05/06（应留）| — | 1186/679 ✓ |
| community-data 资产 | 30（6.6MB）| **30（287MB，含回填补全的更全版本）** |

数据不仅没丢、反而更全（排空前 force-month 重抓了回填补齐的完整月）。

## 文档

RELEASES.md（§2.3 体量 / §3 核验 / §4 待办闭合）+ repo-slimming-plan §4/§7 记录诊断与修复。本 PR 仅文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nDtfQT5VHH3faWPyxDy11

---
_Generated by [Claude Code](https://claude.ai/code/session_013nDtfQT5VHH3faWPyxDy11)_