### PR TITLE
docs(bpt): fold Claude Design into the Desktop UI structural spec + wireframe

### DIFF
--- a/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-structure-20260704.md
+++ b/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-structure-20260704.md
@@ -21,7 +21,7 @@
 | 维度 | 事实 |
 |------|------|
 | 形态 | 桌面应用（Electron 系），macOS（Universal dmg）/ Windows（x64 + ARM64 setup，另有企业 MSIX）/ Linux beta（apt / .deb） |
-| 顶层结构 | **三标签**：**Chat**（对话）/ **Cowork**（Dispatch 与长时 agent 工作）/ **Code**（软件开发）。标签是应用的最高层导航，三者共用账号与登录态 |
+| 顶层结构 | **三标签**：**Chat**（对话）/ **Cowork**（Dispatch 与长时 agent 工作）/ **Code**（软件开发）。标签是应用的最高层导航，三者共用账号与登录态。另有 **Claude Design**（Labs 研究预览）经侧栏入口进入独立工作区（详见 §6，其导航割裂是社区公认反面教材） |
 | 账号 | 启动即登录（订阅制 Pro / Max / Team / Enterprise；Code 标签必须付费订阅）；企业可强制 SSO（SAML / OIDC） |
 | 更新 | macOS / Windows 启动自更新 + 菜单「Check for Updates」（macOS 在 Claude 菜单、Windows 在 Help 菜单）；About 页版本号点击即复制 |
 | 通知 | OS 级桌面通知：Code 会话完成任务且用户不在看该会话时发；CI 结束时发；Dispatch 完成 / 需审批时推手机 |
@@ -243,7 +243,57 @@ mode、Auto mode 开关、Preview 总开关、Persist preview sessions。
 - Desktop 不做的事：`--print` 脚本化 / 无 headless、inline 补全、agent teams（CLI 专属）、
   终端对话框类命令（/permissions、/config、/doctor 在 Code 标签回「不可用」）
 
-## §6 可提炼的设计模式（给 BPT 的结构性启示）
+## §6 Claude Design（Labs 视觉工作区）【官方公告 + 产品页 + 帮助中心 + 社区来源】
+
+2026-04-17 发布的 Anthropic Labs 研究预览产品，视觉设计协作工作区（Opus 4.7 驱动）；
+Web 端在 `claude.ai/design`，桌面应用经**侧栏入口**进入。Pro / Max / Team / Enterprise 可用
+（Enterprise 默认关、管理员在组织设置启用）；**无独立额度**——与 Chat / Code / Cowork
+共享同一计划用量池（与 Code 标签用量环的「plan usage 全平台共享」同一设计）。
+
+### §6.1 入口画面【社区来源（带截图的第三方评测）】
+
+进入即选起点：**Prototype / Slide deck / From template / Other** 四选一，
+并选保真度档位：**rough wireframes**（粗线框）或 **high-fidelity mockups**（高保真、带真实品牌元素）。
+
+### §6.2 工作区布局【帮助中心】
+
+**双区结构：左侧聊天区 + 右侧画布（canvas）**——对话驱动生成，画布承载结果并可直接编辑。
+与 Chat 标签的 Artifacts 面板是同族范式（对话 + 并排产物面板），但这里产物面板升级为
+可操作的编辑器而非只读预览。
+
+### §6.3 画布编辑能力【帮助中心】
+
+- 直接操作：拖拽元素、调整大小、对齐
+- **rich layout controls**：间距 / 颜色 / 布局的实时调整旋钮；文字可直接改
+- **行内评论**：点画布任意部位留评论请求定向修改（已知缺陷：评论偶尔未被读取，
+  官方兜底建议是把评论粘回聊天框——「画布批注回灌对话」链路尚不可靠）
+- 版本：对话指令式保存（"Save what we have and try a completely different approach"），
+  无独立版本树 UI（与 Artifacts 的版本切换器不同）
+
+### §6.4 输入与品牌系统【官方公告 + 产品页】
+
+- 输入四路：文本提示 / 上传图片与文档（DOCX / PPTX / XLSX）/ 指向代码库 / 网页元素捕获工具
+- **设计系统集成**：扫描代码库与设计文件自动构建组织设计系统（颜色 / 排版 / 组件），
+  后续项目自动套用——「品牌一次导入、处处生效」
+- 产出谱系：交互原型、线框与高保真 mockup、幻灯片 / pitch deck、单页、营销素材，
+  以及代码驱动原型（语音 / 视频 / 着色器 / 3D / 内嵌 AI）
+
+### §6.5 导出与交接【帮助中心】
+
+右上角 **Export** 按钮：.zip / PDF / PPTX / 独立 HTML，及 Canva、Adobe、Base44、Gamma、
+Lovable、Miro、Replit、Vercel、Wix 等集成导出；**交接 Claude Code**（本地或 Web）——
+Code 侧有 `/design-sync` 命令同步设计交付包。分享走组织内链接，
+**查看 / 评论 / 编辑**三档权限，支持群组对话协作。
+
+### §6.6 桌面集成的反面教材【社区来源，2026-06】
+
+Design 并入桌面应用后的社区批评（r/claude，高热帖）：入口**藏两层深**，进入后是
+「完全另一个世界」，**无法直接回到 Chat / Cowork / Code**——顶层导航在 Design 内消失。
+这与三标签「一壳三模式、随时切换」的骨架相悖，是「新表面硬塞进成熟壳」的典型集成失败。
+对 BPT 的教训：**新增工作面必须挂在顶层导航同级，进得去也要一步出得来**；
+宁可标签多一个，不可让用户掉进无返回键的子世界。
+
+## §7 可提炼的设计模式（给 BPT 的结构性启示）
 
 1. **会话 = 一等资源**：会话自带环境 + 工作区 + 变更集 + 上下文，侧栏是资源管理器而非聊天历史。
    比 BPT 现有「单对话窗」模型高一个维度，是 Code 标签一切并行能力的地基。
@@ -260,8 +310,13 @@ mode、Auto mode 开关、Preview 总开关、Persist preview sessions。
 9. **渐进披露**：工具调用默认折叠摘要、点击展开；子代理进 tasks pane 不刷屏主流。
 10. **失败兜底分级**：computer use 的「精确工具优先、屏控兜底」+ 按 app 类别封顶权限——
     能力越广、默认权限越窄。
+11. **对话 + 可编辑画布双平面**（Claude Design）：产物面板从只读预览（Artifacts）进化为
+    直接编辑器（画布拖拽 / 旋钮微调 / 行内批注回灌对话）。BPT 若做 artifact 面板，
+    该演进方向值得预留——先只读，但布局上给「产物侧可交互」留位。
+12. **反模式——子世界无返回**（Design 集成失败，§6.6）：新表面不进顶层导航 = 用户迷路。
+    顶层导航必须全程可达。
 
-## §7 与 BPT/SDK 的落差清单（结构性差异，非逐件映射）
+## §8 与 BPT/SDK 的落差清单（结构性差异，非逐件映射）
 
 逐件 UI↔SDK 对接表见姊妹档案 `bpt-desktop-ui-reference-20260704.md` §5。本节只列
 Code 标签新观察到、上一档未覆盖的映射：
@@ -277,11 +332,12 @@ Code 标签新观察到、上一档未覆盖的映射：
 | 用量环 | `result.metrics`（SDKRunMetrics）现成 |
 | Computer use | SDK 不含屏控工具；属宿主自定义工具线（canUseTool + 自注册工具可承载） |
 | 云会话 / SSH 环境切换 | SDK 是进程内库，无远程执行面；BPT 如需要属宿主架构议题 |
+| Design 画布（对话 + 可编辑产物双平面） | SDK 无涉（产物生成走普通 assistant 输出）；画布编辑器属纯前端重投资，BPT 近期建议只做 Artifacts 级只读预览 + 按模式 11 留位 |
 
-## §8 残余盲区（本档案没拿到实锤的）
+## §9 残余盲区（本档案没拿到实锤的）
 
 - Chat 标签侧栏与设置页的**逐像素级**现状（§3 大半为训练期知识，2026 年内可能已改版）
-- Claude Design（2026-04 Labs 新入口，社区反馈称藏得深、与三标签导航割裂）未展开
+- Claude Design 桌面入口的精确位置与层级（§6.6 只有社区「藏两层深」定性描述，无官方导航文档）
 - Cowork 移动端（iOS/Android）界面
 - 各弹窗的精确文案与空态 / 错误态插画
 
@@ -289,4 +345,4 @@ Code 标签新观察到、上一档未覆盖的映射：
 
 ---
 
-*来源清单：code.claude.com/docs/en/desktop（全文）；claude.com/resources/tutorials/navigating-the-claude-desktop-app；support.claude.com articles 13345190（Cowork 入门）/ 13947068（Dispatch)/ 9487310（Artifacts）；claude.com/product/cowork；anthropic.com/engineering/desktop-extensions；claude.com/blog/claude-code-desktop-redesign（2026-04-14 重设计公告）。*
+*来源清单：code.claude.com/docs/en/desktop（全文）；claude.com/resources/tutorials/navigating-the-claude-desktop-app；support.claude.com articles 13345190（Cowork 入门）/ 13947068（Dispatch)/ 9487310（Artifacts）/ 14604416（Claude Design 入门）；claude.com/product/cowork；claude.com/product/design；anthropic.com/news/claude-design-anthropic-labs（2026-04-17 发布公告）；anthropic.com/engineering/desktop-extensions；claude.com/blog/claude-code-desktop-redesign（2026-04-14 重设计公告）；r/claude Design 桌面集成讨论（2026-06，仅 §6.6 定性引用）。*

--- a/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-wireframe-20260704.html
+++ b/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-wireframe-20260704.html
@@ -48,6 +48,7 @@
   <button class="on" data-t="chat">Chat</button>
   <button data-t="cowork">Cowork</button>
   <button data-t="code">Code</button>
+  <button data-t="design">Design（Labs）</button>
 </div>
 
 <!-- ============ CHAT ============ -->
@@ -127,14 +128,35 @@
   </div>
 </div>
 
-<div class="note">交互提示：点上方 Chat / Cowork / Code 切换线框。快捷键 / 权限模式 / launch.json 字段等契约级明细见规格档 §5。</div>
+<!-- ============ DESIGN ============ -->
+<div class="frame hidden" id="t-design">
+  <div class="titlebar">Claude Design（Labs 研究预览 · 侧栏入口进入的独立工作区）<span class="seg">警示：顶层 Chat/Cowork/Code 导航在此消失（社区批评的集成反模式）</span></div>
+  <div class="lay">
+    <div class="side col">
+      <div class="box"><b>入口画面</b><span>Prototype / Slide deck / From template / Other 四选一</span></div>
+      <div class="box"><b>保真度档位</b><span>rough wireframes / high-fidelity mockups</span></div>
+      <div class="box grow"><b>输入四路</b><span>文本提示 · 上传 DOCX/PPTX/XLSX/图片 · 指向代码库 · 网页元素捕获</span></div>
+      <div class="box"><b>品牌系统</b><span>扫描代码库与设计文件自动建设计系统（色 / 排版 / 组件），项目间自动套用</span></div>
+    </div>
+    <div class="main col">
+      <div class="row grow">
+        <div class="box"><b>聊天区（左）</b><span>对话驱动生成与修改 · 版本以指令保存（无版本树 UI）</span></div>
+        <div class="box"><b>画布 canvas（右）</b><span>拖拽 / 缩放 / 对齐 · rich layout controls（间距 / 颜色 / 布局旋钮）· 文字直改 · 行内评论（回灌链路尚不可靠）</span></div>
+      </div>
+      <div class="box"><b>Export（右上角）</b><span>.zip / PDF / PPTX / 独立 HTML · Canva / Adobe / Miro / Vercel 等集成 · 交接 Claude Code（/design-sync）</span></div>
+      <div class="box"><b>分享</b><span>组织内链接 · 查看 / 评论 / 编辑三档权限 · 群组对话</span></div>
+    </div>
+  </div>
+</div>
+
+<div class="note">交互提示：点上方 Chat / Cowork / Code / Design 切换线框。快捷键 / 权限模式 / launch.json 字段等契约级明细见规格档 §5，Claude Design 见 §6。</div>
 
 <script>
   document.querySelectorAll('.tabs button').forEach(function(b){
     b.addEventListener('click', function(){
       document.querySelectorAll('.tabs button').forEach(function(x){x.classList.remove('on')});
       b.classList.add('on');
-      ['chat','cowork','code'].forEach(function(t){
+      ['chat','cowork','code','design'].forEach(function(t){
         document.getElementById('t-'+t).classList.toggle('hidden', t!==b.dataset.t);
       });
     });

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -178,8 +178,9 @@
   净室边界（Claude Desktop 逆向产物零复制）。**第二弹（同日）**：Claude Desktop 本体全结构黑箱观察规格
   `Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-structure-20260704.md`（三标签 Chat/Cowork/Code
   逐节结构；Code 标签为官方文档全文取证最高置信——会话/worktree 模型、权限五档、八 pane、diff 行评、
-  CI 状态条、computer use 三档 app 权限、快捷键全表；附证据分级与残余盲区）+ 配套单文件线框图
-  `claude-desktop-ui-wireframe-20260704.html`
+  CI 状态条、computer use 三档 app 权限、快捷键全表；附证据分级与残余盲区；同日修订融入
+  **Claude Design** 节——Labs 视觉工作区双平面布局 / 画布编辑 / Export 交接 / 桌面集成反模式教训）
+  + 配套单文件线框图 `claude-desktop-ui-wireframe-20260704.html`（四线框：Chat/Cowork/Code/Design）
 - **完成度（表面等价）**：对官方 SDK **0.3.199 基线**约 **89.5%**（v0.1 基线 68.3% → v0.2+v0.3 补齐后重算）。
   审计矩阵与逐行台账落 `Public-Info-Pool/Resource/repo-engineering/bpt-agent-sdk-completion-audit-20260703.md`
   + 同名 `-matrix-20260703.json`（146 行）


### PR DESCRIPTION
## 概述

Desktop UI 参考线第三弹（守密人「融入 Claude Design」派发）：把 Claude Design（Anthropic Labs 研究预览，2026-04-17 发布）的完整结构融入既有规格档 `claude-desktop-ui-structure-20260704.md`（新增 §6 六小节 + 设计模式 11/12 + 落差表与盲区更新），线框图补第四标签。同产物同日修订，按 Public-Info-Pool 纪律原文件覆盖更新。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [x] 文档完善（CLAUDE.md / BIAV-SC.md / README.md / 子项目 CONTEXT.md）
- [ ] Bug 修复
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 其他（请说明）：Public-Info-Pool `repo-engineering` 既有两产物的同日修订 + `memory/project-status.md` 指针更新

---

## 来源声明

- [x] 本 PR 涉及的数据可在以下公开来源查到：

  ```
  https://www.anthropic.com/news/claude-design-anthropic-labs（发布公告）
  https://claude.com/product/design（产品页）
  https://support.claude.com/en/articles/14604416（Claude Design 入门，画布/导出/分享细节）
  r/claude Design 桌面集成讨论（2026-06，仅作 §6.6 集成反模式的定性引用）
  ```

- [ ] 翻译类 PR：不适用

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 全部内容为公开来源的自然语言转写。
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**；不含任何 Claude Design 逆向代码 / 资产 / 提示词文本。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 纯文档变更（md 修订 + 自包含 html 修订 + 状态档指针），无代码 / 数据 / 测试改动，按 §7.6 免跑 pytest
- [x] 线框图仍为零外链自包含 HTML，四标签切换脚本已同步
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案

---

## 关联 Issue

- Refs：无（守密人会话直接派发；前两弹见已合并 #424 / #425）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrLRxJdAj3DyXtHZQuw9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrLRxJdAj3DyXtHZQuw9U)_