### PR TITLE
docs(claude-md): surface bpt-agent-sdk in §6 auto-loaded structure tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,11 +238,12 @@ brain-in-a-vat/
 ├── assets/                        # 事实圣经层（只读引用源）
 │   ├── data/                      # 角色卡 / 采访 / 叙事 / 设计决策 JSON（见 §5.1）
 │   └── images/                    # 立绘 / CG 等公开图像资产
-├── projects/                      # 四子项目（各有 CONTEXT.md，动手前先读）
+├── projects/                      # 子项目 + 工程产物（各有 CONTEXT.md，动手前先读）
 │   ├── news/   # 使命#1 黑池信息入口：采集器 + 全量档案 + 输出展示层
 │   ├── wiki/   # 使命#2 社区知识底座：VitePress 站点 + 72 角色数据库
 │   ├── site/   # 对外门户：静态站（public/）+ 设计令牌（design/）
-│   └── game/   # 衍生游戏（退主线，守密人个人兴趣，不主线派发）
+│   ├── game/   # 衍生游戏（退主线，守密人个人兴趣，不主线派发）
+│   └── bpt-agent-sdk/  # 银芯→黑池单向输出物（非使命线）：Claude Agent SDK 干净重实现，见 project-status「## BPT Agent SDK」
 ├── memory/                        # 银芯记忆层（决策 / 方法论 / 踩坑 / active hub）
 │   ├── active/                    # 主题入口卡（4 个高频 hub，优先读这里再下钻）
 │   ├── archive/ research/ strategy/
@@ -262,7 +263,9 @@ brain-in-a-vat/
 ```
 
 子项目纪律：每个 `projects/<x>/CONTEXT.md` 是该子项目的会话上下文与当前 milestone，
-动手前必读。news 与 wiki 是 Phase 2 双核心主线，site 维护稳定，game 不主线派发。
+动手前必读。news 与 wiki 是 Phase 2 双核心主线，site 维护稳定，game 不主线派发；
+`projects/bpt-agent-sdk/` 为银芯→黑池单向输出的工程产物（**非使命线**，与 §1.1-HC 防火墙同向：
+银芯→黑池单向输出、黑池不回流），状态与两轴保真模型见 `memory/project-status.md`「## BPT Agent SDK」。
 
 ### §6.1 OKF Bundle（`okf/`）
 


### PR DESCRIPTION
## 概述

把 `bpt-agent-sdk` 补进 `CLAUDE.md §6` 仓库结构树，令其在**自动加载层**即可见。承接 #382（状态权威 `project-status.md` 已加锚点，但那层是**按需 fetch**）——本 PR 补最后一公里：§6 结构树是每会话开局自动加载的，此前只列 news/wiki/site/game，全新会话扫结构时无从得知 bpt-agent-sdk 存在。守密人裁定「A（补指针）」后执行。

---

## 变更类型

- [x] 文档完善（CLAUDE.md / BIAV-SC.md / README.md / 子项目 CONTEXT.md）— 具体为 `CLAUDE.md §6`

改动两处：
1. **§6 projects/ 树加行** `bpt-agent-sdk/`，标注为「银芯→黑池单向输出物（非使命线）」；表头注释「四子项目」去计数化为「子项目 + 工程产物」（四条使命/门户子项目与工程产物是不同类，避免误读成第五条使命线）。
2. **子项目纪律收尾句**补 bpt-agent-sdk 条款，指向 `project-status`「## BPT Agent SDK」，框架定性与 §1.1-HC 防火墙同向（银芯→黑池单向输出、黑池不回流）。

---

## 来源声明

不涉及游戏数据；纯治理档案结构指针更新，事实源自本仓库自有目录（`projects/bpt-agent-sdk/` 实存）。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **仅引用公开素材**；无内部资产、无解包原始文件。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] CLAUDE.md 对账三卫 `pytest tests/test_claude_md*.py` — **7 passed**（路径引用 / 覆盖 / 日期一致性）
- [x] **未引入任何「日期 + 裁定」引用**（`decisions.md` 仅守密人可改），日期对账哨兵保持绿
- [x] 新增 backtick 路径 `projects/bpt-agent-sdk/` 与 `memory/project-status.md` 实测存在（forward-path guard 通过）
- [x] 不引入 emoji（CLAUDE.md 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联 Issue

- Refs #382（状态权威锚点）、#380（v0.2+v0.3 本体）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsuLDoFj5js9z8X8MFTMVa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsuLDoFj5js9z8X8MFTMVa)_