### PR TITLE
feat(migrate): 解包 text 迁入 git 工具(二进制留 Releases)

### DIFF
--- a/.github/workflows/migrate-unpacked-to-git.yml
+++ b/.github/workflows/migrate-unpacked-to-git.yml
@@ -1,0 +1,55 @@
+name: Migrate Unpacked Text to Git
+
+# 把 unpacked-data release 的 text 部分（gamescript/sdk/text-data/config 的 txt）
+# 迁入 git 的 Public-Info-Pool/game-unpacked-data/，二进制（lua-bytecode / config
+# 的 binary+debug）留在 Releases（守密人 2026-06-21 裁定，逆转决策 178/179/199 的
+# text 部分；二进制仍守 Releases 路线）。
+#
+# 为何走 workflow 而非云容器：决策 2026-06-20——云容器无 Releases 写权限、大推易
+# 触发 413；迁移在 GitHub 基建上提交（push 得动、有 token）。**手动触发**，守密人点火。
+#
+# 非破坏：本工作流只把 text 复制进 git，不删 Releases 资产（config 的 text/binary
+# 同包，删除需重打包，另作）。数据短期在 git+Releases 两处冗余，安全。
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: migrate-unpacked-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Migrate unpacked text into git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/migrate_unpacked_to_git.py \
+            --dest Public-Info-Pool/game-unpacked-data
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Public-Info-Pool/game-unpacked-data
+          if git diff --staged --quiet; then
+            echo "unpacked text already migrated"
+          else
+            git commit -m "chore: migrate unpacked text data into git [skip ci]"
+            for i in 1 2 3 4; do
+              git pull --rebase origin main && git push origin main && exit 0
+              echo "Push attempt $i failed, retrying in ${i}s..."
+              sleep $i
+            done
+            echo "All push attempts failed"
+            exit 1
+          fi

--- a/scripts/migrate_unpacked_to_git.py
+++ b/scripts/migrate_unpacked_to_git.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""把 unpacked-data release 的 **text 部分** 迁入 git（二进制留 Releases）。
+
+守密人 2026-06-21 裁定：Releases 只留真·二进制（立绘/音频/视频 + lua-bytecode +
+config 的 binary/debug 块）；可 diff/grep/溯源的 text 解包数据迁回 git。本脚本下载
+unpacked-data 的 text-bearing 资产，**按 text-only 过滤解包**到目标目录。
+
+text vs 二进制分类（实测 2026-06-21）：
+  gamescript  2295 .txt           → 全收
+  sdk-scripts 1007 .txt + 127 json → 全收
+  text-data   94 .txt + 24 .lua    → 全收
+  config      150 .txt + config_binary/ + config_debug/ + .luac → 仅收 text，滤二进制
+  lua-bytecode 1592 .luac          → 不下载（纯二进制，留 Releases）
+
+执行约束（决策 2026-06-20）：云容器无 Releases 写权限、大推易触发 413；本脚本
+经 GitHub Actions（migrate-data-to-git.yml）跑，在 GitHub 基建上提交。受限环境
+本地可跑「下载+解包」验证产出，但**不要从容器直推**。
+
+下载双路径同 restore_release_data：release API（CI 带 token）/ github.com 下载主机。
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from restore_release_data import download, list_assets, DOWNLOAD  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+TAG = "unpacked-data"
+# text-bearing 资产（lua-bytecode 纯二进制，不取）
+TEXT_ASSETS = [
+    "morimens-gamescript.tar.gz",
+    "morimens-sdk-scripts.tar.gz",
+    "morimens-text-data.tar.gz",
+    "morimens-config.tar.gz",   # 混合：解包时滤掉 binary 成员
+]
+# 二进制成员特征（config 内）：路径片段 / 扩展名
+_BINARY_DIRS = ("config_binary/", "config_debug/", "hook_capture/")
+_BINARY_EXT = (".luac",)
+
+
+def _is_text_member(name: str) -> bool:
+    low = name.lower()
+    if any(d in low for d in _BINARY_DIRS):
+        return False
+    if low.endswith(_BINARY_EXT):
+        return False
+    return True
+
+
+def _asset_urls() -> list[tuple[str, str]]:
+    """(name, url)。优先 release API（拿真实 URL），失败回落下载主机直拼。"""
+    try:
+        assets = {a["name"]: a["browser_download_url"] for a in list_assets(TAG)}
+        return [(n, assets[n]) for n in TEXT_ASSETS if n in assets]
+    except Exception as e:
+        print(f"[migrate] release API unreachable ({e}); using download host directly")
+        return [(n, f"{DOWNLOAD}/{TAG}/{n}") for n in TEXT_ASSETS]
+
+
+def migrate(dest: Path) -> tuple[int, int]:
+    dest = (REPO / dest) if not dest.is_absolute() else dest
+    dest.mkdir(parents=True, exist_ok=True)
+    files, skipped = 0, 0
+    with tempfile.TemporaryDirectory() as tmp:
+        for name, url in _asset_urls():
+            tgz = Path(tmp) / name
+            print(f"[migrate] {name}")
+            download(url, tgz)
+            with tarfile.open(tgz, "r:gz") as tar:
+                members = []
+                for m in tar.getmembers():
+                    if m.isdir():
+                        continue
+                    if _is_text_member(m.name):
+                        members.append(m)
+                        files += 1
+                    else:
+                        skipped += 1
+                tar.extractall(dest, members=members)
+    try:
+        shown = dest.relative_to(REPO)
+    except ValueError:
+        shown = dest
+    print(f"[migrate] extracted {files} text file(s) into {shown}/ "
+          f"({skipped} binary member(s) skipped, left in Releases)")
+    return files, skipped
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Migrate text portion of unpacked-data release into git.")
+    ap.add_argument("--dest", type=Path, default=Path("Public-Info-Pool/game-unpacked-data"),
+                    help="目标目录（repo-relative；默认 Public-Info-Pool/game-unpacked-data）")
+    args = ap.parse_args()
+    migrate(args.dest)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 背景

守密人 2026-06-21 裁定:Releases 只留真·二进制(立绘/音频/视频 + lua-bytecode + config 的 binary/debug 块);可 diff/grep/溯源的 **text 解包数据迁回 git**,落 `Public-Info-Pool/game-unpacked-data/`。逆转决策 178/179/199 的 text 部分(二进制仍守 Releases 路线)。

## 改动(本 PR 只含解包 text,非破坏)

| 文件 | 作用 |
|------|------|
| `scripts/migrate_unpacked_to_git.py` | 下载 unpacked-data,**text-only 过滤解包**:收 gamescript(2295 txt)/sdk-scripts(txt+json)/text-data(txt+lua)/config 的 txt;滤掉 lua-bytecode `.luac`、`config_binary/`、`config_debug/` |
| `.github/workflows/migrate-unpacked-to-git.yml` | **手动触发**迁移,在 GitHub 基建提交(云容器无 Release 写权限 + 大推 413,决策 2026-06-20)|

本地验证:**3696 个 text 文件,0 二进制残留,268MB**。

非破坏:只把 text 复制进 git,**不删 Releases 资产**(config 包内 text/binary 混装,真要 Releases-only-binary 需重打包,另作)。短期 git+Releases 冗余,安全。

## 执行方式

云容器**不能**直接推这批数据(决策 2026-06-20:无 Release 写权限 + 413)。本 PR 只含**工具**;实际 ~268MB text 由守密人**手动触发** `migrate-unpacked-to-git.yml` 在 CI 上提交。

## 待守密人/后续

- **决策反转入档**:逆转 178/179/199(text 部分),艾瑞卡无权改 `decisions.md`(§3.1),请守密人记一笔。
- **discord relocation 单独处理**:`projects/news/data/discord` 被 16+ 文件引用(含线上采集器),迁到 `Public-Info-Pool/discord` 风险高,本 PR 不含,另议。
- **Releases 瘦身**(删 text、留 binary,需重打包 config)后续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5o8UGSbKD3hM2LYQAmozf

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5o8UGSbKD3hM2LYQAmozf)_