### PR TITLE
feat(news): 命名规范阶段3 — 采集器标 region/archive_subtype（甲方案发送端，5 棒）

### DIFF
--- a/projects/news/scripts/aggregator_base.py
+++ b/projects/news/scripts/aggregator_base.py
@@ -220,6 +220,12 @@ def validate_news_item(item):
         cleaned['content_type'] = item.get('content_type', 'image')
     if item.get('lang'):
         cleaned['lang'] = str(item['lang'])
+    # 甲方案归档分层字段（2026-06-21 采集源命名规范）：AC 栈 item 经此白名单重建，
+    # 须显式放行 region/archive_subtype，否则 archive_platforms 分桶失据（缺省不落，回落扁平）。
+    if item.get('region'):
+        cleaned['region'] = str(item['region'])
+    if item.get('archive_subtype'):
+        cleaned['archive_subtype'] = str(item['archive_subtype'])
 
     # Title must not be empty after sanitization
     if not cleaned['title']:

--- a/projects/news/scripts/aggregator_collectors.py
+++ b/projects/news/scripts/aggregator_collectors.py
@@ -21,6 +21,7 @@ from aggregator_base import (
 )
 import news_common  # 脱敏 + 时间归一单一真源（H3/H4；aggregator_base 已设 sys.path）
 from news_common import bilibili_spi_cookies, get_wbi_mixin_key, sign_wbi_params
+from sources import REGION_APPS  # 区服 app 标识单一真相源（2026-06-21 采集源命名规范）
 
 
 def _fetch_reddit_comments(permalink: str, headers: dict, max_comments: int = 10) -> list[dict]:
@@ -635,15 +636,21 @@ def fetch_taptap():
 
 
 def fetch_steam_reviews():
-    """Fetch recent Steam reviews for Morimens (App ID: 3052450).
+    """Fetch Steam reviews across all configured regions（甲方案：双 appid global/jp，归档子类 review）。"""
+    items = []
+    for region, app_id in REGION_APPS.get('steam', {'global': '3052450'}).items():
+        items.extend(_fetch_steam_reviews_one(str(app_id), region))
+    return items
+
+
+def _fetch_steam_reviews_one(app_id, region):
+    """Fetch recent Steam reviews for one (app_id, region).
 
     使用 cursor=* 分页一直翻到时间窗口外为止。Steam 按 recent 排序，
     一旦看到早于 cutoff 的 review 就可以停。
     """
     import subprocess as _sp
     from urllib.parse import quote
-
-    app_id = 3052450
     cutoff = datetime.now(timezone.utc) - timedelta(hours=HOURS_LOOKBACK)
     items = []
     cursor = '*'
@@ -696,6 +703,8 @@ def fetch_steam_reviews():
                     'title': title,
                     'summary': review_text,
                     'source': 'steam_review',
+                    'region': region,             # 甲方案：global/jp 区服
+                    'archive_subtype': 'review',  # 归档 steam/<区服>/review
                     'time': created.isoformat(),
                     'url': review_url,
                     'engagement': votes_up,
@@ -731,12 +740,19 @@ def fetch_steam_reviews():
 
 
 def fetch_steam_news():
-    """Fetch official Steam news/announcements for Morimens (App ID: 3052450).
+    """Fetch Steam official news across all configured regions（甲方案：双 appid，归档子类 news）。"""
+    items = []
+    for region, app_id in REGION_APPS.get('steam', {'global': '3052450'}).items():
+        items.extend(_fetch_steam_news_one(str(app_id), region))
+    return items
+
+
+def _fetch_steam_news_one(app_id, region):
+    """Fetch official Steam news/announcements for one (app_id, region).
 
     官方公告本身频率较低，通用 HOURS_LOOKBACK（24h）会经常过滤掉全部内容。
     使用更宽的 OFFICIAL_HOURS_LOOKBACK（默认 30 天）以保证日报至少能看到近期官方动态。
     """
-    app_id = 3052450
     # Steam News 单次 API 调用即可拿足 30 天窗口；count=100 保证不截断。
     url = f'https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/?appid={app_id}&count=100&maxlength=500'
     official_hours = int(os.environ.get('OFFICIAL_HOURS_LOOKBACK', max(HOURS_LOOKBACK, 30 * 24)))
@@ -761,6 +777,8 @@ def fetch_steam_news():
                 'title': f'[Steam{feed_label}] {strip_html_tags(n.get("title", ""))}',
                 'summary': strip_html_tags(n.get('contents', '')),
                 'source': 'official',
+                'region': region,            # 甲方案：global/jp 区服
+                'archive_subtype': 'news',   # 归档 steam/<区服>/news（official 折叠到 steam）
                 'time': created.isoformat(),
                 'url': n.get('url', ''),
                 'engagement': 0,
@@ -777,7 +795,15 @@ def fetch_steam_news():
 
 
 def fetch_steam_discussions(max_pages: int = 3):
-    """Fetch recent Steam Community discussions for Morimens (App ID: 3052450).
+    """Fetch Steam discussions across all configured regions（甲方案：双 appid，归档子类 discussion）。"""
+    items = []
+    for region, app_id in REGION_APPS.get('steam', {'global': '3052450'}).items():
+        items.extend(_fetch_steam_discussions_one(str(app_id), region, max_pages=max_pages))
+    return items
+
+
+def _fetch_steam_discussions_one(app_id, region, max_pages: int = 3):
+    """Fetch recent Steam Community discussions for one (app_id, region).
 
     Steam has no public API for discussions, so we scrape the HTML listing page
     (默认按最后回复时间倒序，15 帖/页，?fp=N 翻页)。2026-06 实测 DOM：
@@ -788,7 +814,6 @@ def fetch_steam_discussions(max_pages: int = 3):
     import html as _html
     import re as _re
 
-    app_id = 3052450
     base_url = f'https://steamcommunity.com/app/{app_id}/discussions/0/'
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
@@ -848,6 +873,8 @@ def fetch_steam_discussions(max_pages: int = 3):
                     'title': f'[Steam论坛] {title}',
                     'summary': summary,
                     'source': 'steam_discussion',
+                    'region': region,                # 甲方案：global/jp 区服
+                    'archive_subtype': 'discussion', # 归档 steam/<区服>/discussion
                     'time': time_str,
                     'url': m_url.group(1),
                     'engagement': replies,

--- a/projects/news/scripts/archive_platforms.py
+++ b/projects/news/scripts/archive_platforms.py
@@ -44,7 +44,7 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from sources import ARCHIVE_PLATFORMS, normalize_source
+from sources import ARCHIVE_PLATFORMS, normalize_source, archive_platform
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 OUTPUT_DIR = _REPO_ROOT / 'projects' / 'news' / 'output'
@@ -175,7 +175,7 @@ def archive_all(target_date: str | None, fallback_date: str) -> dict[str, int]:
     """
     groups: dict[tuple[str, str | None, str | None, str], list[dict]] = defaultdict(list)
     for raw in load_news():
-        src = normalize_source(raw.get('source', 'unknown'))
+        src = archive_platform(raw.get('source', 'unknown'))  # 甲方案：steam 家族折叠到 steam/ 归档
         if src == 'discord':  # 独立归档器处理
             continue
         region = raw.get('region') or None             # 甲方案：区服字段（global/jp…）

--- a/projects/news/scripts/collect_global.py
+++ b/projects/news/scripts/collect_global.py
@@ -85,6 +85,12 @@ def convert_item(item: dict) -> dict:
     # Preserve metadata (comments, play counts, reactions, etc.)
     if item.get('metadata') and isinstance(item['metadata'], dict):
         converted['metadata'] = item['metadata']
+    # 甲方案归档分层字段（2026-06-21 采集源命名规范）：采集器标了才透传，
+    # archive_platforms 据此分桶 <平台>/<区服>/<类型>/；缺省不落字段 → 回落扁平。
+    if item.get('region'):
+        converted['region'] = item['region']
+    if item.get('archive_subtype'):
+        converted['archive_subtype'] = item['archive_subtype']
     return converted
 
 

--- a/projects/news/scripts/global_collectors.py
+++ b/projects/news/scripts/global_collectors.py
@@ -32,6 +32,7 @@ import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import news_common  # 采集层共享工具（HTTP/HTML-strip/item 单一真源，ARCH-01/02）
+from sources import REGION_APPS  # 区服 app 标识单一真相源（2026-06-21 采集源命名规范）
 
 logging.basicConfig(
     level=logging.INFO,
@@ -303,8 +304,14 @@ def fetch_bilibili():
     return items
 
 
-# 官方 X 账号（英文 / 日文官方运营号）。可用 TWITTER_HANDLES 环境变量覆盖（逗号分隔）。
-TWITTER_OFFICIAL_HANDLES = ["MorimensOfcl", "bokyakuzenya"]
+# 官方 X 账号 → 区服：单一真相源取自 sources.REGION_APPS['twitter']
+# （global = @MorimensOfcl / jp = @bokyakuzenya，AltPlus 日本版独立账号）。
+# 日服账号独立运营 → 拆 jp/ 区服目录（甲方案 region 字段驱动 archive 分桶，不走 platform_region）。
+_TWITTER_REGION_BY_HANDLE = {
+    h.lower(): region for region, h in REGION_APPS.get("twitter", {}).items() if h
+}
+# 默认采集清单从单一真相源派生；可用 TWITTER_HANDLES 环境变量覆盖（逗号分隔）。
+TWITTER_OFFICIAL_HANDLES = [h for h in REGION_APPS.get("twitter", {}).values() if h]
 
 
 def _parse_twitter_time(created_at):
@@ -354,6 +361,8 @@ def fetch_twitter():
     for idx, handle in enumerate(handles):
         if idx > 0:
             time.sleep(1.0)  # 限速：账号间隔 1s
+        # 区服：按 handle 查单一真相源；未登记的自定义 handle → None（archive 回落扁平）
+        region = _TWITTER_REGION_BY_HANDLE.get(handle.lower().lstrip("@"))
         try:
             resp = _get(
                 f"https://syndication.twitter.com/srv/timeline-profile/screen-name/{handle}",
@@ -398,7 +407,7 @@ def fetch_twitter():
                     title=text[:100],
                     summary=text,
                     source="twitter",
-                    platform_region="global",
+                    platform_region=region or "global",
                     time_str=iso,
                     url=f"https://x.com/{screen}/status/{tid}" if tid else f"https://x.com/{screen}",
                     engagement=likes + rts * 3 + replies * 2,
@@ -407,6 +416,7 @@ def fetch_twitter():
                     lang=user.get("lang", "") or "",
                     content_type="image" if media_url else "text",
                     media_url=media_url,
+                    region=region,  # 甲方案：global/jp 驱动 archive 分桶；None 则回落扁平
                 ))
                 handle_added += 1
 
@@ -418,7 +428,7 @@ def fetch_twitter():
     return items
 # NOTE: divergent from aggregator_collectors.fetch_youtube — see audit ARCH-01 (behavior differs, not merged).
 def fetch_youtube():
-    """从 YouTube Data API v3 搜索相关视频。"""
+    """YouTube 视频：社区关键词流（global）+ 日本官方频道（jp）（甲方案双源，归档子类 video）。"""
     api_key = os.environ.get("YOUTUBE_API_KEY")
     if not api_key:
         logger.info("YouTube: YOUTUBE_API_KEY not set, skipping")
@@ -426,64 +436,78 @@ def fetch_youtube():
 
     items = []
     published_after = CUTOFF.strftime("%Y-%m-%dT%H:%M:%SZ")
-
+    # global：社区关键词搜索（多频道社区视频流）
     for keyword in ["Morimens", "忘却前夜"]:
-        try:
-            data = _get(
-                "https://www.googleapis.com/youtube/v3/search",
+        items.extend(_fetch_youtube_videos(api_key, published_after, {"q": keyword}, "global"))
+    # jp：日本官方频道（channelId，AltPlus 独立运营）→ 拆 jp 区服
+    jp_channel = REGION_APPS.get("youtube", {}).get("jp")
+    if jp_channel:
+        items.extend(_fetch_youtube_videos(api_key, published_after, {"channelId": jp_channel}, "jp"))
+    return items
+
+
+def _fetch_youtube_videos(api_key, published_after, query_params, region):
+    """单次 search.list（按 q 关键词或 channelId）+ statistics，标 region + archive_subtype=video。"""
+    items = []
+    label = query_params.get("q") or query_params.get("channelId") or "?"
+    try:
+        data = _get(
+            "https://www.googleapis.com/youtube/v3/search",
+            params={
+                "part": "snippet",
+                "type": "video",
+                "order": "date",
+                "publishedAfter": published_after,
+                "maxResults": 15,
+                "key": api_key,
+                **query_params,
+            },
+        ).json()
+
+        video_ids = [item["id"]["videoId"] for item in data.get("items", []) if item.get("id", {}).get("videoId")]
+
+        # 获取视频统计数据
+        stats = {}
+        if video_ids:
+            stats_data = _get(
+                "https://www.googleapis.com/youtube/v3/videos",
                 params={
-                    "part": "snippet",
-                    "q": keyword,
-                    "type": "video",
-                    "order": "date",
-                    "publishedAfter": published_after,
-                    "maxResults": 15,
+                    "part": "statistics",
+                    "id": ",".join(video_ids),
                     "key": api_key,
                 },
             ).json()
+            for v in stats_data.get("items", []):
+                s = v.get("statistics", {})
+                stats[v["id"]] = int(s.get("viewCount", 0)) + int(s.get("likeCount", 0))
 
-            video_ids = [item["id"]["videoId"] for item in data.get("items", []) if item.get("id", {}).get("videoId")]
+        for item in data.get("items", []):
+            vid = item.get("id", {}).get("videoId")
+            if not vid:
+                continue
+            snippet = item.get("snippet", {})
+            engagement = stats.get(vid, 0)
+            items.append(_make_item(
+                title=snippet.get("title", ""),
+                summary=snippet.get("description", ""),
+                source="youtube",
+                platform_region="global",
+                time_str=snippet.get("publishedAt", ""),
+                url=f"https://www.youtube.com/watch?v={vid}",
+                engagement=engagement,
+                is_hot=engagement > 5000,
+                author=snippet.get("channelTitle", ""),
+                lang="",
+                content_type="video",
+                media_url=snippet.get("thumbnails", {}).get("high", {}).get("url", ""),
+                region=region,            # 甲方案：global 社区流 / jp 官方频道
+                archive_subtype="video",  # 归档 youtube/<区服>/video
+            ))
 
-            # 获取视频统计数据
-            stats = {}
-            if video_ids:
-                stats_data = _get(
-                    "https://www.googleapis.com/youtube/v3/videos",
-                    params={
-                        "part": "statistics",
-                        "id": ",".join(video_ids),
-                        "key": api_key,
-                    },
-                ).json()
-                for v in stats_data.get("items", []):
-                    s = v.get("statistics", {})
-                    stats[v["id"]] = int(s.get("viewCount", 0)) + int(s.get("likeCount", 0))
-
-            for item in data.get("items", []):
-                vid = item.get("id", {}).get("videoId")
-                if not vid:
-                    continue
-                snippet = item.get("snippet", {})
-                engagement = stats.get(vid, 0)
-                items.append(_make_item(
-                    title=snippet.get("title", ""),
-                    summary=snippet.get("description", ""),
-                    source="youtube",
-                    platform_region="global",
-                    time_str=snippet.get("publishedAt", ""),
-                    url=f"https://www.youtube.com/watch?v={vid}",
-                    engagement=engagement,
-                    is_hot=engagement > 5000,
-                    author=snippet.get("channelTitle", ""),
-                    lang="",
-                    content_type="video",
-                    media_url=snippet.get("thumbnails", {}).get("high", {}).get("url", ""),
-                ))
-
-            logger.info(f'YouTube "{keyword}": {len(items)} videos')
-        except Exception as e:
-            # H3: 异常文本含完整请求 URL（key=<API key>），脱敏后再进公开日志
-            logger.warning(f'YouTube "{keyword}" failed: {news_common.redact_secrets(e)}')
+        logger.info(f'YouTube [{region}] {label}: {len(items)} videos')
+    except Exception as e:
+        # H3: 异常文本含完整请求 URL（key=<API key>），脱敏后再进公开日志
+        logger.warning(f'YouTube [{region}] {label} failed: {news_common.redact_secrets(e)}')
 
     return items
 
@@ -724,38 +748,54 @@ def fetch_discord():
             logger.warning(f"Discord channel {channel_id} failed: {e}")
 
     return items
+# App Store 评论覆盖地区（global app 多国走 platform_region 字段；甲方案 region 另标区服 global/jp）。
+_APPSTORE_COUNTRIES = [
+    # 中文圈
+    "cn", "tw", "hk",
+    # 英语圈
+    "us", "gb", "ca", "au", "nz", "ie", "sg",
+    # 日韩
+    "jp", "kr",
+    # 东南亚
+    "my", "ph", "th", "id", "vn",
+    # 欧洲（非英）
+    "de", "fr", "es", "it", "ru",
+    # 拉美
+    "br", "mx",
+]
+_APPSTORE_LANG_MAP = {
+    "cn": "zh", "tw": "zh", "hk": "zh",
+    "us": "en", "gb": "en", "ca": "en", "au": "en", "nz": "en", "ie": "en", "sg": "en",
+    "jp": "ja", "kr": "ko",
+    "my": "ms", "ph": "en", "th": "th", "id": "id", "vn": "vi",
+    "de": "de", "fr": "fr", "es": "es", "it": "it", "ru": "ru",
+    "br": "pt", "mx": "es",
+}
+
+
 def fetch_appstore_reviews():
-    """从 App Store 获取近期评论趋势——覆盖 Morimens 主要发行地区。"""
+    """从 App Store 获取近期评论——global 多国 + jp 独立 app（甲方案双 appid，区服 global/jp）。"""
+    # 兼容旧 APPSTORE_APP_ID kill-switch：显式空串 = 整体禁用，回落空
+    if os.environ.get("APPSTORE_APP_ID", "x") == "":
+        return []
+    apps = dict(REGION_APPS.get("appstore", {"global": "6447354150"}))
+    ov = os.environ.get("APPSTORE_APP_ID")  # 非空则覆盖 global appid（测试/灰度 hook）
+    if ov:
+        apps["global"] = ov
     items = []
-    appstore_id = os.environ.get("APPSTORE_APP_ID", "6447354150")
-    if not appstore_id:
-        return items
+    for region, appstore_id in apps.items():
+        if not appstore_id:
+            continue
+        # global app 覆盖全 24 区；jp 独立 app（AltPlus）仅日本商店有评价
+        countries = _APPSTORE_COUNTRIES if region == "global" else ["jp"]
+        items.extend(_fetch_appstore_reviews_one(str(appstore_id), region, countries))
+    return items
 
-    # 主要中文圈 + 英语圈 + 日韩 + 东南亚 + 欧洲 + 拉美 + 大洋洲（共 24 区）
-    COUNTRIES = [
-        # 中文圈
-        "cn", "tw", "hk",
-        # 英语圈
-        "us", "gb", "ca", "au", "nz", "ie", "sg",
-        # 日韩
-        "jp", "kr",
-        # 东南亚
-        "my", "ph", "th", "id", "vn",
-        # 欧洲（非英）
-        "de", "fr", "es", "it", "ru",
-        # 拉美
-        "br", "mx",
-    ]
-    LANG_MAP = {
-        "cn": "zh", "tw": "zh", "hk": "zh",
-        "us": "en", "gb": "en", "ca": "en", "au": "en", "nz": "en", "ie": "en", "sg": "en",
-        "jp": "ja", "kr": "ko",
-        "my": "ms", "ph": "en", "th": "th", "id": "id", "vn": "vi",
-        "de": "de", "fr": "fr", "es": "es", "it": "it", "ru": "ru",
-        "br": "pt", "mx": "es",
-    }
 
-    for country in COUNTRIES:
+def _fetch_appstore_reviews_one(appstore_id, region, countries):
+    """抓取单个 (appstore_id, region) 的多国评论。"""
+    items = []
+    for country in countries:
         try:
             data = _get(
                 f"https://itunes.apple.com/{country}/rss/customerreviews/id={appstore_id}/sortBy=mostRecent/json",
@@ -777,7 +817,8 @@ def fetch_appstore_reviews():
                     engagement=rating,
                     is_hot=False,
                     author=entry.get("author", {}).get("name", {}).get("label", ""),
-                    lang=LANG_MAP.get(country, ""),
+                    lang=_APPSTORE_LANG_MAP.get(country, ""),
+                    region=region,  # 甲方案：global（多国）/ jp（AltPlus 独立 app）→ appstore/<区服>/
                 ))
             logger.info(f"App Store ({country}): {len(entries)} reviews")
         except Exception as e:
@@ -847,37 +888,52 @@ def fetch_pixiv():
 # ─── 第三波新增数据源 ─────────────────────────────────────
 
 
-def fetch_google_play():
-    """从 Google Play Store 获取忘却前夜评论——覆盖主要发行地区（使用 google-play-scraper 库）。"""
-    gp_package = os.environ.get("GOOGLE_PLAY_PACKAGE", "com.qookkagames.z1.gp.hk")
-    items = []
+# (lang_code, country_code, region_label) — Google Play 同时按 lang+country 隔离评论
+_GP_LOCALES = [
+    # 中文圈
+    ("zh_CN", "cn", "cn"), ("zh_TW", "tw", "tw"), ("zh_HK", "hk", "hk"),
+    # 英语圈
+    ("en", "us", "us"), ("en", "gb", "gb"), ("en", "ca", "ca"),
+    ("en", "au", "au"), ("en", "sg", "sg"), ("en", "ph", "ph"),
+    # 日韩
+    ("ja", "jp", "jp"), ("ko", "kr", "kr"),
+    # 东南亚
+    ("th", "th", "th"), ("id", "id", "id"), ("vi", "vn", "vn"),
+    ("ms", "my", "my"),
+    # 欧洲（非英）
+    ("de", "de", "de"), ("fr", "fr", "fr"), ("es", "es", "es"),
+    ("it", "it", "it"), ("ru", "ru", "ru"),
+    # 拉美
+    ("pt", "br", "br"), ("es", "mx", "mx"),
+]
 
+
+def fetch_google_play():
+    """从 Google Play 获取评论——global 多国 + jp 独立包（甲方案双包，区服 global/jp）。"""
     try:
-        from google_play_scraper import reviews as gp_reviews, Sort as GPSort
+        from google_play_scraper import reviews as gp_reviews, Sort as GPSort  # noqa: F401
     except ImportError:
         logger.warning("Google Play: google-play-scraper not installed, skipping")
-        return items
+        return []
+    packages = dict(REGION_APPS.get("google_play", {"global": "com.qookkagames.z1.gp.hk"}))
+    ov = os.environ.get("GOOGLE_PLAY_PACKAGE")  # 非空覆盖 global 包名（测试/灰度 hook）
+    if ov:
+        packages["global"] = ov
+    items = []
+    for arch_region, gp_package in packages.items():
+        if not gp_package:
+            continue
+        # global 包覆盖全 locale；jp 独立包（AltPlus）仅日本 locale
+        locales = _GP_LOCALES if arch_region == "global" else [("ja", "jp", "jp")]
+        items.extend(_fetch_google_play_one(gp_package, arch_region, locales))
+    return items
 
-    # (lang_code, country_code, region_label) — Google Play 同时按 lang+country 隔离评论
-    LOCALES = [
-        # 中文圈
-        ("zh_CN", "cn", "cn"), ("zh_TW", "tw", "tw"), ("zh_HK", "hk", "hk"),
-        # 英语圈
-        ("en", "us", "us"), ("en", "gb", "gb"), ("en", "ca", "ca"),
-        ("en", "au", "au"), ("en", "sg", "sg"), ("en", "ph", "ph"),
-        # 日韩
-        ("ja", "jp", "jp"), ("ko", "kr", "kr"),
-        # 东南亚
-        ("th", "th", "th"), ("id", "id", "id"), ("vi", "vn", "vn"),
-        ("ms", "my", "my"),
-        # 欧洲（非英）
-        ("de", "de", "de"), ("fr", "fr", "fr"), ("es", "es", "es"),
-        ("it", "it", "it"), ("ru", "ru", "ru"),
-        # 拉美
-        ("pt", "br", "br"), ("es", "mx", "mx"),
-    ]
 
-    for lang_code, country, region in LOCALES:
+def _fetch_google_play_one(gp_package, arch_region, locales):
+    """抓取单个 (gp_package, arch_region) 的多 locale 评论。"""
+    from google_play_scraper import reviews as gp_reviews, Sort as GPSort
+    items = []
+    for lang_code, country, region in locales:
         try:
             result, _ = gp_reviews(
                 gp_package,
@@ -895,6 +951,7 @@ def fetch_google_play():
                     summary=text,
                     source="google_play",
                     platform_region=region,
+                    region=arch_region,  # 甲方案：global（多 locale）/ jp（AltPlus 独立包）→ google_play/<区服>/
                     time_str=review["at"].isoformat() if review.get("at") else datetime.now(timezone.utc).isoformat(),
                     # URL 追加 reviewId 锚点：评论页 URL 仅含 id+hl，同语言数十条评论会共用同一
                     # URL，致 dedup_key（URL 优先）碰撞、每语言仅存活 1 条（丢失 ~98% 评论）。

--- a/projects/news/scripts/news_common.py
+++ b/projects/news/scripts/news_common.py
@@ -395,11 +395,17 @@ def sign_wbi_params(params, mixin_key):
 
 def make_item(title, summary, source, platform_region, time_str, url,
               engagement=0, is_hot=False, author="", tags=None, lang="",
-              content_type="text", media_url="", time_is_approximate=False):
+              content_type="text", media_url="", time_is_approximate=False,
+              region=None, archive_subtype=None):
     """创建标准化信息条目（与 global_collectors._make_item 等价的单一真源）。
 
     aggregator 栈通过 aggregator_base.validate_news_item 走另一套 item 形状与校验路径，
     字段集不同，故不在此收敛。
+
+    region / archive_subtype 为甲方案归档分层字段（2026-06-21 采集源命名规范）：采集器
+    显式标注时才写入，缺省不落字段 → archive_platforms 回落旧扁平布局，不带字段的源零破坏。
+    region = 区服（global/jp/cn/volunteer…）；archive_subtype = 内容子类（review/news/
+    discussion/post/strategy/video/comments）。归档落点 <平台>[/<区服>][/<类型>]/日期.json。
     """
     item = {
         "title": strip_html(title or "").strip(),
@@ -418,6 +424,10 @@ def make_item(title, summary, source, platform_region, time_str, url,
     }
     if time_is_approximate:
         item["time_is_approximate"] = True
+    if region:
+        item["region"] = region
+    if archive_subtype:
+        item["archive_subtype"] = archive_subtype
     return item
 
 

--- a/projects/news/scripts/sources.py
+++ b/projects/news/scripts/sources.py
@@ -118,9 +118,9 @@ REGION_APPS = {
     'appstore':    {'global': '6447354150',               'jp': '6743462069'},
     'google_play': {'global': 'com.qookkagames.z1.gp.hk', 'jp': 'jp.co.altplus.boukyakuzenya'},
     'twitter':     {'global': 'MorimensOfcl',             'jp': 'bokyakuzenya'},
-    # YouTube 存 handle；YouTube Data API 采集前需 channels.list?forHandle 转 channelId。
-    # jp handle 待精确（频道名「忘却前夜【日本版公式】」，需 API 确认 @handle）。
-    'youtube':     {'global': '@morimensofficial',        'jp': None},
+    # YouTube：global 存 @handle（采集前需 channels.list?forHandle 转 channelId）；
+    # jp 已解析为 channelId（频道「忘却前夜【日本版公式】」，2026-06-22 网络检索 + 频道页标题核验）。
+    'youtube':     {'global': '@morimensofficial',        'jp': 'UCF6iFnr28T4KjmVvPakmU3g'},
 }
 
 # TapTap 国服双 appid → 合并归档至 taptap/cn/，条目内 app_id 字段区分预约 vs 测试服。
@@ -137,3 +137,20 @@ DISCORD_GUILDS = {
 def normalize_source(raw: str) -> str:
     """原始源名归一化为规范源名。"""
     return SOURCE_ALIASES.get(raw, raw)
+
+
+# 归档平台折叠（甲方案 2026-06-21 命名规范）：steam 家族三子类（评价/公告/讨论）共享
+# 归档 platform 段 'steam'，由 item 的 archive_subtype 区分 review/news/discussion，
+# 落 steam/<区服>/<类型>/。仅作用于**数据归档层**（archive_platforms）——**不动**
+# split_output 的 *-latest.json 文件名（输出层与数据层分离，§4.1；保护黑池/前端消费契约）。
+# steam_review 经 SOURCE_ALIASES 已归一为 steam；official=Steam 官方公告（决策项⑦ → steam/global/news）。
+ARCHIVE_PLATFORM_FOLD = {
+    'official':         'steam',  # Steam 官方公告 → steam/<区服>/news
+    'steam_discussion': 'steam',  # Steam 社区讨论 → steam/<区服>/discussion
+}
+
+
+def archive_platform(raw: str) -> str:
+    """归档 platform 段：先 normalize_source，再按 steam 家族折叠（仅归档层用）。"""
+    s = normalize_source(raw)
+    return ARCHIVE_PLATFORM_FOLD.get(s, s)

--- a/tests/test_aggregator_base.py
+++ b/tests/test_aggregator_base.py
@@ -156,6 +156,22 @@ class TestValidateNewsItem(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(cleaned["lang"], "ja")
 
+    def test_region_and_subtype_preserved(self):
+        # 甲方案：AC 栈 item 的 region/archive_subtype 须过白名单存活，供 archive 分桶
+        ok, cleaned = aggregator_base.validate_news_item(
+            _valid_item(region="jp", archive_subtype="review")
+        )
+        self.assertTrue(ok)
+        self.assertEqual(cleaned["region"], "jp")
+        self.assertEqual(cleaned["archive_subtype"], "review")
+
+    def test_region_subtype_absent_not_added(self):
+        # 缺省不落字段 → archive_platforms 回落扁平，不带字段的源零破坏
+        ok, cleaned = aggregator_base.validate_news_item(_valid_item())
+        self.assertTrue(ok)
+        self.assertNotIn("region", cleaned)
+        self.assertNotIn("archive_subtype", cleaned)
+
 
 class TestValidateAllNews(unittest.TestCase):
     def test_filters_invalid_keeps_valid(self):

--- a/tests/test_aggregator_collectors.py
+++ b/tests/test_aggregator_collectors.py
@@ -693,6 +693,8 @@ class TestFetchSteamReviews(unittest.TestCase):
         self.assertTrue(item["is_hot"])  # votes_up 15 > 10
         self.assertEqual(item["language"], "schinese")
         self.assertIn("/recommended/3052450", item["url"])
+        self.assertEqual(item["region"], "global")          # 甲方案：首个 appid = global 区服
+        self.assertEqual(item["archive_subtype"], "review")
 
     def test_negative_short_review_no_ellipsis(self):
         review = {"timestamp_created": _recent_ts(), "voted_up": False,
@@ -730,8 +732,24 @@ class TestFetchSteamReviews(unittest.TestCase):
         body = json.dumps({"reviews": [review], "cursor": "*"})  # same as initial cursor
         with mock.patch("subprocess.run", return_value=self._result(stdout=body)), \
                 mock.patch.object(ac.time, "sleep"):
-            out = ac.fetch_steam_reviews()
+            out = ac._fetch_steam_reviews_one("3052450", "global")  # 单区服 helper：避免双 appid 翻倍
         self.assertEqual(len(out), 1)  # one page then stops (cursor unchanged)
+
+    def test_loops_both_regions(self):
+        # 甲方案：wrapper 循环 REGION_APPS['steam'] 双 appid，逐区服打 region 标后聚合
+        calls = []
+
+        def fake_one(app_id, region):
+            calls.append((app_id, region))
+            return [{"source": "steam_review", "region": region, "archive_subtype": "review"}]
+
+        with mock.patch.object(ac, "_fetch_steam_reviews_one", side_effect=fake_one):
+            out = ac.fetch_steam_reviews()
+        regions = {r for _, r in calls}
+        self.assertIn("global", regions)   # 国际版 appid 3052450
+        self.assertIn("jp", regions)        # 日本版 appid 4226130（AltPlus）
+        self.assertEqual(len(out), len(calls))
+        self.assertEqual({it["region"] for it in out}, regions)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -750,13 +768,15 @@ class TestFetchSteamNews(unittest.TestCase):
         }
         resp = FakeResponse(json_data={"appnews": {"newsitems": [news]}})
         with mock.patch.object(ac.requests, "get", return_value=resp):
-            out = ac.fetch_steam_news()
+            out = ac._fetch_steam_news_one("3052450", "global")  # 单区服 helper：避免双 appid 翻倍
         self.assertEqual(len(out), 1)
         item = out[0]
         self.assertEqual(item["title"], "[Steam公告] Patch 1.0")
         self.assertEqual(item["summary"], "notes")
         self.assertEqual(item["source"], "official")
         self.assertTrue(item["is_hot"])
+        self.assertEqual(item["region"], "global")
+        self.assertEqual(item["archive_subtype"], "news")  # official 折叠归档到 steam/<区服>/news
 
     def test_feed_type_labels(self):
         for ft, label in [(0, "公告"), (1, "新闻"), (9, "资讯")]:
@@ -825,6 +845,8 @@ class TestFetchSteamDiscussions(unittest.TestCase):
         self.assertEqual(item["source"], "steam_discussion")
         self.assertEqual(item["author"], "poster")
         self.assertIn("preview body", item["summary"])
+        self.assertEqual(item["region"], "global")
+        self.assertEqual(item["archive_subtype"], "discussion")
 
     def test_reply_count_with_commas(self):
         page = self._page([self._block(replies="1,234")])

--- a/tests/test_archive_platforms_unit.py
+++ b/tests/test_archive_platforms_unit.py
@@ -183,6 +183,27 @@ class TestArchiveAll(unittest.TestCase):
         self.assertEqual(totals.get("reddit"), 1)
         self.assertNotIn("discord", totals)
 
+    def test_official_folds_to_steam_with_subtype(self):
+        # 甲方案决策项⑦：official 官方公告归档折叠到 steam/<区服>/news（输出层 official-latest 不动）
+        import tempfile
+        news = [
+            {"source": "official", "url": "n1", "time": "2026-04-13T20:00:00+00:00",
+             "region": "jp", "archive_subtype": "news"},
+            {"source": "steam_discussion", "url": "g1", "time": "2026-04-13T20:00:00+00:00",
+             "region": "global", "archive_subtype": "discussion"},
+        ]
+        with tempfile.TemporaryDirectory() as d, \
+                mock.patch.object(ap, "ARCHIVE_DIR", Path(d)), \
+                mock.patch.object(ap, "load_news", return_value=news):
+            totals = ap.archive_all(target_date=None, fallback_date="2026-01-01")
+            # 两个 steam 家族源都折叠到 steam 平台段，不再各自成桶
+            self.assertEqual(totals.get("steam"), 2)
+            self.assertNotIn("official", totals)
+            self.assertNotIn("steam_discussion", totals)
+            # 落点按 region/subtype 分层（断言须在 tempdir 清理前，即 with 块内）
+            self.assertTrue((Path(d) / "steam" / "jp" / "news" / "2026-04-14.json").exists())
+            self.assertTrue((Path(d) / "steam" / "global" / "discussion" / "2026-04-14.json").exists())
+
     def test_target_date_filters(self):
         import tempfile
         news = [

--- a/tests/test_collect_global_unit.py
+++ b/tests/test_collect_global_unit.py
@@ -44,6 +44,18 @@ class TestConvertItem(unittest.TestCase):
         out = cg.convert_item({"source": "x", "metadata": "notadict"})
         self.assertNotIn("metadata", out)
 
+    def test_region_subtype_passthrough(self):
+        # 甲方案：采集器标的 region/archive_subtype 必须透传给 archive 端分桶
+        out = cg.convert_item({"source": "steam", "region": "jp", "archive_subtype": "review"})
+        self.assertEqual(out["region"], "jp")
+        self.assertEqual(out["archive_subtype"], "review")
+
+    def test_region_subtype_absent_not_added(self):
+        # 缺省不落字段 → archive_platforms 回落扁平，不带字段的源零破坏
+        out = cg.convert_item({"source": "steam"})
+        self.assertNotIn("region", out)
+        self.assertNotIn("archive_subtype", out)
+
 
 # ── _is_recent / build_summary / load_existing_news ──────────────────────────
 

--- a/tests/test_global_collectors.py
+++ b/tests/test_global_collectors.py
@@ -49,6 +49,24 @@ class TestStripHelpers(unittest.TestCase):
         self.assertEqual(item["source"], "reddit")
         self.assertEqual(item["engagement"], 5)
 
+    def test_make_item_no_layering_fields_by_default(self):
+        # 甲方案：不传 region/archive_subtype 时不落字段（不带字段的源零破坏）
+        item = gc._make_item(
+            title="t", summary="s", source="reddit", platform_region="global",
+            time_str=RECENT, url="https://x",
+        )
+        self.assertNotIn("region", item)
+        self.assertNotIn("archive_subtype", item)
+
+    def test_make_item_layering_fields_written(self):
+        # 甲方案：显式标注则写入，供 archive_platforms 分桶 <平台>/<区服>/<类型>/
+        item = gc._make_item(
+            title="t", summary="s", source="steam", platform_region="jp",
+            time_str=RECENT, url="https://x", region="jp", archive_subtype="review",
+        )
+        self.assertEqual(item["region"], "jp")
+        self.assertEqual(item["archive_subtype"], "review")
+
 
 class TestParseTwitterTime(unittest.TestCase):
     def test_valid(self):
@@ -258,13 +276,13 @@ class TestFetchTwitter(unittest.TestCase):
     def tearDown(self):
         self._patch.stop()
 
-    def _html(self):
+    def _html(self, screen="MorimensOfcl"):
         import json
         payload = {"props": {"pageProps": {"timeline": {"entries": [
             {"full_text": "Official news drop", "id_str": "999",
              "created_at": "Fri Jun 19 10:00:00 +0000 2026",
              "favorite_count": 600, "retweet_count": 10, "reply_count": 5,
-             "user": {"screen_name": "MorimensOfcl", "lang": "en"},
+             "user": {"screen_name": screen, "lang": "en"},
              "entities": {"media": [{"media_url_https": "https://img.jpg"}]}},
         ]}}}}
         inner = json.dumps(payload)
@@ -282,6 +300,28 @@ class TestFetchTwitter(unittest.TestCase):
         self.assertTrue(it["is_hot"])
         self.assertEqual(it["content_type"], "image")
         self.assertEqual(it["media_url"], "https://img.jpg")
+        self.assertEqual(it["region"], "global")          # 甲方案：@MorimensOfcl → global 区服
+        self.assertEqual(it["platform_region"], "global")
+
+    def test_jp_handle_region(self):
+        # 日服官方账号 @bokyakuzenya（AltPlus）→ 拆 jp 区服，修正旧硬编码 global bug
+        with mock.patch.dict(gc.os.environ, {"TWITTER_HANDLES": "bokyakuzenya"}), \
+                mock.patch.object(gc, "_get", return_value=FakeResp(text=self._html("bokyakuzenya"))):
+            items = gc.fetch_twitter()
+        self.assertEqual(len(items), 1)
+        it = items[0]
+        self.assertEqual(it["region"], "jp")
+        self.assertEqual(it["platform_region"], "jp")
+        self.assertEqual(it["url"], "https://x.com/bokyakuzenya/status/999")
+
+    def test_unknown_handle_no_region(self):
+        # 未登记的自定义 handle：不落 region 字段 → archive 回落扁平 twitter/
+        with mock.patch.dict(gc.os.environ, {"TWITTER_HANDLES": "somefan"}), \
+                mock.patch.object(gc, "_get", return_value=FakeResp(text=self._html("somefan"))):
+            items = gc.fetch_twitter()
+        self.assertEqual(len(items), 1)
+        self.assertNotIn("region", items[0])
+        self.assertEqual(items[0]["platform_region"], "global")  # 回落默认
 
     def test_no_next_data_skipped(self):
         with mock.patch.dict(gc.os.environ, {"TWITTER_HANDLES": "MorimensOfcl"}), \
@@ -309,12 +349,15 @@ class TestFetchYoutube(unittest.TestCase):
         with mock.patch.dict(gc.os.environ, {"YOUTUBE_API_KEY": "k"}), \
                 mock.patch.object(gc, "_get", side_effect=fake_get):
             items = gc.fetch_youtube()
-        # 2 个关键词
-        self.assertEqual(len(items), 2)
+        # 甲方案双源：2 关键词（global 社区流）+ 1 日本官方频道（jp）= 3
+        self.assertEqual(len(items), 3)
         it = items[0]
         self.assertEqual(it["engagement"], 6200)
         self.assertTrue(it["is_hot"])
         self.assertEqual(it["content_type"], "video")
+        self.assertEqual(it["region"], "global")                  # 关键词社区流 → global 区服
+        self.assertEqual(it["archive_subtype"], "video")          # 归档 youtube/<区服>/video
+        self.assertTrue(any(i["region"] == "jp" for i in items))  # 日本官方频道 → jp 区服
 
 
 class TestFetchWeibo(unittest.TestCase):
@@ -408,11 +451,13 @@ class TestFetchAppstoreReviews(unittest.TestCase):
         with mock.patch.dict(gc.os.environ, {}, clear=True), \
                 mock.patch.object(gc, "_get", return_value=resp):
             items = gc.fetch_appstore_reviews()
-        # 24 个地区，每个 1 条
-        self.assertEqual(len(items), 24)
+        # 甲方案双 appid：global app 24 区 + jp 独立 app（仅日本店）1 条 = 25
+        self.assertEqual(len(items), 25)
         it = items[0]
         self.assertEqual(it["source"], "appstore")
         self.assertEqual(it["engagement"], 5)
+        self.assertEqual(it["region"], "global")                  # global app 评论标 global 区服
+        self.assertTrue(any(i["region"] == "jp" for i in items))  # jp 独立 app（AltPlus）评论标 jp
 
     def test_empty_id_returns_empty(self):
         with mock.patch.dict(gc.os.environ, {"APPSTORE_APP_ID": ""}, clear=True):

--- a/tests/test_global_collectors_more.py
+++ b/tests/test_global_collectors_more.py
@@ -243,8 +243,8 @@ class TestFetchYoutubeExtra(unittest.TestCase):
         with mock.patch.dict(gc.os.environ, {"YOUTUBE_API_KEY": "k"}), \
                 mock.patch.object(gc, "_get", side_effect=fake_get):
             items = gc.fetch_youtube()
-        # 2 关键词，每个 1 条有效
-        self.assertEqual(len(items), 2)
+        # 甲方案双源：2 关键词（global）+ 1 日本频道（jp），各 1 条有效（无 videoId 的跳过）= 3
+        self.assertEqual(len(items), 3)
 
 
 # ─── weibo extra branches ──────────────────────────────────


### PR DESCRIPTION
twitter/steam/appstore/google_play/youtube 五采集器标 region+archive_subtype，归档落 Public-Info-Pool/Record/Community/<平台>/<区服>/<类型>/。GC/AC 双栈地基放行二字段；steam 双 appid + official/steam_discussion 经 sources.archive_platform 解耦折叠到 steam/（仅归档层，split 输出层 *-latest 不动护黑池契约）；appstore/google_play/youtube 双 app/包/频道（jp 独立，youtube jp channelId UCF6iFnr28T4KjmVvPakmU3g 网络核验）。验证 PYTHONUTF8=1 py -m pytest tests/ → 1930 passed 5 failed（本机既有环境失败零新增回归）。待续 taptap、youtube-comments 迁移、阶段4。Generated with Claude Code