### PR TITLE
feat(bpt-agent-sdk): 官方 SDK 裸对比 job（速度 + 正确性）

### DIFF
--- a/.github/workflows/bpt-agent-sdk.yml
+++ b/.github/workflows/bpt-agent-sdk.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: boolean
         default: false
+      vs_official:
+        description: 'Head-to-head vs @anthropic-ai/claude-agent-sdk (speed + correctness; installs the official pkg --no-save, never a repo dependency)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: bpt-agent-sdk-${{ github.ref }}
@@ -125,5 +130,65 @@ jobs:
         if: always()
         with:
           name: ab-report
+          path: projects/bpt-agent-sdk/ab-report-*.json
+          if-no-files-found: ignore
+
+  vs-official:
+    # Head-to-head bare comparison against the OFFICIAL @anthropic-ai/
+    # claude-agent-sdk: same model, same 7 tasks, both engines. Measures the
+    # two objectively-comparable axes — response speed (wall-clock / API ms /
+    # TTFT) and output correctness (same check() pass-rate). Quality is NOT
+    # judged here (that axis is confounded by the proprietary system prompt —
+    # see docs/POSITIONING.md §2/§4).
+    #
+    # Clean-room discipline: the official package is installed with
+    # `npm i --no-save` for this run ONLY. It never enters package.json /
+    # package-lock.json and is never a dependency of this SDK. The official
+    # engine is treated purely as a black box we time and check — we read its
+    # INPUT/OUTPUT behavior, never its prompt text.
+    #
+    # The official SDK spawns the Claude Code CLI as its engine. If it cannot
+    # start headless, the official arm skips (exit 2) and the job reports the
+    # BPT numbers plus "official engine could not start" — itself a finding.
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.vs_official == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            /*
+            !/Public-Info-Pool/Record/
+            !/Public-Info-Pool/Reference/
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Install the official SDK (transient, --no-save, not a repo dep)
+        run: npm i --no-save @anthropic-ai/claude-agent-sdk @anthropic-ai/claude-code || echo "official install failed; the official arm will skip"
+      - name: Bare comparison — this SDK
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: node tests/integration/ab-benchmark.mjs --engine=bpt "--model=${{ github.event.inputs.model }}" --out=ab-report-bpt.json
+      - name: Bare comparison — official SDK (black box; may skip if CLI cannot start)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        continue-on-error: true
+        run: node tests/integration/ab-benchmark.mjs --engine=official "--model=${{ github.event.inputs.model }}" --out=ab-report-official.json
+      - name: Compare (skips gracefully if the official report is missing)
+        run: |
+          if [ -f ab-report-official.json ]; then
+            node tests/integration/ab-benchmark.mjs --compare ab-report-bpt.json ab-report-official.json
+          else
+            echo "No official report produced — the official engine did not run headless. BPT-only numbers are in ab-report-bpt.json."
+          fi
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: vs-official-report
           path: projects/bpt-agent-sdk/ab-report-*.json
           if-no-files-found: ignore

--- a/projects/bpt-agent-sdk/CONTEXT.md
+++ b/projects/bpt-agent-sdk/CONTEXT.md
@@ -93,6 +93,23 @@ shell（BashOutput 增量读 + 按行 filter / KillShell 击杀，进程组 SIGT
 已在干净目录实测安装 + import 通过。③ **A/B 测量线**（POSITIONING §7 测量强制令）：
 `tests/integration/ab-benchmark.mjs` 七任务代表集（含中文两项），产 JSON 报告 + offender 排序；
 挂 `bpt-agent-sdk.yml` 的 `ab_benchmark` dispatch 输入，报告作 artifact 上传。**691 单测全绿**。
+首轮真 API 实测（haiku，7/7 全过，$0.076/18 轮）：工具耗时全毫秒级、缓存命中 0%（短会话摊不平缓存写入溢价，
+实证 POSITIONING §6「缓存复利只在多轮长对话显现」），offender 头部为 4 轮写改类（轮数是成本主乘数）。
+
+**官方裸对比（v0.5+，守密人 2026-07-04「先跑裸对比」裁定）**：`bpt-agent-sdk.yml` 加 `vs-official` job
+（`vs_official` dispatch 输入）——同模型同 7 任务、本 SDK vs 官方 `@anthropic-ai/claude-agent-sdk` 两引擎各跑，
+`--compare` 出并排表。只比**客观两轴**：响应速度（墙钟/API ms/TTFT）+ 输出正确性（同 `check()` 通过率）；
+**质量不评判**（该轴被专有系统提示词混淆，属 POSITIONING §2/§4 结构性天花板）。官方包用 `npm i --no-save` 仅本次装、
+**绝不进 package.json/lockfile、绝不成本包依赖**（净室纪律）；官方引擎当**纯黑箱**计时+判分，读其输入输出行为、
+绝不读其提示词文本。官方 SDK 靠 spawn Claude Code CLI，无头 CI 起不来则官方臂跳过（exit 2），
+「官方引擎无头起不来」本身即结论（正是 BPT 换引擎的动机）。
+
+**Backlog（守密人「先存下来」，2026-07-04）——黑箱行为观测法收窄能力层差**：质量/行为差里，
+「能力层」（agent 环转数/决策对不对）可干净室安全地逼近官方，方法是**黑箱行为克隆**（Compaq 逆向 IBM BIOS 金标准）：
+跑官方当黑箱、只观测其输入→输出行为（选哪个工具/怎么分步/答案排版），据此**独立撰写本 SDK 自己的提示词**去逼近
+同样行为，全程不读官方提示词文本 + 拿自造提示词做 A/B 迭代爬坡。「秘方层」（专有提示词本体）仍是不可触碰的结构性天花板。
+**硬红线**：泄漏/流传的官方提示词文本一律不并入本仓（净室=MIT 合法性地基，泄漏≠公开文档，见 POSITIONING §2）。
+
 进度以 `memory/project-status.md` 为唯一权威。
 
 ## v0.2 候选

--- a/projects/bpt-agent-sdk/tests/integration/ab-benchmark.mjs
+++ b/projects/bpt-agent-sdk/tests/integration/ab-benchmark.mjs
@@ -51,10 +51,27 @@ if (!process.env.ANTHROPIC_API_KEY) {
   process.exit(2);
 }
 
-const sdk =
-  ENGINE === 'official'
-    ? await import('@anthropic-ai/claude-agent-sdk')
-    : await import('../../dist/index.js');
+// The official arm imports @anthropic-ai/claude-agent-sdk. It is NEVER a
+// dependency of this package (clean-room discipline); CI installs it with
+// `npm i --no-save` for the comparison run only. A missing package or a
+// CLI-startup failure is reported as a skip (exit 2), not a crash — "the
+// official engine could not start headless" is itself a finding (it is the
+// whole reason BPT needs this SDK).
+let sdk;
+if (ENGINE === 'official') {
+  try {
+    sdk = await import('@anthropic-ai/claude-agent-sdk');
+  } catch (err) {
+    console.log(
+      `ab-benchmark: could not load @anthropic-ai/claude-agent-sdk ` +
+        `(${err instanceof Error ? err.message : String(err)}); skipping the ` +
+        `official arm (exit 2). Install it with \`npm i --no-save\` for this run.`,
+    );
+    process.exit(2);
+  }
+} else {
+  sdk = await import('../../dist/index.js');
+}
 
 // --- Representative task set ---------------------------------------------------
 // Each task: fixture(dir) seeds files; prompt drives the model; check(text)


### PR DESCRIPTION
## 概述

按守密人「先跑裸对比」裁定，加官方 SDK 头对头对照 job。只比**客观两轴**：响应速度（墙钟/API ms/TTFT）+ 输出正确性（同 `check()` 通过率）。质量**不评判**——该轴被专有系统提示词混淆，属 POSITIONING §2/§4 结构性天花板。黑箱行为观测思路按守密人「先存下来」记入 CONTEXT.md backlog。

---

## 变更类型

- [x] 其他：bpt-agent-sdk 官方裸对比测量线 + CI job + backlog 存档

### 明细

- **新 `vs-official` workflow job**（`vs_official` dispatch 输入）：同模型同 7 任务、本 SDK vs 官方 `@anthropic-ai/claude-agent-sdk` 两引擎各跑，`--compare` 出并排表。
- **净室纪律守恒**：官方包用 `npm i --no-save` 仅本次装，**绝不进 package.json/lockfile、绝不成本包依赖**；官方引擎当**纯黑箱**计时+判分，读输入输出行为、绝不读提示词文本。
- **官方臂护栏**：import 失败或无头 CLI 起不来 → 优雅跳过（exit 2）带原因，不崩溃。「官方引擎无头起不来」本身即结论（正是 BPT 换引擎的动机）。
- **CONTEXT.md**：记首轮实测结论 + 存黑箱行为克隆 backlog，重申硬红线——泄漏/流传的官方提示词文本绝不并入本仓（泄漏≠公开文档）。

---

## 来源声明

- [x] 接口面对照公开文档；官方包仅 CI 运行期临时安装，不入仓、不成依赖。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不含游戏资产。**
- [x] **同意按 MIT License 提交贡献。** 净室纪律守恒：零复制专有代码/提示词。

---

## 验证清单

- [x] `node --check` benchmark 通过 + workflow YAML 解析通过；纯 CI/脚本变更，运行时库无涉，单测无涉
- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联 Issue

- Refs：A/B 测量线（#398）的官方对照臂

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDmxgzSjekoPJ2QbbuK7L5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDmxgzSjekoPJ2QbbuK7L5)_