### PR TITLE
chore(deploy): 移除 wiki en/ja 语言区检查（wiki 当前单中文）

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -120,13 +120,6 @@ jobs:
           else
             echo "WARNING: dist/wiki/index.html missing"
           fi
-          for locale in en ja; do
-            if [ -d "dist/wiki/$locale" ]; then
-              echo "OK: dist/wiki/$locale/ exists ($(find dist/wiki/$locale -type f | wc -l) files)"
-            else
-              echo "WARNING: dist/wiki/$locale/ missing"
-            fi
-          done
 
       - name: Deploy to gh-pages branch
         uses: peaceiris/actions-gh-pages@v4
@@ -142,8 +135,8 @@ jobs:
           echo "Waiting 30s for GitHub Pages to propagate..."
           sleep 30
           BASE="https://lightproud.github.io/brain-in-a-vat"
-          # zh content is at /wiki/ root (via VitePress rewrites), not /wiki/zh/
-          for url in "$BASE/" "$BASE/wiki/" "$BASE/wiki/en/" "$BASE/news/"; do
+          # wiki is zh-only (single locale at /wiki/ root); no en/ja locales configured
+          for url in "$BASE/" "$BASE/wiki/" "$BASE/news/"; do
             status=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "000")
             if [ "$status" = "200" ]; then
               echo "OK: $url → $status"


### PR DESCRIPTION
## 背景

排查「git 部署网页全站 404」时发现根因是 GitHub Pages 服务被关（`has_pages: false`），守密人在 Settings → Pages 重新指向 `gh-pages` 分支后全站恢复 200。

恢复后验证发现 `wiki/en/`、`wiki/ja/` 仍 404——核查为**预期状态**：`projects/wiki/docs/.vitepress/config.mts` 仅配 `lang: 'zh-CN'`、未配置 `locales`，gh-pages 产物中本就无 `wiki/en`、`wiki/ja` 目录。wiki 当前是单中文站。

## 改动

`deploy-site.yml` 删除两处对不存在语言区的检查：

- **Enhanced build verification**：移除 `for locale in en ja` 目录检查循环（每次部署刷 `WARNING: dist/wiki/{en,ja}/ missing`）
- **Post-deploy smoke test**：从探测 URL 列表移除 `$BASE/wiki/en/`（每次刷无意义 404）

部署成功判定不受影响（这两处原本就是 WARNING/`continue-on-error`，非失败门）。日志只保留真实存在的 zh 根 + news 探测。

## 验证

线上全站现状（守密人开启 Pages 后实测）：根 / wiki / news / biav / docs 均 200。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AizTGWZp87SAg1SCW1tCxb)_