### PR TITLE
fix(bpt-agent-sdk): live-smoke 第二阶段补 bypass 联锁参数

### DIFF
--- a/projects/bpt-agent-sdk/tests/integration/live-real-api.mjs
+++ b/projects/bpt-agent-sdk/tests/integration/live-real-api.mjs
@@ -144,6 +144,7 @@ try {
       cwd: sandbox,
       persistSession: false,
       permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true, // bypass interlock (v0.3 #385)
       model,
       maxTurns: 6,
     },


### PR DESCRIPTION
## 概述

换密钥后的 dispatch [run #27](https://github.com/lightproud/brain-in-a-vat/actions/runs/28710808706) 中 A/B benchmark **7/7 全过**（真 API 跑通），但 live-smoke 第二阶段（PDF document 块）抛 `ConfigurationError: bypassPermissions requires allowDangerouslySkipPermissions`——第一阶段设了联锁标志、第二阶段漏设。本 PR 补上，共 1 行。

---

## 变更类型

- [x] Bug 修复（测试脚本参数缺漏）

---

## 来源声明

- [x] 纯工程代码，无外部数据引用。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不含游戏资产。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `node --check` 语法通过；仅 live-smoke 脚本一行参数，运行时库无涉，单测无涉
- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联 Issue

- Refs：run #27 live-smoke 第二阶段失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmxgzSjekoPJ2QbbuK7L5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDmxgzSjekoPJ2QbbuK7L5)_