### PR TITLE
fix(news): 修复评论源 dedup URL 碰撞(丢弃约 98% 商店评论)

### DIFF
--- a/projects/news/scripts/global_collectors.py
+++ b/projects/news/scripts/global_collectors.py
@@ -764,13 +764,16 @@ def fetch_appstore_reviews():
             review_url = f"https://apps.apple.com/{country}/app/id{appstore_id}?see-all=reviews"
             for entry in entries:
                 rating = int(entry.get("im:rating", {}).get("label", "0"))
+                # RSS entry id 是评论唯一标识。不追加锚点时同 country 数十条评论共用 review_url，
+                # 致 dedup_key（URL 优先）碰撞、每 country 仅存活 1 条。fragment 使每条 key 唯一。
+                entry_id = entry.get("id", {}).get("label", "")
                 items.append(_make_item(
                     title=entry.get("title", {}).get("label", ""),
                     summary=entry.get("content", {}).get("label", ""),
                     source="appstore",
                     platform_region=country,
                     time_str=entry.get("updated", {}).get("label", ""),
-                    url=review_url,
+                    url=f"{review_url}#as-{entry_id}" if entry_id else review_url,
                     engagement=rating,
                     is_hot=False,
                     author=entry.get("author", {}).get("name", {}).get("label", ""),
@@ -893,7 +896,10 @@ def fetch_google_play():
                     source="google_play",
                     platform_region=region,
                     time_str=review["at"].isoformat() if review.get("at") else datetime.now(timezone.utc).isoformat(),
-                    url=f"https://play.google.com/store/apps/details?id={gp_package}&hl={lang_code}",
+                    # URL 追加 reviewId 锚点：评论页 URL 仅含 id+hl，同语言数十条评论会共用同一
+                    # URL，致 dedup_key（URL 优先）碰撞、每语言仅存活 1 条（丢失 ~98% 评论）。
+                    # fragment 使每条 key 唯一，不影响链接访问，跨轮次去重仍按恒定 reviewId 生效。
+                    url=f"https://play.google.com/store/apps/details?id={gp_package}&hl={lang_code}#gp-{review.get('reviewId', '')}",
                     engagement=review.get("thumbsUpCount", 0),
                     is_hot=False,
                     author=review.get("userName", ""),


### PR DESCRIPTION
## 修复:评论源 dedup URL 碰撞,丢弃约 98% 的商店评论

### 根因
`google_play` / `appstore` 评论的 URL 仅含 locale 级标识(gp: `id+hl`;appstore: `country`),**同一 locale 的数十条评论共用一个 URL**。`dedup_key` 以 URL 优先(`collect_global.py:91`),于是 `merge_and_dedup` 把同 locale 评论全判为重复,**每 locale 仅存活 engagement 最高的 1 条**。

实测:`fetch_google_play` 每轮采到 **927 条**评论,dedup 后**仅剩 16 条**(多为历史高赞旧评论 → 归档层时间长期卡在 06-06)。`appstore` 同病(17 条 ≈ 各 country 1 条)。

> 比喻:几十个学生交作业,老师只按"语言"分格子收,每格最后只留点赞最高的一份,其余几十份全扔了——抄回 927 份,只存下 16 份还都是旧的。

### 修复
URL 追加唯一锚点 fragment,使每条评论 `dedup_key` 唯一:
- google_play:`#gp-{reviewId}`(reviewId 为 UUID,已验证)
- appstore:`#as-{RSS entry id}`(iTunes RSS 标准唯一字段)

fragment 不影响链接访问(浏览器忽略),跨轮次去重仍按恒定 id 生效。

### 验证
- 实测修复后 google_play dedup 存活数 **16 → 627**
- `pytest tests/`:**1885 通过,零回归**(15 个 OKF bundle 指针失败为基底 #333 数据迁移既有,与本修复无关;已向守密人单独提示)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzcdzvL7v49DQ9BsuLajWi)_