### PR TITLE
feat(bpt-agent-sdk): v0.3 #17 type-surface tail (annotations / mcpServerStatus / listSessions / Usage)

### DIFF
--- a/projects/bpt-agent-sdk/CONTEXT.md
+++ b/projects/bpt-agent-sdk/CONTEXT.md
@@ -58,10 +58,12 @@ TodoWrite）/ 外部会话存储 + 文件检查点 + 工具搜索。
 v0.3 进行中：per-run 预算度量（`result.metrics`）已落；**观测消息流扩容（task #16）
 已落**——`SDKMessage` union 补齐观测臂全 25 变体（`SDKObservabilityMessage`），
 其中 `permission_denied` 真发射（gate deny 时 yield，与 `result.permission_denials`
-台账一致），其余类型化待驱动源（详见 `docs/COMPAT.md` 观测臂表）。634 测试全绿。
-task #17（P1/P2 长尾）进行中：**Read 图像已支持**（PNG/JPEG/GIF/WebP magic-byte
-嗅探→image 块；PDF 给精确「暂不内联」提示，document 块进 tool_result 的 API 形状待验证为后续）。
-剩余尾项：ToolAnnotations 接线 / mcpServerStatus 富化 / Usage 字段 / listSessions option 形状。
+台账一致），其余类型化待驱动源（详见 `docs/COMPAT.md` 观测臂表）。
+**task #17（P1/P2 长尾）已收口**：Read 图像（PNG/JPEG/GIF/WebP magic-byte 嗅探→image 块）+
+tool() 第 5 参 ToolAnnotations 转发 + mcpServerStatus 富化（config/tools[]/scope 类型）+
+listSessions option（dir 别名 + limit）+ Usage 字段（server_tool_use/service_tier）。644 测试全绿。
+遗留后续（需真 API 或行为决策）：PDF document 块进 tool_result 的 API 形状验证、
+readOnlyHint→并行/自动批准的行为接线（依赖并行工具执行）、rate_limit/api_retry 的 transport→stream 桥接。
 进度以 `memory/project-status.md` 为唯一权威。
 
 ## v0.2 候选

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -57,9 +57,9 @@ Tiers:
 | Export | Tier | Notes |
 |---|---|---|
 | `query()` | FULL | string and AsyncIterable prompt modes |
-| `tool()` | FULL | zod v4 raw shapes; JSON Schema derived via `z.toJSONSchema` |
+| `tool()` | FULL | zod v4 raw shapes; JSON Schema derived via `z.toJSONSchema`; optional 5th `annotations` (ToolAnnotations) forwarded onto the definition (task #17) |
 | `createSdkMcpServer()` | FULL | in-process dispatch, no wire protocol |
-| `listSessions()` / `getSessionInfo()` | PARTIAL | reads this SDK's own JSONL store only |
+| `listSessions()` / `getSessionInfo()` | PARTIAL | reads this SDK's own JSONL store only; option bag accepts `dir` (alias for `sessionDir`) + `limit`; `includeWorkspace` typed but not honored (no Claude Code store interop) (task #17) |
 | `startup()` / `WarmQuery` | UNSUPPORTED | no subprocess to pre-warm; direct API needs no warmup |
 | `getSessionMessages()` / `renameSession()` / `tagSession()` / `resolveSettings()` | UNSUPPORTED | v0.2 candidates |
 
@@ -185,7 +185,7 @@ house `uuid`/`session_id` envelope. Union: `SDKObservabilityMessage`.
 | `interrupt()` | FULL | |
 | `setPermissionMode()` / `setModel()` / `setMaxThinkingTokens()` | FULL | |
 | `initializationResult()` / `supportedModels()` / `supportedCommands()` / `supportedAgents()` | PARTIAL | static/empty data (no CLI to introspect) |
-| `mcpServerStatus()` | FULL | |
+| `mcpServerStatus()` | FULL | now carries `config` (echoed back) + per-server `tools[]` when connected; `scope` typed but not tracked (task #17) |
 | `accountInfo()` | PARTIAL | apiKeySource only |
 | `streamInput()` | FULL | streaming-input mode |
 | `close()` | FULL | |

--- a/projects/bpt-agent-sdk/src/mcp/registry.ts
+++ b/projects/bpt-agent-sdk/src/mcp/registry.ts
@@ -99,9 +99,14 @@ export class DefaultMcpRegistry implements McpRegistry {
       const status: McpServerStatus = {
         name: entry.name,
         status: entry.enabled ? entry.baseStatus : 'disabled',
+        config: entry.config,
       };
       if (entry.serverInfo) status.serverInfo = entry.serverInfo;
       if (entry.error) status.error = entry.error;
+      // Per-server tool names, once the server is connected (task #17).
+      if (entry.enabled && entry.baseStatus === 'connected' && entry.tools.length > 0) {
+        status.tools = entry.tools.map((t) => t.toolName);
+      }
       return status;
     });
   }

--- a/projects/bpt-agent-sdk/src/mcp/sdk-server.ts
+++ b/projects/bpt-agent-sdk/src/mcp/sdk-server.ts
@@ -13,6 +13,7 @@ import type {
   McpSdkServerConfigWithInstance,
   SdkMcpServerInstance,
   SdkMcpToolDefinition,
+  ToolAnnotations,
 } from '../types.js';
 import { AbortError, isAbortError } from '../errors.js';
 
@@ -27,6 +28,7 @@ export function tool<S extends z.ZodRawShape>(
   description: string,
   inputSchema: S,
   handler: (args: z.infer<z.ZodObject<S>>, extra: unknown) => Promise<CallToolResult>,
+  annotations?: ToolAnnotations,
 ): SdkMcpToolDefinition<z.infer<z.ZodObject<S>>> {
   const schema = z.object(inputSchema);
   // io: 'input' generates the INPUT-side JSON schema, which is what both the
@@ -64,6 +66,7 @@ export function tool<S extends z.ZodRawShape>(
     description,
     inputJsonSchema: inputJsonSchema as JSONSchema,
     handler: wrappedHandler,
+    ...(annotations !== undefined ? { annotations } : {}),
   };
 }
 

--- a/projects/bpt-agent-sdk/src/sessions/store.ts
+++ b/projects/bpt-agent-sdk/src/sessions/store.ts
@@ -324,8 +324,22 @@ export class JsonlSessionStore implements SessionStore {
 
 export type SessionListOptions = {
   sessionDir?: string;
+  /** Alias for sessionDir (the official option name); sessionDir wins if both set. */
+  dir?: string;
+  /** Cap the number of sessions returned (newest first). Omit for all. */
+  limit?: number;
+  /** Typed for compat; reading Claude Code's own session store is not supported. */
+  includeWorkspace?: boolean;
   env?: Record<string, string | undefined>;
 };
+
+/** Resolve the `dir` alias onto `sessionDir` (sessionDir takes precedence). */
+function resolveSessionDir(options: SessionListOptions): SessionListOptions {
+  if (options.sessionDir === undefined && options.dir !== undefined) {
+    return { ...options, sessionDir: options.dir };
+  }
+  return options;
+}
 
 function toSessionInfo(s: StoredSession, fileSize?: number): SDKSessionInfo {
   const firstLine = (s.firstPrompt ?? '').split('\n', 1)[0] ?? '';
@@ -348,10 +362,15 @@ function toSessionInfo(s: StoredSession, fileSize?: number): SDKSessionInfo {
 export async function listSessions(
   options: SessionListOptions = {},
 ): Promise<SDKSessionInfo[]> {
-  const store = new JsonlSessionStore(options);
+  const resolved = resolveSessionDir(options);
+  const store = new JsonlSessionStore(resolved);
   const sessions = await store.list();
+  const capped =
+    options.limit !== undefined && options.limit >= 0
+      ? sessions.slice(0, options.limit)
+      : sessions;
   const infos: SDKSessionInfo[] = [];
-  for (const s of sessions) {
+  for (const s of capped) {
     let fileSize: number | undefined;
     try {
       fileSize = (await stat(store.filePath(s.sessionId))).size;
@@ -368,7 +387,7 @@ export async function getSessionInfo(
   sessionId: string,
   options: SessionListOptions = {},
 ): Promise<SDKSessionInfo | null> {
-  const store = new JsonlSessionStore(options);
+  const store = new JsonlSessionStore(resolveSessionDir(options));
   const loaded = await store.load(sessionId);
   if (loaded === null) return null;
   let fileSize: number | undefined;

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -15,11 +15,20 @@
 // Anthropic Messages API wire types (minimal clean-room subset)
 // ---------------------------------------------------------------------------
 
+/** Server-side tool invocation counts the API reports on a response usage. */
+export type ServerToolUse = {
+  web_search_requests?: number;
+};
+
 export type Usage = {
   input_tokens: number;
   output_tokens: number;
   cache_creation_input_tokens?: number | null;
   cache_read_input_tokens?: number | null;
+  /** Server tool call counts (e.g. web_search_requests), when the API reports them. */
+  server_tool_use?: ServerToolUse | null;
+  /** The service tier that served the response (e.g. 'standard', 'batch'), when reported. */
+  service_tier?: string | null;
 };
 
 /** Usage with cache fields normalized to numbers (never null/undefined). */
@@ -545,6 +554,12 @@ export type McpServerStatus = {
   status: 'connected' | 'failed' | 'needs-auth' | 'pending' | 'disabled';
   serverInfo?: { name: string; version: string };
   error?: string;
+  /** The config this server was registered with (echoed back; task #17). */
+  config?: McpServerConfig;
+  /** Per-server tool names, present once the server is connected. */
+  tools?: string[];
+  /** Provenance of the config. Typed for compat; not tracked by this engine. */
+  scope?: 'user' | 'project' | 'local' | 'dynamic';
 };
 
 /** MCP tool result content (subset of the MCP CallToolResult schema). */

--- a/projects/bpt-agent-sdk/tests/mcp.test.ts
+++ b/projects/bpt-agent-sdk/tests/mcp.test.ts
@@ -87,6 +87,24 @@ describe('mcp/sdk-server tool()', () => {
     expect(def.inputJsonSchema.required ?? []).not.toContain('tag');
   });
 
+  it('forwards ToolAnnotations onto the definition (task #17)', () => {
+    const withAnn = tool(
+      'annotated',
+      'read-only tool',
+      { q: z.string() },
+      async () => ({ content: [] }),
+      { readOnlyHint: true, title: 'Reader', idempotentHint: true },
+    );
+    expect(withAnn.annotations).toEqual({
+      readOnlyHint: true,
+      title: 'Reader',
+      idempotentHint: true,
+    });
+
+    const noAnn = tool('plain', 'no annotations', {}, async () => ({ content: [] }));
+    expect(noAnn.annotations).toBeUndefined();
+  });
+
   it('passes zod-validated args (defaults applied) to the handler', async () => {
     let seen: unknown;
     const def = tool(
@@ -202,6 +220,10 @@ describe('DefaultMcpRegistry with an sdk instance', () => {
       status: 'connected',
       serverInfo: { name: 'calc', version: '1.0.0' },
     });
+    // task #17: status carries the config it was registered with + per-server
+    // tool names once connected.
+    expect(statuses[0]!.config).toBeDefined();
+    expect(statuses[0]!.tools).toEqual(['add']);
 
     const tools = reg.allTools();
     expect(tools.map((t) => t.qualifiedName)).toEqual(['mcp__calc__add']);

--- a/projects/bpt-agent-sdk/tests/sessions-store.test.ts
+++ b/projects/bpt-agent-sdk/tests/sessions-store.test.ts
@@ -14,6 +14,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   JsonlSessionStore,
   isSafeSessionId,
+  listSessions,
+  getSessionInfo,
 } from '../src/sessions/store.js';
 import type { APIMessageParam } from '../src/types.js';
 
@@ -207,5 +209,44 @@ describe('JsonlSessionStore pairing repair (finding #37)', () => {
     // Sanity: no tool_result block remains without a preceding tool_use.
     const file = readFileSync(join(dir, 's4.jsonl'), 'utf8');
     expect(file).toContain('orphan'); // raw transcript untouched
+  });
+});
+
+describe('listSessions option shape (task #17)', () => {
+  function seed(sessionId: string, createdAt: number, prompt: string): void {
+    const file = join(dir, `${sessionId}.jsonl`);
+    appendFileSync(
+      file,
+      `${JSON.stringify({ type: 'meta', sessionId, createdAt })}\n` +
+        `${JSON.stringify({ type: 'user', message: { role: 'user', content: prompt } })}\n`,
+      'utf8',
+    );
+  }
+
+  it('honors the `dir` alias for `sessionDir`', async () => {
+    seed('a1', 1, 'hello');
+    const viaDir = await listSessions({ dir });
+    expect(viaDir.map((s) => s.sessionId)).toContain('a1');
+    // getSessionInfo honors the alias too.
+    const info = await getSessionInfo('a1', { dir });
+    expect(info?.sessionId).toBe('a1');
+  });
+
+  it('sessionDir takes precedence over `dir` when both are given', async () => {
+    seed('b1', 1, 'in real dir');
+    const list = await listSessions({ sessionDir: dir, dir: '/nonexistent/path' });
+    expect(list.map((s) => s.sessionId)).toContain('b1');
+  });
+
+  it('caps results with `limit` (newest first)', async () => {
+    seed('old', 1, 'oldest');
+    seed('mid', 2, 'middle');
+    seed('new', 3, 'newest');
+    const all = await listSessions({ dir });
+    expect(all.length).toBe(3);
+    const limited = await listSessions({ dir, limit: 2 });
+    expect(limited).toHaveLength(2);
+    // The two returned are a prefix of the full newest-first ordering.
+    expect(limited.map((s) => s.sessionId)).toEqual(all.slice(0, 2).map((s) => s.sessionId));
   });
 });


### PR DESCRIPTION
## 概述

bpt-agent-sdk v0.3 task #17（P1/P2 长尾）收口批：把剩余四项以**纯增量表面精修**补齐（承接 #387 Read 图像）。

---

## 变更类型

- [x] 其他：SDK 功能实现（类型面 + 单测 + 文档）

- **tool() ToolAnnotations**：新增可选第 5 参 `annotations`，转发到 `SdkMcpToolDefinition`（类型本就有 `annotations?`，此前只是 factory 无法赋值）。readOnlyHint→并行/自动批准的**行为**接线依赖并行工具执行，列为后续。
- **mcpServerStatus() 富化**：每条 status 现携带 `config`（注册时的配置，回显给其拥有者）+ 连接后的 per-server `tools[]`（工具名）；`scope` 类型化但不追踪（引擎无 provenance）。
- **listSessions() / getSessionInfo() option 形状**：option bag 接受 `dir`（`sessionDir` 别名，二者都给时 sessionDir 胜）+ `limit`（newest-first 上限）；`includeWorkspace` 类型化但不 honor（无 Claude Code store 互操作）。
- **Usage 字段**：API 形状的 `Usage` 类型加可选 `server_tool_use` + `service_tier`（真实 passthrough 表面，未聚合到 result.usage）。

**遗留后续**（需真 API 或行为决策）：PDF document 块进 tool_result 的 API 形状验证、readOnlyHint→并行/自动批准行为接线、rate_limit/api_retry 的 transport→stream 桥接。

---

## 来源声明

不涉及游戏数据；银芯自有工程产物。干净室：接口取自公开文档、引擎自研。事实取自 `vitest`/`tsc`/`build` 直接输出。

---

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布数据。** 无专有代码 / 系统提示词复制。
- [x] **仅引用公开素材。**
- [x] **同意按 MIT License 提交。**

---

## 验证清单

- [x] `npx vitest run` — **644 passed（18 文件，+4）**：tool() 转发/省略 annotations；registry status 携带 config + tools[]；listSessions honor dir 别名、sessionDir 优先、limit
- [x] `tsc --noEmit` + `npm run build` — exit 0
- [x] 不引入 emoji（CLAUDE.md 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联 Issue

- Refs #380（v0.2+v0.3 本体）、#384（#16 观测流）、#387（#17 Read 图像）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsuLDoFj5js9z8X8MFTMVa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsuLDoFj5js9z8X8MFTMVa)_