### PR TITLE
fix(bpt-agent-sdk): live-smoke 与 ab-benchmark 日志补 errorMessage 诊断口

### DIFF
--- a/projects/bpt-agent-sdk/tests/integration/ab-benchmark.mjs
+++ b/projects/bpt-agent-sdk/tests/integration/ab-benchmark.mjs
@@ -212,6 +212,7 @@ async function runTask(task) {
     id: task.id,
     name: task.name,
     subtype: resultMsg?.subtype ?? 'no-result',
+    error: resultMsg?.errorMessage,
     passed: resultMsg?.subtype === 'success' && task.check(finalText, resultMsg) === true,
     turns: resultMsg?.num_turns ?? 0,
     costUsd: resultMsg?.total_cost_usd ?? 0,
@@ -236,6 +237,9 @@ for (const task of selected) {
     console.log(
       `${row.passed ? 'ok' : 'CHECK-FAILED'} turns=${row.turns} cost=$${row.costUsd.toFixed(4)}`,
     );
+    if (!row.passed && row.error !== undefined) {
+      console.log(`    error(${row.subtype}): ${row.error}`);
+    }
   } catch (err) {
     console.log(`ERROR ${err instanceof Error ? err.message : String(err)}`);
     rows.push({ id: task.id, name: task.name, subtype: 'harness-error', passed: false });

--- a/projects/bpt-agent-sdk/tests/integration/live-real-api.mjs
+++ b/projects/bpt-agent-sdk/tests/integration/live-real-api.mjs
@@ -110,6 +110,10 @@ try {
       if (m.subtype === 'success') {
         console.log(`[answer] ${m.result}`);
         ok = true;
+      } else if (m.errorMessage) {
+        // Diagnosis line: without this an API-side failure (401/billing/
+        // overloaded) is indistinguishable from an engine bug in the CI log.
+        console.log(`[error] ${m.errorMessage}${m.api_error_status !== undefined ? ` (HTTP ${m.api_error_status})` : ''}`);
       }
     }
   }


### PR DESCRIPTION
## 概述

dispatch 运行 #23 中 live-smoke 与 ab-benchmark 每次 API 调用约 250ms 即回 `error_during_execution`（零 token），但两脚本均未打印错误文本，无法区分 API 侧故障（401 / 余额 / overloaded）与引擎缺陷。本 PR 在非 success 结果上打印 `result.errorMessage`（含 `api_error_status`），共 8 行诊断代码。

---

## 变更类型

- [ ] 数据补全 / 翻译贡献 / 文档完善 / 视觉改进
- [x] Bug 修复（诊断可观测性缺口）

---

## 来源声明

- [x] 纯工程代码，无外部数据引用。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不含游戏资产。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `node --check` 两脚本语法通过；仅日志行变更，不涉运行时库代码，单测无涉
- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联 Issue

- Refs：run [#23](https://github.com/lightproud/brain-in-a-vat/actions/runs/28710322647) 失败诊断

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmxgzSjekoPJ2QbbuK7L5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDmxgzSjekoPJ2QbbuK7L5)_