### PR TITLE
docs(CLAUDE.md): 同步结构树与测试层至当前状态

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,8 @@ brain-in-a-vat/
 │   └── *.md / *.json              # 见 §5.3
 ├── okf/                           # Open Knowledge Format v0.1 bundle（生成物，见 §6.1）
 ├── scripts/                       # 顶层 Python 工具层（人格 / 记忆写入 / 解包-解析 / 运营）
-├── tests/                         # pytest 单元测试（解析 / 采集 / 记忆 / 文本）
+├── tests/                         # pytest 单元测试（解析 / 采集 / 记忆 / 文本；覆盖率门控见 §7.2）
+├── docs/                          # 工程文档（testing-strategy.md 分层测试策略，见 §7.1/§7.2）
 ├── Public-Info-Pool/              # 公开信息层总池（BPT 5R：取代旧 deliverables/，见 §6.2）
 │   ├── Resource/{主题类型}/       #   A类正式产物（报告/分析），按主题类型分目录，进 git 长期归档
 │   ├── Record/Community/          #   社区全量档案 text（discord + 16+ 平台，#333 迁入，见 §5.2）
@@ -253,7 +254,7 @@ brain-in-a-vat/
 │   ├── Rough/                     #   C类即兴草稿/过程废料，.gitignore，可晋升进 Resource
 │   └── types.json                 #   Resource 主题类型开放注册表（形式定死/清单可增）
 ├── extracted_lua/                 # 客户端解包 Lua 原文（wiki/角色数据源）
-├── .claude/                       # 会话钩子 / slash 命令 / 技能 / settings.json
+├── .claude/                       # slash 命令 / 技能 / settings.json（当前无会话钩子，见 §7.4）
 └── .github/workflows/             # CI 自动化（见 §7.2）
 ```
 
@@ -308,6 +309,7 @@ brain-in-a-vat/
 | 场景 | 命令 |
 |------|------|
 | 运行验证程序（全量单测）| `pytest tests/ -v` |
+| 覆盖率本地核验 | `pytest tests/ --cov --cov-fail-under=85`（CI 同闸；分层测试策略见 `docs/testing-strategy.md`）|
 | wiki 本地开发 | `cd projects/wiki && npm run dev`（VitePress dev）|
 | wiki 构建产出 | `cd projects/wiki && npm run docs:build` |
 | 数据校验（wiki JSON）| slash `/validate-data` 或 `python scripts/...`（见 schema 目录）|
@@ -320,6 +322,13 @@ brain-in-a-vat/
 数据（抓取 / 解包 / 校验 / 版本检测）、测试、部署运维。精确清单以
 `ls .github/workflows/` 为准；机器提交带 `[skip ci]` 防触发循环。日报定时已停用，
 报告改在会话内生成（详见 `memory/project-status.md`）。
+
+**测试层四道护栏**（运行参照 `docs/testing-strategy.md`）：(1) 行覆盖率门控
+（`test.yml` 跑 `--cov-fail-under=85`，实测约 97%，门控刻意留余量防采集器凑数测试）；
+(2) 变异测试（`mutation-test.yml` + `setup.cfg`，手动触发，验断言是否真钉住行为）；
+(3) 真集成测试（`tests/test_integration_*.py`，真依赖 / 真路径）；(4) 数据纪律测试
+（`tests/test_data_discipline.py`，防全量层 vs 输出层混用，见 §4.1）。CLAUDE.md 自身受
+`tests/test_claude_md*.py` 三哨兵守护（路径存在性 / 裁定日期跨档对账 / 核心脚本反向漂移）。
 
 ### §7.3 脚本层
 


### PR DESCRIPTION
## 概述

审计 CLAUDE.md 与仓库实际状态的偏差并修正。CLAUDE.md 主体已维护至 2026-06-21/22，自那以来 git log 仅有自动归档机器提交、无结构性变更；本次只补三处真实漂移，不动既有裁定与措辞（外科手术式改动）。

---

## 变更类型

- [x] 文档完善（CLAUDE.md / BIAV-SC.md / README.md / 子项目 CONTEXT.md）

具体三处：
- §6 结构树新增 `docs/`（`testing-strategy.md` 分层测试策略已落盘，原树缺收）
- §6 结构树修正 `.claude/` 注释：会话钩子已于 2026-06-14 全部退役（与 §7.4 对齐），不再写「会话钩子」
- §7.1 新增「覆盖率本地核验」命令行；§7.2 补「测试层四道护栏」段（行覆盖率 85% 闸 / 变异测试 / 真集成 / 数据纪律）+ CLAUDE.md 三哨兵说明

---

## 来源声明

- [x] 不涉及游戏数据，纯仓库内工程文档对账，来源即仓库当前文件树与 `docs/testing-strategy.md`。

---

## 安全声明（强制）

- [x] 本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。
- [x] 本贡献的游戏图片 / 数据 / 文本仅引用公开素材（本 PR 不含任何游戏素材）。
- [x] 同意按 MIT License 提交贡献。

---

## 验证清单

- [x] 全量单测通过：`pytest tests/` → 1931 passed, 7 skipped, 14 subtests passed
- [x] CLAUDE.md 三哨兵全绿（`test_claude_md.py` 路径存在性 / `test_claude_md_dates.py` 裁定日期跨档对账 / `test_claude_md_coverage.py` 核心脚本反向漂移）
- [x] 未引入 emoji（CLAUDE.md 硬约束）
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md`（仅引用，不修改）

---

## 关联 Issue

- Refs #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013YdniyvjENecPm11ws2GaT)_