### PR TITLE
feat(news): 命名规范实施阶段2 — archive 按区服/类型分层(甲方案接收端)

### DIFF
--- a/projects/news/scripts/archive_platforms.py
+++ b/projects/news/scripts/archive_platforms.py
@@ -92,9 +92,23 @@ def item_date_utc8(item: dict, fallback: str) -> str:
         return fallback
 
 
-def load_existing_archive(platform: str, date_str: str) -> dict:
+def archive_path(platform: str, region: str | None, subtype: str | None, date_str: str) -> Path:
+    """归档落点：``<平台>[/<区服>][/<类型>]/YYYY-MM-DD.json``。
+
+    甲方案（2026-06-21 命名规范）：item 带 ``region`` / ``archive_subtype`` 字段才分层，
+    缺省则省略该层、回落旧扁平 ``<平台>/YYYY-MM-DD.json``——现有不带字段的源零破坏。
+    """
+    parts = [platform]
+    if region:
+        parts.append(region)
+    if subtype:
+        parts.append(subtype)
+    return ARCHIVE_DIR.joinpath(*parts) / f'{date_str}.json'
+
+
+def load_existing_archive(platform: str, region: str | None, subtype: str | None, date_str: str) -> dict:
     """Load existing archive file if it exists."""
-    path = ARCHIVE_DIR / platform / f'{date_str}.json'
+    path = archive_path(platform, region, subtype, date_str)
     if not path.exists():
         return {}
     with open(path, encoding='utf-8') as f:
@@ -123,15 +137,16 @@ def merge_items(existing_items: list[dict], new_items: list[dict]) -> list[dict]
     return merged
 
 
-def write_archive(platform: str, date_str: str, new_items: list[dict]) -> int:
-    """Merge new_items into the (platform, date) archive file. Returns final count."""
-    existing = load_existing_archive(platform, date_str)
+def write_archive(platform: str, region: str | None, subtype: str | None,
+                  date_str: str, new_items: list[dict]) -> int:
+    """Merge new_items into the (platform, region, subtype, date) archive. Returns final count."""
+    existing = load_existing_archive(platform, region, subtype, date_str)
     merged = merge_items(existing.get('items', []), new_items)
     if not merged:
         return 0
 
-    platform_dir = ARCHIVE_DIR / platform
-    platform_dir.mkdir(parents=True, exist_ok=True)
+    path = archive_path(platform, region, subtype, date_str)
+    path.parent.mkdir(parents=True, exist_ok=True)
 
     archive_data = {
         'date': date_str,
@@ -140,7 +155,11 @@ def write_archive(platform: str, date_str: str, new_items: list[dict]) -> int:
         'item_count': len(merged),
         'items': merged,
     }
-    with open(platform_dir / f'{date_str}.json', 'w', encoding='utf-8') as f:
+    if region:
+        archive_data['region'] = region
+    if subtype:
+        archive_data['content_subtype'] = subtype
+    with open(path, 'w', encoding='utf-8') as f:
         json.dump(archive_data, f, ensure_ascii=False, indent=2)
     return len(merged)
 
@@ -154,19 +173,21 @@ def archive_all(target_date: str | None, fallback_date: str) -> dict[str, int]:
 
     target_date 非空时只归档该日；为空时归档 news.json 内出现的全部日期。
     """
-    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    groups: dict[tuple[str, str | None, str | None, str], list[dict]] = defaultdict(list)
     for raw in load_news():
         src = normalize_source(raw.get('source', 'unknown'))
         if src == 'discord':  # 独立归档器处理
             continue
+        region = raw.get('region') or None             # 甲方案：区服字段（global/jp…）
+        subtype = raw.get('archive_subtype') or None   # 甲方案：内容类型字段（review/news…）
         d = item_date_utc8(raw, fallback_date)
         if target_date and d != target_date:
             continue
-        groups[(src, d)].append(raw)
+        groups[(src, region, subtype, d)].append(raw)
 
     totals: dict[str, int] = defaultdict(int)
-    for (src, d), items in groups.items():
-        write_archive(src, d, items)
+    for (src, region, subtype, d), items in groups.items():
+        write_archive(src, region, subtype, d, items)
         totals[src] += len(items)
     return totals
 
@@ -183,15 +204,16 @@ def show_stats():
             print(f'  {platform:12s}  (无归档)')
             continue
 
-        files = sorted(platform_dir.glob('*.json'))
+        files = sorted(platform_dir.rglob('*.json'))  # rglob 兼容甲方案分层(区服/类型子目录)
         if not files:
             print(f'  {platform:12s}  (无归档)')
             continue
 
         file_count = len(files)
         item_count = 0
-        first_date = files[0].stem
-        last_date = files[-1].stem
+        dates = sorted(f.stem for f in files)
+        first_date = dates[0]
+        last_date = dates[-1]
 
         for f in files:
             try:

--- a/tests/test_archive_platforms_unit.py
+++ b/tests/test_archive_platforms_unit.py
@@ -96,14 +96,14 @@ class TestArchiveIO(unittest.TestCase):
     def test_load_existing_missing_returns_empty(self):
         import tempfile
         with tempfile.TemporaryDirectory() as d, self._patch_dir(d):
-            self.assertEqual(ap.load_existing_archive("steam", "2026-01-01"), {})
+            self.assertEqual(ap.load_existing_archive("steam", None, None, "2026-01-01"), {})
 
     def test_write_then_load_roundtrip(self):
         import tempfile
         with tempfile.TemporaryDirectory() as d, self._patch_dir(d):
-            n = ap.write_archive("steam", "2026-04-14", [{"url": "u1", "engagement": 3}])
+            n = ap.write_archive("steam", None, None, "2026-04-14", [{"url": "u1", "engagement": 3}])
             self.assertEqual(n, 1)
-            loaded = ap.load_existing_archive("steam", "2026-04-14")
+            loaded = ap.load_existing_archive("steam", None, None, "2026-04-14")
             self.assertEqual(loaded["item_count"], 1)
             self.assertEqual(loaded["source"], "steam")
             self.assertEqual(loaded["date"], "2026-04-14")
@@ -111,15 +111,60 @@ class TestArchiveIO(unittest.TestCase):
     def test_write_empty_returns_zero_no_file(self):
         import tempfile
         with tempfile.TemporaryDirectory() as d, self._patch_dir(d):
-            self.assertEqual(ap.write_archive("steam", "2026-04-14", []), 0)
+            self.assertEqual(ap.write_archive("steam", None, None, "2026-04-14", []), 0)
             self.assertFalse((Path(d) / "steam").exists())
 
     def test_write_merges_existing(self):
         import tempfile
         with tempfile.TemporaryDirectory() as d, self._patch_dir(d):
-            ap.write_archive("reddit", "2026-04-14", [{"url": "u1"}])
-            n = ap.write_archive("reddit", "2026-04-14", [{"url": "u2"}])
+            ap.write_archive("reddit", None, None, "2026-04-14", [{"url": "u1"}])
+            n = ap.write_archive("reddit", None, None, "2026-04-14", [{"url": "u2"}])
             self.assertEqual(n, 2)
+
+
+class TestArchivePathLayering(unittest.TestCase):
+    """甲方案（2026-06-21）：region/subtype 字段 → 子目录分层，无字段回落扁平。"""
+
+    def _patch_dir(self, d):
+        return mock.patch.object(ap, "ARCHIVE_DIR", Path(d))
+
+    def test_path_flat_fallback_no_fields(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d, self._patch_dir(d):
+            p = ap.archive_path("steam", None, None, "2026-01-01")
+            self.assertEqual(p, Path(d) / "steam" / "2026-01-01.json")
+
+    def test_path_layered_region_and_subtype(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d, self._patch_dir(d):
+            p = ap.archive_path("steam", "jp", "review", "2026-01-01")
+            self.assertEqual(p, Path(d) / "steam" / "jp" / "review" / "2026-01-01.json")
+
+    def test_path_subtype_only(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d, self._patch_dir(d):
+            p = ap.archive_path("youtube", None, "comments", "2026-01-01")
+            self.assertEqual(p, Path(d) / "youtube" / "comments" / "2026-01-01.json")
+
+    def test_write_layered_roundtrip_with_meta(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d, self._patch_dir(d):
+            n = ap.write_archive("steam", "jp", "review", "2026-04-14", [{"url": "u1"}])
+            self.assertEqual(n, 1)
+            self.assertTrue((Path(d) / "steam" / "jp" / "review" / "2026-04-14.json").exists())
+            loaded = ap.load_existing_archive("steam", "jp", "review", "2026-04-14")
+            self.assertEqual(loaded["region"], "jp")
+            self.assertEqual(loaded["content_subtype"], "review")
+
+    def test_flat_and_layered_dont_collide(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d, self._patch_dir(d):
+            ap.write_archive("steam", None, None, "2026-04-14", [{"url": "flat"}])
+            ap.write_archive("steam", "jp", "review", "2026-04-14", [{"url": "jp"}])
+            flat = ap.load_existing_archive("steam", None, None, "2026-04-14")
+            jp = ap.load_existing_archive("steam", "jp", "review", "2026-04-14")
+            self.assertEqual(flat["items"][0]["url"], "flat")
+            self.assertEqual(jp["items"][0]["url"], "jp")
 
 
 class TestArchiveAll(unittest.TestCase):
@@ -153,6 +198,25 @@ class TestArchiveAll(unittest.TestCase):
     def test_empty_news_yields_empty_totals(self):
         with mock.patch.object(ap, "load_news", return_value=[]):
             self.assertEqual(dict(ap.archive_all(None, "2026-01-01")), {})
+
+    def test_buckets_by_region_and_subtype(self):
+        """甲方案：item 带 region/archive_subtype 字段 → 分桶到 平台/区服/类型/ 子目录。"""
+        import tempfile
+        news = [
+            {"source": "steam", "url": "g1", "time": "2026-04-13T20:00:00+00:00",
+             "region": "global", "archive_subtype": "review"},
+            {"source": "steam", "url": "j1", "time": "2026-04-13T20:00:00+00:00",
+             "region": "jp", "archive_subtype": "review"},
+            {"source": "steam", "url": "n1", "time": "2026-04-13T20:00:00+00:00",
+             "region": "global", "archive_subtype": "news"},
+        ]
+        with tempfile.TemporaryDirectory() as d, \
+                mock.patch.object(ap, "ARCHIVE_DIR", Path(d)), \
+                mock.patch.object(ap, "load_news", return_value=news):
+            ap.archive_all(target_date=None, fallback_date="2026-01-01")
+            self.assertTrue((Path(d) / "steam" / "global" / "review" / "2026-04-14.json").exists())
+            self.assertTrue((Path(d) / "steam" / "jp" / "review" / "2026-04-14.json").exists())
+            self.assertTrue((Path(d) / "steam" / "global" / "news" / "2026-04-14.json").exists())
 
 
 class TestShowStatsAndMain(unittest.TestCase):


### PR DESCRIPTION
## 命名规范实施 — 阶段 2(甲方案接收端:archive 分层)

承接 #353(配置层)。本 PR 实现**甲方案的归档接收端**:`archive_platforms` 按 item 字段分桶到 `平台/区服/类型/` 子目录。**零破坏增量**——现有不带字段的源回落旧扁平路径。

### 改动
- **`archive_path(platform, region, subtype, date)`**:区服/类型缺省则省略该层,回落 `<平台>/YYYY-MM-DD.json`(现有源零破坏)。
- `write_archive` / `load_existing_archive` / `archive_all` 全链路传 region/subtype;`archive_all` 从 item 读 `region` + `archive_subtype` 字段。
- 归档元数据增 `region` / `content_subtype`。
- `show_stats` 改 `rglob` 兼容分层。
- 单测 +6:路径分层/扁平回落/不碰撞/区服+类型分桶。

### 验证
- `tests/test_archive_platforms_unit.py` **31 通过**
- 全量 `pytest tests/` **1916 通过、零回归**

### 后续(发送端)
采集器给 item 标 `region`/`archive_subtype`(steam 双区服、youtube/taptap 合并),消费方(`silent_sources_audit` / `community_index`)递归读适配。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzcdzvL7v49DQ9BsuLajWi)_