### PR TITLE
site: 将知识库（OKF 关系图）接入对外门户入口

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -11,6 +11,7 @@ on:
       - 'projects/wiki/package.json'
       - 'projects/news/index.html'
       - 'Public-Info-Pool/Resource/proposal/**'
+      - 'okf/visualizer.html'
       - '.github/workflows/deploy-site.yml'
   workflow_dispatch:
 
@@ -81,6 +82,8 @@ jobs:
           cp projects/news/index.html dist/news/index.html
           mkdir -p dist/news/data
           [ -f projects/news/output/news.json ] && cp projects/news/output/news.json dist/news/data/news.json
+          mkdir -p dist/kb
+          [ -f "okf/visualizer.html" ] && cp "okf/visualizer.html" dist/kb/index.html
           mkdir -p dist/docs
           [ -f "Public-Info-Pool/Resource/proposal/biav-project-plan-202603.html" ] && cp "Public-Info-Pool/Resource/proposal/biav-project-plan-202603.html" dist/docs/brain-in-a-vat-project.html
           [ -f "Public-Info-Pool/Resource/proposal/biav-project-plan-202603.pdf" ] && cp "Public-Info-Pool/Resource/proposal/biav-project-plan-202603.pdf" dist/docs/brain-in-a-vat-project.pdf
@@ -94,7 +97,7 @@ jobs:
           echo "=== index.html title ==="
           grep '<title>' dist/index.html
           echo ""
-          for f in dist/index.html dist/wiki/index.html dist/news/index.html; do
+          for f in dist/index.html dist/wiki/index.html dist/news/index.html dist/kb/index.html; do
             if [ ! -f "$f" ]; then
               echo "MISSING: $f" && exit 1
             fi
@@ -136,7 +139,7 @@ jobs:
           sleep 30
           BASE="https://lightproud.github.io/brain-in-a-vat"
           # wiki is zh-only (single locale at /wiki/ root); no en/ja locales configured
-          for url in "$BASE/" "$BASE/wiki/" "$BASE/news/"; do
+          for url in "$BASE/" "$BASE/wiki/" "$BASE/news/" "$BASE/kb/"; do
             status=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "000")
             if [ "$status" = "200" ]; then
               echo "OK: $url → $status"

--- a/projects/site/CONTEXT.md
+++ b/projects/site/CONTEXT.md
@@ -49,6 +49,7 @@ Code-site 会话负责：
 
 - **主站导航页**：已上线，深黑金色调
   - 段落顺序：nav → hero → **mission**（D-mission 新增）→ features → world-strip → community → footer
+  - **知识库入口（D-kb，2026-07-04）**：nav 新增「知识库」链接 → `/kb/`；mission 段下方加底座入口卡（105 概念 · 104 关系，链 `/kb/`）；biav 页出口区同步加「知识库」。部署期 `cp okf/visualizer.html dist/kb/index.html`（放指针不放本体，okf/ 为真值源）。知识库定位为「二核心使命共用事实底座」，**非**第三使命（避免重蹈三卡对外漂移坑）
   - 合规基线：emoji 全清（D-fix + 自审），nav 全部链接可达且无重复，community 仅保留 4 真实 URL（Discord 国际服 / NGA / Reddit / TapTap）
   - SEO/可访问性基线：favicon（inline SVG 宋体「夜」字）+ canonical + og:locale 三语 + twitter:card；语言切换为可访问 details/summary（替代旧 select onchange 反模式）
   - 设计系统：`design/morimens-design-tokens.css` 为视觉 Token 真值源，`public/index.html` 与 `public/biav/index.html` 通过 `<link rel="stylesheet">` 引入并以 `var(--m-*, fallback)` 模式映射；改 design-tokens.css 即全站生效（D-token-unify 已落地）
@@ -66,6 +67,7 @@ https://lightproud.github.io/brain-in-a-vat/
 ├── /         ← projects/site/public/index.html（主站导航页，单文件 HTML，全内联 CSS）
 ├── /404.html ← projects/site/public/404.html（GitHub Pages 自动接管错误页）
 ├── /biav/    ← projects/site/public/biav/index.html（D-biav 项目说明页）
+├── /kb/      ← okf/visualizer.html（知识库关系图，部署期 cp 成 kb/index.html；okf/ 为唯一真值源，非 public/ 下本体）
 ├── /design/  ← projects/site/design/（设计系统 Token + 落地指南，对外可访问）
 ├── /wiki/    ← projects/wiki/docs/.vitepress/dist/*（Code-wiki 维护，VitePress base: /brain-in-a-vat/wiki/）
 ├── /news/    ← projects/news/index.html + 数据（Code-news 维护）

--- a/projects/site/public/biav/index.html
+++ b/projects/site/public/biav/index.html
@@ -177,6 +177,7 @@
       <a class="exit-link" href="../">主站</a>
       <a class="exit-link" href="../wiki/">Wiki</a>
       <a class="exit-link" href="../news/">News</a>
+      <a class="exit-link" href="../kb/">知识库</a>
       <a class="exit-link" href="https://github.com/lightproud/brain-in-a-vat" target="_blank" rel="noopener">GitHub 仓库</a>
       <a class="exit-link" href="https://discord.gg/morimens" target="_blank" rel="noopener">Discord 国际服</a>
     </div>

--- a/projects/site/public/index.html
+++ b/projects/site/public/index.html
@@ -98,6 +98,15 @@
   .mission-name{font-family:var(--serif);font-weight:600;font-size:16px;color:var(--gold-l);margin-bottom:8px}
   .mission-desc{font-size:14px;color:var(--txt-m);line-height:1.7}
   .mission-meta{font-size:11px;color:var(--txt-d);letter-spacing:0.04em;margin-top:12px}
+  .kb-entry{display:flex;align-items:center;justify-content:space-between;gap:24px;margin-top:20px;background:var(--bg2);border:1px solid var(--border);border-radius:8px;padding:24px 28px;color:inherit;transition:border-color 0.3s,transform 0.3s}
+  .kb-entry:hover{border-color:rgba(197,163,86,0.18);transform:translateY(-2px)}
+  .kb-entry-name{font-family:var(--serif);font-weight:600;font-size:16px;color:var(--gold-l);margin-bottom:8px}
+  .kb-entry-desc{font-size:14px;color:var(--txt-m);line-height:1.7}
+  .kb-entry-stat{display:flex;align-items:baseline;gap:6px;flex-shrink:0}
+  .kb-num{font-family:var(--serif);font-weight:700;font-size:32px;color:var(--gold-d);line-height:1}
+  .kb-unit{font-size:12px;color:var(--txt-d);letter-spacing:0.04em}
+  .kb-arrow{font-size:20px;color:var(--gold-d);margin-left:10px;transition:transform 0.3s}
+  .kb-entry:hover .kb-arrow{transform:translateX(4px)}
 
   /* ── COMMUNITY ── */
   .comm-grid{display:flex;gap:16px;flex-wrap:wrap;justify-content:center}
@@ -124,6 +133,7 @@
     .sec-title{font-size:22px}
     .feat-grid{grid-template-columns:1fr}
     .mission-grid{grid-template-columns:1fr}
+    .kb-entry{flex-direction:column;align-items:flex-start;gap:16px}
     .world-strip{padding:60px 0}
     .world-inner{padding:0 20px}
   }
@@ -146,6 +156,7 @@
     <a href="wiki/zh/awakeners/">唤醒体</a>
     <a href="wiki/story">剧情</a>
     <a href="news/">情报</a>
+    <a href="kb/">知识库</a>
     <a href="biav/">BIAV</a>
     <a href="https://github.com/lightproud/brain-in-a-vat" target="_blank" rel="noopener">GitHub</a>
   </div>
@@ -232,6 +243,16 @@
       <div class="mission-meta">wiki 子项目 · 解包数据驱动</div>
     </a>
   </div>
+  <a class="kb-entry reveal" href="kb/">
+    <div class="kb-entry-body">
+      <div class="kb-entry-name">知识库关系图</div>
+      <div class="kb-entry-desc">两大使命共用的事实底座——72 唤醒体、剧情结构、17 社区数据源与记忆档案，编成一张可导航的知识图谱。双击即览概念与关系。</div>
+    </div>
+    <div class="kb-entry-stat">
+      <span class="kb-num">105</span><span class="kb-unit">概念 · 104 关系</span>
+      <span class="kb-arrow" aria-hidden="true">→</span>
+    </div>
+  </a>
 </section>
 
 <!-- ═══ COMMUNITY ═══ -->


### PR DESCRIPTION
## 概述

将银芯运行时知识库（§1.4 第 5 条）的静态可视化面 `okf/visualizer.html` 接入对外门户 site，作为发布页的入口之一。知识库定位为「二核心使命共用的事实底座」，**非**第三使命——避免重蹈 CONTEXT 记录的「第三张使命卡对外漂移」坑。

---

## 变更类型

- [x] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 文档完善（子项目 CONTEXT.md）

具体变更：
- 主站 `public/index.html`：nav 新增「知识库」链接 → `/kb/`；mission 段下方新增底座入口卡（105 概念 · 104 关系，链 `/kb/`），含配套 CSS 与移动端响应式规则
- `public/biav/index.html`：出口区同步加「知识库」链接（`../kb/`），保持跨页导航一致
- `.github/workflows/deploy-site.yml`：部署期 `cp okf/visualizer.html dist/kb/index.html`（okf/ 为唯一真值源，放指针不放本体）；同步扩展 `okf/visualizer.html` 路径触发器、构建烟测清单、部署后 URL 检查至 `/kb/`
- `projects/site/CONTEXT.md`：部署架构图加 `/kb/` 行 + 当前状态记 D-kb

---

## 来源声明

- [x] 本 PR 不涉及新增外部数据；`okf/visualizer.html` 为仓内既有生成物（`scripts/build_okf_bundle.py` 从公开权威源可复现生成），本次仅将其接入部署与门户入口

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 可视化器数据源为银芯自有 OKF bundle（整层公开）
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 本地跑通全量单测：`pytest tests/` → **2049 passed, 10 skipped**（无回归）
- [x] 本地演练部署搬运：`cp okf/visualizer.html dist/kb/index.html` 产物校验通过（自包含 `const G`、含 `<html`、title 正确）
- [x] deploy-site.yml YAML 合法性校验通过
- [x] 不引入 emoji（按 CLAUDE.md 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联 Issue

- Refs 知识库门户入口接入（守密人 2026-07-04 会话派发）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STbCpCYkVzTwub3sqTiACP

---
_Generated by [Claude Code](https://claude.ai/code/session_01STbCpCYkVzTwub3sqTiACP)_