### PR TITLE
feat(bpt-agent-sdk): v0.3 #16 observability message stream

### DIFF
--- a/projects/bpt-agent-sdk/CONTEXT.md
+++ b/projects/bpt-agent-sdk/CONTEXT.md
@@ -53,8 +53,14 @@ src/
 
 v0.2 完成（2026-07-03）：v0.1 已合并入 main；v0.2 补齐上下文压缩 / 结构化输出 /
 子代理运行时 / 权限 v2 / 提示缓存 / 新工具（WebFetch·WebSearch·AskUserQuestion·
-TodoWrite）/ 外部会话存储 + 文件检查点 + 工具搜索。628 测试全绿。进度以
-`memory/project-status.md` 为唯一权威。
+TodoWrite）/ 外部会话存储 + 文件检查点 + 工具搜索。
+
+v0.3 进行中：per-run 预算度量（`result.metrics`）已落；**观测消息流扩容（task #16）
+已落**——`SDKMessage` union 补齐观测臂全 25 变体（`SDKObservabilityMessage`），
+其中 `permission_denied` 真发射（gate deny 时 yield，与 `result.permission_denials`
+台账一致），其余类型化待驱动源（详见 `docs/COMPAT.md` 观测臂表）。634 测试全绿。
+下一步 task #17（P1/P2 长尾：Read 图像·PDF / ToolAnnotations 接线 / mcpServerStatus
+富化 / Usage 字段）。进度以 `memory/project-status.md` 为唯一权威。
 
 ## v0.2 候选
 

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -32,10 +32,14 @@ v0.2 implemented most of the P0/P1 gaps the audit flagged. Now **FULL / PARTIAL*
   `rewindFiles`; tool search (deferred MCP schemas); standalone session
   functions; Query methods (reconnect/toggle/setMcpServers/rewindFiles/stopTask).
 
-Still deliberately out of scope (N/A-by-design or v0.3): the CLI-coupled
-subsystems (CLI system prompt, settings engine, bubblewrap sandbox,
-Bedrock/Vertex/Foundry, OTel), the full 33-variant observability stream, and
-the WarmQuery/startup pre-warm lifecycle. See the audit for the rationale.
+The full observability/status message arm was TYPED in v0.3 (task #16) so the
+SDKMessage union is exhaustive for drop-in consumers; `permission_denied` is
+emitted, the rest are typed-not-emitted (see the Observability arm table below).
+
+Still deliberately out of scope (N/A-by-design): the CLI-coupled subsystems
+(CLI system prompt, settings engine, bubblewrap sandbox, Bedrock/Vertex/Foundry,
+OTel), and the WarmQuery/startup pre-warm lifecycle. See the audit for the
+rationale.
 
 The per-field tiers below were reconciled against actual code as of the v0.1
 adversarial-review pass; the v0.2 graduations above supersede the "MISSING/
@@ -124,8 +128,33 @@ SDK implements the agent loop directly against the public Messages API:
 | `assistant` | FULL | full `APIAssistantMessage` |
 | `user` (echo + tool results) | FULL | prompt echo and tool_result user turns both yielded and persisted in order |
 | `stream_event` | FULL | behind `includePartialMessages` |
-| `result` success / error_max_turns / error_during_execution / `error_max_budget_usd` | PARTIAL | budget subtype uses the official name `error_max_budget_usd`; success arm omits official extras (ttft_ms, structured_output, …); error arm carries `errorMessage: string` rather than official `errors: string[]` |
-| `system/compact_boundary` | UNSUPPORTED | no auto-compaction in v0.1 |
+| `result` success / error_max_turns / error_during_execution / `error_max_budget_usd` / `error_max_structured_output_retries` | PARTIAL | success arm carries ttft_ms + structured_output + deferred_tool_use + v0.3 `metrics`; error arm carries `errorMessage: string` rather than official `errors: string[]` |
+| `system/compact_boundary` | FULL | emitted on manual `/compact` + auto-compaction (v0.2) |
+| `system/mirror_error` | FULL | emitted on a session-store mirror failure |
+
+### Observability arm (v0.3 — task #16)
+
+The official SDKMessage union carries a large observability/status arm. We add
+the full set of variant TYPES so drop-in consumers can switch exhaustively, and
+EMIT the subset this headless engine has a real source event for.
+
+Design note: the official docs/types are internally inconsistent about
+top-level `type` vs `type:'system'+subtype` for these variants (and its own
+issue #181 has `SDKRateLimitEvent`/`SDKPromptSuggestionMessage`
+referenced-but-unexported). We model the arm with **top-level `type`**
+discriminators — the most likely consumer pattern (`msg.type === 'permission_denied'`)
+— except `status`, kept as `system/status`. Field shapes the official leaves
+undocumented are a self-consistent clean-room reconstruction. All carry the
+house `uuid`/`session_id` envelope. Union: `SDKObservabilityMessage`.
+
+| Variant | Tier | Notes |
+|---|---|---|
+| `permission_denied` | FULL (emitted) | yielded on every permission-gate deny, before the tool_result; mirrors the `result.permission_denials` ledger; `blocker:'canUseTool'` set on a canUseTool interrupt, else omitted |
+| `tool_progress`, `tool_use_summary` | TYPED | no mid-tool progress channel (tools are one-shot) |
+| `task_started` / `task_progress` / `task_updated` / `task_notification` | TYPED | subagents run detached; lifecycle not surfaced as stream events yet |
+| `hook_started` / `hook_progress` / `hook_response` | TYPED | would gate behind `includeHookEvents`; hooks currently report via debug only |
+| `rate_limit_event`, `api_retry` | TYPED | the transport retries 429/5xx internally and surfaces attempts via the debug callback, not the stream (a follow-up can bridge transport→stream) |
+| `files_persisted`, `local_command_output`, `commands_changed`, `auth_status`, `elicitation_complete`, `informational`, `notification`, `prompt_suggestion`, `memory_recall`, `worker_shutting_down`, `plugin_install`, `session_state_changed`, `system/status` | TYPED | no source event in a headless engine with no plugins/skills/CC-host/slash-command framework |
 
 ## Hooks
 

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -18,6 +18,7 @@ import type {
   NonNullableUsage,
   RawMessageStreamEvent,
   SDKMessage,
+  SDKPermissionDeniedMessage,
   SDKResultMessage,
   SDKRunMetrics,
   SDKToolMetrics,
@@ -96,6 +97,9 @@ type ToolExecOutcome = {
   result: ToolResultBlockParam;
   stop?: { reason: string };
   defer?: { tool_use_id: string; tool_name: string; tool_input: Record<string, unknown> };
+  /** Observability messages (e.g. permission_denied) to yield before the batch
+   * continues. Sourced inside executeToolUse, which cannot yield itself. */
+  observability?: SDKMessage[];
 };
 
 /** Mutable holder for a stream attempt's usage-so-far (survives a throw). */
@@ -513,15 +517,29 @@ export async function* runAgentLoop(
       decisionReason: pre?.decisionReason,
     });
     if (check.decision === 'deny') {
+      // Surface a permission_denied observability message (task #16) alongside
+      // the tool_result. blocker: a canUseTool interrupt is the only source we
+      // can distinguish at this seam; rule/mode/hook denials carry their detail
+      // in `reason`, so blocker is left off rather than guessed.
+      const denied: SDKPermissionDeniedMessage = {
+        type: 'permission_denied',
+        uuid: randomUUID(),
+        session_id: config.sessionId,
+        tool_name: toolName,
+        tool_use_id: block.id,
+        reason: check.message,
+        ...(check.interrupt === true ? { blocker: 'canUseTool' as const } : {}),
+      };
       // interrupt:true (e.g. canUseTool returned behavior:'deny', interrupt)
       // means "deny AND stop the whole run", not just skip this call.
       if (check.interrupt === true) {
         return {
           result: errorToolResult(check.message),
           stop: { reason: check.message },
+          observability: [denied],
         };
       }
-      return { result: errorToolResult(check.message) };
+      return { result: errorToolResult(check.message), observability: [denied] };
     }
     if (check.decision === 'skip') {
       // canUseTool returned null: the app is resolving this call out of band.
@@ -811,6 +829,11 @@ export async function* runAgentLoop(
           }
           // Sequential, in content order.
           const outcome = await executeToolUse(block);
+          // Surface any observability messages (e.g. permission_denied) the call
+          // produced, before its tool_result is folded into the next turn.
+          if (outcome.observability !== undefined) {
+            for (const msg of outcome.observability) yield msg;
+          }
           results.push(outcome.result);
           if (outcome.stop !== undefined) batchStop = outcome.stop;
           if (outcome.defer !== undefined) batchDefer = outcome.defer;

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -882,6 +882,316 @@ export type SDKCompactBoundaryMessage = {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Observability / status message variants (v0.3 — task #16)
+//
+// Drop-in surface for the official SDKMessage union's observability arm. The
+// published docs/types NAME these discriminators but leave several PAYLOAD
+// shapes unspecified (the SDK's own issue #181 has SDKRateLimitEvent /
+// SDKPromptSuggestionMessage referenced-but-unexported), and are internally
+// inconsistent about top-level `type` vs `type:'system'+subtype`. We model the
+// observability arm with TOP-LEVEL `type` discriminators — the most likely
+// consumer pattern (e.g. `msg.type === 'permission_denied'`) — except `status`,
+// which stays a `system` subtype since `system/status` is its canonical form.
+// Every message carries our house `uuid`/`session_id` envelope.
+//
+// EMITTED by this engine today: SDKPermissionDeniedMessage (on a gate deny).
+// The rest are TYPED for union exhaustiveness but have no source event in a
+// headless engine with no plugins/skills/CC-host/background-task framework; see
+// docs/COMPAT.md for the emitted-vs-typed split. Field shapes the official
+// leaves undocumented are a self-consistent clean-room reconstruction.
+// ---------------------------------------------------------------------------
+
+/** A tool call the permission gate denied. EMITTED on every gate deny. */
+export type SDKPermissionDeniedMessage = {
+  type: 'permission_denied';
+  uuid: string;
+  session_id: string;
+  tool_name: string;
+  tool_use_id: string;
+  /** The gate's human-readable denial reason. */
+  reason: string;
+  /** Coarse source of the block, when derivable (else omitted). */
+  blocker?: 'rule' | 'mode' | 'hook' | 'canUseTool' | 'other';
+};
+
+/** Progress (0..100) from a long-running tool. Typed; not emitted. */
+export type SDKToolProgressMessage = {
+  type: 'tool_progress';
+  uuid: string;
+  session_id: string;
+  tool_use_id: string;
+  progress: number;
+  status?: string;
+  details?: Record<string, unknown>;
+};
+
+/** A compact summary of a completed tool call. Typed; not emitted. */
+export type SDKToolUseSummaryMessage = {
+  type: 'tool_use_summary';
+  uuid: string;
+  session_id: string;
+  tool_name: string;
+  tool_use_id: string;
+  input_summary: string;
+  result_summary: string;
+};
+
+/** A background task / subagent started. Typed; not emitted. */
+export type SDKTaskStartedMessage = {
+  type: 'task_started';
+  uuid: string;
+  session_id: string;
+  task_id: string;
+  task_name: string;
+  agent_id?: string;
+};
+
+/** Progress from a background task / subagent. Typed; not emitted. */
+export type SDKTaskProgressMessage = {
+  type: 'task_progress';
+  uuid: string;
+  session_id: string;
+  task_id: string;
+  progress: number;
+  status?: string;
+  summary?: string;
+  blocked?: boolean;
+};
+
+/** Terminal update for a background task / subagent. Typed; not emitted. */
+export type SDKTaskUpdatedMessage = {
+  type: 'task_updated';
+  uuid: string;
+  session_id: string;
+  task_id: string;
+  status: 'completed' | 'failed' | 'cancelled';
+  result?: string;
+  error?: string;
+};
+
+/** Background-task lifecycle notification. Typed; not emitted. */
+export type SDKTaskNotificationMessage = {
+  type: 'task_notification';
+  uuid: string;
+  session_id: string;
+  task_id: string;
+  event: 'completed' | 'failed' | 'stopped';
+  message?: string;
+};
+
+/** Hook execution began (gated by includeHookEvents). Typed; not emitted. */
+export type SDKHookStartedMessage = {
+  type: 'hook_started';
+  uuid: string;
+  session_id: string;
+  hook_id: string;
+  hook_event: HookEvent;
+};
+
+/** Hook execution progress (gated by includeHookEvents). Typed; not emitted. */
+export type SDKHookProgressMessage = {
+  type: 'hook_progress';
+  uuid: string;
+  session_id: string;
+  hook_id: string;
+  hook_event: HookEvent;
+  progress?: number;
+  status?: string;
+};
+
+/** Hook execution finished (gated by includeHookEvents). Typed; not emitted. */
+export type SDKHookResponseMessage = {
+  type: 'hook_response';
+  uuid: string;
+  session_id: string;
+  hook_id: string;
+  hook_event: HookEvent;
+  result?: string;
+  error?: string;
+};
+
+/** Files written / changed during a turn. Typed; not emitted. */
+export type SDKFilesPersistedMessage = {
+  type: 'files_persisted';
+  uuid: string;
+  session_id: string;
+  files: Array<{
+    path: string;
+    operation: 'created' | 'modified' | 'deleted';
+    size?: number;
+  }>;
+};
+
+/** Output of a local slash-command run. Typed; not emitted. */
+export type SDKLocalCommandOutputMessage = {
+  type: 'local_command_output';
+  uuid: string;
+  session_id: string;
+  command: string;
+  output: string;
+  exit_code?: number;
+};
+
+/** The available slash-command set changed. Typed; not emitted. */
+export type SDKCommandsChangedMessage = {
+  type: 'commands_changed';
+  uuid: string;
+  session_id: string;
+  available_commands: SlashCommand[];
+};
+
+/** A rate limit was hit and a retry scheduled. Typed; not emitted (the
+ * transport retries internally and surfaces attempts via the debug callback). */
+export type SDKRateLimitEventMessage = {
+  type: 'rate_limit_event';
+  uuid: string;
+  session_id: string;
+  retry_after_ms: number;
+  limit_type: 'api' | 'token' | 'requests';
+  requests_remaining?: number;
+};
+
+/** An API call is being retried. Typed; not emitted (see rate_limit_event). */
+export type SDKApiRetryMessage = {
+  type: 'api_retry';
+  uuid: string;
+  session_id: string;
+  attempt: number;
+  max_retries: number;
+  status?: number;
+  reason?: string;
+};
+
+/** Authentication status. Typed; not emitted. */
+export type SDKAuthStatusMessage = {
+  type: 'auth_status';
+  uuid: string;
+  session_id: string;
+  status: 'authenticated' | 'unauthenticated' | 'expired';
+  provider?: string;
+};
+
+/** A server-initiated elicitation resolved. Typed; not emitted. */
+export type SDKElicitationCompleteMessage = {
+  type: 'elicitation_complete';
+  uuid: string;
+  session_id: string;
+  elicitation_id: string;
+  result: 'accepted' | 'declined' | 'error';
+  value?: unknown;
+  error?: string;
+};
+
+/** A free-form informational log surfaced into the stream. Typed; not emitted. */
+export type SDKInformationalMessage = {
+  type: 'informational';
+  uuid: string;
+  session_id: string;
+  level: 'info' | 'warning' | 'debug';
+  message: string;
+  details?: Record<string, unknown>;
+};
+
+/** A user-facing notification. Typed; not emitted. */
+export type SDKNotificationMessage = {
+  type: 'notification';
+  uuid: string;
+  session_id: string;
+  level: 'info' | 'warning' | 'error';
+  title: string;
+  message: string;
+};
+
+/** A suggested next prompt (gated by promptSuggestions). Typed; not emitted. */
+export type SDKPromptSuggestionMessage = {
+  type: 'prompt_suggestion';
+  uuid: string;
+  session_id: string;
+  suggestion: string;
+  reasoning?: string;
+};
+
+/** A memory item recalled into context. Typed; not emitted. */
+export type SDKMemoryRecallMessage = {
+  type: 'memory_recall';
+  uuid: string;
+  session_id: string;
+  context: string;
+  source: 'user' | 'project' | 'local';
+  confidence?: number;
+};
+
+/** The worker is shutting down. Typed; not emitted. */
+export type SDKWorkerShuttingDownMessage = {
+  type: 'worker_shutting_down';
+  uuid: string;
+  session_id: string;
+  graceful: boolean;
+  reason?: string;
+};
+
+/** Plugin install lifecycle. Typed; not emitted. */
+export type SDKPluginInstallMessage = {
+  type: 'plugin_install';
+  uuid: string;
+  session_id: string;
+  plugin_name: string;
+  status: 'installing' | 'installed' | 'failed' | 'completed';
+  error?: string;
+};
+
+/** Session state transition. Typed; not emitted. */
+export type SDKSessionStateChangedMessage = {
+  type: 'session_state_changed';
+  uuid: string;
+  session_id: string;
+  state: 'active' | 'paused' | 'completed';
+  reason?: string;
+};
+
+/** A coarse engine status (canonical `system`/`status` form). Typed; not emitted. */
+export type SDKStatusMessage = {
+  type: 'system';
+  subtype: 'status';
+  uuid: string;
+  session_id: string;
+  status: string | null;
+  details?: Record<string, unknown>;
+};
+
+/**
+ * The observability / status arm of the SDKMessage union (task #16). Only
+ * SDKPermissionDeniedMessage is emitted today; the rest are typed for drop-in
+ * exhaustiveness (see docs/COMPAT.md).
+ */
+export type SDKObservabilityMessage =
+  | SDKPermissionDeniedMessage
+  | SDKToolProgressMessage
+  | SDKToolUseSummaryMessage
+  | SDKTaskStartedMessage
+  | SDKTaskProgressMessage
+  | SDKTaskUpdatedMessage
+  | SDKTaskNotificationMessage
+  | SDKHookStartedMessage
+  | SDKHookProgressMessage
+  | SDKHookResponseMessage
+  | SDKFilesPersistedMessage
+  | SDKLocalCommandOutputMessage
+  | SDKCommandsChangedMessage
+  | SDKRateLimitEventMessage
+  | SDKApiRetryMessage
+  | SDKAuthStatusMessage
+  | SDKElicitationCompleteMessage
+  | SDKInformationalMessage
+  | SDKNotificationMessage
+  | SDKPromptSuggestionMessage
+  | SDKMemoryRecallMessage
+  | SDKWorkerShuttingDownMessage
+  | SDKPluginInstallMessage
+  | SDKSessionStateChangedMessage
+  | SDKStatusMessage;
+
 export type SDKMessage =
   | SDKAssistantMessage
   | SDKUserMessage
@@ -890,7 +1200,8 @@ export type SDKMessage =
   | SDKSystemMessage
   | SDKCompactBoundaryMessage
   | SDKMirrorErrorMessage
-  | SDKPartialAssistantMessage;
+  | SDKPartialAssistantMessage
+  | SDKObservabilityMessage;
 
 // ---------------------------------------------------------------------------
 // v0.2 subsystem types

--- a/projects/bpt-agent-sdk/tests/observability.test.ts
+++ b/projects/bpt-agent-sdk/tests/observability.test.ts
@@ -1,0 +1,214 @@
+/**
+ * v0.3 task #16 — observability message stream.
+ *
+ * Two guards:
+ *  1. Behavioral: a gate deny surfaces an SDKPermissionDeniedMessage in the
+ *     stream (before the terminal result), matching the denial ledger.
+ *  2. Structural: an exhaustive switch over SDKObservabilityMessage that only
+ *     compiles when every variant is present in the union (a `never` default),
+ *     exercised at runtime over one sample of each variant.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { query } from '../src/index.js';
+import type {
+  SDKMessage,
+  SDKObservabilityMessage,
+  SDKPermissionDeniedMessage,
+  SDKResultMessage,
+} from '../src/index.js';
+import { makeSSEFetch } from './helpers/sse-fetch.js';
+import { textReplyEvents, toolUseReplyEvents } from './helpers/mock-transport.js';
+
+let sandbox: string;
+
+beforeEach(() => {
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'bpt-observ-'));
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+async function collect(q: AsyncGenerator<SDKMessage, void>): Promise<SDKMessage[]> {
+  const out: SDKMessage[] = [];
+  for await (const m of q) out.push(m);
+  return out;
+}
+
+function opts(extra: Record<string, unknown> = {}) {
+  return {
+    provider: { apiKey: 'test-key', promptCaching: false },
+    sessionDir: path.join(sandbox, '.sessions'),
+    cwd: sandbox,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    ...extra,
+  };
+}
+
+describe('v0.3 permission_denied emission', () => {
+  it('emits SDKPermissionDeniedMessage when the gate denies a tool', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeSSEFetch([
+        toolUseReplyEvents('Bash', { command: 'echo hi' }),
+        textReplyEvents('done'),
+      ]),
+    );
+    const messages = await collect(
+      query({
+        prompt: 'run it',
+        options: opts({
+          permissionMode: 'default',
+          // Falls through to canUseTool for a non-readonly tool in default mode;
+          // a deny here is recorded in the ledger and drives permission_denied.
+          canUseTool: async () => ({ behavior: 'deny' as const, message: 'nope' }),
+        }),
+      }),
+    );
+
+    const denied = messages.filter(
+      (m): m is SDKPermissionDeniedMessage => m.type === 'permission_denied',
+    );
+    expect(denied).toHaveLength(1);
+    expect(denied[0]!.tool_name).toBe('Bash');
+    expect(denied[0]!.tool_use_id).toBeTruthy();
+    expect(denied[0]!.reason).toBeTruthy();
+    expect(denied[0]!.session_id).toBeTruthy();
+
+    // It precedes the terminal result in the stream.
+    const idxDenied = messages.findIndex((m) => m.type === 'permission_denied');
+    const idxResult = messages.findIndex((m) => m.type === 'result');
+    expect(idxDenied).toBeGreaterThanOrEqual(0);
+    expect(idxResult).toBeGreaterThan(idxDenied);
+
+    // The same denial is reflected in the result's permission_denials ledger.
+    const result = messages[messages.length - 1] as SDKResultMessage;
+    expect(result.type).toBe('result');
+    expect(result.permission_denials.some((d) => d.tool_name === 'Bash')).toBe(true);
+  });
+
+  it('does not emit permission_denied when the tool is allowed', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeSSEFetch([
+        toolUseReplyEvents('Bash', { command: 'echo hi' }),
+        textReplyEvents('done'),
+      ]),
+    );
+    const messages = await collect(
+      query({
+        prompt: 'run it',
+        options: opts({ permissionMode: 'bypassPermissions' }),
+      }),
+    );
+    expect(messages.some((m) => m.type === 'permission_denied')).toBe(false);
+  });
+});
+
+/**
+ * Exhaustive discriminator over the observability arm. The `never` assignment
+ * in the default branch fails to COMPILE if any SDKObservabilityMessage variant
+ * is missing here — so this function doubles as a union-completeness guard.
+ */
+function variantName(m: SDKObservabilityMessage): string {
+  switch (m.type) {
+    case 'permission_denied':
+      return 'permission_denied';
+    case 'tool_progress':
+      return 'tool_progress';
+    case 'tool_use_summary':
+      return 'tool_use_summary';
+    case 'task_started':
+      return 'task_started';
+    case 'task_progress':
+      return 'task_progress';
+    case 'task_updated':
+      return 'task_updated';
+    case 'task_notification':
+      return 'task_notification';
+    case 'hook_started':
+      return 'hook_started';
+    case 'hook_progress':
+      return 'hook_progress';
+    case 'hook_response':
+      return 'hook_response';
+    case 'files_persisted':
+      return 'files_persisted';
+    case 'local_command_output':
+      return 'local_command_output';
+    case 'commands_changed':
+      return 'commands_changed';
+    case 'rate_limit_event':
+      return 'rate_limit_event';
+    case 'api_retry':
+      return 'api_retry';
+    case 'auth_status':
+      return 'auth_status';
+    case 'elicitation_complete':
+      return 'elicitation_complete';
+    case 'informational':
+      return 'informational';
+    case 'notification':
+      return 'notification';
+    case 'prompt_suggestion':
+      return 'prompt_suggestion';
+    case 'memory_recall':
+      return 'memory_recall';
+    case 'worker_shutting_down':
+      return 'worker_shutting_down';
+    case 'plugin_install':
+      return 'plugin_install';
+    case 'session_state_changed':
+      return 'session_state_changed';
+    case 'system':
+      return `system/${m.subtype}`;
+    default: {
+      const never: never = m;
+      return never;
+    }
+  }
+}
+
+describe('v0.3 observability union completeness', () => {
+  it('routes every variant through the exhaustive discriminator', () => {
+    const env = { uuid: 'u', session_id: 's' };
+    const samples: SDKObservabilityMessage[] = [
+      { type: 'permission_denied', ...env, tool_name: 'Bash', tool_use_id: 't', reason: 'no' },
+      { type: 'tool_progress', ...env, tool_use_id: 't', progress: 50 },
+      { type: 'tool_use_summary', ...env, tool_name: 'Bash', tool_use_id: 't', input_summary: 'i', result_summary: 'r' },
+      { type: 'task_started', ...env, task_id: 'k', task_name: 'n' },
+      { type: 'task_progress', ...env, task_id: 'k', progress: 10 },
+      { type: 'task_updated', ...env, task_id: 'k', status: 'completed' },
+      { type: 'task_notification', ...env, task_id: 'k', event: 'completed' },
+      { type: 'hook_started', ...env, hook_id: 'h', hook_event: 'PreToolUse' },
+      { type: 'hook_progress', ...env, hook_id: 'h', hook_event: 'PreToolUse' },
+      { type: 'hook_response', ...env, hook_id: 'h', hook_event: 'PreToolUse' },
+      { type: 'files_persisted', ...env, files: [{ path: 'a', operation: 'created' }] },
+      { type: 'local_command_output', ...env, command: '/x', output: 'o' },
+      { type: 'commands_changed', ...env, available_commands: [] },
+      { type: 'rate_limit_event', ...env, retry_after_ms: 100, limit_type: 'api' },
+      { type: 'api_retry', ...env, attempt: 1, max_retries: 3 },
+      { type: 'auth_status', ...env, status: 'authenticated' },
+      { type: 'elicitation_complete', ...env, elicitation_id: 'e', result: 'accepted' },
+      { type: 'informational', ...env, level: 'info', message: 'm' },
+      { type: 'notification', ...env, level: 'info', title: 't', message: 'm' },
+      { type: 'prompt_suggestion', ...env, suggestion: 's' },
+      { type: 'memory_recall', ...env, context: 'c', source: 'user' },
+      { type: 'worker_shutting_down', ...env, graceful: true },
+      { type: 'plugin_install', ...env, plugin_name: 'p', status: 'installed' },
+      { type: 'session_state_changed', ...env, state: 'active' },
+      { type: 'system', subtype: 'status', ...env, status: 'pending' },
+    ];
+    const names = samples.map(variantName);
+    // 24 top-level variants + 1 system/status.
+    expect(names).toHaveLength(25);
+    expect(new Set(names).size).toBe(25);
+    expect(names).toContain('permission_denied');
+    expect(names).toContain('system/status');
+  });
+});


### PR DESCRIPTION
## 概述

bpt-agent-sdk v0.3 task #16：把官方 SDKMessage union 的**观测/状态臂**补齐，令 drop-in 消费端可穷尽 switch，并**真发射**本无头引擎有真实来源事件的那一个变体（`permission_denied`）。这是当前最大单项表面缺口（官方 33 变体 union，此前仅 8）。

---

## 变更类型

- [x] 其他：SDK 功能实现（TypeScript 类型 + 引擎发射 + 单测 + 文档）

**类型**（新增 `SDKObservabilityMessage` union，25 变体）：permission_denied / tool_progress / tool_use_summary / task_started·progress·updated·notification / hook_started·progress·response / files_persisted / local_command_output / commands_changed / rate_limit_event / api_retry / auth_status / elicitation_complete / informational / notification / prompt_suggestion / memory_recall / worker_shutting_down / plugin_install / session_state_changed / system/status。

**设计取舍**：官方文档在「top-level `type` vs `type:'system'+subtype`」上自相矛盾（其 issue #181 有 rate_limit_event / prompt_suggestion 被引用却未导出）。本实现统一用 **top-level `type`** 判别式（最可能的消费模式 `msg.type === 'permission_denied'`），`status` 保留 `system/status`；官方未公开的字段 shape 为自洽干净室重建，已在 COMPAT.md 明示。

**发射**：`permission_denied` 在每次权限 gate deny 时 yield（tool_result 入栈前），经 ToolExecOutcome 新增的 observability 侧信道（executeToolUse 自身不能 yield）。与 `result.permission_denials` 台账一致；`blocker:'canUseTool'` 仅在 canUseTool interrupt 时设、否则省略（不臆造来源）。其余为**类型化未发射**（无 plugins/skills/CC 宿主/后台任务/slash 框架则无来源事件）——COMPAT.md 列出「发射 vs 类型化」拆分，rate_limit_event/api_retry 记为 transport→stream 桥接后续项。

---

## 来源声明

不涉及游戏数据；银芯自有工程产物。官方接口 shape 取自公开文档（干净室：学接口非抄实现），事实取自本仓库直接产出（`vitest` 运行输出、`tsc`/`build` 退出码）。

---

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布数据。** 无系统提示词 / 专有代码复制（干净室纪律）。
- [x] **仅引用公开素材。**
- [x] **同意按 MIT License 提交。**

---

## 验证清单

- [x] `npx vitest run` — **634 passed（18 文件，+3）**：permission_denied 在 canUseTool deny 时发射、允许时不发射；穷尽判别器以 `never` 默认分支把 union 完整性变成编译期守卫
- [x] `tsc -p tsconfig.json --noEmit` + `npm run build` — exit 0
- [x] 不引入 emoji（CLAUDE.md 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联 Issue

- Refs #380（v0.2+v0.3 本体）；承接定位 `projects/bpt-agent-sdk/docs/POSITIONING.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsuLDoFj5js9z8X8MFTMVa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsuLDoFj5js9z8X8MFTMVa)_