### PR TITLE
feat(news): stamp output-layer files with data_layer:output (close lesson-#30 gap)

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -84,14 +84,17 @@ CLAUDE.md §4 的「全量档案层 vs 输出展示层不可互换」是**语义
 - `build_community_index` 自报 `_meta.data_layer == "full_archive"`；
 - `split_output` 产出对输入是**严格子集/抽样**（count ≤ 档案、每条 url 可溯源），直接编码 lesson #30 护栏。
 
-### ⚠ 已知未设防缺口（守密人留意）
+### ✓ 已闭合缺口：split_output 输出层戳记（2026-06-21）
 
-数据纪律测试过程中发现一处**约定靠人记、代码不设防**的地带：
+数据纪律测试曾发现一处**约定靠人记、代码不设防**的地带——现已设防：
 
-> **`split_output` 的输出文件 payload 不携带任何 `data_layer` 戳记**。输出层「我是抽样」这一
-> 身份在产物里没有机器可读标记，纯靠约定——正是 lesson #30 当年踩坑的同类未设防地带。
-> 子集关系目前只能靠结构（count、url 溯源）间接断言。
+> 此前 **`split_output` 的输出文件 payload 不携带任何 `data_layer` 戳记**，输出层「我是抽样」
+> 这一身份在产物里没有机器可读标记，纯靠约定（lesson #30 同类未设防地带）。
 
-建议（未实施，待守密人裁定）：在 `split_output.write_source_file` 的 payload 补一个
-`data_layer: "output"` 字段，让输出文件像 `community_index` 那样自带机器可读戳记，把这条
-纪律从「约定」升级为「代码设防」。
+**处置（已落盘）**：`split_output.py` 新增模块常量 `DATA_LAYER = 'output'`，每个 `{source}-latest.json`
+与合并的 `all-latest.json` payload 现都带 `data_layer: "output"` 字段。消费端可程序化拒绝把抽样
+当全量。`tests/test_data_discipline.py::test_every_output_file_stamps_data_layer_output` 守护此不变量。
+该纪律从「人记」升级为「代码设防」，与 `community_index` 的 `_meta.data_layer=full_archive` 对称。
+
+> 小学生比喻：以前样品柜上没贴「样品」标签全靠管理员记性，现在每个样品瓶都印死了「样品」二字——
+> 谁再想把它当总库存，瓶身就先拦住他。

--- a/projects/news/scripts/split_output.py
+++ b/projects/news/scripts/split_output.py
@@ -17,6 +17,7 @@ split_output.py — 按数据源分割 projects/news/output/news.json
   {
     "collected_at": "ISO 8601 时间戳",
     "source": "bilibili",
+    "data_layer": "output",
     "item_count": 5,
     "items": [
       {
@@ -46,6 +47,11 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent  # brain-in-a-vat/
 INPUT_PATH = _REPO_ROOT / 'projects' / 'news' / 'output' / 'news.json'
 OUTPUT_DIR = _REPO_ROOT / 'projects' / 'news' / 'output'
+
+# 数据层戳记（CLAUDE.md §4 数据纪律）：这些文件是输出/展示层——全量档案层的
+# 过滤抽样，绝不可当全量数据用（lesson #30）。此前该身份纯靠约定、产物无机器可读
+# 标记；现落标，让消费端能程序化判别，把纪律从「人记」升级为「代码设防」。
+DATA_LAYER = 'output'
 
 # ── 数据源规范化 ──────────────────────────────────────────────────────────────
 # bilibili_articles / bilibili_dynamic 都归入 bilibili
@@ -143,6 +149,7 @@ def write_source_file(source: str, items: list[dict], collected_at: str) -> None
     payload = {
         'collected_at': collected_at,
         'source': source,
+        'data_layer': DATA_LAYER,
         'item_count': len(items),
         'items': items,
     }
@@ -199,6 +206,7 @@ def main() -> None:
         json.dump({
             'collected_at': collected_at,
             'source': 'all',
+            'data_layer': DATA_LAYER,
             'item_count': len(all_items),
             'items': all_items,
         }, f, ensure_ascii=False, indent=2)

--- a/tests/test_data_discipline.py
+++ b/tests/test_data_discipline.py
@@ -324,3 +324,29 @@ class TestOutputIsSubsetOfArchive:
         emitted_urls = {it["url"] for it in reddit["items"]}
         assert emitted_urls == {"u-fresh"}
         assert "u-stale" not in emitted_urls
+
+    def test_every_output_file_stamps_data_layer_output(self, tmp_path, monkeypatch):
+        """Every split_output product must self-declare data_layer == "output".
+
+        Closes the gap surfaced by the prior data-discipline pass: the output
+        layer's "I am a sample" identity used to be convention-only, with NO
+        machine-readable marker in the payload. Now each per-source file AND the
+        merged all-latest.json carries a data_layer stamp, so a consumer can
+        programmatically refuse to treat a sample as the full archive (lesson
+        #30). Discipline moves from "humans must remember" to "code enforces".
+        """
+        items = [
+            {"source": "reddit", "time": self._recent(1), "title": "a", "url": "u-a"},
+            {"source": "youtube", "time": self._recent(2), "title": "b", "url": "u-b"},
+        ]
+        _, payloads = self._run_split(tmp_path, monkeypatch, items)
+        assert payloads, "split produced no output files"
+        for source, payload in payloads.items():
+            assert payload.get("data_layer") == "output", (
+                f"{source}-latest.json is missing the data_layer:output stamp "
+                f"(got {payload.get('data_layer')!r}) — output identity unguarded")
+            # An output-layer file must NEVER claim to be the full archive.
+            assert payload["data_layer"] != "full_archive", (
+                f"{source} output file masquerades as full_archive")
+        # the merged file is covered too (it is the most tempting to mis-read).
+        assert payloads["all"]["data_layer"] == "output"


### PR DESCRIPTION
## 背景

承接 PR #329 数据纪律测试揭出的真实防护漏洞：`split_output` 输出文件无机器可读的 `data_layer` 戳记，输出层「我是抽样」身份纯靠约定——正是 lesson #30 同类未设防地带。本 PR 把它从「约定」升级为「代码设防」。

## 改动

- `685split_output.py`：新增模块常量 `DATA_LAYER = 'output'`，每个 `{source}-latest.json` 与合并的 `all-latest.json` payload 现都带 `data_layer: "output"` 字段，与 `community_index` 的 `_meta.data_layer="full_archive"` 对称。
- 字段为**加法式**，既有按键读取的消费端（`data_quality` / `archive_platforms` / `build_okf_bundle`）不受影响。
- `tests/test_data_discipline.py`：新增 `test_every_output_file_stamps_data_layer_output` 守护——每个输出文件（含 all-latest）必带 `data_layer:output`、绝不冒充 `full_archive`。
- `docs/testing-strategy.md`：该缺口标记为已闭合。

## 验证

全量 **1693 passed, 3 skipped**。

> 小学生比喻：以前样品柜没贴「样品」标签全靠管理员记性，现在每个样品瓶印死「样品」二字——谁想把它当总库存，瓶身先拦住他。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yhocmg6Pox7gqRxi8BoUT

---
_Generated by [Claude Code](https://claude.ai/code/session_017yhocmg6Pox7gqRxi8BoUT)_