### PR TITLE
fix(site): 站点定位文案翻回公开层（对齐 §0 广义裁定）

### DIFF
--- a/projects/site/public/biav/index.html
+++ b/projects/site/public/biav/index.html
@@ -125,7 +125,7 @@
   <div class="sec-label">Silver Core</div>
   <div class="sec-title">银芯系统</div>
   <div class="sec-body">
-    <p><strong>银芯（Silver Core / BIAV-SC）</strong>是 BIAV 项目的知识层系统名，定位为 Studio 的<em>受限 / 非公开层</em>：负责采集、整理外部社区与解包信息，单向输出至内部层（黑池），是 Studio 对外的"眼睛和耳朵"。</p>
+    <p><strong>银芯（Silver Core / BIAV-SC）</strong>是 BIAV 项目的知识层系统名，定位为 Studio 的<em>公开信息层</em>（整层公开，自身工程产物亦属公开信息）：负责采集、整理外部社区与解包信息，向内部层（黑池）单向输出，是 Studio 对外的"眼睛和耳朵"。需注意：定位公开<strong>不解除</strong>第三方平台对采集的约束，黑池→银芯方向亦<strong>永久关闭</strong>——越公开，这道单向防火墙越关键。</p>
     <p>银芯的记忆不再依赖自建检索栈，而是收回到三条互补支柱：<strong>CLAUDE.md</strong>（每会话自动加载的统一入口与协议）、<strong>memory/*.md</strong>（人工策展的决策 / 踩坑 / 状态 / 方法论档案），以及 Claude 平台原生的上下文管理。每一轮协作产出的事实与决策被写入策展档案，让下一轮会话从已有沉淀起步。</p>
     <p>会话之外，MCP 服务 <span class="code">biav-sc-memory</span> 提供四件协作工具：<span class="code">character_persona</span>（人格激活）、<span class="code">record_decision</span>（决策落档）、<span class="code">record_lesson</span>（教训沉淀）、<span class="code">current_continuity</span>（连续性读取）。这是 Studio 在 AI 协作时代的方法论尝试：<em>让记忆成为基础设施，让协议优先于工具</em>。</p>
   </div>

--- a/projects/site/public/index.html
+++ b/projects/site/public/index.html
@@ -217,7 +217,7 @@
 <section>
   <div class="sec-label reveal">Mission</div>
   <div class="sec-title reveal">银芯三新使命</div>
-  <div class="sec-desc reveal">本站由银芯（B.I.A.V. Silver Core）知识层驱动。银芯是 Studio 的 AI 协作知识层，自 2026-04 起承载三条使命，为社区提供可追溯的事实底座。</div>
+  <div class="sec-desc reveal">本站由银芯（B.I.A.V. Silver Core）公开信息层驱动。银芯是 Studio 的 AI 协作公开知识层，自 2026-04 起承载三条使命，为社区提供可追溯的事实底座。</div>
   <div class="mission-grid">
     <a class="mission-card reveal" href="news/">
       <div class="mission-num" aria-hidden="true">壹</div>


### PR DESCRIPTION
## 背景

守密人 2026-06-21 在并行 /grill 会话下达 **§0 广义裁定**：银芯整层从「受限 / 非公开层」（2026-06-11）**翻回公开信息层**（commit df0f6810 / PR #342）。

本会话早些时候已合并的 PR #338 曾按 6-11 旧裁定把站点文案改成「受限 / 非公开层」，现回滚对齐最新裁定。

## 改动

- `index.html` mission 段：「知识层」→「公开信息层 / 公开知识层」
- `biav/index.html` 银芯系统段：「受限 / 非公开层」→「公开信息层（整层公开，自身工程产物亦属公开信息）」
- 同时**显式保留两条射程外硬约束**（裁定明确不变）：公开定位不解除第三方平台 ToS 采集约束；§1.1-HC 黑池→银芯防火墙永久关闭（越公开越关键）

仅动定位措辞；#338 已修的采集节奏（每小时）、死链清理、记忆系统更新均不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AizTGWZp87SAg1SCW1tCxb)_