### PR TITLE
fix(news): 采集层检视——登记孤儿源 + 清 telegram 残留

### DIFF
--- a/projects/news/output/telegram-latest.json
+++ b/projects/news/output/telegram-latest.json
@@ -1,6 +1,0 @@
-{
-  "collected_at": "2026-06-15T20:23:18.235510+00:00",
-  "source": "telegram",
-  "item_count": 0,
-  "items": []
-}

--- a/projects/news/scripts/silent_sources_audit.py
+++ b/projects/news/scripts/silent_sources_audit.py
@@ -32,14 +32,14 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from sources import KNOWN_SOURCES, CORE_SOURCES, LEGACY_SOURCES
+from sources import KNOWN_SOURCES, CORE_SOURCES, LEGACY_SOURCES, INDEPENDENT_ARCHIVE_SOURCES
 
 ARCHIVE_DIR = _REPO_ROOT / 'projects' / 'news' / 'data' / 'platforms'
 DISCORD_ARCHIVE_DIR = _REPO_ROOT / 'projects' / 'news' / 'data' / 'discord' / 'activity_daily'
 HEALTH_PATH = _REPO_ROOT / 'projects' / 'news' / 'output' / 'source-health.json'
 
 # 已注册采集源 —— 来自 sources.py 单一真相源（含 discord）
-ALL_REGISTERED_SOURCES = list(KNOWN_SOURCES)
+ALL_REGISTERED_SOURCES = list(KNOWN_SOURCES) + list(INDEPENDENT_ARCHIVE_SOURCES)
 
 # 与 data_quality.SilentPlatformTracker 保持一致
 DEGRADED_THRESHOLD = 7

--- a/projects/news/scripts/sources.py
+++ b/projects/news/scripts/sources.py
@@ -43,6 +43,8 @@ KNOWN_SOURCES = [
     'weixin',
     # 官方 X 账号时间线（syndication 接口，无 key；仅官方号，无关键词搜索）
     'twitter',
+    # TapTap 评论流（taptap_collector 衍生 source，与 taptap 论坛帖分桶归档；走主线 news.json）
+    'taptap_review',
 ]
 
 # 原始源名 → 规范源名
@@ -60,7 +62,7 @@ SPARSE_SOURCES = {
     'pixiv',
     'stopgame',
     'note_com', 'ruliweb', 'arca_live', 'bahamut',
-    'taptap',
+    'taptap', 'taptap_review',
     'discord',
     'twitter',  # 官方号公告，发布不频繁，用 30 天宽窗
 }
@@ -91,6 +93,13 @@ ARCHIVE_PLATFORMS = [s for s in KNOWN_SOURCES if s != 'discord']
 BACKFILL_PLATFORMS = [
     'bilibili', 'appstore', 'steam_review', 'arca_live',
     'pixiv', 'ruliweb', 'weixin', 'taptap',
+]
+
+# 独立归档源：由专用采集器直接写 data/platforms/，不经主线 news.json
+# （故不进 KNOWN_SOURCES——否则 split_output 会按 news.json 切出空 latest 文件）。
+# 活跃采集中，需纳入静默源审计的正常分级（见 silent_sources_audit.ALL_REGISTERED_SOURCES）。
+INDEPENDENT_ARCHIVE_SOURCES = [
+    'youtube_comments',  # collect_video_comments.py 直写 platforms/youtube_comments/
 ]
 
 # data/platforms/ 下仍有历史归档、但采集逻辑已移除的遗留源。


### PR DESCRIPTION
## 采集层检视报告

应守密人「检查采集器」派发,对 news 采集三层做了一次体检,并处置发现项。

### 体检结论:采集器整体健康
- 运行验证程序 **1651 通过 / 5 跳过**,无失败
- `update-news` CI 连续 8 轮全 `success`,节拍每 2–5 小时一轮
- 采集器最后心跳 2026-06-21 13:05,本轮产 44 条

### 两处「降级」均为假阳性(已查实,不需修复)
- **official**:Steam 官方公告 API 正常,30 天窗口仅 1 条(06-04 V2.5.1 广播剧)。官方本就低频,17 天无新公告是真实情况。
- **google_play**:CI 日志(06-21 13:06)原文 `google_play 16 条`、`官方采集 Google Play(927)`,采集与归档均成功。本地审计报「沉默 15 天」是因归档大资产滚动移入 Release、本地副本不全所致(审计工具固有局限,读本地不完整归档),非采集故障。

### 本 PR 实际改动(处置发现项)
1. **`taptap_review` 登记**:此前由 `taptap_collector.py` 采集并归档(440 条,活跃),却未进 `KNOWN_SOURCES`,被审计误列为「遗留未登记」。现入 `KNOWN_SOURCES` + `SPARSE_SOURCES`,进正常分级。
2. **`youtube_comments` 登记**:由 `collect_video_comments.py` 直写 `platforms/`、不经主线 news.json。直接加 `KNOWN_SOURCES` 会令 `split_output` 切出空 latest 污染输出,故新增 `INDEPENDENT_ARCHIVE_SOURCES` 类别容纳,并让 `silent_sources_audit.ALL_REGISTERED_SOURCES` 纳入。
3. **删除 `output/telegram-latest.json` 残留**:telegram 已退役、不在注册表、无归档、停更于 06-15。

### 比喻
- 假阳性降级 = 老员工的近期考勤表被归档到了别的柜子,前台名册没翻到就以为他旷工了。
- 登记孤儿源 = 两个一直在干活却没写进花名册的人,补登记后考勤系统才认他们。
- 删 telegram 残留 = 摘掉离职员工工位上的旧名牌。

### 验证
- `pytest tests/` 全过(1651 通过 / 5 跳过)
- 重跑 `silent_sources_audit.py`:`taptap_review` 进【活跃】、`youtube_comments` 进正常分级,【遗留/未登记】段消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzcdzvL7v49DQ9BsuLajWi)_