### PR TITLE
feat(bpt-agent-sdk): 表面对齐增量——bypass 联锁 / MCP resources / Grep offset·-o / ModelInfo.value 等（与 main 并行工作对账后仅补独有项）

### DIFF
--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -106,7 +106,8 @@ SDK implements the agent loop directly against the public Messages API:
 | `maxTurns` | FULL | |
 | `mcpServers` | PARTIAL | stdio/http/sdk FULL; `sse` legacy transport UNSUPPORTED |
 | `model` | FULL | default `ANTHROPIC_MODEL` env or `claude-sonnet-4-5` |
-| `permissionMode` | PARTIAL | `default`/`acceptEdits`/`bypassPermissions`/`plan`/`dontAsk`; `auto` (classifier) not offered |
+| `permissionMode` | PARTIAL | `default`/`acceptEdits`/`bypassPermissions`/`plan`/`dontAsk`; `auto` (classifier) not offered. `bypassPermissions` requires the `allowDangerouslySkipPermissions` interlock (below) |
+| `allowDangerouslySkipPermissions` | FULL | safety interlock: `bypassPermissions` (initial or via `setPermissionMode`) throws `ConfigurationError` unless this is `true` |
 | `persistSession` / `sessionId` / `resume` | FULL | JSONL store |
 | `provider` | FULL | **BPT extension** — direct-API connection settings |
 | `settingSources` | ACCEPTED | no filesystem settings in v0.1 |
@@ -116,7 +117,7 @@ SDK implements the agent loop directly against the public Messages API:
 | `tools` | PARTIAL | string[] filters built-ins; preset = all built-ins |
 | `betas` | FULL | forwarded as `anthropic-beta` header |
 | `debug` / `debugFile` | PARTIAL | `debug` → stderr callback; `debugFile` ACCEPTED |
-| `agent`, `settings`, `permissionPromptToolName`, `extraArgs`, `effort`, `outputFormat`, `sandbox`, `plugins`, `skills`, `toolAliases`, `toolConfig`, `sessionStore*`, `managedSettings`, `enableFileCheckpointing`, `taskBudget`, `onElicitation`, `planModeInstructions`, `promptSuggestions`, `agentProgressSummaries`, `forwardSubagentText`, `includeHookEvents`, `loadTimeoutMs`, `allowDangerouslySkipPermissions`, `title`, `resumeSessionAt` | ACCEPTED | each present key emits exactly one debug warning, then ignored in v0.1 |
+| `agent`, `settings`, `permissionPromptToolName`, `extraArgs`, `effort`, `outputFormat`, `sandbox`, `plugins`, `skills`, `toolAliases`, `toolConfig`, `sessionStore*`, `managedSettings`, `enableFileCheckpointing`, `taskBudget`, `onElicitation`, `planModeInstructions`, `promptSuggestions`, `agentProgressSummaries`, `forwardSubagentText`, `includeHookEvents`, `loadTimeoutMs`, `title`, `resumeSessionAt` | ACCEPTED | each present key emits exactly one debug warning, then ignored |
 
 ## Built-in tools
 

--- a/projects/bpt-agent-sdk/package-lock.json
+++ b/projects/bpt-agent-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bpt-agent-sdk",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
@@ -18,7 +18,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.3.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "BPT Agent SDK - clean-room agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -164,6 +164,18 @@ function mapMcpResult(res: CallToolResult): ToolResultPayload {
         break;
     }
   }
+  // Surface a structuredContent payload as trailing JSON text so the model
+  // can read it (the API tool_result carries no structured channel).
+  if (res.structuredContent !== undefined) {
+    try {
+      parts.push({
+        type: 'text',
+        text: `[structuredContent] ${JSON.stringify(res.structuredContent)}`,
+      });
+    } catch {
+      // Non-serializable payload: skip rather than throw.
+    }
+  }
   return { content: parts.length > 0 ? parts : '', isError: res.isError === true };
 }
 

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -296,11 +296,13 @@ export async function* runAgentLoop(
       | 'error_max_budget_usd'
       | 'error_max_structured_output_retries',
     errorMessage: string,
+    apiErrorStatus?: number,
   ): SDKResultMessage => ({
     type: 'result',
     subtype,
     is_error: true,
     errorMessage,
+    ...(apiErrorStatus !== undefined ? { api_error_status: apiErrorStatus } : {}),
     ...resultBase(),
   });
 
@@ -1096,7 +1098,8 @@ export async function* runAgentLoop(
     if (isAbortError(err)) throw toAbortError(err);
     const message = err instanceof Error ? err.message : String(err);
     deps.debug(`engine: error during execution: ${message}`);
-    yield errorResult('error_during_execution', message);
+    const apiStatus = err instanceof APIStatusError ? err.status : undefined;
+    yield errorResult('error_during_execution', message, apiStatus);
     return;
   }
 }

--- a/projects/bpt-agent-sdk/src/internal/contracts.ts
+++ b/projects/bpt-agent-sdk/src/internal/contracts.ts
@@ -16,6 +16,8 @@ import type {
   HookInput,
   ImageBlockParam,
   JSONSchema,
+  McpResource,
+  McpResourceContent,
   McpServerConfig,
   McpServerStatus,
   McpSetServersResult,
@@ -94,6 +96,11 @@ export type ToolContext = {
   webSearch?: WebSearchHandler;
   /** v0.2 AskUserQuestion handler; undefined -> the tool returns a not-configured error. */
   askUser?: UserQuestionHandler;
+  /** MCP resources access; undefined when no MCP registry is wired. */
+  mcpResources?: {
+    list(server: string | undefined, signal: AbortSignal): Promise<McpResource[]>;
+    read(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]>;
+  };
   /** v0.2 WebFetch escape hatch for localhost/private hosts (default false). */
   allowPrivateWebFetch?: boolean;
   /** Injectable fetch for tests; defaults to globalThis.fetch when undefined. */
@@ -265,6 +272,10 @@ export interface McpRegistry {
     args: Record<string, unknown>,
     signal: AbortSignal,
   ): Promise<CallToolResult>;
+  /** List resources across connected servers (or one named server). */
+  listResources(server: string | undefined, signal: AbortSignal): Promise<McpResource[]>;
+  /** Read one resource's contents from a named server. */
+  readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]>;
   reconnect(serverName: string): Promise<void>;
   setEnabled(serverName: string, enabled: boolean): void;
   /** Replace the live server set at runtime; returns the new statuses. */

--- a/projects/bpt-agent-sdk/src/mcp/http.ts
+++ b/projects/bpt-agent-sdk/src/mcp/http.ts
@@ -18,9 +18,12 @@ import type {
   ElicitationHandler,
   JSONSchema,
   McpHttpServerConfig,
+  McpResource,
+  McpResourceContent,
   McpSSEServerConfig,
 } from '../types.js';
 import { AbortError, NotImplementedError } from '../errors.js';
+import { parseResourcesList, parseResourceContents } from './stdio.js';
 import { resolveElicitation } from './elicitation.js';
 
 const MCP_PROTOCOL_VERSION = '2025-06-18';
@@ -142,6 +145,23 @@ export class HttpMcpConnection {
   ): Promise<CallToolResult> {
     const result = await this.rpcRequest('tools/call', { name, arguments: args }, signal);
     return normalizeCallToolResult(result);
+  }
+
+  /** resources/list (single page); [] when the server has no resources support. */
+  async listResources(signal?: AbortSignal): Promise<McpResource[]> {
+    try {
+      const result = await this.rpcRequest('resources/list', {}, signal);
+      return parseResourcesList(result);
+    } catch (err) {
+      if (err instanceof AbortError) throw err;
+      return [];
+    }
+  }
+
+  /** resources/read for one uri. */
+  async readResource(uri: string, signal?: AbortSignal): Promise<McpResourceContent[]> {
+    const result = await this.rpcRequest('resources/read', { uri }, signal);
+    return parseResourceContents(result);
   }
 
   /** Cancel all in-flight requests; further calls fail with AbortError. */

--- a/projects/bpt-agent-sdk/src/mcp/http.ts
+++ b/projects/bpt-agent-sdk/src/mcp/http.ts
@@ -482,13 +482,14 @@ function normalizeCallToolResult(raw: unknown): CallToolResult {
   if (!raw || typeof raw !== 'object') {
     return { content: [{ type: 'text', text: JSON.stringify(raw ?? null) }] };
   }
-  const obj = raw as { content?: unknown; isError?: unknown };
+  const obj = raw as { content?: unknown; isError?: unknown; structuredContent?: unknown };
   const content: CallToolResultContent[] = [];
   if (Array.isArray(obj.content)) {
     for (const item of obj.content) content.push(normalizeContentItem(item));
   }
   const result: CallToolResult = { content };
   if (obj.isError === true) result.isError = true;
+  if (obj.structuredContent !== undefined) result.structuredContent = obj.structuredContent;
   return result;
 }
 

--- a/projects/bpt-agent-sdk/src/mcp/registry.ts
+++ b/projects/bpt-agent-sdk/src/mcp/registry.ts
@@ -14,6 +14,8 @@ import type {
   ElicitationHandler,
   JSONSchema,
   McpHttpServerConfig,
+  McpResource,
+  McpResourceContent,
   McpSSEServerConfig,
   McpSdkServerConfigWithInstance,
   McpServerConfig,
@@ -40,6 +42,8 @@ type McpConnectionLike = {
     args: Record<string, unknown>,
     signal?: AbortSignal,
   ): Promise<CallToolResult>;
+  listResources(signal?: AbortSignal): Promise<McpResource[]>;
+  readResource(uri: string, signal?: AbortSignal): Promise<McpResourceContent[]>;
   close(): Promise<void>;
 };
 
@@ -156,6 +160,40 @@ export class DefaultMcpRegistry implements McpRegistry {
       if (signal.aborted) throw new AbortError();
       return errorResult(`MCP tool '${qualifiedName}' failed: ${errMessage(err)}`);
     }
+  }
+
+  /** List resources across connected servers (or one named server). */
+  async listResources(
+    server: string | undefined,
+    signal: AbortSignal,
+  ): Promise<McpResource[]> {
+    const out: McpResource[] = [];
+    for (const entry of this.entries) {
+      if (server !== undefined && entry.name !== server) continue;
+      if (!entry.enabled || entry.baseStatus !== 'connected' || !entry.connection) continue;
+      try {
+        const list = await entry.connection.listResources(signal);
+        for (const r of list) out.push({ ...r, server: entry.name });
+      } catch (err) {
+        if (isAbortError(err)) throw err;
+        this.debug(`[mcp] listResources '${entry.name}' failed: ${errMessage(err)}`);
+      }
+    }
+    return out;
+  }
+
+  /** Read one resource's contents from a named, connected server. */
+  async readResource(
+    server: string,
+    uri: string,
+    signal: AbortSignal,
+  ): Promise<McpResourceContent[]> {
+    const entry = this.entries.find((e) => e.name === server);
+    if (!entry) throw new Error(`No such MCP server: ${server}`);
+    if (!entry.enabled || entry.baseStatus !== 'connected' || !entry.connection) {
+      throw new Error(`MCP server '${server}' is not connected`);
+    }
+    return await entry.connection.readResource(uri, signal);
   }
 
   /** Tear down and re-establish one server's connection. Never throws. */

--- a/projects/bpt-agent-sdk/src/mcp/sdk-server.ts
+++ b/projects/bpt-agent-sdk/src/mcp/sdk-server.ts
@@ -10,6 +10,8 @@ import { z } from 'zod';
 import type {
   CallToolResult,
   JSONSchema,
+  McpResource,
+  McpResourceContent,
   McpSdkServerConfigWithInstance,
   SdkMcpServerInstance,
   SdkMcpToolDefinition,
@@ -154,6 +156,15 @@ export class SdkMcpConnection {
         isError: true,
       };
     }
+  }
+
+  /** In-process SDK servers expose tools only, no resources. */
+  async listResources(_signal?: AbortSignal): Promise<McpResource[]> {
+    return [];
+  }
+
+  async readResource(_uri: string, _signal?: AbortSignal): Promise<McpResourceContent[]> {
+    return [];
   }
 
   /** In-process: nothing to release. */

--- a/projects/bpt-agent-sdk/src/mcp/stdio.ts
+++ b/projects/bpt-agent-sdk/src/mcp/stdio.ts
@@ -409,13 +409,14 @@ function normalizeCallToolResult(raw: unknown): CallToolResult {
   if (!raw || typeof raw !== 'object') {
     return { content: [{ type: 'text', text: JSON.stringify(raw ?? null) }] };
   }
-  const obj = raw as { content?: unknown; isError?: unknown };
+  const obj = raw as { content?: unknown; isError?: unknown; structuredContent?: unknown };
   const content: CallToolResultContent[] = [];
   if (Array.isArray(obj.content)) {
     for (const item of obj.content) content.push(normalizeContentItem(item));
   }
   const result: CallToolResult = { content };
   if (obj.isError === true) result.isError = true;
+  if (obj.structuredContent !== undefined) result.structuredContent = obj.structuredContent;
   return result;
 }
 

--- a/projects/bpt-agent-sdk/src/mcp/stdio.ts
+++ b/projects/bpt-agent-sdk/src/mcp/stdio.ts
@@ -13,6 +13,8 @@ import type {
   CallToolResultContent,
   ElicitationHandler,
   JSONSchema,
+  McpResource,
+  McpResourceContent,
   McpStdioServerConfig,
 } from '../types.js';
 import { AbortError } from '../errors.js';
@@ -180,6 +182,24 @@ export class StdioMcpConnection {
   ): Promise<CallToolResult> {
     const result = await this.request('tools/call', { name, arguments: args }, signal);
     return normalizeCallToolResult(result);
+  }
+
+  /** resources/list (single page); [] when the server has no resources support. */
+  async listResources(signal?: AbortSignal): Promise<McpResource[]> {
+    try {
+      const result = await this.request('resources/list', {}, signal);
+      return parseResourcesList(result);
+    } catch (err) {
+      if (err instanceof AbortError) throw err;
+      this.debug(`[mcp:${this.label}] resources/list failed: ${String(err)}`);
+      return [];
+    }
+  }
+
+  /** resources/read for one uri. */
+  async readResource(uri: string, signal?: AbortSignal): Promise<McpResourceContent[]> {
+    const result = await this.request('resources/read', { uri }, signal);
+    return parseResourceContents(result);
   }
 
   /** Terminate the child: SIGTERM, then SIGKILL after a short grace period. */
@@ -397,6 +417,42 @@ function normalizeCallToolResult(raw: unknown): CallToolResult {
   const result: CallToolResult = { content };
   if (obj.isError === true) result.isError = true;
   return result;
+}
+
+/** Parse a resources/list JSON-RPC result into McpResource[]. */
+export function parseResourcesList(raw: unknown): McpResource[] {
+  const arr = (raw as { resources?: unknown } | null)?.resources;
+  if (!Array.isArray(arr)) return [];
+  const out: McpResource[] = [];
+  for (const item of arr) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Record<string, unknown>;
+    if (typeof r.uri !== 'string') continue;
+    const res: McpResource = { uri: r.uri };
+    if (typeof r.name === 'string') res.name = r.name;
+    if (typeof r.description === 'string') res.description = r.description;
+    if (typeof r.mimeType === 'string') res.mimeType = r.mimeType;
+    out.push(res);
+  }
+  return out;
+}
+
+/** Parse a resources/read JSON-RPC result into McpResourceContent[]. */
+export function parseResourceContents(raw: unknown): McpResourceContent[] {
+  const arr = (raw as { contents?: unknown } | null)?.contents;
+  if (!Array.isArray(arr)) return [];
+  const out: McpResourceContent[] = [];
+  for (const item of arr) {
+    if (!item || typeof item !== 'object') continue;
+    const c = item as Record<string, unknown>;
+    if (typeof c.uri !== 'string') continue;
+    const content: McpResourceContent = { uri: c.uri };
+    if (typeof c.mimeType === 'string') content.mimeType = c.mimeType;
+    if (typeof c.text === 'string') content.text = c.text;
+    if (typeof c.blob === 'string') content.blob = c.blob;
+    out.push(content);
+  }
+  return out;
 }
 
 function normalizeContentItem(item: unknown): CallToolResultContent {

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -108,7 +108,6 @@ const ACCEPTED_OPTION_KEYS: readonly string[] = [
   'agentProgressSummaries',
   'forwardSubagentText',
   'includeHookEvents',
-  'allowDangerouslySkipPermissions',
   'title',
   'resumeSessionAt',
   'debugFile',
@@ -338,7 +337,7 @@ export function query(args: {
   for (const key of ACCEPTED_OPTION_KEYS) {
     if ((options as Record<string, unknown>)[key] !== undefined) {
       debug(
-        `option '${key}' is accepted for compatibility but has no effect in v0.1 (see docs/COMPAT.md)`,
+        `option '${key}' is accepted for compatibility but has no effect in this SDK (see docs/COMPAT.md)`,
       );
     }
   }
@@ -378,6 +377,19 @@ export function query(args: {
     debug,
     betas: options.betas,
   });
+  // Safety interlock: bypassPermissions must be explicitly unlocked with
+  // allowDangerouslySkipPermissions (matches @anthropic-ai/claude-agent-sdk).
+  // Enforced for the initial mode here and for setPermissionMode() below.
+  const allowDangerousBypass = options.allowDangerouslySkipPermissions === true;
+  const assertBypassUnlocked = (mode: PermissionMode | undefined): void => {
+    if (mode === 'bypassPermissions' && !allowDangerousBypass) {
+      throw new ConfigurationError(
+        "permissionMode 'bypassPermissions' requires allowDangerouslySkipPermissions: true",
+      );
+    }
+  };
+  assertBypassUnlocked(options.permissionMode);
+
   const gate = new DefaultPermissionGate({
     mode: options.permissionMode,
     allowedTools: options.allowedTools,
@@ -1257,6 +1269,7 @@ export function query(args: {
       }
     },
     async setPermissionMode(mode: PermissionMode): Promise<void> {
+      assertBypassUnlocked(mode);
       gate.setMode(mode);
     },
     async setModel(model?: string): Promise<void> {

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -70,10 +70,10 @@ const CLAUDE_CODE_VERSION = '0.1.0';
 
 /** Static model list surfaced by supportedModels()/initializationResult(). */
 const SUPPORTED_MODELS: readonly ModelInfo[] = [
-  { id: 'claude-opus-4-8' },
-  { id: 'claude-sonnet-5' },
-  { id: 'claude-haiku-4-5' },
-  { id: 'claude-sonnet-4-5' },
+  { value: 'claude-opus-4-8', displayName: 'Claude Opus 4.8' },
+  { value: 'claude-sonnet-5', displayName: 'Claude Sonnet 5' },
+  { value: 'claude-haiku-4-5', displayName: 'Claude Haiku 4.5' },
+  { value: 'claude-sonnet-4-5', displayName: 'Claude Sonnet 4.5' },
 ];
 
 /**

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -15,6 +15,8 @@ import type {
   APIUserMessage,
   CallToolResult,
   ContentBlock,
+  McpResource,
+  McpResourceContent,
   McpServerConfig,
   McpServerStatus,
   McpSetServersResult,
@@ -171,6 +173,12 @@ class ToolFilterMcpRegistry implements McpRegistry {
     signal: AbortSignal,
   ): Promise<CallToolResult> {
     return this.inner.call(qualifiedName, args, signal);
+  }
+  listResources(server: string | undefined, signal: AbortSignal): Promise<McpResource[]> {
+    return this.inner.listResources(server, signal);
+  }
+  readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]> {
+    return this.inner.readResource(server, uri, signal);
   }
   reconnect(serverName: string): Promise<void> {
     return this.inner.reconnect(serverName);
@@ -428,6 +436,13 @@ export function query(args: {
     }
   } else {
     builtinTools = allBuiltins;
+  }
+  // The MCP resource tools are only advertised by default when MCP servers
+  // exist (they are no-ops otherwise). An explicit options.tools selection is
+  // honored verbatim.
+  if (!Array.isArray(options.tools) && Object.keys(mergedServers).length === 0) {
+    builtinTools.delete('ListMcpResourcesTool');
+    builtinTools.delete('ReadMcpResourceTool');
   }
   // Drop bare-name-disallowed built-ins so their definitions never reach the
   // model (nor the system prompt tool list nor the init message).
@@ -1050,6 +1065,10 @@ export function query(args: {
           spawnSubagent: subagentRuntime.makeSpawnFn(0),
           webSearch: options.webSearch,
           askUser: options.onUserQuestion,
+          mcpResources: {
+            list: (server, signal) => mcpEff.listResources(server, signal),
+            read: (server, uri, signal) => mcpEff.readResource(server, uri, signal),
+          },
           allowPrivateWebFetch: options.allowPrivateWebFetch === true,
           recordFileChange: checkpointStore
             ? (abs, pre): void => checkpointStore!.record(abs, pre)

--- a/projects/bpt-agent-sdk/src/subagents/runtime.ts
+++ b/projects/bpt-agent-sdk/src/subagents/runtime.ts
@@ -30,6 +30,8 @@ import type {
   APIMessageParam,
   CallToolResult,
   ContentBlock,
+  McpResource,
+  McpResourceContent,
   McpServerStatus,
   ModelUsage,
   NonNullableUsage,
@@ -159,6 +161,12 @@ class ChildMcpFilter implements McpRegistry {
     signal: AbortSignal,
   ): Promise<CallToolResult> {
     return this.inner.call(qualifiedName, args, signal);
+  }
+  listResources(server: string | undefined, signal: AbortSignal): Promise<McpResource[]> {
+    return this.inner.listResources(server, signal);
+  }
+  readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]> {
+    return this.inner.readResource(server, uri, signal);
   }
   reconnect(serverName: string): Promise<void> {
     return this.inner.reconnect(serverName);

--- a/projects/bpt-agent-sdk/src/tools/grep.ts
+++ b/projects/bpt-agent-sdk/src/tools/grep.ts
@@ -35,6 +35,27 @@ const TYPE_GLOBS: Record<string, string[]> = {
   cpp: ['**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.hpp', '**/*.hh', '**/*.hxx'],
   md: ['**/*.md', '**/*.markdown'],
   json: ['**/*.json'],
+  html: ['**/*.html', '**/*.htm'],
+  css: ['**/*.css', '**/*.scss', '**/*.sass', '**/*.less'],
+  sh: ['**/*.sh', '**/*.bash', '**/*.zsh'],
+  yaml: ['**/*.yaml', '**/*.yml'],
+  toml: ['**/*.toml'],
+  xml: ['**/*.xml'],
+  sql: ['**/*.sql'],
+  rb: ['**/*.rb'],
+  php: ['**/*.php'],
+  swift: ['**/*.swift'],
+  kotlin: ['**/*.kt', '**/*.kts'],
+  scala: ['**/*.scala', '**/*.sc'],
+  cs: ['**/*.cs'],
+  lua: ['**/*.lua'],
+  vue: ['**/*.vue'],
+  svelte: ['**/*.svelte'],
+  ex: ['**/*.ex', '**/*.exs'],
+  dart: ['**/*.dart'],
+  r: ['**/*.r', '**/*.R'],
+  proto: ['**/*.proto'],
+  tex: ['**/*.tex'],
 };
 
 function looksBinary(buf: Buffer): boolean {
@@ -229,6 +250,12 @@ export const grepTool: BuiltinTool = {
         description:
           'Lines of context before and after each match (content mode).',
       },
+      '-o': {
+        type: 'boolean',
+        description:
+          'Only-matching: in content mode, print each matched substring on its ' +
+          'own line instead of the whole line (context flags are ignored).',
+      },
       multiline: {
         type: 'boolean',
         description:
@@ -237,6 +264,12 @@ export const grepTool: BuiltinTool = {
       head_limit: {
         type: 'number',
         description: `Limit output to the first N lines/entries (default ${DEFAULT_HEAD_LIMIT}; 0 = unlimited).`,
+      },
+      offset: {
+        type: 'number',
+        description:
+          'Skip the first N lines/entries before applying head_limit ' +
+          '(pagination; equivalent to "| tail -n +N | head"). Default 0.',
       },
     },
     required: ['pattern'],
@@ -274,6 +307,7 @@ export const grepTool: BuiltinTool = {
     const caseInsensitive = input['-i'] === true;
     const showLineNumbers = input['-n'] !== false; // default true
     const multiline = input['multiline'] === true;
+    const onlyMatching = input['-o'] === true;
     const bothContext = asOptionalCount(input['-C']);
     const before = asOptionalCount(input['-B']) ?? bothContext ?? 0;
     const after = asOptionalCount(input['-A']) ?? bothContext ?? 0;
@@ -284,6 +318,10 @@ export const grepTool: BuiltinTool = {
         ? Math.max(0, Math.floor(rawLimit))
         : DEFAULT_HEAD_LIMIT;
     const limited = headLimit > 0;
+    // Skip the first `offset` entries before head_limit (pagination). When
+    // limited we must collect offset+headLimit rows before we can stop.
+    const offset = asOptionalCount(input['offset']) ?? 0;
+    const collectCap = limited ? offset + headLimit : Number.POSITIVE_INFINITY;
 
     // m always; i on -i; s only in multiline mode (dot matches newlines).
     let flags = 'm';
@@ -362,7 +400,7 @@ export const grepTool: BuiltinTool = {
 
     for (const file of files) {
       if (ctx.signal.aborted) throw new AbortError();
-      if (limited && out.length >= headLimit) break;
+      if (out.length >= collectCap) break;
 
       const scan = await scanFile(file, pattern, flags, multiline);
       if (scan === null || scan.matches.length === 0) continue;
@@ -378,6 +416,23 @@ export const grepTool: BuiltinTool = {
       }
 
       // content mode
+      if (onlyMatching) {
+        // Print each matched substring on its own line; context is ignored.
+        const re = new RegExp(pattern, flags.includes('g') ? flags : `${flags}g`);
+        for (const i of scan.matches) {
+          if (out.length >= collectCap) break;
+          const line = scan.lines[i] ?? '';
+          re.lastIndex = 0;
+          let m: RegExpExecArray | null;
+          while ((m = re.exec(line)) !== null) {
+            if (out.length >= collectCap) break;
+            const lineNo = showLineNumbers ? `${i + 1}:` : '';
+            out.push(`${file}:${lineNo}${clipLine(m[0])}`);
+            if (m[0].length === 0) re.lastIndex++; // avoid zero-length loop
+          }
+        }
+        continue;
+      }
       if (useContext && !firstContentFile) out.push('--');
       firstContentFile = false;
       const matchSet = new Set(scan.matches);
@@ -388,12 +443,12 @@ export const grepTool: BuiltinTool = {
         Math.max(scan.lines.length - 1, 0),
       );
       for (let h = 0; h < hunks.length; h++) {
-        if (limited && out.length >= headLimit) break;
+        if (out.length >= collectCap) break;
         const hunk = hunks[h];
         if (hunk === undefined) continue;
         if (useContext && h > 0) out.push('--');
         for (let i = hunk.start; i <= hunk.end; i++) {
-          if (limited && out.length >= headLimit) break;
+          if (out.length >= collectCap) break;
           const isMatch = matchSet.has(i);
           const sep = isMatch ? ':' : '-';
           const lineNo = showLineNumbers ? `${i + 1}${sep}` : '';
@@ -405,7 +460,12 @@ export const grepTool: BuiltinTool = {
     if (!anyMatch) {
       return { content: 'No matches found' };
     }
-    const capped = limited ? out.slice(0, headLimit) : out;
+    const capped = limited
+      ? out.slice(offset, offset + headLimit)
+      : out.slice(offset);
+    if (capped.length === 0) {
+      return { content: 'No matches found' };
+    }
     return { content: capped.join('\n') };
   },
 };

--- a/projects/bpt-agent-sdk/src/tools/index.ts
+++ b/projects/bpt-agent-sdk/src/tools/index.ts
@@ -14,6 +14,7 @@ import { webFetchTool } from './webfetch.js';
 import { webSearchTool } from './websearch.js';
 import { askUserQuestionTool } from './askuserquestion.js';
 import { todoWriteTool } from './todo.js';
+import { listMcpResourcesTool, readMcpResourceTool } from './resources.js';
 
 /** Fresh Map per call so callers can filter without affecting others. */
 export function createBuiltinTools(): Map<string, BuiltinTool> {
@@ -28,6 +29,8 @@ export function createBuiltinTools(): Map<string, BuiltinTool> {
     webSearchTool,
     askUserQuestionTool,
     todoWriteTool,
+    listMcpResourcesTool,
+    readMcpResourceTool,
   ];
   return new Map(tools.map((t) => [t.name, t]));
 }

--- a/projects/bpt-agent-sdk/src/tools/resources.ts
+++ b/projects/bpt-agent-sdk/src/tools/resources.ts
@@ -1,0 +1,88 @@
+/**
+ * Built-in MCP resource tools: ListMcpResourcesTool / ReadMcpResourceTool.
+ *
+ * They route to the MCP registry via ctx.mcpResources (wired by the engine).
+ * When no registry is present (no MCP servers configured) the tools return a
+ * not-configured error result. Clean-room implementation from public docs.
+ */
+
+import type {
+  BuiltinTool,
+  ToolContext,
+  ToolResultPayload,
+} from '../internal/contracts.js';
+import { AbortError, isAbortError } from '../errors.js';
+
+function errorResult(message: string): ToolResultPayload {
+  return { content: message, isError: true };
+}
+
+export const listMcpResourcesTool: BuiltinTool = {
+  name: 'ListMcpResourcesTool',
+  description:
+    'List the resources exposed by connected MCP servers. Optionally restrict ' +
+    'to a single server by name. Returns each resource with its uri, name, ' +
+    'description, mimeType and owning server.',
+  readOnly: true,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      server: {
+        type: 'string',
+        description: 'Restrict the listing to this MCP server name (optional).',
+      },
+    },
+  },
+  async execute(input: Record<string, unknown>, ctx: ToolContext): Promise<ToolResultPayload> {
+    if (ctx.signal.aborted) throw new AbortError();
+    if (!ctx.mcpResources) {
+      return errorResult('ListMcpResourcesTool: no MCP servers are configured.');
+    }
+    const rawServer = input['server'];
+    const server = typeof rawServer === 'string' && rawServer.length > 0 ? rawServer : undefined;
+    try {
+      const resources = await ctx.mcpResources.list(server, ctx.signal);
+      return { content: JSON.stringify(resources) };
+    } catch (e) {
+      if (isAbortError(e)) throw new AbortError('ListMcpResourcesTool was aborted');
+      return errorResult(`ListMcpResourcesTool failed: ${(e as Error).message}`);
+    }
+  },
+};
+
+export const readMcpResourceTool: BuiltinTool = {
+  name: 'ReadMcpResourceTool',
+  description:
+    'Read the contents of one MCP resource from a named server. Returns the ' +
+    'resource contents (text and/or base64 blob) as JSON.',
+  readOnly: true,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      server: { type: 'string', description: 'The MCP server that owns the resource.' },
+      uri: { type: 'string', description: 'The resource uri to read.' },
+    },
+    required: ['server', 'uri'],
+  },
+  async execute(input: Record<string, unknown>, ctx: ToolContext): Promise<ToolResultPayload> {
+    if (ctx.signal.aborted) throw new AbortError();
+    if (!ctx.mcpResources) {
+      return errorResult('ReadMcpResourceTool: no MCP servers are configured.');
+    }
+    const server = input['server'];
+    const uri = input['uri'];
+    if (typeof server !== 'string' || server.length === 0) {
+      return errorResult('ReadMcpResourceTool: "server" must be a non-empty string.');
+    }
+    if (typeof uri !== 'string' || uri.length === 0) {
+      return errorResult('ReadMcpResourceTool: "uri" must be a non-empty string.');
+    }
+    try {
+      const contents = await ctx.mcpResources.read(server, uri, ctx.signal);
+      return { content: JSON.stringify(contents) };
+    } catch (e) {
+      if (isAbortError(e)) throw new AbortError('ReadMcpResourceTool was aborted');
+      return errorResult(`ReadMcpResourceTool failed: ${(e as Error).message}`);
+    }
+  },
+};

--- a/projects/bpt-agent-sdk/src/tools/toolsearch.ts
+++ b/projects/bpt-agent-sdk/src/tools/toolsearch.ts
@@ -21,6 +21,8 @@ import type {
 } from '../internal/contracts.js';
 import type {
   JSONSchema,
+  McpResource,
+  McpResourceContent,
   McpServerConfig,
   McpServerStatus,
   McpSetServersResult,
@@ -65,6 +67,14 @@ export class DeferredMcpRegistry implements McpRegistry {
     signal: AbortSignal,
   ): Promise<CallToolResult> {
     return this.inner.call(qualifiedName, args, signal);
+  }
+
+  listResources(server: string | undefined, signal: AbortSignal): Promise<McpResource[]> {
+    return this.inner.listResources(server, signal);
+  }
+
+  readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]> {
+    return this.inner.readResource(server, uri, signal);
   }
 
   reconnect(serverName: string): Promise<void> {

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -616,6 +616,8 @@ export type CallToolResultContent =
 export type CallToolResult = {
   content: CallToolResultContent[];
   isError?: boolean;
+  /** Optional machine-readable payload (MCP structuredContent). */
+  structuredContent?: unknown;
 };
 
 export type ToolAnnotations = {

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -581,6 +581,24 @@ export type McpServerStatus = {
   scope?: 'user' | 'project' | 'local' | 'dynamic';
 };
 
+/** One MCP resource descriptor (resources/list entry). */
+export type McpResource = {
+  uri: string;
+  name?: string;
+  description?: string;
+  mimeType?: string;
+  /** Owning server name (populated by the registry when aggregating). */
+  server?: string;
+};
+
+/** One MCP resource's contents (resources/read entry). */
+export type McpResourceContent = {
+  uri: string;
+  mimeType?: string;
+  text?: string;
+  blob?: string;
+};
+
 /** MCP tool result content (subset of the MCP CallToolResult schema). */
 export type CallToolResultContent =
   | { type: 'text'; text: string }

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -1415,8 +1415,12 @@ export type SDKMirrorErrorMessage = {
 // ---------------------------------------------------------------------------
 
 export type ModelInfo = {
-  id: string;
+  /** Model id/alias (official field name; consumers read `.value`). */
+  value: string;
+  resolvedModel?: string;
   displayName?: string;
+  description?: string;
+  supportsEffort?: boolean;
 };
 
 export type SlashCommand = {
@@ -1431,6 +1435,13 @@ export type AgentInfo = {
 
 export type AccountInfo = {
   apiKeySource: ApiKeySource;
+  // Surface parity with the official SDK. Not populated by the direct-API
+  // engine (no CLI account introspection channel); typed so consumers that
+  // read these fields narrow correctly instead of hitting `never`.
+  email?: string;
+  organization?: string;
+  subscriptionType?: string;
+  tokenSource?: string;
 };
 
 export type SDKInitializationResult = {

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -726,6 +726,13 @@ export type Options = {
   mcpServers?: Record<string, McpServerConfig>;
   model?: string;
   permissionMode?: PermissionMode;
+  /**
+   * Safety interlock required to enter `permissionMode: 'bypassPermissions'`.
+   * Matches @anthropic-ai/claude-agent-sdk: bypassPermissions is refused unless
+   * this is explicitly `true`. Applies to the initial mode and to
+   * `setPermissionMode('bypassPermissions')` mid-session.
+   */
+  allowDangerouslySkipPermissions?: boolean;
   /** Persist the session transcript to disk (default true). */
   persistSession?: boolean;
   /** BPT extension: direct Messages API connection settings. */

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -882,6 +882,8 @@ export type SDKResultMessage =
       usage: NonNullableUsage;
       modelUsage: Record<string, ModelUsage>;
       permission_denials: SDKPermissionDenial[];
+      /** HTTP status of the last API error observed during the run, if any. */
+      api_error_status?: number;
       /** v0.3 per-run budget/efficiency metrics. */
       metrics?: SDKRunMetrics;
     }
@@ -903,6 +905,8 @@ export type SDKResultMessage =
       modelUsage: Record<string, ModelUsage>;
       permission_denials: SDKPermissionDenial[];
       errorMessage?: string;
+      /** HTTP status when the run ended on an API error (e.g. 429, 529). */
+      api_error_status?: number;
       /** Time to first token (ms); only present when a token actually arrived. */
       ttft_ms?: number;
       ttft_stream_ms?: number;

--- a/projects/bpt-agent-sdk/tests/engine.test.ts
+++ b/projects/bpt-agent-sdk/tests/engine.test.ts
@@ -1145,6 +1145,23 @@ describe('runAgentLoop', () => {
     expect(result.modelUsage['claude-fallback']!.inputTokens).toBe(50);
   });
 
+  it('records api_error_status on an unrecovered APIStatusError result', async () => {
+    const transport = new MockTransport([
+      () => {
+        throw new APIStatusError(529, 'overloaded_error', 'overloaded');
+      },
+    ]);
+    const deps = makeDeps(transport);
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+
+    const messages = await collect(runAgentLoop(history, deps, makeConfig()));
+    const result = lastResult(messages);
+    expect(result.subtype).toBe('error_during_execution');
+    if (result.subtype === 'error_during_execution') {
+      expect(result.api_error_status).toBe(529);
+    }
+  });
+
   // ----- finding #6: PostToolUse continue:false stops the run -----
 
   it('honors PostToolUse continue:false by stopping the run after the batch (#6)', async () => {

--- a/projects/bpt-agent-sdk/tests/integration/emulator-e2e.test.ts
+++ b/projects/bpt-agent-sdk/tests/integration/emulator-e2e.test.ts
@@ -126,6 +126,7 @@ describe('emulator end-to-end (real stack, scripted model)', () => {
         cwd: sandbox,
         sessionDir,
         permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
         mcpServers: { demo },
         allowedTools: ['mcp__demo__*'],
         model: 'claude-emulator-1',
@@ -194,6 +195,7 @@ describe('emulator end-to-end (real stack, scripted model)', () => {
         cwd: sandbox,
         persistSession: false,
         permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
         model: 'claude-emulator-1',
       },
     });

--- a/projects/bpt-agent-sdk/tests/integration/live-real-api.mjs
+++ b/projects/bpt-agent-sdk/tests/integration/live-real-api.mjs
@@ -52,6 +52,7 @@ try {
       cwd: sandbox,
       persistSession: false,
       permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
       model,
       maxTurns: 12,
     },

--- a/projects/bpt-agent-sdk/tests/mcp.test.ts
+++ b/projects/bpt-agent-sdk/tests/mcp.test.ts
@@ -165,20 +165,6 @@ describe('mcp/sdk-server tool()', () => {
     expect(defaulted.instance.tools.size).toBe(0);
   });
 
-  it('tool() attaches annotations from the 5th extras arg', () => {
-    const withAnn = tool(
-      'ro',
-      'read-only tool',
-      { q: z.string() },
-      async () => ({ content: [] }),
-      { annotations: { readOnlyHint: true, title: 'Reader' } },
-    );
-    expect(withAnn.annotations).toEqual({ readOnlyHint: true, title: 'Reader' });
-
-    const without = tool('plain', 'no annotations', {}, async () => ({ content: [] }));
-    expect(without.annotations).toBeUndefined();
-  });
-
   it('callTool preserves a structuredContent payload on the result', async () => {
     const def = tool('struct', 'returns structured data', {}, async () => ({
       content: [{ type: 'text', text: 'see structured' }],
@@ -245,6 +231,7 @@ describe('DefaultMcpRegistry with an sdk instance', () => {
       name: 'calc',
       status: 'connected',
       serverInfo: { name: 'calc', version: '1.0.0' },
+      tools: ['add'],
     });
     // task #17: status carries the config it was registered with + per-server
     // tool names once connected.

--- a/projects/bpt-agent-sdk/tests/mcp.test.ts
+++ b/projects/bpt-agent-sdk/tests/mcp.test.ts
@@ -165,6 +165,31 @@ describe('mcp/sdk-server tool()', () => {
     expect(defaulted.instance.tools.size).toBe(0);
   });
 
+  it('tool() attaches annotations from the 5th extras arg', () => {
+    const withAnn = tool(
+      'ro',
+      'read-only tool',
+      { q: z.string() },
+      async () => ({ content: [] }),
+      { annotations: { readOnlyHint: true, title: 'Reader' } },
+    );
+    expect(withAnn.annotations).toEqual({ readOnlyHint: true, title: 'Reader' });
+
+    const without = tool('plain', 'no annotations', {}, async () => ({ content: [] }));
+    expect(without.annotations).toBeUndefined();
+  });
+
+  it('callTool preserves a structuredContent payload on the result', async () => {
+    const def = tool('struct', 'returns structured data', {}, async () => ({
+      content: [{ type: 'text', text: 'see structured' }],
+      structuredContent: { ok: true, items: [1, 2, 3] },
+    }));
+    const cfg = createSdkMcpServer({ name: 'structsrv', tools: [def] });
+    const conn = new SdkMcpConnection(cfg.instance);
+    const result = await conn.callTool('struct', {});
+    expect(result.structuredContent).toEqual({ ok: true, items: [1, 2, 3] });
+  });
+
   it('duplicate tool names follow last-wins Map semantics', async () => {
     const first = tool('dup', 'first', {}, async () => ({
       content: [{ type: 'text', text: 'first' }],

--- a/projects/bpt-agent-sdk/tests/mcp.test.ts
+++ b/projects/bpt-agent-sdk/tests/mcp.test.ts
@@ -19,6 +19,7 @@ import { z } from 'zod';
 
 import { createSdkMcpServer, SdkMcpConnection, tool } from '../src/mcp/sdk-server.js';
 import { HttpMcpConnection } from '../src/mcp/http.js';
+import { parseResourcesList, parseResourceContents } from '../src/mcp/stdio.js';
 import { DefaultMcpRegistry } from '../src/mcp/registry.js';
 import type { CallToolResult, SdkMcpToolDefinition } from '../src/types.js';
 
@@ -760,5 +761,48 @@ describe('HttpMcpConnection server-initiated request over SSE (regression #19)',
     } finally {
       await srv.stop();
     }
+  });
+});
+
+describe('MCP resources wire parsing + registry aggregation', () => {
+  it('parseResourcesList picks well-formed resource descriptors', () => {
+    const parsed = parseResourcesList({
+      resources: [
+        { uri: 'file:///a', name: 'A', description: 'd', mimeType: 'text/plain' },
+        { uri: 'file:///b' },
+        { name: 'no-uri' }, // dropped: no uri
+        'garbage', // dropped
+      ],
+    });
+    expect(parsed).toEqual([
+      { uri: 'file:///a', name: 'A', description: 'd', mimeType: 'text/plain' },
+      { uri: 'file:///b' },
+    ]);
+    expect(parseResourcesList(null)).toEqual([]);
+    expect(parseResourcesList({})).toEqual([]);
+  });
+
+  it('parseResourceContents keeps text and blob variants', () => {
+    const parsed = parseResourceContents({
+      contents: [
+        { uri: 'file:///a', mimeType: 'text/plain', text: 'hi' },
+        { uri: 'file:///b', blob: 'YmFzZTY0' },
+        { mimeType: 'x' }, // dropped: no uri
+      ],
+    });
+    expect(parsed).toEqual([
+      { uri: 'file:///a', mimeType: 'text/plain', text: 'hi' },
+      { uri: 'file:///b', blob: 'YmFzZTY0' },
+    ]);
+  });
+
+  it('registry.listResources returns [] for an sdk server (tools-only)', async () => {
+    const t = tool('add', 'add', { a: z.number() }, async () => ({ content: [] }));
+    const cfg = createSdkMcpServer({ name: 'calc', tools: [t] });
+    const reg = new DefaultMcpRegistry({ servers: { calc: cfg }, debug: () => {} });
+    await reg.connectAll();
+    const list = await reg.listResources(undefined, new AbortController().signal);
+    expect(list).toEqual([]);
+    await reg.closeAll();
   });
 });

--- a/projects/bpt-agent-sdk/tests/metrics.test.ts
+++ b/projects/bpt-agent-sdk/tests/metrics.test.ts
@@ -37,6 +37,7 @@ function opts(extra: Record<string, unknown> = {}) {
     env: { PATH: process.env.PATH, HOME: process.env.HOME },
     model: 'claude-sonnet-4-5',
     permissionMode: 'bypassPermissions' as const,
+    allowDangerouslySkipPermissions: true,
     ...extra,
   };
 }

--- a/projects/bpt-agent-sdk/tests/observability.test.ts
+++ b/projects/bpt-agent-sdk/tests/observability.test.ts
@@ -103,7 +103,10 @@ describe('v0.3 permission_denied emission', () => {
     const messages = await collect(
       query({
         prompt: 'run it',
-        options: opts({ permissionMode: 'bypassPermissions' }),
+        options: opts({
+          permissionMode: 'bypassPermissions',
+          allowDangerouslySkipPermissions: true,
+        }),
       }),
     );
     expect(messages.some((m) => m.type === 'permission_denied')).toBe(false);

--- a/projects/bpt-agent-sdk/tests/query.test.ts
+++ b/projects/bpt-agent-sdk/tests/query.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  ConfigurationError,
   getSessionInfo,
   isAbortError,
   listSessions,
@@ -259,7 +260,10 @@ describe('query() e2e - tool roundtrip', () => {
     );
     const q = query({
       prompt: 'run echo',
-      options: baseOptions({ permissionMode: 'bypassPermissions' }),
+      options: baseOptions({
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+      }),
     });
     const messages = await collect(q);
 
@@ -541,7 +545,7 @@ describe('query() e2e - compat options, budget, control surface', () => {
     expect(
       lines
         .filter((l) => l.includes("option '"))
-        .every((l) => l.includes('no effect in v0.1')),
+        .every((l) => l.includes('no effect in this SDK')),
     ).toBe(true);
   });
 
@@ -560,6 +564,7 @@ describe('query() e2e - compat options, budget, control surface', () => {
       options: baseOptions({
         maxBudgetUsd: 0.0000001,
         permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
       }),
     });
     const messages = await collect(q);
@@ -728,7 +733,10 @@ describe('query() e2e - confirmed-finding regressions', () => {
     );
     const q = query({
       prompt: 'run',
-      options: baseOptions({ permissionMode: 'bypassPermissions' }),
+      options: baseOptions({
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+      }),
     });
     const messages = await collect(q);
 
@@ -1246,6 +1254,7 @@ describe('query() e2e - v0.2 confirmed-finding regressions (query)', () => {
       prompt: 'go',
       options: baseOptions({
         permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
         thinking: { type: 'enabled' },
         maxThinkingTokens: 5000,
       }),
@@ -1420,6 +1429,7 @@ describe('query() e2e - v0.2 confirmed-finding regressions (query)', () => {
       prompt: 'go',
       options: baseOptions({
         permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
         agents: { worker: { description: 'w', prompt: 'WORKER_SYS_PROMPT' } },
         hooks: {
           SubagentStop: [
@@ -1450,5 +1460,49 @@ describe('query() e2e - v0.2 confirmed-finding regressions (query)', () => {
         );
       }),
     ]);
+  });
+});
+
+describe('bypassPermissions safety interlock', () => {
+  it('query() throws ConfigurationError when bypass is set without the unlock flag', () => {
+    expect(() =>
+      query({
+        prompt: 'hi',
+        options: baseOptions({ permissionMode: 'bypassPermissions' }),
+      }),
+    ).toThrow(ConfigurationError);
+  });
+
+  it('query() constructs and runs when bypass is unlocked', async () => {
+    stubFetch(makeSSEFetch([textReplyEvents('ok')]));
+    const q = query({
+      prompt: 'hi',
+      options: baseOptions({
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+      }),
+    });
+    const messages = await collect(q);
+    expect((messages[0] as SDKSystemMessage).permissionMode).toBe('bypassPermissions');
+    expect(lastResult(messages).subtype).toBe('success');
+  });
+
+  it('setPermissionMode(bypass) rejects without the unlock flag', async () => {
+    stubFetch(makeSSEFetch([textReplyEvents('ok')]));
+    const q = query({ prompt: 'hi', options: baseOptions() });
+    await expect(q.setPermissionMode('bypassPermissions')).rejects.toBeInstanceOf(
+      ConfigurationError,
+    );
+    await q.close();
+  });
+
+  it('setPermissionMode(bypass) resolves when the unlock flag is set', async () => {
+    stubFetch(makeSSEFetch([textReplyEvents('ok')]));
+    const q = query({
+      prompt: 'hi',
+      options: baseOptions({ allowDangerouslySkipPermissions: true }),
+    });
+    await expect(q.setPermissionMode('bypassPermissions')).resolves.toBeUndefined();
+    await q.close();
   });
 });

--- a/projects/bpt-agent-sdk/tests/query.test.ts
+++ b/projects/bpt-agent-sdk/tests/query.test.ts
@@ -588,8 +588,9 @@ describe('query() e2e - compat options, budget, control surface', () => {
 
     const models = await q.supportedModels();
     expect(models.length).toBeGreaterThan(0);
-    expect(models.every((m) => typeof m.id === 'string')).toBe(true);
-    expect(models.some((m) => m.id === 'claude-sonnet-4-5')).toBe(true);
+    expect(models.every((m) => typeof m.value === 'string')).toBe(true);
+    expect(models.some((m) => m.value === 'claude-sonnet-4-5')).toBe(true);
+    expect(models.every((m) => typeof m.displayName === 'string')).toBe(true);
 
     expect(await q.supportedCommands()).toEqual([]);
     expect(await q.supportedAgents()).toEqual([]);

--- a/projects/bpt-agent-sdk/tests/tools-exec.test.ts
+++ b/projects/bpt-agent-sdk/tests/tools-exec.test.ts
@@ -623,6 +623,76 @@ describe('Grep tool', () => {
     expect(text(res).split('\n')).toHaveLength(300);
   });
 
+  it('offset skips the first N entries before head_limit (pagination)', async () => {
+    const dir = await makeDir('grep-offset');
+    const body = Array.from(
+      { length: 10 },
+      (_, i) => `match line ${i + 1}`,
+    ).join('\n');
+    await writeFile(path.join(dir, 'many.txt'), `${body}\n`);
+    const file = path.join(dir, 'many.txt');
+    const res = await grepTool.execute(
+      {
+        pattern: 'match',
+        path: 'many.txt',
+        output_mode: 'content',
+        head_limit: 2,
+        offset: 3,
+      },
+      makeCtx(dir),
+    );
+    expect(text(res).split('\n')).toEqual([
+      `${file}:4:match line 4`,
+      `${file}:5:match line 5`,
+    ]);
+  });
+
+  it('offset past the last match yields no matches', async () => {
+    const dir = await makeDir('grep-offset-past');
+    await writeFile(path.join(dir, 'few.txt'), 'match a\nmatch b\n');
+    const res = await grepTool.execute(
+      {
+        pattern: 'match',
+        path: 'few.txt',
+        output_mode: 'content',
+        offset: 5,
+      },
+      makeCtx(dir),
+    );
+    expect(text(res)).toBe('No matches found');
+  });
+
+  it('-o prints only the matched substrings, one per match', async () => {
+    const dir = await makeDir('grep-only-matching');
+    const file = path.join(dir, 'o.txt');
+    await writeFile(file, 'foo=1 foo=2\nbar\nfoo=3\n');
+    const res = await grepTool.execute(
+      {
+        pattern: 'foo=\\d',
+        path: 'o.txt',
+        output_mode: 'content',
+        '-o': true,
+      },
+      makeCtx(dir),
+    );
+    expect(text(res).split('\n')).toEqual([
+      `${file}:1:foo=1`,
+      `${file}:1:foo=2`,
+      `${file}:3:foo=3`,
+    ]);
+  });
+
+  it('recognizes an extended file type (yaml)', async () => {
+    const dir = await makeDir('grep-yaml');
+    await writeFile(path.join(dir, 'conf.yaml'), 'target: 1\n');
+    await writeFile(path.join(dir, 'note.md'), 'target doc\n');
+    const res = await grepTool.execute(
+      { pattern: 'target', type: 'yaml' },
+      makeCtx(dir),
+    );
+    expect(text(res).split('\n')).toEqual([path.join(dir, 'conf.yaml')]);
+  });
+
   it('multiline mode matches patterns spanning lines', async () => {
     const dir = await makeDir('grep-multiline');
     const file = path.join(dir, 'multi.txt');

--- a/projects/bpt-agent-sdk/tests/tools-v2.test.ts
+++ b/projects/bpt-agent-sdk/tests/tools-v2.test.ts
@@ -16,6 +16,7 @@ import { webFetchTool } from '../src/tools/webfetch.js';
 import { webSearchTool } from '../src/tools/websearch.js';
 import { askUserQuestionTool } from '../src/tools/askuserquestion.js';
 import { todoWriteTool } from '../src/tools/todo.js';
+import { listMcpResourcesTool, readMcpResourceTool } from '../src/tools/resources.js';
 import {
   resolveElicitation,
   parseElicitationParams,
@@ -726,5 +727,55 @@ describe('resolveElicitation', () => {
       requestedSchema: { type: 'object', properties: { a: {} } },
     });
     expect(seenSignal).toBe(signal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP resource tools
+// ---------------------------------------------------------------------------
+
+describe('ListMcpResourcesTool / ReadMcpResourceTool', () => {
+  it('lists resources via ctx.mcpResources', async () => {
+    const ctx = makeCtx({
+      mcpResources: {
+        list: async (server) => [
+          { uri: 'file:///a.txt', name: 'a', server: server ?? 'srv1' },
+        ],
+        read: async () => [],
+      },
+    });
+    const res = await listMcpResourcesTool.execute({ server: 'srv1' }, ctx);
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content as string)).toEqual([
+      { uri: 'file:///a.txt', name: 'a', server: 'srv1' },
+    ]);
+  });
+
+  it('reads one resource via ctx.mcpResources', async () => {
+    const ctx = makeCtx({
+      mcpResources: {
+        list: async () => [],
+        read: async (server, uri) => [{ uri, mimeType: 'text/plain', text: `from ${server}` }],
+      },
+    });
+    const res = await readMcpResourceTool.execute({ server: 'srv1', uri: 'file:///a.txt' }, ctx);
+    expect(JSON.parse(res.content as string)).toEqual([
+      { uri: 'file:///a.txt', mimeType: 'text/plain', text: 'from srv1' },
+    ]);
+  });
+
+  it('returns a not-configured error when no MCP registry is wired', async () => {
+    const list = await listMcpResourcesTool.execute({}, makeCtx());
+    expect(list.isError).toBe(true);
+    const read = await readMcpResourceTool.execute({ server: 's', uri: 'u' }, makeCtx());
+    expect(read.isError).toBe(true);
+  });
+
+  it('validates ReadMcpResourceTool required args', async () => {
+    const ctx = makeCtx({ mcpResources: { list: async () => [], read: async () => [] } });
+    const noServer = await readMcpResourceTool.execute({ uri: 'u' }, ctx);
+    expect(noServer.isError).toBe(true);
+    const noUri = await readMcpResourceTool.execute({ server: 's' }, ctx);
+    expect(noUri.isError).toBe(true);
   });
 });


### PR DESCRIPTION
## 概述

本 PR 与 main 已合并的并行实现（#384-#392：#16 观测流 / Read 图像 / PDF / 并行执行 / 类型表面）**对账后重构**，**只保留 main 尚缺的独有项**、不回退 main 任何已合并工作。已 rebase 到最新 main（`3fdbea06`），无冲突。

## 本 PR 独有项（main 没有）

- **MCP `resources/*`**：`ListMcpResourcesTool` + `ReadMcpResourceTool`（stdio/http `resources/list`·`resources/read` + registry 聚合 + `ctx.mcpResources` 接线；有 MCP 服务时默认广告）
- **Grep**：`offset` 分页 / `-o` only-matching / TYPE_GLOBS 10→~30 类型
- **bypass 安全联锁**：`bypassPermissions`（初始 + `setPermissionMode`）无 `allowDangerouslySkipPermissions` 即抛 `ConfigurationError`；版本 0.2.0→**0.3.0**
- **`ModelInfo.value`**（原 `id`，官方名，消费方 `.value` 静默破坏修复）+ `AccountInfo` 字段
- **`CallToolResult.structuredContent`**（stdio/http 线解析 + 映射为 trailing JSON）
- **`result.api_error_status`**（未恢复 API 错误时填 HTTP status）

**对账跳过**（main 已有，不重复）：#16 观测变体、Read 图像、并行只读执行、PDF、`mcpServerStatus.tools`、会话 option-shape、`thinking.budgetTokens`、`Usage.server_tool_use`/`service_tier`、tool() annotations。

---

## 变更类型

- [x] Bug 修复（bypass 安全联锁缺失）
- [x] 其他：MCP 资源工具 / Grep 表面 / 类型对齐 / 版本 0.3.0

## 来源声明

- [x] 实现依据全部来自公开来源：`code.claude.com/docs/en/agent-sdk/*` + 公开 Messages API 文档 + MCP 开放规范。净室纪律：零复制专有代码/形状。

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **仅引用公开素材**；不含内部资产。
- [x] **同意按 MIT License 提交贡献。**

## 验证清单

- [x] `npm run typecheck` 干净
- [x] `npm run build` 干净（ESM + d.ts → dist/）
- [x] `npm test`：**665 passed / 0 failed**（18 套件）
- [x] 无 emoji；不动 `memory/decisions.md` / `memory/lessons-learned.md`

## 关联 Issue

- Closes #（无）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016K5grsSiKncfiuKc9hGFu3