### PR TITLE
fix(ci): regenerate stale OKF bundle + required-check reports on all PRs + record branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,12 @@ on:
       - 'memory/decisions-archive.md'
       - '.github/workflows/test.yml'
   pull_request:
-    paths:
-      - 'scripts/**'
-      - 'projects/news/scripts/**'
-      - 'tests/**'
-      - 'CLAUDE.md'
-      - 'memory/decisions.md'
-      - 'memory/decisions-archive.md'
+    # NO paths filter on purpose: `test` is a REQUIRED status check on main
+    # (branch ruleset, 2026-06-21). A required check gated behind a paths filter
+    # never reports on PRs that don't touch those paths (e.g. docs-only PRs),
+    # leaving the PR deadlocked forever on "Expected — waiting for status".
+    # Running on every PR to main guarantees the required check always reports.
+    # The suite is ~5s so the cost is negligible.
   workflow_dispatch:
 
 concurrency:

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -117,3 +117,32 @@ CLAUDE.md §4 的「全量档案层 vs 输出展示层不可互换」是**语义
 
 > 小学生比喻：以前样品柜上没贴「样品」标签全靠管理员记性，现在每个样品瓶都印死了「样品」二字——
 > 谁再想把它当总库存，瓶身就先拦住他。
+
+## 5. 合并门：main 分支保护（2026-06-21 起）
+
+四层护栏只在「测试真被跑且红了能拦住合并」时才有意义。2026-06-21 守密人在 GitHub
+设置侧对 **main** 启用了分支保护规则集（ruleset），把「CI 绿才能合」从约定升级为机器强制：
+
+- **Require status checks to pass** → 必需检查 `test`（`.github/workflows/test.yml`，GitHub Actions）
+- **Require branches to be up to date before merging** ← 根治「陈旧分支带过时绿章合并」：
+  PR 必须先对齐最新 main 重跑 CI 才能合
+- **Block force pushes**；**Do not allow bypassing**（连合并机器人也须验票，无后门）
+
+> 触发它的连环事件（均为 #333「数据迁入 Public-Info-Pool」迁移后未同步的连锁）：
+> (1) PR #333 基于旧 main、合并前未对齐最新代码重跑 CI，把 #335 新增的 `build_community_index`
+> 测试撞红 11 个仍合进主线；(2) 同源迁移后 OKF bundle 未重生成，`okf/sources/*.md` 15 个指针
+> 仍指向迁走的旧路径，再红 15 个。两批共 26 个红测试在主线长期未被拦截。
+> 小学生比喻：施工队改了管网却没人对着新图复检——闸门此前根本没装，旧合格证一路放行。
+
+### 配套：必需检查必须在每个 PR 上都上报（否则反被卡死）
+
+必需检查若被 `paths` 过滤门控，碰到不触及那些路径的 PR（如纯文档 PR）会永不上报、PR 永久卡在
+「等待状态」。故 `test.yml` 的 `pull_request` 触发**刻意去掉 paths 过滤**，对每个到 main 的 PR
+都跑（suite ~5s，代价可忽略）。`mutation-test.yml` 是手动 `workflow_dispatch`，**绝不可**设为必需。
+
+### 对合并流程的影响（与 CLAUDE.md §7.6 调和）
+
+main 受保护后，合并从「本地验证完→立即 squash」变为「推 PR → 等 `test` 转绿（几分钟）→ 合并」。
+仍是「CI 绿即合、无需人工评审」，只是多等一次 CI——**不再是字面的「不停留等待」**。§7.6「默认立即
+合并、不停留等待」应理解为补一条注脚：**main 受保护后，合并须等 required check 转绿**（§7.6 属决策
+档、仅守密人可改；此处先在文档层留痕，防文档与实际再次脱节——正是这类脱节酿成上述 26 个红测试）。

--- a/okf/sources/appstore.md
+++ b/okf/sources/appstore.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "appstore 社区数据源"
 description: "appstore 平台采集档案，全量 439 条，健康度 active。"
-resource: "/projects/news/data/platforms/appstore/"
+resource: "/Public-Info-Pool/Record/Community/appstore/"
 tags: ["data_layer:full_archive", "platform:appstore", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | appstore |
-| 全量档案层（本体） | `projects/news/data/platforms/appstore/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/appstore/` |
 | 输出展示层（抽样） | `projects/news/output/appstore-latest.json` |
 | 全量条数 | 439 |
 | 采集健康度 | active |

--- a/okf/sources/bilibili.md
+++ b/okf/sources/bilibili.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "bilibili 社区数据源"
 description: "bilibili 平台采集档案，全量 2193 条，健康度 active。"
-resource: "/projects/news/data/platforms/bilibili/"
+resource: "/Public-Info-Pool/Record/Community/bilibili/"
 tags: ["data_layer:full_archive", "platform:bilibili", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | bilibili |
-| 全量档案层（本体） | `projects/news/data/platforms/bilibili/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/bilibili/` |
 | 输出展示层（抽样） | `projects/news/output/bilibili-latest.json` |
 | 全量条数 | 2193 |
 | 采集健康度 | active |

--- a/okf/sources/discord.md
+++ b/okf/sources/discord.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "discord 社区数据源"
 description: "discord 平台采集档案，全量 7668192 条，健康度 active。"
-resource: "/projects/news/data/discord/"
+resource: "/Public-Info-Pool/Record/Community/discord/"
 tags: ["data_layer:full_archive", "platform:discord", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | discord |
-| 全量档案层（本体） | `projects/news/data/discord/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/discord/` |
 | 输出展示层（抽样） | `projects/news/output/discord-latest.json` |
 | 全量条数 | 7668192 |
 | 采集健康度 | active |

--- a/okf/sources/google_play.md
+++ b/okf/sources/google_play.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "google_play 社区数据源"
 description: "google_play 平台采集档案，全量 491 条，健康度 degraded。"
-resource: "/projects/news/data/platforms/google_play/"
+resource: "/Public-Info-Pool/Record/Community/google_play/"
 tags: ["data_layer:full_archive", "platform:google_play", "health:degraded"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | google_play |
-| 全量档案层（本体） | `projects/news/data/platforms/google_play/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/google_play/` |
 | 输出展示层（抽样） | `projects/news/output/google_play-latest.json` |
 | 全量条数 | 491 |
 | 采集健康度 | degraded |

--- a/okf/sources/official.md
+++ b/okf/sources/official.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "official 社区数据源"
 description: "official 平台采集档案，全量 331 条，健康度 degraded。"
-resource: "/projects/news/data/platforms/official/"
+resource: "/Public-Info-Pool/Record/Community/official/"
 tags: ["data_layer:full_archive", "platform:official", "health:degraded"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | official |
-| 全量档案层（本体） | `projects/news/data/platforms/official/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/official/` |
 | 输出展示层（抽样） | `projects/news/output/official-latest.json` |
 | 全量条数 | 331 |
 | 采集健康度 | degraded |

--- a/okf/sources/pixiv.md
+++ b/okf/sources/pixiv.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "pixiv 社区数据源"
 description: "pixiv 平台采集档案，全量 513 条，健康度 active。"
-resource: "/projects/news/data/platforms/pixiv/"
+resource: "/Public-Info-Pool/Record/Community/pixiv/"
 tags: ["data_layer:full_archive", "platform:pixiv", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | pixiv |
-| 全量档案层（本体） | `projects/news/data/platforms/pixiv/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/pixiv/` |
 | 输出展示层（抽样） | `projects/news/output/pixiv-latest.json` |
 | 全量条数 | 513 |
 | 采集健康度 | active |

--- a/okf/sources/reddit.md
+++ b/okf/sources/reddit.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "reddit 社区数据源"
 description: "reddit 平台采集档案，全量 3152 条，健康度 active。"
-resource: "/projects/news/data/platforms/reddit/"
+resource: "/Public-Info-Pool/Record/Community/reddit/"
 tags: ["data_layer:full_archive", "platform:reddit", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | reddit |
-| 全量档案层（本体） | `projects/news/data/platforms/reddit/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/reddit/` |
 | 输出展示层（抽样） | `projects/news/output/reddit-latest.json` |
 | 全量条数 | 3152 |
 | 采集健康度 | active |

--- a/okf/sources/ruliweb.md
+++ b/okf/sources/ruliweb.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "ruliweb 社区数据源"
 description: "ruliweb 平台采集档案，全量 375 条，健康度 active。"
-resource: "/projects/news/data/platforms/ruliweb/"
+resource: "/Public-Info-Pool/Record/Community/ruliweb/"
 tags: ["data_layer:full_archive", "platform:ruliweb", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | ruliweb |
-| 全量档案层（本体） | `projects/news/data/platforms/ruliweb/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/ruliweb/` |
 | 输出展示层（抽样） | `projects/news/output/ruliweb-latest.json` |
 | 全量条数 | 375 |
 | 采集健康度 | active |

--- a/okf/sources/steam.md
+++ b/okf/sources/steam.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "steam 社区数据源"
 description: "steam 平台采集档案，全量 4966 条，健康度 active。"
-resource: "/projects/news/data/platforms/steam/"
+resource: "/Public-Info-Pool/Record/Community/steam/"
 tags: ["data_layer:full_archive", "platform:steam", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | steam |
-| 全量档案层（本体） | `projects/news/data/platforms/steam/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/steam/` |
 | 输出展示层（抽样） | `projects/news/output/steam-latest.json` |
 | 全量条数 | 4966 |
 | 采集健康度 | active |

--- a/okf/sources/steam_discussion.md
+++ b/okf/sources/steam_discussion.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "steam_discussion 社区数据源"
 description: "steam_discussion 平台采集档案，全量 38 条，健康度 active。"
-resource: "/projects/news/data/platforms/steam_discussion/"
+resource: "/Public-Info-Pool/Record/Community/steam_discussion/"
 tags: ["data_layer:full_archive", "platform:steam_discussion", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | steam_discussion |
-| 全量档案层（本体） | `projects/news/data/platforms/steam_discussion/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/steam_discussion/` |
 | 输出展示层（抽样） | `projects/news/output/steam_discussion-latest.json` |
 | 全量条数 | 38 |
 | 采集健康度 | active |

--- a/okf/sources/stopgame.md
+++ b/okf/sources/stopgame.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "stopgame 社区数据源"
 description: "stopgame 平台采集档案，全量 63 条，健康度 active。"
-resource: "/projects/news/data/platforms/stopgame/"
+resource: "/Public-Info-Pool/Record/Community/stopgame/"
 tags: ["data_layer:full_archive", "platform:stopgame", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | stopgame |
-| 全量档案层（本体） | `projects/news/data/platforms/stopgame/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/stopgame/` |
 | 输出展示层（抽样） | `projects/news/output/stopgame-latest.json` |
 | 全量条数 | 63 |
 | 采集健康度 | active |

--- a/okf/sources/taptap.md
+++ b/okf/sources/taptap.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "taptap 社区数据源"
 description: "taptap 平台采集档案，全量 4 条，健康度 active。"
-resource: "/projects/news/data/platforms/taptap/"
+resource: "/Public-Info-Pool/Record/Community/taptap/"
 tags: ["data_layer:full_archive", "platform:taptap", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | taptap |
-| 全量档案层（本体） | `projects/news/data/platforms/taptap/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/taptap/` |
 | 输出展示层（抽样） | `projects/news/output/taptap-latest.json` |
 | 全量条数 | 4 |
 | 采集健康度 | active |

--- a/okf/sources/weibo.md
+++ b/okf/sources/weibo.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "weibo 社区数据源"
 description: "weibo 平台采集档案，全量 7417 条，健康度 active。"
-resource: "/projects/news/data/platforms/weibo/"
+resource: "/Public-Info-Pool/Record/Community/weibo/"
 tags: ["data_layer:full_archive", "platform:weibo", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | weibo |
-| 全量档案层（本体） | `projects/news/data/platforms/weibo/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/weibo/` |
 | 输出展示层（抽样） | `projects/news/output/weibo-latest.json` |
 | 全量条数 | 7417 |
 | 采集健康度 | active |

--- a/okf/sources/weixin.md
+++ b/okf/sources/weixin.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "weixin 社区数据源"
 description: "weixin 平台采集档案，全量 3958 条，健康度 active。"
-resource: "/projects/news/data/platforms/weixin/"
+resource: "/Public-Info-Pool/Record/Community/weixin/"
 tags: ["data_layer:full_archive", "platform:weixin", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | weixin |
-| 全量档案层（本体） | `projects/news/data/platforms/weixin/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/weixin/` |
 | 输出展示层（抽样） | `projects/news/output/weixin-latest.json` |
 | 全量条数 | 3958 |
 | 采集健康度 | active |

--- a/okf/sources/youtube.md
+++ b/okf/sources/youtube.md
@@ -2,7 +2,7 @@
 type: "dataset"
 title: "youtube 社区数据源"
 description: "youtube 平台采集档案，全量 2222 条，健康度 active。"
-resource: "/projects/news/data/platforms/youtube/"
+resource: "/Public-Info-Pool/Record/Community/youtube/"
 tags: ["data_layer:full_archive", "platform:youtube", "health:active"]
 timestamp: "2026-06-21T13:06:38.663607+00:00"
 ---
@@ -14,7 +14,7 @@ timestamp: "2026-06-21T13:06:38.663607+00:00"
 | 项 | 值 |
 |------|------|
 | 平台 | youtube |
-| 全量档案层（本体） | `projects/news/data/platforms/youtube/` |
+| 全量档案层（本体） | `Public-Info-Pool/Record/Community/youtube/` |
 | 输出展示层（抽样） | `projects/news/output/youtube-latest.json` |
 | 全量条数 | 2222 |
 | 采集健康度 | active |


### PR DESCRIPTION
## 背景

承接刚开启的 main 分支保护（required `test` check）。开启后发现 main 自身 CI 是**红的**——分支保护因此冻结了所有合并。本 PR 把主线恢复绿、并补上保护规则所需的配套与文档。

## 三处耦合改动

**1. 重新生成过期的 OKF bundle（15 个 `okf/sources/*.md` 指针）**
PR #333 把社区数据迁入 `Public-Info-Pool/Record/Community`，却**没重生成 OKF bundle**，导致每个源指针仍悬挂在已迁走的 `projects/news/data/platforms/*` 旧路径 → 主线 15 个 `test_okf_bundle` 红测试。`build_okf_bundle.py` 本就优先新布局，重生成即重新指向；216 个 okf 测试全过。

**2. 去掉 `test.yml` 的 `pull_request` paths 过滤**
`test` 现为 main 必需检查。必需检查若被 paths 过滤门控，碰到不触及那些路径的 PR（如纯文档 PR）会**永不上报、PR 永久卡死**在「等待状态」。改为对每个到 main 的 PR 都跑（suite ~5s），保证必需检查恒上报。

**3. 落档分支保护决策**（`docs/testing-strategy.md` 第 5 节）
记录规则集配置、触发它的 #333/#335/okf 连环回归、以及与 §7.6 合并流程的注脚。

## 验证

全量 **1909 passed, 3 skipped**。

> 比喻：刚装好的主管道闸门一落，才发现管网本身早有两处暗漏（#333 漏改的 11 个 + okf 没重生成的 15 个，共 26 处）。本 PR 把暗漏补好、给发票窗口对每辆车开门、并把这道闸的装法白纸黑字记进档案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yhocmg6Pox7gqRxi8BoUT

---
_Generated by [Claude Code](https://claude.ai/code/session_017yhocmg6Pox7gqRxi8BoUT)_