### PR TITLE
docs(CLAUDE): 放宽 PR 订阅约束，不再强制退订

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,10 +356,11 @@ MCP 服务端 `biav-sc-memory`（`scripts/mcp_server.py`）对接知识层工具
 - **合并默认规则**（守密人 2026-06-11 裁定）：feature 分支任务完成且全量验证通过后，
   守密人下达「合并」即默认合并 main，PR 无需停留等待逐项确认；遇合并冲突按
   「自动生成状态档案取最新、人工档案先报告再处置」原则解决。
-- **直接合并 main + 不订阅 PR（守密人 2026-06-14 裁定，硬约束）**：
+- **直接合并 main（守密人 2026-06-14 裁定 / 2026-06-21 宽解订阅约束）**：
   Web 环境强制建 PR，但任务完成且验证通过后**默认立即合并 main**（squash），不停留等待。
-  **绝不主动调用 `subscribe_pr_activity`**；若会话被环境自动订阅（出现
-  `<github-webhook-activity>` 提示），**立即 `unsubscribe_pr_activity` 退订**。
-  彻底关闭自动订阅需在 Web 环境配置侧设置（见 https://code.claude.com/docs/en/claude-code-on-the-web），仓库内无法根治。
+  **订阅约束已放宽**：2026-06-21 守密人撤销「绝不订阅 / 检测到自动订阅须立即退订」的硬约束——
+  会话被环境自动订阅或守密人要求看护 PR 时，**不再强制 `unsubscribe_pr_activity` 退订**，
+  按实际需要决定是否守护；仅当守密人明确要求停止看护时才退订。
+  彻底关闭自动订阅仍可在 Web 环境配置侧设置（见 https://code.claude.com/docs/en/claude-code-on-the-web）。
 - commit message 可用英文，过程说明 / 状态报告用中文（§2.1.3）。
 - 产出文件后必附可点击超链接向守密人汇报（§2.2.2）。


### PR DESCRIPTION
## 修正内容

§7.6 分支与提交 — 撤销「绝不订阅 / 自动订阅须立即退订」的硬约束。

- 原约束（守密人 2026-06-14 裁定）：`绝不主动调用 subscribe_pr_activity`；检测到自动订阅须`立即 unsubscribe_pr_activity 退订`。
- 新规则（守密人 2026-06-21 宽解）：订阅约束放宽，**不再强制退订**；会话被自动订阅或守密人要求看护 PR 时按需守护，仅当守密人明确要求停止时才退订。
- 「默认立即合并 main（squash）」规则保持不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDgWsDAEHGy2P3TRFK571b

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDgWsDAEHGy2P3TRFK571b)_