### PR TITLE
test: 补齐 sources SSOT 与 compact_discord_archive 的覆盖盲区

### DIFF
--- a/tests/test_compact_discord_archive_unit.py
+++ b/tests/test_compact_discord_archive_unit.py
@@ -1,0 +1,114 @@
+"""compact_discord_archive.process_file 文件级编排测试（P1）。
+
+该脚本会**原地重写 721 万条** Discord 全量归档记录，自述「幂等、可重入、临时文件原子
+rename、无法解析的行不丢」。这些安全保证此前 0% 覆盖——一个会改写全量档案层本体的
+工具，幂等性与无损性全靠自述。本测试用小样 fixture 钉死这些保证。
+
+compact_record 本身的 schema 契约已由 test_discord_compact_unit 覆盖，此处不重复，
+只测 process_file 的文件级行为。
+"""
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / 'projects' / 'news' / 'scripts'))
+
+# compact_discord_archive 在 scripts/ 下，且 import 时会 sys.path 注入 discord_compact
+_spec = importlib.util.spec_from_file_location(
+    'compact_discord_archive', _ROOT / 'scripts' / 'compact_discord_archive.py')
+cda = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cda)
+
+
+def _full_record(**over):
+    """一条完整 schema 记录（多数字段为默认值，紧凑化时应被删除）。"""
+    rec = {
+        'id': '1', 'channel_id': 'c1', 'type': 0, 'author_id': 'a1',
+        'author_name': 'nick', 'author_bot': False, 'content': 'hello',
+        'timestamp': '2026-06-01T00:00:00', 'edited_timestamp': None,
+        'pinned': False, 'mentions': [], 'reactions': [], 'attachments': [],
+        'embeds': [], 'reply_to': None, 'has_thread': False, 'thread_id': None,
+        'flags': 0,
+    }
+    rec.update(over)
+    return rec
+
+
+def _write_jsonl(path, records):
+    lines = [json.dumps(r, ensure_ascii=False) for r in records]
+    path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+
+
+class TestProcessFile(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = Path(__file__).resolve().parent / '_tmp_cda'
+        self._tmpdir.mkdir(exist_ok=True)
+        self.f = self._tmpdir / 'sample.jsonl'
+
+    def tearDown(self):
+        for p in self._tmpdir.glob('*'):
+            p.unlink()
+        self._tmpdir.rmdir()
+
+    def _read_records(self):
+        return [json.loads(l) for l in self.f.read_text(encoding='utf-8').splitlines() if l]
+
+    def test_compacts_and_shrinks(self):
+        _write_jsonl(self.f, [_full_record(), _full_record(id='2')])
+        orig, new, n = cda.process_file(self.f, dry_run=False)
+        self.assertEqual(n, 2)
+        self.assertLess(new, orig, '紧凑后字节应小于原始')
+        # 默认值字段应已被删除，恒留字段仍在
+        recs = self._read_records()
+        self.assertEqual(recs[0].get('id'), '1')
+        self.assertNotIn('type', recs[0])      # type=0 默认值删除
+        self.assertNotIn('pinned', recs[0])
+
+    def test_idempotent_second_run_no_change(self):
+        _write_jsonl(self.f, [_full_record(type=19, author_bot=True)])
+        cda.process_file(self.f, dry_run=False)
+        after_first = self.f.read_text(encoding='utf-8')
+        orig2, new2, _ = cda.process_file(self.f, dry_run=False)
+        after_second = self.f.read_text(encoding='utf-8')
+        self.assertEqual(after_first, after_second, '第二次运行不应再改动文件（幂等）')
+        self.assertEqual(orig2, new2, '已紧凑文件原字节应等于新字节')
+
+    def test_dry_run_does_not_write(self):
+        _write_jsonl(self.f, [_full_record()])
+        before = self.f.read_text(encoding='utf-8')
+        orig, new, n = cda.process_file(self.f, dry_run=True)
+        self.assertEqual(self.f.read_text(encoding='utf-8'), before, 'dry-run 不得落盘')
+        self.assertEqual(n, 1)
+        self.assertLess(new, orig, 'dry-run 仍应正确预估省字节')
+
+    def test_unparseable_lines_preserved(self):
+        # 无法解析的行必须原样保留，绝不丢数据
+        good = json.dumps(_full_record(), ensure_ascii=False)
+        self.f.write_text(good + '\n' + 'this-is-not-json\n', encoding='utf-8')
+        orig, new, n = cda.process_file(self.f, dry_run=False)
+        self.assertEqual(n, 1, '只统计可解析记录')
+        content = self.f.read_text(encoding='utf-8')
+        self.assertIn('this-is-not-json', content, '坏行必须保留')
+
+    def test_blank_lines_skipped(self):
+        good = json.dumps(_full_record(), ensure_ascii=False)
+        self.f.write_text(good + '\n\n\n', encoding='utf-8')
+        orig, new, n = cda.process_file(self.f, dry_run=False)
+        self.assertEqual(n, 1)
+
+    def test_nondefault_values_preserved_through_rewrite(self):
+        _write_jsonl(self.f, [_full_record(type=19, flags=2, reply_to='99',
+                                           reactions=[{'emoji': 'x', 'count': 3}])])
+        cda.process_file(self.f, dry_run=False)
+        rec = self._read_records()[0]
+        self.assertEqual(rec['type'], 19)
+        self.assertEqual(rec['flags'], 2)
+        self.assertEqual(rec['reply_to'], '99')
+        self.assertEqual(rec['reactions'], [{'emoji': 'x', 'count': 3}])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_sources_invariants.py
+++ b/tests/test_sources_invariants.py
@@ -1,0 +1,144 @@
+"""sources.py 采集源单一真相源的契约不变量测试（P0）。
+
+sources.py 是 7 个生产脚本共享的源清单 SSOT，其存在理由就是「杜绝清单漂移」
+（文件头自述：历史上各脚本各存一份清单，漂移导致「采了不归档 / 归档了不审计」盲区）。
+模块文档化了一批集合关系，但此前无任何测试钉住它们——有人改一个清单破坏不变量，
+全绿照过。本测试把那些口头契约升级为可执行断言。
+
+覆盖两层：
+  1) 模块内部不变量（KNOWN 去重 / ARCHIVE = KNOWN - discord / 子集关系 / 别名闭包 …）
+  2) 跨模块同步（sources.BACKFILL_PLATFORMS == backfill_platforms.BACKFILL_REGISTRY.keys()）
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'projects' / 'news' / 'scripts'))
+import sources  # noqa: E402
+
+
+class TestKnownSources(unittest.TestCase):
+    def test_no_duplicates(self):
+        self.assertEqual(len(sources.KNOWN_SOURCES), len(set(sources.KNOWN_SOURCES)),
+                         'KNOWN_SOURCES 含重复项')
+
+    def test_all_lowercase_nonempty(self):
+        for s in sources.KNOWN_SOURCES:
+            self.assertTrue(s and s == s.lower(), f'源名应非空小写: {s!r}')
+
+
+class TestArchivePlatforms(unittest.TestCase):
+    def test_equals_known_minus_discord(self):
+        # ARCHIVE_PLATFORMS 文档定义 = KNOWN - discord（discord 走独立归档器）
+        expected = [s for s in sources.KNOWN_SOURCES if s != 'discord']
+        self.assertEqual(sources.ARCHIVE_PLATFORMS, expected)
+
+    def test_discord_excluded(self):
+        self.assertNotIn('discord', sources.ARCHIVE_PLATFORMS)
+
+
+class TestSubsetRelations(unittest.TestCase):
+    def test_core_subset_of_known(self):
+        self.assertTrue(set(sources.CORE_SOURCES) <= set(sources.KNOWN_SOURCES),
+                        f'CORE 越界: {set(sources.CORE_SOURCES) - set(sources.KNOWN_SOURCES)}')
+
+    def test_r1_hard_fail_strict_subset_of_core(self):
+        # 文档：R1_HARD_FAIL 是 CORE 的严格子集（单次跑命脉源，不含可降级的 youtube/discord）
+        r1, core = sources.R1_HARD_FAIL_SOURCES, set(sources.CORE_SOURCES)
+        self.assertTrue(r1 <= core, f'R1 越界: {r1 - core}')
+        self.assertTrue(r1 < core, 'R1 应为 CORE 的严格子集')
+
+    def test_auth_gated_keys_in_known(self):
+        self.assertTrue(set(sources.AUTH_GATED) <= set(sources.KNOWN_SOURCES),
+                        f'AUTH_GATED 含未知源: {set(sources.AUTH_GATED) - set(sources.KNOWN_SOURCES)}')
+
+    def test_sparse_subset_of_known(self):
+        self.assertTrue(set(sources.SPARSE_SOURCES) <= set(sources.KNOWN_SOURCES),
+                        f'SPARSE 含未知源: {set(sources.SPARSE_SOURCES) - set(sources.KNOWN_SOURCES)}')
+
+
+class TestAliases(unittest.TestCase):
+    def test_alias_targets_are_known(self):
+        # 别名必须归一化到一个真实的 KNOWN 源
+        for raw, canon in sources.SOURCE_ALIASES.items():
+            self.assertIn(canon, sources.KNOWN_SOURCES,
+                          f'别名 {raw!r} 指向未知规范源 {canon!r}')
+
+    def test_alias_keys_not_themselves_known(self):
+        # 别名键是「原始变体名」，不应同时是规范 KNOWN 源（否则归一化语义自相矛盾）
+        for raw in sources.SOURCE_ALIASES:
+            self.assertNotIn(raw, sources.KNOWN_SOURCES,
+                             f'别名键 {raw!r} 不应同时出现在 KNOWN_SOURCES')
+
+    def test_normalize_idempotent(self):
+        for raw in list(sources.SOURCE_ALIASES) + list(sources.KNOWN_SOURCES):
+            once = sources.normalize_source(raw)
+            self.assertEqual(sources.normalize_source(once), once,
+                             f'normalize 非幂等: {raw!r}')
+
+
+class TestArchivePlatformFold(unittest.TestCase):
+    def test_fold_keys_and_values_resolve_to_known(self):
+        for raw, folded in sources.ARCHIVE_PLATFORM_FOLD.items():
+            self.assertIn(sources.normalize_source(raw), sources.KNOWN_SOURCES,
+                          f'折叠键 {raw!r} 无法归一到 KNOWN')
+            self.assertIn(folded, sources.KNOWN_SOURCES,
+                          f'折叠目标 {folded!r} 非 KNOWN 源')
+
+    def test_archive_platform_idempotent(self):
+        samples = list(sources.KNOWN_SOURCES) + list(sources.SOURCE_ALIASES) \
+            + list(sources.ARCHIVE_PLATFORM_FOLD)
+        for s in samples:
+            once = sources.archive_platform(s)
+            self.assertEqual(sources.archive_platform(once), once,
+                             f'archive_platform 非幂等: {s!r}')
+
+    def test_archive_platform_folds_steam_family(self):
+        self.assertEqual(sources.archive_platform('official'), 'steam')
+        self.assertEqual(sources.archive_platform('steam_discussion'), 'steam')
+        self.assertEqual(sources.archive_platform('steam_review'), 'steam')  # 经别名 + 折叠
+
+
+class TestBackfillPlatforms(unittest.TestCase):
+    def test_each_backfill_resolves_to_known(self):
+        # BACKFILL 项允许是别名键（如 steam_review），但归一化后必须落在 KNOWN
+        for p in sources.BACKFILL_PLATFORMS:
+            self.assertIn(sources.normalize_source(p), sources.KNOWN_SOURCES,
+                          f'回溯平台 {p!r} 无法归一到 KNOWN')
+
+    def test_sync_with_backfill_registry(self):
+        # 跨模块漂移守卫：sources.BACKFILL_PLATFORMS 与 backfill_platforms 的实际注册表必须一致
+        import backfill_platforms
+        self.assertEqual(
+            set(sources.BACKFILL_PLATFORMS),
+            set(backfill_platforms.BACKFILL_REGISTRY),
+            'sources.BACKFILL_PLATFORMS 与 backfill_platforms.BACKFILL_REGISTRY 已漂移')
+
+
+class TestSeparateRegistries(unittest.TestCase):
+    def test_independent_archive_disjoint_from_known(self):
+        # 独立归档源不得进 KNOWN（否则 split_output 会切出空 latest 文件，见 sources.py 注释）
+        self.assertEqual(set(sources.INDEPENDENT_ARCHIVE_SOURCES) & set(sources.KNOWN_SOURCES), set())
+
+    def test_legacy_disjoint_from_known(self):
+        # 遗留源采集逻辑已移除，不应仍在活跃 KNOWN 清单里
+        self.assertEqual(set(sources.LEGACY_SOURCES) & set(sources.KNOWN_SOURCES), set())
+
+
+class TestRegionRegistries(unittest.TestCase):
+    def test_region_apps_platforms_known(self):
+        for platform, regions in sources.REGION_APPS.items():
+            self.assertIn(platform, sources.KNOWN_SOURCES,
+                          f'REGION_APPS 平台 {platform!r} 非 KNOWN 源')
+            self.assertIn('global', regions, f'{platform} 缺 global 区服')
+            self.assertIn('jp', regions, f'{platform} 缺 jp 区服')
+
+    def test_discord_guilds_have_three_regions(self):
+        self.assertEqual(set(sources.DISCORD_GUILDS), {'global', 'jp', 'volunteer'})
+
+    def test_taptap_cn_apps_present(self):
+        self.assertEqual(set(sources.TAPTAP_CN_APPS), {'reserve', 'cbt'})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 概述

测试覆盖审计发现两处「源代码会跑、但无断言守护」的盲区，本 PR 各补一个测试档案堵上。改动仅新增 `tests/` 下两个文件，不触碰任何生产代码。

---

## 变更类型

- [x] Bug 修复（测试加固，无功能改动）
- [ ] 其他：测试覆盖补齐

---

## 背景：审计发现

全量 `pytest tests/` 跑出 94% 覆盖率、1931 通过，底子扎实，但有两处真盲区：

1. **`projects/news/scripts/sources.py`（采集源 SSOT）** — 被 7 个生产脚本 import 以「杜绝清单漂移」，模块文档化了一批集合关系（`ARCHIVE = KNOWN - discord`、子集关系、别名闭包…），但**无任何测试钉住它们**。覆盖率不报警，因消费方 import 时其行被顺带执行，可没一条断言守契约。改一个清单破坏不变量，全绿照过。
2. **`scripts/compact_discord_archive.py`（0% 覆盖）** — 原地重写 721 万条 Discord 全量归档记录，自述「幂等 / 原子 rename / 无法解析的行不丢」，这些安全保证此前零验证。

---

## 改动内容

- `tests/test_sources_invariants.py`（21 测试）：KNOWN 去重、`ARCHIVE_PLATFORMS == KNOWN - discord`、CORE/R1/AUTH/SPARSE 子集关系、别名闭包 + `normalize` 幂等、`archive_platform` 折叠幂等、区服注册表完整性，以及一条**跨模块漂移守卫**——断言 `sources.BACKFILL_PLATFORMS == backfill_platforms.BACKFILL_REGISTRY` 键集一致。
- `tests/test_compact_discord_archive_unit.py`（6 测试）：聚焦 0% 的 `process_file` 文件级编排——紧凑缩字节、二次运行幂等不改文件、dry-run 不落盘、坏行原样保留、空行跳过、非默认值经重写无损保留。

---

## 安全声明

- [x] 本贡献不含任何 BIAV 内网 / 黑池 / 未发布渠道数据；新增内容仅为针对仓内既有公开脚本的单元测试（小样 fixture 由测试自造）。

---

## 验证清单

- [x] 本地跑通：`pytest tests/` → **1958 passed, 7 skipped**（新增 27 测试，无回归）
- [x] 覆盖率（与 CI 同口径）94% → 95%；`compact_discord_archive` 0% → 59%（余下为 `main()` CLI 驱动），`sources.py` 现已完全覆盖
- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qsmv169ZAcsYaJDt4q7Hv)_