### PR TITLE
redesign(site): 主站 + BIAV 页全量重写对齐现状

### DIFF
--- a/projects/site/public/biav/index.html
+++ b/projects/site/public/biav/index.html
@@ -4,13 +4,13 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>缸中之脑 / Brain in a Vat — B.I.A.V. Studio</title>
-<meta name="description" content="缸中之脑（Brain in a Vat / B.I.A.V.）— B.I.A.V. Studio 的 AI 协作元项目。从笛卡尔思想实验到银芯系统，承载三新使命的公开协议层。">
+<meta name="description" content="缸中之脑（Brain in a Vat / B.I.A.V.）— B.I.A.V. Studio 的 AI 协作元项目。从笛卡尔思想实验到银芯系统，承载三新使命的知识层与记忆基底。">
 <meta name="author" content="B.I.A.V. Studio">
 <meta name="theme-color" content="#c5a356">
 <link rel="canonical" href="https://lightproud.github.io/brain-in-a-vat/biav/">
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' fill='%230a0b10'/%3E%3Ctext x='32' y='46' font-family='Noto Serif SC,serif' font-weight='700' font-size='44' fill='%23c5a356' text-anchor='middle'%3E夜%3C/text%3E%3C/svg%3E">
 <meta property="og:title" content="缸中之脑 / Brain in a Vat">
-<meta property="og:description" content="B.I.A.V. Studio 的 AI 协作元项目 — 承载三新使命的公开协议层。">
+<meta property="og:description" content="B.I.A.V. Studio 的 AI 协作元项目 — 承载三新使命的知识层与记忆基底。">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://lightproud.github.io/brain-in-a-vat/biav/">
 <meta property="og:site_name" content="B.I.A.V. Studio">
@@ -54,6 +54,7 @@
   .sec-body p{margin-bottom:14px}
   .sec-body strong{color:var(--gold-l);font-weight:600}
   .sec-body em{color:var(--txt);font-style:normal;font-family:var(--serif)}
+  .code{font-family:'JetBrains Mono','SF Mono',monospace;font-size:13px;color:var(--gold);background:rgba(197,163,86,0.06);padding:1px 6px;border-radius:2px}
 
   .grid-3{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:8px}
   .card{background:var(--bg2);border:1px solid var(--border);border-radius:8px;padding:24px}
@@ -105,7 +106,7 @@
   <h1 class="hero-title">缸中之脑 / Brain in a Vat</h1>
   <div class="hero-sub">B.I.A.V. — Silver Core</div>
   <div class="hero-div"></div>
-  <div class="hero-tagline">B.I.A.V. Studio 的 AI 协作元项目。<br>不是游戏，不是百科，而是承载游戏与百科的协议层与记忆基底。</div>
+  <div class="hero-tagline">B.I.A.V. Studio 的 AI 协作元项目。<br>不是游戏，不是百科，而是承载游戏与百科的知识层与记忆基底。</div>
 </div>
 
 <div class="deco">◇ ◇ ◇</div>
@@ -116,7 +117,7 @@
   <div class="sec-body">
     <p><strong>Brain in a Vat</strong> 出自笛卡尔与普特南的同名哲学思想实验：一个脱离躯体、被维持在营养液中的大脑，能否区分"真实经验"与"被注入的经验"？</p>
     <p>Studio 选择此名作为身份锚点，并非声称给出答案，而是接受其前提：<em>制作者所感知的世界，本身可能就是被构建的</em>。这个不确定性是创作《忘却前夜》克苏鲁式认知恐惧叙事的精神基底——所有"已知"都可能被更高阶的存在证伪。</p>
-    <p>在工程层面，本仓库 <code style="font-family:'JetBrains Mono',monospace;font-size:13px;color:var(--gold);background:rgba(197,163,86,0.06);padding:1px 6px;border-radius:2px">brain-in-a-vat</code> 就是这个思想实验的具象——一个由 AI 协作维护、自动情报循环、知识图谱驱动的"脱体大脑"，承载 Studio 的记忆与协议。</p>
+    <p>在工程层面，本仓库 <span class="code">brain-in-a-vat</span> 就是这个思想实验的具象——一个由 AI 协作维护、自动情报循环驱动的"脱体大脑"，承载 Studio 的记忆、决策与协议。</p>
   </div>
 </section>
 
@@ -124,9 +125,9 @@
   <div class="sec-label">Silver Core</div>
   <div class="sec-title">银芯系统</div>
   <div class="sec-body">
-    <p><strong>银芯（Silver Core / BIAV-SC）</strong>是 BIAV 项目的内部系统名，由九个记忆模块构成：TF-IDF 语义搜索、知识图谱、MemRL 效用评分、Sleep-Time Compute 预计算缓存、哨兵异常检测、MCP Server、上下文管理、Reflexion 失败学习、选择性记忆膨胀检测。</p>
-    <p>九模块协同实现"组织级记忆宫殿"——AI 会话不再是孤立的一次性对话，而是接续上一轮记忆继续推进的循环。每一轮对话产出的事实、决策、踩坑教训，都会被自动写入图谱、索引、复用，让下一轮会话从已有沉淀起步。</p>
-    <p>这是 Studio 在 AI 协作时代的方法论尝试：<em>让记忆成为基础设施，让协议优先于工具</em>。</p>
+    <p><strong>银芯（Silver Core / BIAV-SC）</strong>是 BIAV 项目的知识层系统名，定位为 Studio 的<em>受限 / 非公开层</em>：负责采集、整理外部社区与解包信息，单向输出至内部层（黑池），是 Studio 对外的"眼睛和耳朵"。</p>
+    <p>银芯的记忆不再依赖自建检索栈，而是收回到三条互补支柱：<strong>CLAUDE.md</strong>（每会话自动加载的统一入口与协议）、<strong>memory/*.md</strong>（人工策展的决策 / 踩坑 / 状态 / 方法论档案），以及 Claude 平台原生的上下文管理。每一轮协作产出的事实与决策被写入策展档案，让下一轮会话从已有沉淀起步。</p>
+    <p>会话之外，MCP 服务 <span class="code">biav-sc-memory</span> 提供四件协作工具：<span class="code">character_persona</span>（人格激活）、<span class="code">record_decision</span>（决策落档）、<span class="code">record_lesson</span>（教训沉淀）、<span class="code">current_continuity</span>（连续性读取）。这是 Studio 在 AI 协作时代的方法论尝试：<em>让记忆成为基础设施，让协议优先于工具</em>。</p>
   </div>
 </section>
 
@@ -134,24 +135,24 @@
   <div class="sec-label">Mission</div>
   <div class="sec-title">三新使命</div>
   <div class="sec-body">
-    <p>2026-04 银芯重新定位后，BIAV 项目承载三条公开使命：</p>
+    <p>2026-04 银芯重新定位后，BIAV 项目承载三条使命：</p>
     <div class="grid-3">
       <div class="card">
         <div class="card-num">壹</div>
-        <div class="card-name">黑池公开信息入口</div>
-        <div class="card-desc">为内部消费层提供多平台社区情报的统一视野。每日两次自动聚合 Bilibili / Discord / Reddit / NGA / TapTap / Steam 等平台。</div>
+        <div class="card-name">多平台社区情报入口</div>
+        <div class="card-desc">为内部消费层提供多平台社区情报的统一视野。每小时自动聚合 Bilibili / Discord / Reddit / NGA / TapTap / Steam 等平台。</div>
         <div class="card-meta">主载体 — news 子项目</div>
       </div>
       <div class="card">
         <div class="card-num">贰</div>
         <div class="card-name">社区共建知识底座</div>
-        <div class="card-desc">让外部社区与 Studio 派生内容拥有可贡献的事实底座。目标 72 角色三语完整资料 + 客户端解包数据 + 制作者一手陈述。</div>
+        <div class="card-desc">以客户端一手解包数据重建可信底座。剧情正文与 lore 档案已开放；角色基线正在以解包字段重建中（禁用合成占位）。</div>
         <div class="card-meta">主载体 — wiki 子项目</div>
       </div>
       <div class="card">
         <div class="card-num">叁</div>
         <div class="card-name">Studio 团队 AI 协作训练场</div>
-        <div class="card-desc">基于公开 AI 信息的协作方法论沉淀场。当前以仓库形式开放思考过程，供 Studio 内成员衍生项目与企划。</div>
+        <div class="card-desc">AI 协作方法论的沉淀场。以仓库形式开放决策、踩坑与协议档案，供 Studio 内成员衍生项目与企划。</div>
         <div class="card-meta">备扩展位 — 全局 / 未来 game</div>
       </div>
     </div>
@@ -165,10 +166,10 @@
     <table class="struct">
       <tr><th>子项目</th><th>路径</th><th>职责</th></tr>
       <tr><td>site</td><td><code>projects/site/</code></td><td>对外门户、部署流水线、跨站视觉一致性</td></tr>
-      <tr><td>news</td><td><code>projects/news/</code></td><td>多平台社区情报聚合、Discord 归档、日报生成</td></tr>
-      <tr><td>wiki</td><td><code>projects/wiki/</code></td><td>72 角色资料库、技能命轮、三语 i18n、VitePress 构建</td></tr>
-      <tr><td>memory</td><td><code>memory/ + scripts/</code></td><td>九模块记忆系统、决策档案、做梦循环、教训沉淀</td></tr>
-      <tr><td>事实圣经</td><td><code>assets/data/</code></td><td>72 角色权威事实 + 设计决策 + 制作者采访 + 校验脚本</td></tr>
+      <tr><td>news</td><td><code>projects/news/</code></td><td>多平台社区情报聚合、Discord 归档、报告生成</td></tr>
+      <tr><td>wiki</td><td><code>projects/wiki/</code></td><td>客户端解包数据、剧情正文与 lore 档案、角色基线重建、VitePress 构建</td></tr>
+      <tr><td>memory</td><td><code>memory/*.md</code></td><td>人工策展记忆层：决策档案、踩坑教训、状态权威、方法论</td></tr>
+      <tr><td>事实圣经</td><td><code>assets/data/</code></td><td>角色卡 / 设计决策 / 制作者采访 / 叙事结构 + 校验脚本</td></tr>
     </table>
   </div>
 </section>

--- a/projects/site/public/index.html
+++ b/projects/site/public/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>忘却前夜 Morimens — B.I.A.V. Studio</title>
-<meta name="description" content="忘却前夜 (Morimens) — 洛夫克拉夫特式肉鸽卡牌构建游戏。在认知的边界之外，遗忘是最后的慈悲。">
+<meta name="description" content="忘却前夜 (Morimens) — 洛夫克拉夫特式肉鸽卡牌构建游戏。在认知的边界之外，遗忘是最后的慈悲。社区 Wiki、剧情档案与多平台情报由银芯知识层维护。">
 <meta name="author" content="B.I.A.V. Studio">
 <meta name="theme-color" content="#c5a356">
 <link rel="canonical" href="https://lightproud.github.io/brain-in-a-vat/">
@@ -15,8 +15,6 @@
 <meta property="og:url" content="https://lightproud.github.io/brain-in-a-vat/">
 <meta property="og:site_name" content="B.I.A.V. Studio">
 <meta property="og:locale" content="zh_CN">
-<meta property="og:locale:alternate" content="en_US">
-<meta property="og:locale:alternate" content="ja_JP">
 <meta name="twitter:card" content="summary">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -41,13 +39,7 @@
   .nav-links{display:flex;gap:28px}
   .nav-links a{font-size:13px;color:var(--txt-d);font-weight:500;letter-spacing:0.02em;transition:color 0.3s}
   .nav-links a:hover,.nav-links a.active{color:var(--gold)}
-  .nav-lang{position:relative;font-size:12px}
-  .nav-lang summary{list-style:none;color:var(--txt-d);border:1px solid var(--border);border-radius:2px;padding:4px 10px;cursor:pointer;transition:border-color 0.3s;user-select:none}
-  .nav-lang summary::-webkit-details-marker{display:none}
-  .nav-lang[open] summary,.nav-lang summary:hover{border-color:rgba(197,163,86,0.2);color:var(--gold)}
-  .nav-lang-menu{position:absolute;top:calc(100% + 4px);right:0;min-width:120px;background:rgba(10,11,16,0.96);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border:1px solid var(--border);border-radius:2px;padding:4px 0;list-style:none}
-  .nav-lang-menu a{display:block;padding:6px 14px;font-size:12px;color:var(--txt-d);transition:color 0.3s,background 0.3s}
-  .nav-lang-menu a:hover,.nav-lang-menu a[aria-current="page"]{color:var(--gold);background:rgba(197,163,86,0.06)}
+  .nav-tag{font-size:11px;color:var(--txt-d);border:1px solid var(--border);border-radius:2px;padding:4px 10px;letter-spacing:0.04em}
 
   /* ── HERO ── */
   .hero{position:relative;min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:56px 24px 60px;overflow:hidden}
@@ -58,8 +50,8 @@
   .hero-title{font-family:var(--serif);font-weight:700;font-size:42px;color:var(--txt);letter-spacing:0.5em;padding-left:0.5em;animation:fadeUp 1.2s ease-out both}
   .hero-sub{font-family:var(--serif);font-weight:400;font-size:16px;color:var(--gold);letter-spacing:0.2em;text-transform:uppercase;margin-top:4px;animation:fadeUp 1.2s 0.15s ease-out both}
   .hero-div{width:48px;height:1px;background:linear-gradient(90deg,transparent,var(--gold-d),transparent);margin:24px auto;animation:fadeUp 1.2s 0.3s ease-out both}
-  .hero-tagline{font-size:14px;color:var(--txt-d);max-width:420px;line-height:1.8;margin:0 auto 32px;animation:fadeUp 1.2s 0.45s ease-out both}
-  .hero-cta{display:flex;gap:16px;justify-content:center;animation:fadeUp 1.2s 0.6s ease-out both}
+  .hero-tagline{font-size:14px;color:var(--txt-d);max-width:440px;line-height:1.8;margin:0 auto 32px;animation:fadeUp 1.2s 0.45s ease-out both}
+  .hero-cta{display:flex;gap:16px;justify-content:center;flex-wrap:wrap;animation:fadeUp 1.2s 0.6s ease-out both}
   .btn-p{display:inline-flex;align-items:center;padding:10px 28px;background:var(--gold);color:var(--bg);font-family:var(--sans);font-weight:700;font-size:13px;letter-spacing:0.06em;border-radius:2px;border:none;cursor:pointer;transition:all 0.3s}
   .btn-p:hover{background:var(--gold-l);box-shadow:0 0 20px rgba(197,163,86,0.25)}
   .btn-g{display:inline-flex;align-items:center;padding:10px 28px;background:transparent;color:var(--txt-m);font-family:var(--sans);font-weight:500;font-size:13px;letter-spacing:0.06em;border-radius:2px;border:1px solid rgba(197,163,86,0.2);cursor:pointer;transition:all 0.3s}
@@ -91,7 +83,7 @@
   .world-inner{position:relative;z-index:2;max-width:960px;margin:0 auto;padding:0 40px;text-align:center}
   .world-inner .sec-title{margin-bottom:20px}
   .world-quote{font-family:var(--serif);font-size:18px;color:var(--txt-m);font-style:italic;max-width:600px;margin:0 auto;line-height:1.7}
-  .realm-row{display:flex;justify-content:center;gap:24px;margin-top:40px}
+  .realm-row{display:flex;justify-content:center;gap:24px;margin-top:40px;flex-wrap:wrap}
   .realm-chip{padding:8px 20px;border-radius:4px;font-size:13px;font-weight:600;font-family:var(--sans)}
   .r-chaos{background:rgba(197,163,86,0.12);color:var(--gold-l)}
   .r-aequor{background:rgba(58,107,107,0.12);color:#5dade2}
@@ -105,6 +97,7 @@
   .mission-num{font-family:var(--serif);font-weight:700;font-size:32px;color:var(--gold-d);letter-spacing:0.04em;margin-bottom:12px;line-height:1}
   .mission-name{font-family:var(--serif);font-weight:600;font-size:16px;color:var(--gold-l);margin-bottom:8px}
   .mission-desc{font-size:14px;color:var(--txt-m);line-height:1.7}
+  .mission-meta{font-size:11px;color:var(--txt-d);letter-spacing:0.04em;margin-top:12px}
 
   /* ── COMMUNITY ── */
   .comm-grid{display:flex;gap:16px;flex-wrap:wrap;justify-content:center}
@@ -133,7 +126,6 @@
     .mission-grid{grid-template-columns:1fr}
     .world-strip{padding:60px 0}
     .world-inner{padding:0 20px}
-    .realm-row{flex-wrap:wrap}
   }
 
   @media(prefers-reduced-motion:reduce){
@@ -152,18 +144,12 @@
     <a class="active" href="#">首页</a>
     <a href="wiki/">Wiki</a>
     <a href="wiki/zh/awakeners/">唤醒体</a>
-    <a href="wiki/zh/guides/">攻略</a>
+    <a href="wiki/story">剧情</a>
+    <a href="news/">情报</a>
     <a href="biav/">BIAV</a>
     <a href="https://github.com/lightproud/brain-in-a-vat" target="_blank" rel="noopener">GitHub</a>
   </div>
-  <details class="nav-lang">
-    <summary aria-label="切换语言 / Switch language">简体中文</summary>
-    <ul class="nav-lang-menu" role="menu">
-      <li role="none"><a role="menuitem" href="./" aria-current="page">简体中文</a></li>
-      <li role="none"><a role="menuitem" href="wiki/en/">English</a></li>
-      <li role="none"><a role="menuitem" href="wiki/ja/">日本語</a></li>
-    </ul>
-  </details>
+  <div class="nav-tag">简体中文</div>
 </nav>
 
 <!-- ═══ HERO ═══ -->
@@ -178,7 +164,7 @@
     <div class="hero-tagline">在认知的边界之外，遗忘是最后的慈悲。<br>洛夫克拉夫特式肉鸽卡牌构建游戏。</div>
     <div class="hero-cta">
       <a class="btn-p" href="wiki/">进入 Wiki</a>
-      <a class="btn-g" href="wiki/zh/guides/beginner">新手指南</a>
+      <a class="btn-g" href="wiki/story">剧情档案</a>
     </div>
   </div>
   <div class="scroll-hint">
@@ -186,30 +172,6 @@
     <small>Scroll</small>
   </div>
 </div>
-
-<!-- ═══ MISSION ═══ -->
-<section>
-  <div class="sec-label reveal">Mission</div>
-  <div class="sec-title reveal">银芯三新使命</div>
-  <div class="sec-desc reveal">缸中之脑（B.I.A.V. Silver Core）自 2026-04 重新定位，由方法论验证场转为承载三条新使命的公开协议层。</div>
-  <div class="mission-grid">
-    <a class="mission-card reveal" href="news/">
-      <div class="mission-num" aria-hidden="true">壹</div>
-      <div class="mission-name">黑池公开信息入口</div>
-      <div class="mission-desc">为内部消费层提供多平台社区情报的统一视野。news 子项目维护，每日两次自动聚合。</div>
-    </a>
-    <a class="mission-card reveal" href="wiki/">
-      <div class="mission-num" aria-hidden="true">贰</div>
-      <div class="mission-name">社区共建知识底座</div>
-      <div class="mission-desc">让外部社区与 Studio 派生内容拥有可贡献的事实底座。wiki 子项目维护，目标 72 角色三语完整。</div>
-    </a>
-    <a class="mission-card reveal" href="https://github.com/lightproud/brain-in-a-vat" target="_blank" rel="noopener">
-      <div class="mission-num" aria-hidden="true">叁</div>
-      <div class="mission-name">Studio 团队 AI 协作训练场</div>
-      <div class="mission-desc">基于公开 AI 信息的协作方法论沉淀场。当前以仓库形式开放思考过程，供 Studio 内成员衍生项目。</div>
-    </a>
-  </div>
-</section>
 
 <!-- ═══ FEATURES ═══ -->
 <section>
@@ -220,7 +182,7 @@
     <div class="feat-card reveal">
       <div class="feat-icon" aria-hidden="true">◈</div>
       <div class="feat-name">卡牌构筑</div>
-      <div class="feat-desc">从初始牌组出发，在每一次选择中打磨策略。指令牌、灵体牌、疯狂牌——三种牌型交织出无穷组合。</div>
+      <div class="feat-desc">从初始牌组出发，在每一次选择中打磨策略。指令牌、灵体牌、疯狂牌——多种牌型交织出无穷组合。</div>
     </div>
     <div class="feat-card reveal">
       <div class="feat-icon" aria-hidden="true">◯</div>
@@ -240,7 +202,7 @@
   <div class="world-fog"></div>
   <div class="world-inner">
     <div class="sec-label reveal">World</div>
-    <div class="sec-title reveal">四大界域</div>
+    <div class="sec-title reveal">界域与阵营</div>
     <div class="world-quote reveal">「每一个界域都是一种认知的极限。<br>跨越它，或被它吞噬。」</div>
     <div class="realm-row reveal">
       <span class="realm-chip r-chaos">混沌 Chaos</span>
@@ -250,6 +212,33 @@
     </div>
   </div>
 </div>
+
+<!-- ═══ MISSION ═══ -->
+<section>
+  <div class="sec-label reveal">Mission</div>
+  <div class="sec-title reveal">银芯三新使命</div>
+  <div class="sec-desc reveal">本站由银芯（B.I.A.V. Silver Core）知识层驱动。银芯是 Studio 的 AI 协作知识层，自 2026-04 起承载三条使命，为社区提供可追溯的事实底座。</div>
+  <div class="mission-grid">
+    <a class="mission-card reveal" href="news/">
+      <div class="mission-num" aria-hidden="true">壹</div>
+      <div class="mission-name">多平台社区情报入口</div>
+      <div class="mission-desc">汇聚 Bilibili / Discord / Reddit / NGA / TapTap / Steam 等平台的社区动态，整理为统一视野。</div>
+      <div class="mission-meta">news 子项目 · 每小时自动聚合</div>
+    </a>
+    <a class="mission-card reveal" href="wiki/">
+      <div class="mission-num" aria-hidden="true">贰</div>
+      <div class="mission-name">社区共建知识底座</div>
+      <div class="mission-desc">以客户端一手解包数据重建可信底座。剧情正文与 lore 档案已开放，角色基线正在重建中。</div>
+      <div class="mission-meta">wiki 子项目 · 解包数据驱动</div>
+    </a>
+    <a class="mission-card reveal" href="https://github.com/lightproud/brain-in-a-vat" target="_blank" rel="noopener">
+      <div class="mission-num" aria-hidden="true">叁</div>
+      <div class="mission-name">Studio AI 协作沉淀场</div>
+      <div class="mission-desc">以仓库形式承载决策、踩坑与协议档案，让 AI 协作的方法论可被复用与衍生。</div>
+      <div class="mission-meta">全局 · 决策与记忆档案</div>
+    </a>
+  </div>
+</section>
 
 <!-- ═══ COMMUNITY ═══ -->
 <section>


### PR DESCRIPTION
## 背景

守密人审计「git 部署网页内容是否符合实际」后裁定**视为全部过时、完全重新设计、直接改并部署**。本 PR 全量重写主站首页与 BIAV 介绍页，逐项对齐现状。

## 纠正项（审计 → 修复）

| 脱节项 | 旧（错误）| 新（现状）|
|--------|-----------|-----------|
| 定位 | 「公开协议层」| 受限/非公开层（守密人 2026-06-11 裁定）|
| 采集节奏 | 「每日两次」| 每小时（`update-news.yml` `0 * * * *`）|
| 首页死链 | `wiki/zh/guides`、`wiki/en`、`wiki/ja`、新手指南（全 404）| 改指实测 200 路由：`wiki/story`、`wiki/zh/awakeners/` 等；移除 en/ja 语言切换（wiki 现单中文）|
| wiki 角色库 | 「72 角色三语完整资料库」| 解包数据驱动、剧情/lore 已开放、角色基线重建中 |
| BIAV 银芯系统段 | 九模块记忆栈 + 做梦循环（**2026-06-14/20 已整套删除**）| 现行 CLAUDE.md + memory/*.md 人工策展 + 平台原生上下文 + MCP `biav-sc-memory` 4 工具 |
| 仓库结构表 | memory「九模块/做梦」、wiki「72/三语 i18n」| 按现状改写两行 |

视觉沿用既有「忘却前夜」设计令牌（`morimens-design-tokens.css`），仅重构信息架构与文案。所有内部链接均经线上 200 实测。

## 验证

合并触发 Deploy Site 自动重部署；本 PR 合并后将实测全站与各导航链接是否 200，并向守密人回报。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AizTGWZp87SAg1SCW1tCxb)_