### PR TITLE
feat(skills): 补装上游原版 grill-with-docs（未改编，与 grill 并存）

### DIFF
--- a/.claude/skills/grill-with-docs/README.md
+++ b/.claude/skills/grill-with-docs/README.md
@@ -1,0 +1,41 @@
+# grill-with-docs — 上游原版（未改编）
+
+This is the **verbatim, un-adapted upstream** `grill-with-docs` skill from
+[mattpocock/skills](https://github.com/mattpocock/skills) (`skills/engineering/grill-with-docs`),
+installed alongside — not replacing — 银芯's own adapted `grill` chain
+(`.claude/skills/grill` + `grilling` + `domain-modeling`).
+
+It is kept in its original generic form on purpose (守密人 2026-06-29 裁定：补装上游原版，
+保留 CONTEXT.md / ADR 通用范式），so the upstream's generic glossary + ADR convention is
+preserved here as a faithful reference, distinct from the 银芯-flavoured adaptation.
+
+## What's in this folder
+
+| File | Source (mattpocock/skills) | Role |
+|------|----------------------------|------|
+| `SKILL.md` | `skills/engineering/grill-with-docs/SKILL.md` | The skill itself — a 2-line delegator |
+| `reference/grilling.md` | `skills/productivity/grilling/SKILL.md` | The relentless one-question interview loop |
+| `reference/domain-modeling.md` | `skills/engineering/domain-modeling/SKILL.md` | Generic glossary + ADR discipline |
+| `reference/CONTEXT-FORMAT.md` | `skills/engineering/domain-modeling/CONTEXT-FORMAT.md` | Generic `CONTEXT.md` glossary format |
+| `reference/ADR-FORMAT.md` | `skills/engineering/domain-modeling/ADR-FORMAT.md` | Generic `docs/adr/` ADR format |
+
+The `reference/` files are bundled as documentation only — they are not registered as
+separate skills (only `SKILL.md` is), so they do **not** collide with the repo's existing
+`/grilling` and `/domain-modeling` skills.
+
+## ⚠ Runtime note (read before relying on the generic form)
+
+`SKILL.md` says verbatim: *"Run a `/grilling` session, using the `/domain-modeling` skill."*
+Those two slugs resolve **globally** within this repo, where `/grilling` and `/domain-modeling`
+already exist as the **银芯-adapted** skills (which target `memory/decisions.md` /
+`memory/morimens-context.md`, not generic `CONTEXT.md` / `docs/adr/`).
+
+Therefore, invoking `/grill-with-docs` here behaves **functionally like the adapted `/grill`**.
+The generic CONTEXT.md / ADR convention lives in `reference/` as a faithful on-disk copy for
+reference and comparison; it is not what executes at runtime. To drive the generic convention,
+follow the `reference/*` files manually.
+
+## License / attribution
+
+Adapted-from-nothing — these are verbatim copies. Original work © 2026 Matt Pocock,
+released under the MIT License. See https://github.com/mattpocock/skills.

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-with-docs
+description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session, using the `/domain-modeling` skill.

--- a/.claude/skills/grill-with-docs/reference/ADR-FORMAT.md
+++ b/.claude/skills/grill-with-docs/reference/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.claude/skills/grill-with-docs/reference/CONTEXT-FORMAT.md
+++ b/.claude/skills/grill-with-docs/reference/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.claude/skills/grill-with-docs/reference/domain-modeling.md
+++ b/.claude/skills/grill-with-docs/reference/domain-modeling.md
@@ -1,0 +1,74 @@
+---
+name: domain-modeling
+description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
+---
+
+# Domain Modeling
+
+Actively build and sharpen the project's domain model as you design. This is the *active* discipline — challenging terms, inventing edge-case scenarios, and writing the glossary and decisions down the moment they crystallise. (Merely *reading* `CONTEXT.md` for vocabulary is not this skill — that's a one-line habit any skill can do. This skill is for when you're changing the model, not just consuming it.)
+
+## File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).

--- a/.claude/skills/grill-with-docs/reference/grilling.md
+++ b/.claude/skills/grill-with-docs/reference/grilling.md
@@ -1,0 +1,10 @@
+---
+name: grilling
+description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION
## 概述

补装 [mattpocock/skills](https://github.com/mattpocock/skills)（MIT）的**上游原版** `grill-with-docs` 技能，作为一个自包含、不与现有银芯改编技能冲突的新 bundle 落入 `.claude/skills/grill-with-docs/`。守密人 2026-06-29 裁定：在改编版 `grill` 之外补装上游原文，**保留 CONTEXT.md / ADR 通用范式**。

---

## 变更类型

- [x] 文档完善（新增技能定义 + 上游原文参考文档）
- [x] 其他：补装上游原版技能（未改编，与 `.claude/skills/grill` 改编链并存，零触碰）

---

## 来源声明

- [x] 全部内容逐字复刻自公开仓库 https://github.com/mattpocock/skills（MIT，© 2026 Matt Pocock）：
  - `SKILL.md` ← `skills/engineering/grill-with-docs/SKILL.md`
  - `reference/grilling.md` ← `skills/productivity/grilling/SKILL.md`
  - `reference/domain-modeling.md` ← `skills/engineering/domain-modeling/SKILL.md`
  - `reference/CONTEXT-FORMAT.md` / `reference/ADR-FORMAT.md` ← 同上目录

---

## 安全声明

- [x] 不含黑池 / 内网 / 未发布渠道数据；全部来自公开 GitHub 仓库。
- [x] 不上传内部资产。
- [x] 引用第三方作品保留原 MIT 归属（见 README.md）。

---

## 验证清单

- [x] 纯 markdown 技能/文档改动，无代码/测试/数据变更，按 CLAUDE.md §7.6 免跑 pytest。
- [x] 现有 `grill` / `grilling` / `domain-modeling` 改编链 **零改动**（仅新增 6 个文件）。
- [x] `reference/` 下文件非 `SKILL.md`、置于子目录，不注册为独立技能，**不与现有 `/grilling`、`/domain-modeling` 槽位冲突**。
- [x] 不引入 emoji。
- [x] 未触碰 `memory/decisions.md` / `memory/lessons-learned.md`。

---

## 运行时说明（重要）

上游 `SKILL.md` 逐字内容为「Run a `/grilling` session, using the `/domain-modeling` skill.」——这两个 slug 在本仓库内**全局解析**到已存在的**银芯改编版** `/grilling` + `/domain-modeling`（指向 `memory/decisions.md` 等，而非通用 `CONTEXT.md` / `docs/adr/`）。因此 `/grill-with-docs` 在本仓库运行时**行为等同改编版 `/grill`**；通用 CONTEXT.md / ADR 范式以逐字原文留存在 `reference/` 供参考对照。详见 bundle 内 `README.md`。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0173FYyWEiT1YVbLDkXegVaa)_