### PR TITLE
feat(bpt-agent-sdk): clear bucket-1 remnants — MCP readOnlyHint chain + PDF live-smoke

### DIFF
--- a/projects/bpt-agent-sdk/CONTEXT.md
+++ b/projects/bpt-agent-sdk/CONTEXT.md
@@ -66,9 +66,13 @@ listSessions option（dir 别名 + limit）+ Usage 字段（server_tool_use/serv
 **桶1（守密人「都先全面实现」）已收口**：① Read PDF→base64 document 块（API 文档确认
 document 块可入 tool_result）；② rate_limit_event/api_retry 真发射（transport `onRetry`
 桥接进流）；③ 连续≥2 只读内建工具**并行执行**（Promise.all，结果保序，stop/defer 覆盖同组后续为
-「Not executed」），只读内建工具在 default 模式经 gate 已自动放行。**648 测试全绿。**
-遗留后续（更小/需真 API）：MCP 工具 `readOnlyHint` 注解链（喂进 gate 自动放行 + 并行分组，
-McpToolEntry 暂不携带 annotations）；PDF base64 源在 tool_result 的 live-API 端到端确认。
+「Not executed」）。**遗留两项亦已清（守密人「清遗留」）**：
+① **MCP `readOnlyHint` 注解链**——`listTools` 经 sdk/stdio/http 把 annotations 捕获到
+`McpToolEntry.annotations`，loop `isReadOnlyTool` 统一 builtin.readOnly + MCP readOnlyHint，
+喂进 gate（default/plan/acceptEdits 只读自动放行）+ 并行分组；真 gate 端到端测试证明只读 MCP 工具
+自动放行、非只读被拒。② **PDF base64 源 live-API 确认**——`tests/integration/live-real-api.mjs`
+加阶段2（生成合法最小 PDF→模型 Read→成功即 API 接受 document 块），随 live-smoke workflow
+手动 dispatch 用 `secrets.ANTHROPIC_API_KEY` 跑。**651 单测全绿**（本地无钥不跑阶段2）。
 进度以 `memory/project-status.md` 为唯一权威。
 
 ## v0.2 候选

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -76,14 +76,16 @@ SDK implements the agent loop directly against the public Messages API:
 - No filesystem settings/CLAUDE.md/skills/plugins loading in v0.1
   (`settingSources` ACCEPTED, loads nothing).
 - **Parallel read-only tool execution** (bucket-1): within one assistant turn,
-  a maximal run of ≥2 consecutive **read-only builtin** tools (Read/Glob/Grep)
-  executes concurrently (`Promise.all`); non-read-only and lone tools stay
-  sequential. Results stay in tool_use order; a stop/defer from any tool
-  overrides the rest of its concurrent group with a "Not executed" marker, so
-  the observable contract matches sequential execution. Read-only builtins in
-  `default` mode already auto-approve via the gate; wiring an MCP tool's
-  `readOnlyHint` annotation into that path (auto-approve + parallel grouping)
-  is a follow-up (McpToolEntry does not yet carry annotations).
+  a maximal run of ≥2 consecutive **read-only** tools executes concurrently
+  (`Promise.all`); non-read-only and lone tools stay sequential. Results stay in
+  tool_use order; a stop/defer from any tool overrides the rest of its
+  concurrent group with a "Not executed" marker, so the observable contract
+  matches sequential execution. "Read-only" covers builtins (Read/Glob/Grep via
+  their `readOnly` flag) **and MCP tools whose server annotation sets
+  `readOnlyHint`** — captured through `listTools` onto `McpToolEntry.annotations`
+  (sdk/stdio/http). Read-only tools in `default`/`plan`/`acceptEdits` mode
+  auto-approve via the gate (no canUseTool prompt), so an MCP `readOnlyHint` tool
+  now both auto-approves and joins parallel groups.
 
 ## Options fields
 

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -499,6 +499,17 @@ export async function* runAgentLoop(
   }
 
   /** Full pipeline for one tool_use block: hooks -> gate -> execute -> hooks. */
+  /** A tool is read-only if a builtin flags it, or a connected MCP tool's
+   * server annotation sets readOnlyHint. Feeds the gate's auto-approve
+   * (default/plan/acceptEdits read-only allow) and parallel grouping. */
+  const isReadOnlyTool = (name: string): boolean => {
+    const builtin = deps.builtinTools.get(name);
+    if (builtin !== undefined) return builtin.readOnly === true;
+    return deps.mcp
+      .allTools()
+      .some((t) => t.qualifiedName === name && t.annotations?.readOnlyHint === true);
+  };
+
   async function executeToolUse(block: ToolUseBlock): Promise<ToolExecOutcome> {
     const toolName = block.name;
     let input = block.input;
@@ -548,7 +559,7 @@ export async function* runAgentLoop(
     const check = await deps.permissions.check(toolName, input, {
       toolUseID: block.id,
       signal,
-      readOnly: builtin?.readOnly ?? false,
+      readOnly: isReadOnlyTool(toolName),
       isFileEdit: builtin?.isFileEdit ?? false,
       hook:
         pre !== undefined &&
@@ -860,15 +871,14 @@ export async function* runAgentLoop(
         let batchStop: ToolExecOutcome['stop'];
         let batchDefer: ToolExecOutcome['defer'];
         // Execute in content order, but run a maximal run of >= 2 consecutive
-        // read-only builtin tools CONCURRENTLY (they have no side effects and
-        // are order-independent). Non-read-only and lone read-only tools run
+        // read-only tools CONCURRENTLY (they have no side effects and are
+        // order-independent). Non-read-only and lone read-only tools run
         // sequentially, exactly as before. Results stay in tool_use order (the
         // API pairs by id; history keeps them ordered). A stop/defer from any
         // executed tool suppresses all LATER tools with a "Not executed"
-        // placeholder. MCP tools are treated as non-read-only (conservative);
-        // wiring their readOnlyHint annotation is a follow-up.
-        const isReadOnly = (b: ToolUseBlock): boolean =>
-          deps.builtinTools.get(b.name)?.readOnly === true;
+        // placeholder. "Read-only" covers builtins (readOnly flag) and MCP
+        // tools whose server annotation sets readOnlyHint (isReadOnlyTool).
+        const isReadOnly = (b: ToolUseBlock): boolean => isReadOnlyTool(b.name);
         let ti = 0;
         while (ti < toolUses.length) {
           if (batchStop !== undefined || batchDefer !== undefined) {

--- a/projects/bpt-agent-sdk/src/internal/contracts.ts
+++ b/projects/bpt-agent-sdk/src/internal/contracts.ts
@@ -28,6 +28,7 @@ import type {
   SDKPermissionDenial,
   TextBlockParam,
   ThinkingConfigParam,
+  ToolAnnotations,
   UserQuestionHandler,
   WebSearchHandler,
 } from '../types.js';
@@ -258,6 +259,8 @@ export type McpToolEntry = {
   toolName: string;
   description?: string;
   inputSchema: JSONSchema;
+  /** Server-reported tool annotations (e.g. readOnlyHint), when provided. */
+  annotations?: ToolAnnotations;
 };
 
 export interface McpRegistry {

--- a/projects/bpt-agent-sdk/src/mcp/http.ts
+++ b/projects/bpt-agent-sdk/src/mcp/http.ts
@@ -21,6 +21,7 @@ import type {
   McpResource,
   McpResourceContent,
   McpSSEServerConfig,
+  ToolAnnotations,
 } from '../types.js';
 import { AbortError, NotImplementedError } from '../errors.js';
 import { parseResourcesList, parseResourceContents } from './stdio.js';
@@ -117,8 +118,8 @@ export class HttpMcpConnection {
   /** tools/list with cursor pagination. */
   async listTools(
     signal?: AbortSignal,
-  ): Promise<Array<{ name: string; description?: string; inputSchema: JSONSchema }>> {
-    const tools: Array<{ name: string; description?: string; inputSchema: JSONSchema }> = [];
+  ): Promise<Array<{ name: string; description?: string; inputSchema: JSONSchema; annotations?: ToolAnnotations }>> {
+    const tools: Array<{ name: string; description?: string; inputSchema: JSONSchema; annotations?: ToolAnnotations }> = [];
     let cursor: string | undefined;
     for (let page = 0; page < MAX_LIST_PAGES; page++) {
       const result = await this.rpcRequest(
@@ -449,18 +450,38 @@ function extractServerInfo(result: unknown): { name: string; version: string } |
   return undefined;
 }
 
+/** Coerce a raw MCP tool `annotations` object into ToolAnnotations, keeping
+ * only well-typed known fields; undefined when nothing usable is present. */
+function parseToolAnnotations(raw: unknown): ToolAnnotations | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const a = raw as Record<string, unknown>;
+  const out: ToolAnnotations = {};
+  if (typeof a.title === 'string') out.title = a.title;
+  if (typeof a.readOnlyHint === 'boolean') out.readOnlyHint = a.readOnlyHint;
+  if (typeof a.destructiveHint === 'boolean') out.destructiveHint = a.destructiveHint;
+  if (typeof a.idempotentHint === 'boolean') out.idempotentHint = a.idempotentHint;
+  if (typeof a.openWorldHint === 'boolean') out.openWorldHint = a.openWorldHint;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 function parseToolsListResult(result: unknown): {
-  list: Array<{ name: string; description?: string; inputSchema: JSONSchema }>;
+  list: Array<{ name: string; description?: string; inputSchema: JSONSchema; annotations?: ToolAnnotations }>;
   nextCursor?: string;
 } {
-  const list: Array<{ name: string; description?: string; inputSchema: JSONSchema }> = [];
+  const list: Array<{ name: string; description?: string; inputSchema: JSONSchema; annotations?: ToolAnnotations }> = [];
   if (!result || typeof result !== 'object') return { list };
   const obj = result as { tools?: unknown; nextCursor?: unknown };
   if (Array.isArray(obj.tools)) {
     for (const raw of obj.tools) {
       if (!raw || typeof raw !== 'object') continue;
-      const t = raw as { name?: unknown; description?: unknown; inputSchema?: unknown };
+      const t = raw as {
+        name?: unknown;
+        description?: unknown;
+        inputSchema?: unknown;
+        annotations?: unknown;
+      };
       if (typeof t.name !== 'string' || t.name.length === 0) continue;
+      const annotations = parseToolAnnotations(t.annotations);
       list.push({
         name: t.name,
         description: typeof t.description === 'string' ? t.description : undefined,
@@ -468,6 +489,7 @@ function parseToolsListResult(result: unknown): {
           t.inputSchema && typeof t.inputSchema === 'object' && !Array.isArray(t.inputSchema)
             ? (t.inputSchema as JSONSchema)
             : { type: 'object' },
+        ...(annotations !== undefined ? { annotations } : {}),
       });
     }
   }

--- a/projects/bpt-agent-sdk/src/mcp/registry.ts
+++ b/projects/bpt-agent-sdk/src/mcp/registry.ts
@@ -22,6 +22,7 @@ import type {
   McpServerStatus,
   McpSetServersResult,
   McpStdioServerConfig,
+  ToolAnnotations,
 } from '../types.js';
 import { AbortError, ConfigurationError, isAbortError } from '../errors.js';
 import { StdioMcpConnection } from './stdio.js';
@@ -36,7 +37,14 @@ type McpConnectionLike = {
   serverInfo(): { name: string; version: string } | undefined;
   listTools(
     signal?: AbortSignal,
-  ): Promise<Array<{ name: string; description?: string; inputSchema: JSONSchema }>>;
+  ): Promise<
+    Array<{
+      name: string;
+      description?: string;
+      inputSchema: JSONSchema;
+      annotations?: ToolAnnotations;
+    }>
+  >;
   callTool(
     name: string,
     args: Record<string, unknown>,
@@ -297,6 +305,7 @@ export class DefaultMcpRegistry implements McpRegistry {
         toolName: t.name,
         description: t.description,
         inputSchema: t.inputSchema,
+        ...(t.annotations !== undefined ? { annotations: t.annotations } : {}),
       }));
       entry.baseStatus = 'connected';
       this.debug(`[mcp] connected '${entry.name}' (${entry.tools.length} tools)`);

--- a/projects/bpt-agent-sdk/src/mcp/sdk-server.ts
+++ b/projects/bpt-agent-sdk/src/mcp/sdk-server.ts
@@ -120,11 +120,19 @@ export class SdkMcpConnection {
 
   async listTools(
     _signal?: AbortSignal,
-  ): Promise<Array<{ name: string; description?: string; inputSchema: JSONSchema }>> {
+  ): Promise<
+    Array<{
+      name: string;
+      description?: string;
+      inputSchema: JSONSchema;
+      annotations?: ToolAnnotations;
+    }>
+  > {
     return [...this.instance.tools.values()].map((def) => ({
       name: def.name,
       description: def.description,
       inputSchema: def.inputJsonSchema,
+      ...(def.annotations !== undefined ? { annotations: def.annotations } : {}),
     }));
   }
 

--- a/projects/bpt-agent-sdk/src/mcp/stdio.ts
+++ b/projects/bpt-agent-sdk/src/mcp/stdio.ts
@@ -16,6 +16,7 @@ import type {
   McpResource,
   McpResourceContent,
   McpStdioServerConfig,
+  ToolAnnotations,
 } from '../types.js';
 import { AbortError } from '../errors.js';
 import { resolveElicitation } from './elicitation.js';
@@ -154,8 +155,8 @@ export class StdioMcpConnection {
   /** tools/list with cursor pagination. */
   async listTools(
     signal?: AbortSignal,
-  ): Promise<Array<{ name: string; description?: string; inputSchema: JSONSchema }>> {
-    const tools: Array<{ name: string; description?: string; inputSchema: JSONSchema }> = [];
+  ): Promise<Array<{ name: string; description?: string; inputSchema: JSONSchema; annotations?: ToolAnnotations }>> {
+    const tools: Array<{ name: string; description?: string; inputSchema: JSONSchema; annotations?: ToolAnnotations }> = [];
     let cursor: string | undefined;
     for (let page = 0; page < MAX_LIST_PAGES; page++) {
       const result = await this.request(
@@ -376,18 +377,38 @@ function extractServerInfo(result: unknown): { name: string; version: string } |
   return undefined;
 }
 
+/** Coerce a raw MCP tool `annotations` object into ToolAnnotations, keeping
+ * only well-typed known fields; undefined when nothing usable is present. */
+function parseToolAnnotations(raw: unknown): ToolAnnotations | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const a = raw as Record<string, unknown>;
+  const out: ToolAnnotations = {};
+  if (typeof a.title === 'string') out.title = a.title;
+  if (typeof a.readOnlyHint === 'boolean') out.readOnlyHint = a.readOnlyHint;
+  if (typeof a.destructiveHint === 'boolean') out.destructiveHint = a.destructiveHint;
+  if (typeof a.idempotentHint === 'boolean') out.idempotentHint = a.idempotentHint;
+  if (typeof a.openWorldHint === 'boolean') out.openWorldHint = a.openWorldHint;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 function parseToolsListResult(result: unknown): {
-  list: Array<{ name: string; description?: string; inputSchema: JSONSchema }>;
+  list: Array<{ name: string; description?: string; inputSchema: JSONSchema; annotations?: ToolAnnotations }>;
   nextCursor?: string;
 } {
-  const list: Array<{ name: string; description?: string; inputSchema: JSONSchema }> = [];
+  const list: Array<{ name: string; description?: string; inputSchema: JSONSchema; annotations?: ToolAnnotations }> = [];
   if (!result || typeof result !== 'object') return { list };
   const obj = result as { tools?: unknown; nextCursor?: unknown };
   if (Array.isArray(obj.tools)) {
     for (const raw of obj.tools) {
       if (!raw || typeof raw !== 'object') continue;
-      const t = raw as { name?: unknown; description?: unknown; inputSchema?: unknown };
+      const t = raw as {
+        name?: unknown;
+        description?: unknown;
+        inputSchema?: unknown;
+        annotations?: unknown;
+      };
       if (typeof t.name !== 'string' || t.name.length === 0) continue;
+      const annotations = parseToolAnnotations(t.annotations);
       list.push({
         name: t.name,
         description: typeof t.description === 'string' ? t.description : undefined,
@@ -395,6 +416,7 @@ function parseToolsListResult(result: unknown): {
           t.inputSchema && typeof t.inputSchema === 'object' && !Array.isArray(t.inputSchema)
             ? (t.inputSchema as JSONSchema)
             : { type: 'object' },
+        ...(annotations !== undefined ? { annotations } : {}),
       });
     }
   }

--- a/projects/bpt-agent-sdk/tests/integration/live-real-api.mjs
+++ b/projects/bpt-agent-sdk/tests/integration/live-real-api.mjs
@@ -7,6 +7,12 @@
  * `bpt-agent-sdk-live-smoke` GitHub Actions workflow (workflow_dispatch),
  * which injects the ANTHROPIC_API_KEY repository secret into the runner.
  *
+ * Two phases:
+ *   1. Write/Read/Bash round-trip — the core tool loop over the real API.
+ *   2. PDF-in-tool_result — Read returns a base64 `document` block for a PDF;
+ *      a success confirms the API accepts a document block inside a tool_result
+ *      end to end (bucket-1 live confirmation).
+ *
  *   Requires: `npm run build` first (imports the compiled dist).
  *   Reads:    process.env.ANTHROPIC_API_KEY  (never hardcoded, never committed)
  *   Optional: process.argv[2] = model id (default claude-haiku-4-5-20251001)
@@ -18,6 +24,32 @@ import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
+
+/** Build a byte-valid single-page PDF containing `text` (correct xref offsets).
+ * Used by phase 2 to confirm the real API accepts a base64 `document` block
+ * inside a tool_result. */
+function makeMinimalPdf(text) {
+  const esc = String(text).replace(/([\\()])/g, '\\$1');
+  const content = `BT /F1 20 Tf 20 60 Td (${esc}) Tj ET`;
+  const objs = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 320 120] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>',
+    `<< /Length ${Buffer.byteLength(content, 'latin1')} >>\nstream\n${content}\nendstream`,
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  let pdf = '%PDF-1.4\n';
+  const offsets = [];
+  objs.forEach((body, i) => {
+    offsets.push(Buffer.byteLength(pdf, 'latin1'));
+    pdf += `${i + 1} 0 obj\n${body}\nendobj\n`;
+  });
+  const xrefStart = Buffer.byteLength(pdf, 'latin1');
+  pdf += `xref\n0 ${objs.length + 1}\n0000000000 65535 f \n`;
+  for (const off of offsets) pdf += `${String(off).padStart(10, '0')} 00000 n \n`;
+  pdf += `trailer\n<< /Size ${objs.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF`;
+  return Buffer.from(pdf, 'latin1');
+}
 
 const KEY = process.env.ANTHROPIC_API_KEY;
 if (!KEY) {
@@ -88,7 +120,52 @@ try {
   if (exists) console.log('[content]\n' + fs.readFileSync(f, 'utf8'));
   // The model was asked to create the file; treat a missing file as a soft signal, not a hard fail.
   if (!ok) throw new Error('run did not end in a success result');
-  console.log('\n[PASS] live real-API smoke test succeeded.');
+
+  // --- Phase 2: PDF-in-tool_result (bucket-1 live confirmation) ------------
+  // Read returns a PDF as a base64 `document` block; a successful run confirms
+  // the REAL API accepts a document block INSIDE a tool_result end to end (the
+  // docs allow it but only demonstrate a text source; this proves base64).
+  console.log('\n' + '-'.repeat(68));
+  console.log('Phase 2: PDF-in-tool_result (base64 document block)');
+  console.log('-'.repeat(68));
+  const pdfPath = path.join(sandbox, 'note.pdf');
+  fs.writeFileSync(pdfPath, makeMinimalPdf('BPT Agent SDK PDF smoke ok'));
+  let pdfOk = false;
+  const q2 = query({
+    prompt:
+      `Use the Read tool to read the file at ${pdfPath}. ` +
+      'In one short sentence, tell me what text the PDF contains.',
+    options: {
+      provider: { apiKey: KEY },
+      cwd: sandbox,
+      persistSession: false,
+      permissionMode: 'bypassPermissions',
+      model,
+      maxTurns: 6,
+    },
+  });
+  for await (const m of q2) {
+    if (m.type === 'assistant') {
+      for (const b of m.message.content) {
+        if (b.type === 'text' && b.text.trim()) console.log(`\n[pdf/assistant] ${b.text.trim()}`);
+        if (b.type === 'tool_use') console.log(`\n[pdf/tool_use] ${b.name}`);
+      }
+    } else if (m.type === 'result') {
+      console.log(
+        `\n[pdf/result] ${m.subtype} | turns=${m.num_turns} | cost=$${m.total_cost_usd.toFixed(6)}`,
+      );
+      if (m.subtype === 'success') pdfOk = true;
+      else if (m.errorMessage) console.log(`[pdf/error] ${m.errorMessage}`);
+    }
+  }
+  console.log(
+    `\n[pdf] the API ${pdfOk ? 'ACCEPTED' : 'REJECTED'} the base64 document block in tool_result`,
+  );
+  if (!pdfOk) {
+    throw new Error('PDF-in-tool_result run did not succeed (API may have rejected the document block)');
+  }
+
+  console.log('\n[PASS] live real-API smoke test succeeded (both phases).');
 } catch (e) {
   console.error('\n[FAIL]', e?.name, e?.message);
   process.exitCode = 1;

--- a/projects/bpt-agent-sdk/tests/mcp.test.ts
+++ b/projects/bpt-agent-sdk/tests/mcp.test.ts
@@ -246,6 +246,28 @@ describe('DefaultMcpRegistry with an sdk instance', () => {
     await reg.closeAll();
   });
 
+  it('carries a tool readOnlyHint annotation through to McpToolEntry (remnant #1)', async () => {
+    const ro = tool(
+      'peek',
+      'a read-only tool',
+      { q: z.string() },
+      async () => ({ content: [] }),
+      { readOnlyHint: true, title: 'Peek' },
+    );
+    const rw = tool('poke', 'a writing tool', { q: z.string() }, async () => ({ content: [] }));
+    const cfg = createSdkMcpServer({ name: 'srv', tools: [ro, rw] });
+    const reg = new DefaultMcpRegistry({ servers: { srv: cfg }, debug: () => {} });
+    await reg.connectAll();
+
+    const tools = reg.allTools();
+    const peek = tools.find((t) => t.toolName === 'peek');
+    const poke = tools.find((t) => t.toolName === 'poke');
+    expect(peek!.annotations?.readOnlyHint).toBe(true);
+    expect(peek!.annotations?.title).toBe('Peek');
+    expect(poke!.annotations).toBeUndefined();
+    await reg.closeAll();
+  });
+
   it('call() routes to the handler and returns its result', async () => {
     const reg = makeRegistry();
     await reg.connectAll();

--- a/projects/bpt-agent-sdk/tests/query.test.ts
+++ b/projects/bpt-agent-sdk/tests/query.test.ts
@@ -52,6 +52,7 @@ import {
 } from './helpers/mock-transport.js';
 import { HANG_STREAM, encodeSSEFrame, makeSSEFetch } from './helpers/sse-fetch.js';
 import type { SSEFetchStub } from './helpers/sse-fetch.js';
+import { DefaultPermissionGate } from '../src/permissions/gate.js';
 
 let sessionDir: string;
 let cwd: string;
@@ -1240,6 +1241,84 @@ describe('runAgentLoop - v0.2 confirmed-finding regressions (engine)', () => {
     // trips the trigger, so that log never appears.
     expect(debugLines.some((l) => l.includes('nothing safe to fold'))).toBe(true);
     expect(transport.requests).toHaveLength(2);
+  });
+
+  // ----- remnant #1: MCP readOnlyHint drives the gate's auto-approve -----
+
+  function mcpWith(tool: McpToolEntry, calls: string[]): McpRegistry {
+    return {
+      async connectAll(): Promise<void> {},
+      statuses() {
+        return [];
+      },
+      allTools(): McpToolEntry[] {
+        return [tool];
+      },
+      has(q: string): boolean {
+        return q === tool.qualifiedName;
+      },
+      async call(q: string) {
+        calls.push(q);
+        return { content: [{ type: 'text' as const, text: `ran ${tool.toolName}` }], isError: false };
+      },
+      async reconnect(): Promise<void> {},
+      setEnabled(): void {},
+      async setServers() {
+        return { servers: [] };
+      },
+      async closeAll(): Promise<void> {},
+    };
+  }
+
+  async function runOneMcpCall(
+    tool: McpToolEntry,
+  ): Promise<{ calls: string[]; results: ToolResultBlockParam[] }> {
+    const calls: string[] = [];
+    const transport = new MockTransport([
+      toolUseReplyEvents(tool.qualifiedName, {}),
+      textReplyEvents('done'),
+    ]);
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+    const deps: EngineDeps = {
+      transport,
+      builtinTools: new Map(),
+      mcp: mcpWith(tool, calls),
+      // Real gate, default mode, NO canUseTool: only readOnly tools auto-approve.
+      permissions: new DefaultPermissionGate({ debug: () => {} }),
+      hooks: noHooks(),
+      toolContext: engineToolContext(),
+      debug: () => {},
+    };
+    for await (const _m of runAgentLoop(history, deps, engineConfig())) {
+      /* drain */
+    }
+    const userTurn = history.find((m) => m.role === 'user' && Array.isArray(m.content));
+    return { calls, results: (userTurn?.content ?? []) as ToolResultBlockParam[] };
+  }
+
+  it('auto-approves a read-only MCP tool (readOnlyHint) in default mode without canUseTool', async () => {
+    const { calls, results } = await runOneMcpCall({
+      qualifiedName: 'mcp__x__peek',
+      serverName: 'x',
+      toolName: 'peek',
+      inputSchema: { type: 'object' },
+      annotations: { readOnlyHint: true },
+    });
+    expect(calls).toEqual(['mcp__x__peek']); // executed
+    expect(results[0]!.is_error).not.toBe(true);
+    // Result content is the MCP tool's block array; its text carries the output.
+    expect(JSON.stringify(results[0]!.content)).toContain('ran peek');
+  });
+
+  it('does NOT auto-approve a non-read-only MCP tool in default mode without canUseTool', async () => {
+    const { calls, results } = await runOneMcpCall({
+      qualifiedName: 'mcp__x__poke',
+      serverName: 'x',
+      toolName: 'poke',
+      inputSchema: { type: 'object' },
+    });
+    expect(calls).toEqual([]); // never executed
+    expect(results[0]!.is_error).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 概述

守密人「清遗留」——收桶1 的两项剩余遗留。

---

## 变更类型

- [x] 其他：SDK 功能实现（MCP 子系统 + 引擎 + live-smoke 脚手架 + 单测 + 文档）

**遗留① MCP `readOnlyHint` 注解链**（真代码，单测验证）：
- `McpToolEntry` 加 `annotations?: ToolAnnotations`；`listTools` 经三种连接把工具注解捕获（sdk 从定义；stdio/http 从 tools/list 经防御式 `parseToolAnnotations` 解析）。
- loop `isReadOnlyTool()` 统一 builtin.readOnly **或** MCP 工具 annotations.readOnlyHint（经 `mcp.allTools()` 查，无 McpRegistry 接口/包装器改动），同时喂进 gate 的 readOnly（default/plan/acceptEdits 自动放行）+ 并行分组分类器。
- 单测（+3）：注解经 sdk→McpToolEntry 流通；**真 gate** default 模式无 canUseTool 下，只读 MCP 工具自动放行执行、非只读被拒。

**遗留② PDF-in-tool_result live 确认**（脚手架，需真密钥）：
- `tests/integration/live-real-api.mjs` 加阶段2：生成字节合法最小 PDF→模型 Read（返回 base64 document 块）→要求 success 结果，端到端确认**真 API 接受 tool_result 内的 document 块**（官方文档允许但仅演示 text 源，此证 base64）。经既有 live-smoke workflow（workflow_dispatch + `secrets.ANTHROPIC_API_KEY`）跑；无钥 CI 不受影响。

COMPAT.md/CONTEXT.md 更新：MCP readOnlyHint 已接通（非 follow-up）。

> 注：本分支 rebase 时并入并发合并的 #385（MCP resources 等），组合后 668 单测全绿。

---

## 来源声明

不涉及游戏数据；银芯自有工程产物。干净室：MCP 注解形状取自公开 MCP 规范。事实取自 `vitest`/`tsc`/`build` 输出。

---

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布数据。** 无专有代码 / 系统提示词复制。**API 密钥仅经 `secrets.ANTHROPIC_API_KEY` 运行时注入，绝不入库。**
- [x] **仅引用公开素材。**
- [x] **同意按 MIT License 提交。**

---

## 验证清单

- [x] `npx vitest run` — **668 passed（18 文件，rebase 含 #385 后）**：MCP 注解捕获 + 真 gate 只读自动放行/非只读拒绝对比
- [x] `tsc --noEmit` + `npm run build` — exit 0；`node --check` live-smoke 脚本；makeMinimalPdf 产出 %PDF-/%%EOF
- [x] 不引入 emoji；不动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联 Issue

- Refs #391（桶1）、#385（并发 surface-alignment）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsuLDoFj5js9z8X8MFTMVa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsuLDoFj5js9z8X8MFTMVa)_