### PR TITLE
feat(bpt-agent-sdk): v0.4 — task/hook lifecycle emission + contract alignment

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -153,7 +153,11 @@
 - **当前状态（2026-07-04 实测）**：**v0.2 + v0.3 已合并 main**（本体 PR #380 @ `8bd4a54`；v0.3 收尾
   #384 观测流 / #387 Read 图像 / #388 类型面尾批 / #391 桶1 三项）。**v0.3 两待办 #16 + #17 +
   「桶1」（PDF document 块 / 重试流桥接 / 只读工具并行）均已收口。**
-  `pytest` 无涉、Node 侧 **`npx vitest run` 668 单测全绿（18 文件）**；`tsc` + `build` exit 0
+  **v0.4 观测臂生命周期真发射已落**（分支 `claude/bpt-agent-sdk-dev-h5ccmf`）：subagent 任务生命周期
+  task_started/progress/updated/notification + hook 生命周期 hook_started/hook_response
+  （`includeHookEvents` 门控）经共享观测队列在消息边界真发射；error 结果臂补官方 `errors: string[]`；
+  权限规则 `*` / `mcp__*` glob；COMPAT.md 陈旧行对账（会话三函数与 canUseTool suggestions 实为 v0.2 已落地）。
+  `pytest` 无涉、Node 侧 **`npx vitest run` 680 单测全绿（19 文件）**；`tsc` + `build` exit 0
 - **完成度（表面等价）**：对官方 SDK **0.3.199 基线**约 **89.5%**（v0.1 基线 68.3% → v0.2+v0.3 补齐后重算）。
   审计矩阵与逐行台账落 `Public-Info-Pool/Resource/repo-engineering/bpt-agent-sdk-completion-audit-20260703.md`
   + 同名 `-matrix-20260703.json`（146 行）

--- a/projects/bpt-agent-sdk/CONTEXT.md
+++ b/projects/bpt-agent-sdk/CONTEXT.md
@@ -72,7 +72,17 @@ document 块可入 tool_result）；② rate_limit_event/api_retry 真发射（t
 喂进 gate（default/plan/acceptEdits 只读自动放行）+ 并行分组；真 gate 端到端测试证明只读 MCP 工具
 自动放行、非只读被拒。② **PDF base64 源 live-API 确认**——`tests/integration/live-real-api.mjs`
 加阶段2（生成合法最小 PDF→模型 Read→成功即 API 接受 document 块），随 live-smoke workflow
-手动 dispatch 用 `secrets.ANTHROPIC_API_KEY` 跑。**651 单测全绿**（本地无钥不跑阶段2）。
+手动 dispatch 用 `secrets.ANTHROPIC_API_KEY` 跑。
+
+**v0.4（2026-07-04）：观测臂生命周期真发射 + 契约对齐**。① subagent 任务生命周期
+task_started / task_progress（按子回合预算份额）/ task_updated（completed·failed·cancelled，
+带 500 字符结果预览）/ task_notification（仅后台子代理）真发射——runtime 推入共享观测队列，
+loop 与 query 泵在消息边界排空（拉式生成器无法在 await 中途插播，前台事件在其工具组结束后浮出）；
+② hook 生命周期 hook_started / hook_response 成对真发射（`includeHookEvents` 门控，hook_id 关联，
+hook_progress 无诚实来源保持 TYPED）；③ 契约小项：error 结果臂补官方 `errors: string[]`、
+权限规则 deny/allow 位支持 `*` 与 `mcp__*` glob；④ 对账修正：会话三函数
+（getSessionMessages/renameSession/tagSession）与 canUseTool suggestions/requestId 实为 v0.2
+已落地，COMPAT.md 陈旧行已更正。**680 单测全绿**。
 进度以 `memory/project-status.md` 为唯一权威。
 
 ## v0.2 候选

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -33,8 +33,12 @@ v0.2 implemented most of the P0/P1 gaps the audit flagged. Now **FULL / PARTIAL*
   functions; Query methods (reconnect/toggle/setMcpServers/rewindFiles/stopTask).
 
 The full observability/status message arm was TYPED in v0.3 (task #16) so the
-SDKMessage union is exhaustive for drop-in consumers; `permission_denied` is
-emitted, the rest are typed-not-emitted (see the Observability arm table below).
+SDKMessage union is exhaustive for drop-in consumers. EMITTED as of v0.4:
+`permission_denied`, `rate_limit_event` / `api_retry` (v0.3), the subagent
+task lifecycle (`task_started` / `task_progress` / `task_updated` /
+`task_notification`) and the hook lifecycle (`hook_started` / `hook_response`,
+behind `includeHookEvents`); the rest are typed-not-emitted (see the
+Observability arm table below).
 
 Still deliberately out of scope (N/A-by-design): the CLI-coupled subsystems
 (CLI system prompt, settings engine, bubblewrap sandbox, Bedrock/Vertex/Foundry,
@@ -61,7 +65,8 @@ Tiers:
 | `createSdkMcpServer()` | FULL | in-process dispatch, no wire protocol |
 | `listSessions()` / `getSessionInfo()` | PARTIAL | reads this SDK's own JSONL store only; option bag accepts `dir` (alias for `sessionDir`) + `limit`; `includeWorkspace` typed but not honored (no Claude Code store interop) (task #17) |
 | `startup()` / `WarmQuery` | UNSUPPORTED | no subprocess to pre-warm; direct API needs no warmup |
-| `getSessionMessages()` / `renameSession()` / `tagSession()` / `resolveSettings()` | UNSUPPORTED | v0.2 candidates |
+| `getSessionMessages()` / `renameSession()` / `tagSession()` / `deleteSession()` / `forkSession()` | PARTIAL | implemented in v0.2 over this SDK's own JSONL store (or an external `sessionStore`); no Claude Code store interop |
+| `resolveSettings()` | UNSUPPORTED | settings engine is CLI-coupled (N/A-by-design) |
 
 ## Engine difference (the point of this SDK)
 
@@ -94,8 +99,8 @@ SDK implements the agent loop directly against the public Messages API:
 | `abortController` | FULL | |
 | `additionalDirectories` | FULL | fs tools + additionalDirectories containment |
 | `agents` | ACCEPTED | subagents land in v0.2 |
-| `allowedTools` / `disallowedTools` | PARTIAL | `Tool(spec)` prefix rules + `mcp__srv__*` (exact server match); bare-name `disallowedTools` removes the tool definition from the request; plan mode never auto-approves writes via an allow rule; rewritten inputs re-checked against deny rules. Deny-position `*`/`mcp__*` globs not yet supported |
-| `canUseTool` | PARTIAL | invoked on prompt-fallthrough; `updatedInput`/`updatedPermissions` honored (incl. hook-`ask` rewrite); `suggestions`/`requestId` not passed; `null` return treated as deny (not skip-response) |
+| `allowedTools` / `disallowedTools` | FULL | `Tool(spec)` prefix rules + `mcp__srv__*` (exact server match) + `*` / `mcp__*` globs (v0.4); bare-name `disallowedTools` removes the tool definition from the request; plan mode never auto-approves writes via an allow rule; rewritten inputs re-checked against deny rules |
+| `canUseTool` | FULL | invoked on prompt-fallthrough with `signal`/`suggestions`/`requestId`/`toolUseID`; `updatedInput`/`updatedPermissions` honored (incl. hook-`ask` rewrite); `null` return = skip (app resolves out of band) |
 | `continue` | PARTIAL | resumes latest session from this SDK's store |
 | `cwd` | FULL | |
 | `env` | FULL | used for transport + Bash tool |
@@ -118,8 +123,9 @@ SDK implements the agent loop directly against the public Messages API:
 | `systemPrompt` | PARTIAL | preset `claude_code` maps to this SDK's own harness prompt (+`append`) |
 | `tools` | PARTIAL | string[] filters built-ins; preset = all built-ins |
 | `betas` | FULL | forwarded as `anthropic-beta` header |
+| `includeHookEvents` | FULL | v0.4: emits `hook_started` / `hook_response` pairs (per callback invocation, correlated by `hook_id`) into the stream |
 | `debug` / `debugFile` | PARTIAL | `debug` → stderr callback; `debugFile` ACCEPTED |
-| `agent`, `settings`, `permissionPromptToolName`, `extraArgs`, `effort`, `outputFormat`, `sandbox`, `plugins`, `skills`, `toolAliases`, `toolConfig`, `sessionStore*`, `managedSettings`, `enableFileCheckpointing`, `taskBudget`, `onElicitation`, `planModeInstructions`, `promptSuggestions`, `agentProgressSummaries`, `forwardSubagentText`, `includeHookEvents`, `loadTimeoutMs`, `title`, `resumeSessionAt` | ACCEPTED | each present key emits exactly one debug warning, then ignored |
+| `agent`, `settings`, `permissionPromptToolName`, `extraArgs`, `effort`, `outputFormat`, `sandbox`, `plugins`, `skills`, `toolAliases`, `toolConfig`, `sessionStore*`, `managedSettings`, `enableFileCheckpointing`, `taskBudget`, `onElicitation`, `planModeInstructions`, `promptSuggestions`, `agentProgressSummaries`, `forwardSubagentText`, `loadTimeoutMs`, `title`, `resumeSessionAt` | ACCEPTED | each present key emits exactly one debug warning, then ignored |
 
 ## Built-in tools
 
@@ -140,7 +146,7 @@ SDK implements the agent loop directly against the public Messages API:
 | `assistant` | FULL | full `APIAssistantMessage` |
 | `user` (echo + tool results) | FULL | prompt echo and tool_result user turns both yielded and persisted in order |
 | `stream_event` | FULL | behind `includePartialMessages` |
-| `result` success / error_max_turns / error_during_execution / `error_max_budget_usd` / `error_max_structured_output_retries` | PARTIAL | success arm carries ttft_ms + structured_output + deferred_tool_use + v0.3 `metrics`; error arm carries `errorMessage: string` rather than official `errors: string[]` |
+| `result` success / error_max_turns / error_during_execution / `error_max_budget_usd` / `error_max_structured_output_retries` | FULL | success arm carries ttft_ms + structured_output + deferred_tool_use + v0.3 `metrics`; error arm carries both `errorMessage: string` and the official-parallel `errors: string[]` (v0.4; always `[errorMessage]`) |
 | `system/compact_boundary` | FULL | emitted on manual `/compact` + auto-compaction (v0.2) |
 | `system/mirror_error` | FULL | emitted on a session-store mirror failure |
 
@@ -163,8 +169,9 @@ house `uuid`/`session_id` envelope. Union: `SDKObservabilityMessage`.
 |---|---|---|
 | `permission_denied` | FULL (emitted) | yielded on every permission-gate deny, before the tool_result; mirrors the `result.permission_denials` ledger; `blocker:'canUseTool'` set on a canUseTool interrupt, else omitted |
 | `tool_progress`, `tool_use_summary` | TYPED | no mid-tool progress channel (tools are one-shot) |
-| `task_started` / `task_progress` / `task_updated` / `task_notification` | TYPED | subagents run detached; lifecycle not surfaced as stream events yet |
-| `hook_started` / `hook_progress` / `hook_response` | TYPED | would gate behind `includeHookEvents`; hooks currently report via debug only |
+| `task_started` / `task_progress` / `task_updated` / `task_notification` | FULL (emitted, v0.4) | Agent-tool subagent lifecycle: `task_started` at spawn (task_id = agentId, task_name = the Agent call's `description`), `task_progress` per child assistant turn (turn-budget share, `status: 'turn N/M'`), `task_updated` on completed/failed/cancelled (bounded result preview), `task_notification` for BACKGROUND children (completed/failed/stopped). Buffered by the runtime and drained into the stream at message boundaries (foreground events surface after their Agent tool group finishes — a pull-based generator cannot interleave mid-await) |
+| `hook_started` / `hook_response` | FULL (emitted, v0.4) | behind `options.includeHookEvents`: one pair per callback invocation, correlated by `hook_id`; `result` = bounded output JSON, `error` = failure/timeout text. Same message-boundary drain as task events |
+| `hook_progress` | TYPED | callbacks are opaque promises; no honest mid-callback progress source |
 | `rate_limit_event`, `api_retry` | FULL (emitted) | the transport's per-request `onRetry` observer bridges each 429/5xx/network retry into the stream: a `rate_limit_event` on 429 (with `retry_after_ms`), an `api_retry` otherwise (with `status`/`reason`), yielded just before the retried attempt's stream |
 | `files_persisted`, `local_command_output`, `commands_changed`, `auth_status`, `elicitation_complete`, `informational`, `notification`, `prompt_suggestion`, `memory_recall`, `worker_shutting_down`, `plugin_install`, `session_state_changed`, `system/status` | TYPED | no source event in a headless engine with no plugins/skills/CC-host/slash-command framework |
 

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "BPT Agent SDK - clean-room agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -314,6 +314,9 @@ export async function* runAgentLoop(
     subtype,
     is_error: true,
     errorMessage,
+    // Official-surface parallel: the reference SDK reports error text as a
+    // string[]; this engine only ever has the one message.
+    errors: [errorMessage],
     ...(apiErrorStatus !== undefined ? { api_error_status: apiErrorStatus } : {}),
     ...resultBase(),
   });
@@ -707,9 +710,19 @@ export async function* runAgentLoop(
     return { result, stop };
   }
 
+  // v0.4: surface buffered task_* / hook_* lifecycle messages (the subagent
+  // runtime and hook runner cannot yield) at the loop's message boundaries.
+  // The query layer drains the same queue at its own yield points, so events
+  // produced between engine turns are never stranded.
+  function* drainObs(): Generator<SDKMessage> {
+    if (deps.drainObservability === undefined) return;
+    for (const msg of deps.drainObservability()) yield msg;
+  }
+
   try {
     for (;;) {
       if (signal.aborted) throw new AbortError();
+      yield* drainObs();
 
       // --- Context compaction (only when a shared request view exists). -----
       if (deps.requestView !== undefined && config.compaction?.enabled !== false) {
@@ -932,6 +945,10 @@ export async function* runAgentLoop(
             }
           }
           ti += outcomes.length;
+          // Surface lifecycle events produced by the group just executed
+          // (foreground subagent task_*, hook_started/hook_response) before
+          // the next group runs.
+          yield* drainObs();
         }
         pushAssistant(assistant.content);
         const userTurn: APIMessageParam = { role: 'user', content: results };

--- a/projects/bpt-agent-sdk/src/hooks/runner.ts
+++ b/projects/bpt-agent-sdk/src/hooks/runner.ts
@@ -23,12 +23,16 @@
  *     (fire-and-forget) and treated as neutral
  */
 
+import { randomUUID } from 'node:crypto';
+
 import type {
   HookCallback,
   HookEvent,
   HookInput,
   HookJSONOutput,
   Options,
+  SDKHookResponseMessage,
+  SDKHookStartedMessage,
 } from '../types.js';
 import { AbortError } from '../errors.js';
 import type { AggregatedHookResult, HookRunner } from '../internal/contracts.js';
@@ -36,13 +40,33 @@ import { matcherMatches } from './matcher.js';
 
 const DEFAULT_TIMEOUT_SECONDS = 60;
 
+/** hook_response.result carries a bounded JSON preview of the output. */
+const HOOK_RESULT_PREVIEW_CHARS = 500;
+
 export type HookRunnerConfig = {
   hooks: Options['hooks'];
   debug: (msg: string) => void;
+  /** v0.4: hook-lifecycle sink (options.includeHookEvents). When set, every
+   *  callback invocation emits a hook_started / hook_response pair (correlated
+   *  by hook_id) into the SDKMessage stream via the shared observability queue. */
+  onLifecycleEvent?: (msg: SDKHookStartedMessage | SDKHookResponseMessage) => void;
 };
 
 /** A promise that rejects when the signal aborts (used to bound callbacks
  *  that ignore their AbortSignal). Never resolves. */
+/** Bounded JSON preview of a hook output for hook_response.result. */
+function previewJson(value: unknown): string {
+  let text: string;
+  try {
+    text = JSON.stringify(value) ?? 'null';
+  } catch {
+    text = '[non-serializable hook output]';
+  }
+  return text.length > HOOK_RESULT_PREVIEW_CHARS
+    ? `${text.slice(0, HOOK_RESULT_PREVIEW_CHARS)}...`
+    : text;
+}
+
 function abortRejection(signal: AbortSignal): Promise<never> {
   return new Promise((_resolve, reject) => {
     if (signal.aborted) {
@@ -60,10 +84,14 @@ function abortRejection(signal: AbortSignal): Promise<never> {
 export class DefaultHookRunner implements HookRunner {
   private readonly hooks: NonNullable<Options['hooks']>;
   private readonly debug: (msg: string) => void;
+  private readonly onLifecycleEvent?: (
+    msg: SDKHookStartedMessage | SDKHookResponseMessage,
+  ) => void;
 
   constructor(cfg: HookRunnerConfig) {
     this.hooks = cfg.hooks ?? {};
     this.debug = cfg.debug;
+    this.onLifecycleEvent = cfg.onLifecycleEvent;
   }
 
   hasHooks(event: HookEvent): boolean {
@@ -121,6 +149,31 @@ export class DefaultHookRunner implements HookRunner {
     signal: AbortSignal,
   ): Promise<HookJSONOutput | undefined> {
     const combined = AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]);
+    // v0.4 lifecycle emission (includeHookEvents): one started/response pair
+    // per callback invocation, correlated by a fresh hook_id. Every hook input
+    // carries session_id (baseHookFields), read defensively anyway.
+    const hookId = this.onLifecycleEvent !== undefined ? randomUUID() : '';
+    const sessionId =
+      typeof (input as { session_id?: unknown }).session_id === 'string'
+        ? (input as { session_id: string }).session_id
+        : '';
+    this.onLifecycleEvent?.({
+      type: 'hook_started',
+      uuid: randomUUID(),
+      session_id: sessionId,
+      hook_id: hookId,
+      hook_event: event,
+    });
+    const respond = (fields: { result?: string; error?: string }): void => {
+      this.onLifecycleEvent?.({
+        type: 'hook_response',
+        uuid: randomUUID(),
+        session_id: sessionId,
+        hook_id: hookId,
+        hook_event: event,
+        ...fields,
+      });
+    };
     try {
       // The race bounds callbacks that ignore their signal: when the combined
       // signal fires, the callback's eventual result is discarded (detached).
@@ -128,6 +181,7 @@ export class DefaultHookRunner implements HookRunner {
         (async () => cb(input, toolUseID, { signal: combined }))(),
         abortRejection(combined),
       ]);
+      respond(result ? { result: previewJson(result) } : {});
       if (!result) return undefined; // void (or any falsy) output -> neutral
       if (result.async === true) {
         // Fire-and-forget output: already settled, but by contract it
@@ -138,6 +192,7 @@ export class DefaultHookRunner implements HookRunner {
       return result;
     } catch (err) {
       const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+      respond({ error: msg });
       this.debug(`hooks(${event}): callback failed or timed out, ignored (${msg})`);
       return undefined;
     }

--- a/projects/bpt-agent-sdk/src/internal/contracts.ts
+++ b/projects/bpt-agent-sdk/src/internal/contracts.ts
@@ -25,6 +25,7 @@ import type {
   PermissionMode,
   PermissionUpdate,
   RawMessageStreamEvent,
+  SDKMessage,
   SDKPermissionDenial,
   TextBlockParam,
   ThinkingConfigParam,
@@ -343,6 +344,12 @@ export type EngineDeps = {
   /** Root loop only: pull completed background-subagent results to append to
    *  the current tool_result user turn. Returns [] when none pending. */
   drainSubagentResults?: () => TextBlockParam[];
+  /** v0.4 observability drain: pull buffered task_* / hook_* lifecycle
+   *  messages (produced by the subagent runtime + hook runner, which cannot
+   *  yield) so the loop can surface them at message boundaries. The queue is
+   *  shared with the query layer, which drains it at its own yield points;
+   *  splice-style — each buffered message is returned exactly once. */
+  drainObservability?: () => SDKMessage[];
 };
 
 // ---------------------------------------------------------------------------

--- a/projects/bpt-agent-sdk/src/permissions/rules.ts
+++ b/projects/bpt-agent-sdk/src/permissions/rules.ts
@@ -63,6 +63,8 @@ function splitMcpName(qualified: string): { server: string; tool: string } | und
  *
  * Supported forms:
  *   - exact name (`Bash`, `mcp__srv__tool`)
+ *   - `*`              -> every tool (v0.4; official deny-position glob)
+ *   - `mcp__*`         -> every MCP tool of every server (v0.4)
  *   - `mcp__server__*` -> any tool of that MCP server
  *   - `mcp__server`    -> shorthand for the same server-wide wildcard
  *
@@ -73,7 +75,13 @@ function splitMcpName(qualified: string): { server: string; tool: string } | und
  */
 export function matchToolName(pattern: string, toolName: string): boolean {
   if (pattern === toolName) return true;
+  // Global glob: matches every tool. Primarily a deny-position form
+  // (disallowedTools: ['*']); matchToolName is shared, so it works in allow
+  // position too, mirroring the official rule surface.
+  if (pattern === '*') return true;
   if (!pattern.startsWith('mcp__')) return false;
+  // All-MCP glob: any tool that is mcp__X__Y-shaped, regardless of server.
+  if (pattern === 'mcp__*') return splitMcpName(toolName) !== undefined;
 
   // Resolve the server this pattern scopes to (server-wide wildcard forms).
   const patternServer = pattern.endsWith('__*')

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -107,7 +107,6 @@ const ACCEPTED_OPTION_KEYS: readonly string[] = [
   'promptSuggestions',
   'agentProgressSummaries',
   'forwardSubagentText',
-  'includeHookEvents',
   'title',
   'resumeSessionAt',
   'debugFile',
@@ -397,7 +396,22 @@ export function query(args: {
     canUseTool: options.canUseTool,
     debug,
   });
-  const hooks = new DefaultHookRunner({ hooks: options.hooks, debug });
+  // v0.4 observability queue: the subagent runtime (task_* lifecycle) and the
+  // hook runner (hook_started/hook_response, behind includeHookEvents) cannot
+  // yield into the stream, so they push here; the engine loop and this layer's
+  // message pump drain it at message boundaries. Single queue, splice-drained:
+  // each event surfaces exactly once, in production order.
+  const obsQueue: SDKMessage[] = [];
+  const emitObs = (msg: SDKMessage): void => {
+    obsQueue.push(msg);
+  };
+  const drainObservability = (): SDKMessage[] => obsQueue.splice(0, obsQueue.length);
+
+  const hooks = new DefaultHookRunner({
+    hooks: options.hooks,
+    debug,
+    onLifecycleEvent: options.includeHookEvents === true ? emitObs : undefined,
+  });
 
   // Bare-name disallowedTools entries (no `Tool(spec)` specifier) REMOVE the
   // tool definition from the model request entirely (audit v0.1.1 P0): the
@@ -533,6 +547,7 @@ export function query(args: {
     outerSignal: outer.signal,
     sessionId: () => resolvedSessionId,
     debug,
+    emitObservability: emitObs,
   });
 
   // --- Input queue (unified for string and streaming-input modes) -----------
@@ -771,6 +786,8 @@ export function query(args: {
       session_id: sessionId,
       is_error: true,
       errorMessage,
+      // Official-surface parallel of errorMessage (reference SDK: string[]).
+      errors: [errorMessage],
       ...resultCommon(),
     });
 
@@ -834,6 +851,11 @@ export function query(args: {
       if (store instanceof MirroringSessionStore) {
         for (const e of store.takePendingEvents()) yield e;
       }
+    };
+
+    /** v0.4: flush buffered task/hook lifecycle events into the stream. */
+    const drainObs = function* (): Generator<SDKMessage> {
+      for (const m of drainObservability()) yield m;
     };
 
     /** Rewrite an engine-turn result to report session-cumulative totals. */
@@ -941,6 +963,9 @@ export function query(args: {
       });
       yield initMessage;
       yield* drainMirror();
+      // SessionStart hook lifecycle events (includeHookEvents) surface right
+      // after init — they fired before the stream had anywhere to go.
+      yield* drainObs();
 
       if (sessionStartBlocked !== undefined) {
         yield blockedResult(sess.sessionId, sessionStartBlocked);
@@ -1096,6 +1121,7 @@ export function query(args: {
           debug,
           requestView,
           drainSubagentResults: () => subagentRuntime.drainCompletedResults(),
+          drainObservability,
         };
 
         // The engine appends assistant + tool_result-user messages to `history`
@@ -1127,6 +1153,7 @@ export function query(args: {
           for await (const msg of runAgentLoop(history, deps, engineConfig)) {
             yield* flushToolResultUsers();
             yield* drainMirror();
+            yield* drainObs();
             if (msg.type === 'assistant') {
               persistAssistant(sess.sessionId, msg.message.content);
               yield msg;
@@ -1142,6 +1169,9 @@ export function query(args: {
           }
           yield* flushToolResultUsers();
           yield* drainMirror();
+          // Trailing lifecycle events (a background subagent that finished as
+          // the turn ended, Stop-hook responses) surface before the next turn.
+          yield* drainObs();
         } catch (err) {
           // Persist (but do not re-yield on error) any trailing tool_result
           // user turn so the transcript stays durable across the failure.

--- a/projects/bpt-agent-sdk/src/subagents/runtime.ts
+++ b/projects/bpt-agent-sdk/src/subagents/runtime.ts
@@ -35,6 +35,11 @@ import type {
   McpServerStatus,
   ModelUsage,
   NonNullableUsage,
+  SDKMessage,
+  SDKTaskNotificationMessage,
+  SDKTaskProgressMessage,
+  SDKTaskStartedMessage,
+  SDKTaskUpdatedMessage,
   TextBlockParam,
 } from '../types.js';
 import type {
@@ -114,7 +119,26 @@ export type SubagentRuntimeOptions = {
   /** Resolved session id at spawn time (for hook input). */
   sessionId: () => string;
   debug: (msg: string) => void;
+  /** v0.4 task-lifecycle sink: task_started / task_progress / task_updated /
+   *  task_notification messages are pushed here (the runtime cannot yield);
+   *  the query layer drains them into the SDKMessage stream. */
+  emitObservability?: (msg: SDKMessage) => void;
 };
+
+/** task_updated.result carries a bounded preview, not the full child text
+ *  (the full text already crosses via the Agent tool_result). */
+const TASK_RESULT_PREVIEW_CHARS = 500;
+
+type TaskLifecycleMessage =
+  | SDKTaskStartedMessage
+  | SDKTaskProgressMessage
+  | SDKTaskUpdatedMessage
+  | SDKTaskNotificationMessage;
+
+/** Omit that distributes over a union (plain Omit collapses to common keys). */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
 
 const zeroUsage = (): NonNullableUsage => ({
   input_tokens: 0,
@@ -204,8 +228,36 @@ export function createSubagentRuntime(
     outerSignal,
     sessionId,
     debug,
+    emitObservability,
   } = opts;
   const persist = opts.persist === true && store !== undefined;
+
+  // --- Task-lifecycle observability (v0.4) ----------------------------------
+  const emitTask = (
+    msg: DistributiveOmit<TaskLifecycleMessage, 'uuid' | 'session_id'>,
+  ): void => {
+    if (emitObservability === undefined) return;
+    emitObservability({
+      ...msg,
+      uuid: randomUUID(),
+      session_id: sessionId(),
+    } as TaskLifecycleMessage);
+  };
+  const resultPreview = (text: string): string =>
+    text.length > TASK_RESULT_PREVIEW_CHARS
+      ? `${text.slice(0, TASK_RESULT_PREVIEW_CHARS)}...`
+      : text;
+  /** Terminal task_updated for a finished (non-cancelled) child. */
+  const emitTaskFinished = (agentId: string, res: { text: string; isError: boolean }): void => {
+    emitTask({
+      type: 'task_updated',
+      task_id: agentId,
+      status: res.isError ? 'failed' : 'completed',
+      ...(res.isError
+        ? { error: resultPreview(res.text) }
+        : { result: resultPreview(res.text) }),
+    });
+  };
 
   // Bare-name (no `Tool(spec)` specifier) parent disallow patterns propagate to
   // child tool-set filtering, so a fully-denied parent tool never re-surfaces
@@ -420,9 +472,21 @@ export function createSubagentRuntime(
     let lastText = '';
     let sawError = false;
     let errMsg: string | undefined;
+    // task_progress: turn-budget share consumed. The child's maxTurns is always
+    // resolved by spawn() (agentDef -> parent -> DEFAULT), so the denominator
+    // is a real cap, not a guess; capped at 99 (100 is the terminal update's).
+    const turnCap = config.maxTurns ?? DEFAULT_SUBAGENT_MAX_TURNS;
+    let childTurns = 0;
 
     for await (const msg of runAgentLoop(history, deps, config)) {
       if (msg.type === 'assistant') {
+        childTurns += 1;
+        emitTask({
+          type: 'task_progress',
+          task_id: agentId,
+          progress: Math.min(99, Math.floor((childTurns / turnCap) * 100)),
+          status: `turn ${childTurns}/${turnCap}`,
+        });
         const t = concatText(msg.message.content);
         if (t.length > 0) lastText = t;
         if (persist && store !== undefined) {
@@ -492,6 +556,12 @@ export function createSubagentRuntime(
       const agentId = randomUUID();
       const childDepth = depth + 1;
 
+      emitTask({
+        type: 'task_started',
+        task_id: agentId,
+        task_name: params.description ?? resolved.type,
+        agent_id: agentId,
+      });
       await fireSubagentStart(agentId, params.subagentType, params.signal);
 
       // Background is a depth-0-only feature (keeps the drain wiring root-only).
@@ -583,11 +653,36 @@ export function createSubagentRuntime(
                 `[background subagent '${resolved.type}' (agentId: ${agentId}) ` +
                 `completed]\n${result.text}`,
             });
+            emitTaskFinished(agentId, result);
+            emitTask({
+              type: 'task_notification',
+              task_id: agentId,
+              event: result.isError ? 'failed' : 'completed',
+              message: `background subagent '${resolved.type}' ${result.isError ? 'failed' : 'completed'}`,
+            });
           } catch (err) {
             debug(
               `background subagent ${agentId} failed: ` +
                 `${err instanceof Error ? err.message : String(err)}`,
             );
+            // An abort here is a stopTask()/query-close cancellation whose
+            // lifecycle events are emitted at the cancellation site; only a
+            // real failure is reported as failed.
+            if (!isAbortError(err)) {
+              const message = err instanceof Error ? err.message : String(err);
+              emitTask({
+                type: 'task_updated',
+                task_id: agentId,
+                status: 'failed',
+                error: resultPreview(message),
+              });
+              emitTask({
+                type: 'task_notification',
+                task_id: agentId,
+                event: 'failed',
+                message: `background subagent '${resolved.type}' failed: ${resultPreview(message)}`,
+              });
+            }
           } finally {
             backgroundTasks.delete(agentId);
             // Fresh signal: the stop hook must fire even after an outer abort.
@@ -616,6 +711,7 @@ export function createSubagentRuntime(
         childConfig,
         agentId,
       );
+      emitTaskFinished(agentId, result);
       await fireSubagentStop(agentId, resolved.type, params.signal);
       return {
         content: `${result.text}\n\nagentId: ${agentId}`,
@@ -641,6 +737,13 @@ export function createSubagentRuntime(
       }
       task.controller.abort();
       backgroundTasks.delete(taskId);
+      emitTask({ type: 'task_updated', task_id: taskId, status: 'cancelled' });
+      emitTask({
+        type: 'task_notification',
+        task_id: taskId,
+        event: 'stopped',
+        message: `background subagent "${taskId}" stopped via stopTask`,
+      });
       debug(`stopTask: aborted background subagent "${taskId}"`);
     },
     abortAll(): void {

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -721,6 +721,9 @@ export type Options = {
   fallbackModel?: string;
   forkSession?: boolean;
   hooks?: Partial<Record<HookEvent, HookCallbackMatcher[]>>;
+  /** v0.4: surface hook execution as hook_started / hook_response stream
+   *  messages (default false; hooks otherwise report via debug only). */
+  includeHookEvents?: boolean;
   includePartialMessages?: boolean;
   maxBudgetUsd?: number;
   maxThinkingTokens?: number;
@@ -907,6 +910,9 @@ export type SDKResultMessage =
       modelUsage: Record<string, ModelUsage>;
       permission_denials: SDKPermissionDenial[];
       errorMessage?: string;
+      /** Official-surface parallel of errorMessage (the reference SDK reports
+       *  error text as a string[]); always [errorMessage] in this engine. */
+      errors?: string[];
       /** HTTP status when the run ended on an API error (e.g. 429, 529). */
       api_error_status?: number;
       /** Time to first token (ms); only present when a token actually arrived. */
@@ -960,11 +966,14 @@ export type SDKCompactBoundaryMessage = {
 // which stays a `system` subtype since `system/status` is its canonical form.
 // Every message carries our house `uuid`/`session_id` envelope.
 //
-// EMITTED by this engine today: SDKPermissionDeniedMessage (on a gate deny).
-// The rest are TYPED for union exhaustiveness but have no source event in a
-// headless engine with no plugins/skills/CC-host/background-task framework; see
-// docs/COMPAT.md for the emitted-vs-typed split. Field shapes the official
-// leaves undocumented are a self-consistent clean-room reconstruction.
+// EMITTED by this engine today: permission_denied (gate deny), rate_limit_event
+// / api_retry (transport retries, v0.3), task_started / task_progress /
+// task_updated / task_notification (subagent lifecycle, v0.4), hook_started /
+// hook_response (hook lifecycle behind includeHookEvents, v0.4). The rest are
+// TYPED for union exhaustiveness but have no source event in a headless engine
+// with no plugins/skills/CC-host/slash-command framework; see docs/COMPAT.md
+// for the emitted-vs-typed split. Field shapes the official leaves
+// undocumented are a self-consistent clean-room reconstruction.
 // ---------------------------------------------------------------------------
 
 /** A tool call the permission gate denied. EMITTED on every gate deny. */
@@ -1002,7 +1011,8 @@ export type SDKToolUseSummaryMessage = {
   result_summary: string;
 };
 
-/** A background task / subagent started. Typed; not emitted. */
+/** A background task / subagent started. EMITTED (v0.4) when the Agent tool
+ *  spawns a subagent (foreground or background); task_id is the agentId. */
 export type SDKTaskStartedMessage = {
   type: 'task_started';
   uuid: string;
@@ -1012,7 +1022,9 @@ export type SDKTaskStartedMessage = {
   agent_id?: string;
 };
 
-/** Progress from a background task / subagent. Typed; not emitted. */
+/** Progress from a background task / subagent. EMITTED (v0.4) once per child
+ *  assistant turn; `progress` is the share of the child's turn budget consumed
+ *  (0..99), `status` is a human-readable `turn N/M`. */
 export type SDKTaskProgressMessage = {
   type: 'task_progress';
   uuid: string;
@@ -1024,7 +1036,9 @@ export type SDKTaskProgressMessage = {
   blocked?: boolean;
 };
 
-/** Terminal update for a background task / subagent. Typed; not emitted. */
+/** Terminal update for a background task / subagent. EMITTED (v0.4) when a
+ *  subagent finishes (completed/failed) or is stopped via stopTask (cancelled);
+ *  `result` carries a bounded prefix of the child's final text. */
 export type SDKTaskUpdatedMessage = {
   type: 'task_updated';
   uuid: string;
@@ -1035,7 +1049,8 @@ export type SDKTaskUpdatedMessage = {
   error?: string;
 };
 
-/** Background-task lifecycle notification. Typed; not emitted. */
+/** Background-task lifecycle notification. EMITTED (v0.4) for BACKGROUND
+ *  subagents only (their terminal event otherwise has no stream anchor). */
 export type SDKTaskNotificationMessage = {
   type: 'task_notification';
   uuid: string;
@@ -1045,7 +1060,8 @@ export type SDKTaskNotificationMessage = {
   message?: string;
 };
 
-/** Hook execution began (gated by includeHookEvents). Typed; not emitted. */
+/** Hook execution began. EMITTED (v0.4) per hook callback invocation when
+ *  options.includeHookEvents is true; hook_id pairs it with its hook_response. */
 export type SDKHookStartedMessage = {
   type: 'hook_started';
   uuid: string;
@@ -1054,7 +1070,8 @@ export type SDKHookStartedMessage = {
   hook_event: HookEvent;
 };
 
-/** Hook execution progress (gated by includeHookEvents). Typed; not emitted. */
+/** Hook execution progress. Typed; not emitted (callbacks are opaque
+ *  promises — there is no honest mid-callback progress source). */
 export type SDKHookProgressMessage = {
   type: 'hook_progress';
   uuid: string;
@@ -1065,7 +1082,8 @@ export type SDKHookProgressMessage = {
   status?: string;
 };
 
-/** Hook execution finished (gated by includeHookEvents). Typed; not emitted. */
+/** Hook execution finished. EMITTED (v0.4) when options.includeHookEvents is
+ *  true; `result` is the callback output as JSON, `error` the failure/timeout. */
 export type SDKHookResponseMessage = {
   type: 'hook_response';
   uuid: string;
@@ -1106,8 +1124,8 @@ export type SDKCommandsChangedMessage = {
   available_commands: SlashCommand[];
 };
 
-/** A rate limit was hit and a retry scheduled. Typed; not emitted (the
- * transport retries internally and surfaces attempts via the debug callback). */
+/** A rate limit was hit and a retry scheduled. EMITTED (v0.3) via the
+ *  transport's per-request onRetry observer on each 429 retry. */
 export type SDKRateLimitEventMessage = {
   type: 'rate_limit_event';
   uuid: string;
@@ -1117,7 +1135,8 @@ export type SDKRateLimitEventMessage = {
   requests_remaining?: number;
 };
 
-/** An API call is being retried. Typed; not emitted (see rate_limit_event). */
+/** An API call is being retried. EMITTED (v0.3) via the transport's onRetry
+ *  observer on each non-429 (5xx/network) retry. */
 export type SDKApiRetryMessage = {
   type: 'api_retry';
   uuid: string;

--- a/projects/bpt-agent-sdk/tests/observability-v04.test.ts
+++ b/projects/bpt-agent-sdk/tests/observability-v04.test.ts
@@ -1,0 +1,434 @@
+/**
+ * v0.4 — lifecycle emission + contract-alignment increments.
+ *
+ *  1. Subagent task lifecycle: task_started / task_progress / task_updated
+ *     (foreground + background) and task_notification (background only) are
+ *     EMITTED, both at the runtime seam and end-to-end through the stream.
+ *  2. Hook lifecycle: hook_started / hook_response pairs behind
+ *     options.includeHookEvents (off by default).
+ *  3. Error results carry the official-parallel `errors: string[]`.
+ *  4. matchToolName supports the `*` and `mcp__*` globs (deny-position use).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+
+import { query } from '../src/index.js';
+import type {
+  AgentDefinition,
+  Options,
+  SDKMessage,
+  SDKResultMessage,
+  SDKTaskProgressMessage,
+  SDKTaskStartedMessage,
+  SDKTaskUpdatedMessage,
+} from '../src/index.js';
+import type {
+  BuiltinTool,
+  EngineConfig,
+  RawMessageStreamEvent,
+  SpawnSubagentParams,
+} from '../src/internal/contracts.js';
+import type { RawMessageStreamEvent as RawEvent } from '../src/types.js';
+import { createSubagentRuntime } from '../src/subagents/runtime.js';
+import type { SubagentRuntimeOptions } from '../src/subagents/runtime.js';
+import { DefaultHookRunner } from '../src/hooks/runner.js';
+import { DefaultPermissionGate } from '../src/permissions/gate.js';
+import { matchToolName } from '../src/permissions/rules.js';
+import { MockTransport, textReplyEvents, toolUseReplyEvents } from './helpers/mock-transport.js';
+import { makeSSEFetch } from './helpers/sse-fetch.js';
+import type { CallToolResult, McpResource, McpResourceContent, McpServerStatus } from '../src/types.js';
+import type { McpRegistry, McpSetServersResult, McpToolEntry } from '../src/internal/contracts.js';
+import type { McpServerConfig } from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Harnesses
+// ---------------------------------------------------------------------------
+
+class FakeMcp implements McpRegistry {
+  async connectAll(): Promise<void> {}
+  statuses(): McpServerStatus[] {
+    return [];
+  }
+  allTools(): McpToolEntry[] {
+    return [];
+  }
+  has(): boolean {
+    return false;
+  }
+  async call(): Promise<CallToolResult> {
+    throw new Error('no tools');
+  }
+  async listResources(): Promise<McpResource[]> {
+    return [];
+  }
+  async readResource(): Promise<McpResourceContent[]> {
+    return [];
+  }
+  async reconnect(): Promise<void> {}
+  setEnabled(): void {}
+  async setServers(_servers: Record<string, McpServerConfig>): Promise<McpSetServersResult> {
+    return { added: [], removed: [], updated: [], statuses: [] };
+  }
+  async closeAll(): Promise<void> {}
+}
+
+function makeRuntime(cfg: {
+  scripts: Array<RawEvent[] | (() => RawEvent[])>;
+  agents?: Record<string, AgentDefinition>;
+  engineConfig?: Partial<EngineConfig>;
+}) {
+  const transport = new MockTransport(cfg.scripts as RawEvent[][]);
+  const emitted: SDKMessage[] = [];
+  const engineConfig: EngineConfig = {
+    model: 'claude-sonnet-4-5',
+    maxOutputTokens: 1024,
+    systemPrompt: 'parent',
+    includePartialMessages: false,
+    sessionId: 'parent-sess',
+    cwd: '/tmp/obs-v04-test',
+    ...cfg.engineConfig,
+  };
+  const opts: SubagentRuntimeOptions = {
+    agents: cfg.agents ?? {},
+    baseBuiltins: new Map<string, BuiltinTool>(),
+    mcp: new FakeMcp(),
+    transport,
+    hooks: new DefaultHookRunner({ hooks: {}, debug: () => {} }),
+    parentGate: new DefaultPermissionGate({ debug: () => {} }),
+    engineConfig,
+    cwd: '/tmp/obs-v04-test',
+    env: {},
+    additionalDirectories: [],
+    outerSignal: new AbortController().signal,
+    sessionId: () => engineConfig.sessionId,
+    debug: () => {},
+    emitObservability: (m) => emitted.push(m),
+  };
+  return { runtime: createSubagentRuntime(opts), emitted, transport };
+}
+
+const baseParams = (over: Partial<SpawnSubagentParams> = {}): SpawnSubagentParams => ({
+  subagentType: 'general-purpose',
+  prompt: 'do the task',
+  toolUseId: '',
+  signal: new AbortController().signal,
+  ...over,
+});
+
+async function tick(n: number): Promise<void> {
+  for (let i = 0; i < n; i++) await new Promise((r) => setTimeout(r, 1));
+}
+
+function ofType<T extends SDKMessage['type']>(
+  msgs: SDKMessage[],
+  type: T,
+): Array<Extract<SDKMessage, { type: T }>> {
+  return msgs.filter((m): m is Extract<SDKMessage, { type: T }> => m.type === type);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Task lifecycle — runtime seam
+// ---------------------------------------------------------------------------
+
+describe('v0.4 task lifecycle (runtime)', () => {
+  it('foreground: task_started -> task_progress -> task_updated(completed)', async () => {
+    const h = makeRuntime({ scripts: [textReplyEvents('child answer')] });
+    const res = await h.runtime.makeSpawnFn(0)(
+      baseParams({ description: 'my delegated task' }),
+    );
+    expect(res.isError).toBe(false);
+
+    const started = ofType(h.emitted, 'task_started');
+    expect(started).toHaveLength(1);
+    expect(started[0]!.task_name).toBe('my delegated task');
+    expect(started[0]!.task_id).toBe(res.agentId);
+    expect(started[0]!.session_id).toBe('parent-sess');
+
+    const progress = ofType(h.emitted, 'task_progress');
+    expect(progress.length).toBeGreaterThanOrEqual(1);
+    expect(progress[0]!.task_id).toBe(res.agentId);
+    expect(progress[0]!.progress).toBeGreaterThanOrEqual(0);
+    expect(progress[0]!.progress).toBeLessThanOrEqual(99);
+    expect(progress[0]!.status).toMatch(/^turn 1\/\d+$/);
+
+    const updated = ofType(h.emitted, 'task_updated');
+    expect(updated).toHaveLength(1);
+    expect(updated[0]!.status).toBe('completed');
+    expect(updated[0]!.result).toBe('child answer');
+
+    // Foreground children never notify (their result returns inline).
+    expect(ofType(h.emitted, 'task_notification')).toHaveLength(0);
+
+    // Ordering: started before progress before updated.
+    const order = h.emitted.map((m) => m.type);
+    expect(order.indexOf('task_started')).toBeLessThan(order.indexOf('task_progress'));
+    expect(order.indexOf('task_progress')).toBeLessThan(order.indexOf('task_updated'));
+  });
+
+  it('task_name falls back to the resolved agent type without a description', async () => {
+    const h = makeRuntime({ scripts: [textReplyEvents('ok')] });
+    await h.runtime.makeSpawnFn(0)(baseParams());
+    expect(ofType(h.emitted, 'task_started')[0]!.task_name).toBe('general-purpose');
+  });
+
+  it('background: terminal task_updated + task_notification(completed)', async () => {
+    const h = makeRuntime({
+      scripts: [textReplyEvents('bg result')],
+      agents: { worker: { description: 'w', prompt: 'work', background: true } },
+    });
+    const res = await h.runtime.makeSpawnFn(0)(baseParams({ subagentType: 'worker' }));
+    expect(res.background).toBe(true);
+
+    // Started is synchronous with the spawn; the terminal events land when the
+    // detached child finishes.
+    expect(ofType(h.emitted, 'task_started')).toHaveLength(1);
+    for (let i = 0; i < 200 && ofType(h.emitted, 'task_notification').length === 0; i++) {
+      await tick(1);
+    }
+    const updated = ofType(h.emitted, 'task_updated');
+    expect(updated).toHaveLength(1);
+    expect(updated[0]!.status).toBe('completed');
+    expect(updated[0]!.result).toBe('bg result');
+    const notes = ofType(h.emitted, 'task_notification');
+    expect(notes).toHaveLength(1);
+    expect(notes[0]!.event).toBe('completed');
+    expect(notes[0]!.task_id).toBe(res.agentId);
+  });
+
+  it('stopTask: task_updated(cancelled) + task_notification(stopped), no failed double-report', async () => {
+    // The child's (only) stream call hangs on the outer signal via a script
+    // function that defers until abort: simulate with a script whose events are
+    // produced lazily AFTER stopTask by never being consumed — instead, use a
+    // long child (many turns) and stop it between turns.
+    const h = makeRuntime({
+      scripts: [
+        toolUseReplyEvents('NoSuchTool', {}),
+        textReplyEvents('late'),
+      ],
+      agents: { worker: { description: 'w', prompt: 'work', background: true } },
+    });
+    const res = await h.runtime.makeSpawnFn(0)(baseParams({ subagentType: 'worker' }));
+    h.runtime.stopTask(res.agentId);
+    await tick(20);
+
+    const updated = ofType(h.emitted, 'task_updated');
+    const cancelled = updated.filter((u) => u.status === 'cancelled');
+    expect(cancelled).toHaveLength(1);
+    expect(cancelled[0]!.task_id).toBe(res.agentId);
+    const notes = ofType(h.emitted, 'task_notification');
+    expect(notes.some((n) => n.event === 'stopped')).toBe(true);
+    // The aborted child must NOT also surface as failed.
+    expect(updated.filter((u) => u.status === 'failed')).toHaveLength(0);
+  });
+
+  it('task_updated.result is bounded to a preview', async () => {
+    const long = 'x'.repeat(2000);
+    const h = makeRuntime({ scripts: [textReplyEvents(long)] });
+    await h.runtime.makeSpawnFn(0)(baseParams());
+    const updated = ofType(h.emitted, 'task_updated')[0]!;
+    expect(updated.result!.length).toBeLessThanOrEqual(503); // 500 + '...'
+    expect(updated.result!.startsWith('xxx')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2-4. Query-level: stream ordering, hook lifecycle, errors[], globs
+// ---------------------------------------------------------------------------
+
+let sandbox: string;
+
+beforeEach(() => {
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'bpt-obs-v04-'));
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+async function collect(q: AsyncGenerator<SDKMessage, void>): Promise<SDKMessage[]> {
+  const out: SDKMessage[] = [];
+  for await (const m of q) out.push(m);
+  return out;
+}
+
+function opts(extra: Partial<Options> = {}): Options {
+  return {
+    provider: { apiKey: 'test-key', promptCaching: false },
+    sessionDir: path.join(sandbox, '.sessions'),
+    cwd: sandbox,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    ...extra,
+  } as Options;
+}
+
+describe('v0.4 task lifecycle (end-to-end stream)', () => {
+  it('a foreground Agent call surfaces task_* in the stream, before the result', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeSSEFetch([
+        toolUseReplyEvents('Agent', {
+          description: 'sub work',
+          prompt: 'do the sub work',
+          subagent_type: 'general-purpose',
+        }),
+        textReplyEvents('child says hi'),
+        textReplyEvents('parent done'),
+      ]),
+    );
+    const messages = await collect(
+      query({ prompt: 'go', options: opts({ allowedTools: ['Agent'] }) }),
+    );
+
+    const started = ofType(messages, 'task_started');
+    expect(started).toHaveLength(1);
+    expect(started[0]!.task_name).toBe('sub work');
+    const updated = ofType(messages, 'task_updated');
+    expect(updated).toHaveLength(1);
+    expect(updated[0]!.status).toBe('completed');
+    expect(updated[0]!.result).toBe('child says hi');
+    expect(ofType(messages, 'task_progress').length).toBeGreaterThanOrEqual(1);
+
+    const types = messages.map((m) => m.type);
+    expect(types.indexOf('task_started')).toBeLessThan(types.indexOf('task_updated'));
+    expect(types.indexOf('task_updated')).toBeLessThan(types.indexOf('result'));
+
+    const result = ofType(messages, 'result')[0] as SDKResultMessage;
+    expect(result.subtype).toBe('success');
+  });
+});
+
+describe('v0.4 hook lifecycle (includeHookEvents)', () => {
+  const hookSet = () => ({
+    PreToolUse: [
+      {
+        hooks: [
+          async () => ({ systemMessage: 'seen' }),
+        ],
+      },
+    ],
+  });
+
+  it('emits hook_started/hook_response pairs when includeHookEvents is true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeSSEFetch([
+        toolUseReplyEvents('Glob', { pattern: '*.md' }),
+        textReplyEvents('done'),
+      ]),
+    );
+    const messages = await collect(
+      query({
+        prompt: 'go',
+        options: opts({ includeHookEvents: true, hooks: hookSet() }),
+      }),
+    );
+    const started = ofType(messages, 'hook_started');
+    const responded = ofType(messages, 'hook_response');
+    expect(started).toHaveLength(1);
+    expect(responded).toHaveLength(1);
+    expect(started[0]!.hook_event).toBe('PreToolUse');
+    expect(responded[0]!.hook_event).toBe('PreToolUse');
+    // Correlated by hook_id; response carries the output JSON.
+    expect(responded[0]!.hook_id).toBe(started[0]!.hook_id);
+    expect(responded[0]!.result).toContain('seen');
+    // Ordering: the pair surfaces before the terminal result.
+    const types = messages.map((m) => m.type);
+    expect(types.indexOf('hook_response')).toBeLessThan(types.indexOf('result'));
+  });
+
+  it('emits nothing without includeHookEvents (default off)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeSSEFetch([
+        toolUseReplyEvents('Glob', { pattern: '*.md' }),
+        textReplyEvents('done'),
+      ]),
+    );
+    const messages = await collect(
+      query({ prompt: 'go', options: opts({ hooks: hookSet() }) }),
+    );
+    expect(ofType(messages, 'hook_started')).toHaveLength(0);
+    expect(ofType(messages, 'hook_response')).toHaveLength(0);
+  });
+
+  it('a failing hook callback reports its error on hook_response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeSSEFetch([
+        toolUseReplyEvents('Glob', { pattern: '*.md' }),
+        textReplyEvents('done'),
+      ]),
+    );
+    const messages = await collect(
+      query({
+        prompt: 'go',
+        options: opts({
+          includeHookEvents: true,
+          hooks: {
+            PreToolUse: [
+              {
+                hooks: [
+                  async () => {
+                    throw new Error('boom');
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      }),
+    );
+    const responded = ofType(messages, 'hook_response');
+    expect(responded).toHaveLength(1);
+    expect(responded[0]!.error).toContain('boom');
+    expect(responded[0]!.result).toBeUndefined();
+  });
+});
+
+describe('v0.4 result.errors[] (official-surface parallel)', () => {
+  it('error results carry errors === [errorMessage]', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeSSEFetch([toolUseReplyEvents('Glob', { pattern: '*.md' })]),
+    );
+    const messages = await collect(
+      query({ prompt: 'go', options: opts({ maxTurns: 1 }) }),
+    );
+    const result = ofType(messages, 'result')[0] as SDKResultMessage;
+    expect(result.subtype).toBe('error_max_turns');
+    if (result.subtype !== 'success') {
+      expect(result.errors).toEqual([result.errorMessage]);
+    }
+  });
+});
+
+describe('v0.4 tool-name globs (* and mcp__*)', () => {
+  it('matchToolName supports the global and all-MCP globs', () => {
+    expect(matchToolName('*', 'Bash')).toBe(true);
+    expect(matchToolName('*', 'mcp__srv__tool')).toBe(true);
+    expect(matchToolName('mcp__*', 'mcp__srv__tool')).toBe(true);
+    expect(matchToolName('mcp__*', 'mcp__a__b__tool')).toBe(true);
+    expect(matchToolName('mcp__*', 'Bash')).toBe(false);
+    // Not mcp__X__Y-shaped -> not an MCP tool name.
+    expect(matchToolName('mcp__*', 'mcp__loneserver')).toBe(false);
+    // Existing server-scoped forms are unchanged.
+    expect(matchToolName('mcp__srv__*', 'mcp__srv__tool')).toBe(true);
+    expect(matchToolName('mcp__srv__*', 'mcp__other__tool')).toBe(false);
+  });
+
+  it("disallowedTools: ['*'] removes every built-in from the request", async () => {
+    vi.stubGlobal('fetch', makeSSEFetch([textReplyEvents('hi')]));
+    const messages = await collect(
+      query({ prompt: 'go', options: opts({ disallowedTools: ['*'] }) }),
+    );
+    const init = messages.find(
+      (m) => m.type === 'system' && (m as { subtype?: string }).subtype === 'init',
+    ) as { tools: string[] } | undefined;
+    expect(init).toBeDefined();
+    expect(init!.tools).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 概述

BPT Agent SDK v0.4：把观测臂中有真实事件源的变体从 TYPED 升级为 EMITTED（subagent 任务生命周期 + hook 生命周期），并收口两项契约对齐小项与 COMPAT.md 陈旧行对账。版本号 0.3.0 → 0.4.0。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [x] 文档完善（子项目 CONTEXT.md / docs/COMPAT.md / memory/project-status.md 对账）
- [ ] Bug 修复
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 其他（请说明）：bpt-agent-sdk 功能增量（观测消息真发射 + 权限规则 glob + result.errors 契约面）

### 明细

- **subagent 任务生命周期真发射**：`task_started`（spawn 时，task_name 取 Agent 调用的 description）/ `task_progress`（每个子代理 assistant 回合，按回合预算份额 0-99）/ `task_updated`（completed / failed / cancelled，带 500 字符结果预览）/ `task_notification`（仅后台子代理）。runtime 推入共享观测队列，engine loop 与 query 泵在消息边界排空。
- **hook 生命周期真发射**（`options.includeHookEvents` 门控，ACCEPTED → FULL）：每次 hook 回调调用发 `hook_started` / `hook_response` 成对消息（hook_id 关联；result 为有界输出 JSON，error 为失败/超时文本）。`hook_progress` 无诚实的回调中途进度源，保持 TYPED。
- **契约对齐**：error 结果臂补官方并行字段 `errors: string[]`（恒为 `[errorMessage]`）；工具名规则支持 `*` 与 `mcp__*` glob（deny / allow 位共用）。
- **对账修正**：COMPAT.md 中 `getSessionMessages` / `renameSession` / `tagSession` 与 canUseTool `suggestions` / `requestId` 标记为未实现属陈旧行——实际 v0.2 已落地，表已更正为与代码一致。

---

## 来源声明

- [x] 本 PR 涉及的数据可在以下公开来源查到：

  ```
  接口面对照公开文档 code.claude.com/docs/en/agent-sdk/*（净室纪律，零复制专有代码）；
  官方未记载的观测消息字段形状为自洽的 clean-room 重构（docs/COMPAT.md 已注明）。
  ```

- [ ] 翻译类 PR：不适用

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 所有引用素材均来自公开可查阅来源。
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**；本 PR 为纯工程代码，不含游戏资产。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 本地跑通对应校验：`npm run typecheck` + `npm run build` exit 0；`npx vitest run` **680/680 全绿**（19 文件，新增 `tests/observability-v04.test.ts` 12 用例）；仓库级 `pytest tests/` **2085 passed, 2 skipped**
- [ ] site / wiki / news 视觉：不涉及
- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`（仅按惯例更新 `memory/project-status.md` 状态段）

---

## 关联 Issue

- Refs：v0.3 收尾链 #384 / #388 / #391 / #394 的后续增量

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmxgzSjekoPJ2QbbuK7L5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDmxgzSjekoPJ2QbbuK7L5)_