### PR TITLE
docs(bpt): r2 self-consistency revision + M0-M4 UI roadmap draft

### DIFF
--- a/Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-reference-20260704-r2.md
+++ b/Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-reference-20260704-r2.md
@@ -1,6 +1,8 @@
-# BPT Desktop UI 参考实现情报
+# BPT Desktop UI 参考实现情报（r2）
 
-- **日期**：2026-07-04
+- **日期**：2026-07-04；**r2 修订 2026-07-05**（自洽审视回填：权限模式清单补全、
+  对接表增 TodoWrite / AskUserQuestion / compact_boundary / thinking / 斜杠命令五行、
+  §6 底座三层辨析与 adapter 成本注记）
 - **来源**：守密人转交的 GPT-5.5 搜索梗概 + 银芯 AnySearch 实时核验（2026-07-04，许可证逐项实锤）+ `projects/bpt-agent-sdk/docs/COMPAT.md` 契约对照
 - **定位**：银芯 → 黑池**单向输出物**（§1.1-HC 同向）。消费方为 BPT Desktop（Electron/Node）前端线；本档案本体属银芯公开信息层，不含任何黑池数据。
 - **背景**：BPT Desktop 已有自研 UI 前端但开发不顺。本档案回答三个问题：该参考谁、哪些代码法律上能直接借、UI 组件怎么对上 bpt-agent-sdk 的消息流。
@@ -90,7 +92,9 @@ AppShell
 │  └─ Composer
 │     ├─ AttachmentBar（文件 chip）
 │     ├─ Textarea + Send / Stop ← Stop = query.interrupt() / AbortController
-│     └─ ModeSwitch*（permissionMode：default / acceptEdits / plan / dontAsk）
+│     └─ ModeSwitch*（permissionMode 全五档：default / acceptEdits / plan /
+│        dontAsk / bypassPermissions；Claude Desktop 另有 auto（分类器）档，
+│        SDK 不提供，选择器勿照抄）
 └─ RightPanel
    ├─ ArtifactPreview / FilePreview
    ├─ ToolTrace（全量工具时间线）
@@ -117,6 +121,11 @@ bpt-agent-sdk 的 `SDKMessage` 异步生成器。逐件对接（契约出处 `do
 | 停止按钮 | `query.interrupt()` / AbortController | FULL |
 | 后台 shell 面板 | Bash `run_in_background` + `BashOutput`（增量 + 按行 filter）/ `KillShell` | FULL（v0.5） |
 | 文件检查点 / 回滚 | 文件检查点（v0.2）——「改坏了一键回」的 UI 挂点 | 已落地 |
+| 任务清单（checklist） | `TodoWrite` 工具调用（v0.2 新工具）——入参即整份清单，渲染为待办 / 进行中 / 已完成三态列表，agent 客户端标配件 | FULL |
+| 选项问答卡 | `AskUserQuestion` 工具调用（v0.2 新工具）——渲染选项按钮组，用户点选结果作为 tool_result 回流 | FULL |
+| 上下文压缩指示 | `compact_boundary`（v0.2 上下文压缩）——消息流内插「对话已摘要」分隔条，并与用量仪表联动 | FULL |
+| 思考块 | assistant 消息 `thinking` 内容块（`thinking.type:'enabled'` 时产生）——默认折叠、点击展开，Claude Desktop 同款处理 | PARTIAL（字段名与官方有差，见 COMPAT） |
+| 斜杠命令菜单 | `supportedCommands()` 返回静态 / 空数据（无 CLI 命令框架可内省）——BPT 如要 `/` 菜单需自建命令注册表，SDK 只当执行器 | PARTIAL（static） |
 | Electron 主进程接线 | `examples/electron-host.mjs`（四个 host callback 接线范本）+ `docs/MIGRATION.md`（凭据 / 已知行为差异七条 / 试点验收清单） | v0.5 换装就绪包 |
 
 ## §6 技术栈建议
@@ -129,6 +138,25 @@ bpt-agent-sdk 的 `SDKMessage` 异步生成器。逐件对接（契约出处 `do
 | 状态 | Zustand（会话 / 设置）+ 组件内状态（流式缓冲） | 轻，样板少 |
 | 流式 | 直接迭代 SDK `query()` 生成器，renderer 经 IPC 订阅 | 主进程跑 SDK（持文件 / shell / 凭据权限），renderer 纯展示——天然进程隔离，别把 API key 放进 renderer |
 | 本地配置 | JSON 文件起步，量大再 SQLite | 会话本体 SDK 的 JSONL 存储已管 |
+
+### §6.1 底座三层辨析（r2 增补，防概念混装）
+
+「底座」在本线文档里出现过三个不同层，**互不替代**：
+
+1. **引擎底座 = bpt-agent-sdk**（Claude Agent SDK 净室重实现）：跑 agent 环、调模型、
+   执行工具、管权限与会话。住 Electron 主进程，是唯一的「大脑」，没有竞品选项。
+2. **UI 组件底座 = assistant-ui / AI Elements**：React 聊天组件库，只管把消息流画成
+   气泡 / 卡片 / 打字机。住 renderer 进程，是「脸」，可换可自研。
+3. **Vercel AI SDK（`ai` npm 包）= 不需要引入的第三方**：Vercel 家的开源 TS 工具包，
+   功能上是 bpt-agent-sdk 的同类但更薄（统一多家模型 API + React `useChat` hook 管
+   消息状态）。它与 BPT 的唯一关系是：上面两个组件库**默认按它的数据形状设计**。
+
+**adapter 成本（选型前须知）**：assistant-ui / AI Elements 接 bpt-agent-sdk 时，需要
+自写一层薄 adapter——把 `SDKMessage` union 翻译成组件库认识的消息形状（角色 / 内容块 /
+工具状态），并把发送 / 停止动作桥回 `query()` / `interrupt()`。assistant-ui 有自定义
+runtime 接口（ExternalStoreRuntime 一类，装前核实现名）专为「非 Vercel 引擎」预留，
+适配成本约数百行；AI Elements 是纯展示组件、本就不绑状态层，适配更薄但组件间联动
+需自己缝。**两条路都不需要安装 Vercel AI SDK 本体。**
 
 ## §7 净室与许可证硬边界（与 SDK 线共用地基）
 

--- a/Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-roadmap-20260705.md
+++ b/Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-roadmap-20260705.md
@@ -1,0 +1,94 @@
+# BPT Desktop UI 落地路线草案（M0–M4）
+
+- **日期**：2026-07-05
+- **定位**：银芯 → 黑池单向输出物，Desktop UI 参考线第四弹。前三弹回答「参考谁 / 长什么样 /
+  怎么接」，本档回答「先建哪块、每步验收什么」。
+- **前置阅读**：`bpt-desktop-ui-reference-20260704-r2.md`（许可证红绿灯 + 对接表 + 底座三层辨析）、
+  `claude-desktop-ui-structure-20260704-r2.md`（Claude Desktop 结构规格 + 12 条设计模式）
+- **假设声明（草案性质）**：本路线按通用假设排布——BPT Desktop 为 Electron/Node、已有一个
+  开发不顺的自研 UI、目标是换 bpt-agent-sdk 引擎后重建可靠前端。**BPT 侧实际存量（哪些件已
+  能跑、团队人力）会改变 M1/M2 内部顺序**，拿到现状输入后应出 r2 校准。
+
+---
+
+## 总原则
+
+1. **每个里程碑以「可用」收口，不以「代码写完」收口**——验收项全部是用户可操作的行为。
+2. **引擎先行、界面跟进**：M0 把 SDK 在主进程跑通并定死 IPC 契约，之后 UI 迭代不再碰引擎。
+3. **窄启动、留位演进**：起步是单活动会话 + 会话列表（姊妹档案 §4 骨架）；「会话 = 一等资源」
+  （规格档模式 1）作为演进方向在数据模型里预留，不在 M1 实现。
+4. **反模式红线**（规格档模式 12）：任何新增工作面必须挂顶层导航同级、一步可返回。
+
+## M0 地基：引擎接线 + IPC 契约（不出界面）
+
+**做**：
+- 主进程集成 bpt-agent-sdk（`npm pack` tarball 或私有 registry；接线范本
+  `examples/electron-host.mjs`、迁移清单 `docs/MIGRATION.md`）
+- 定死三条 IPC 通道契约：
+  1. `query 流`：主进程迭代 `query()` 生成器 → 逐条 `SDKMessage` 推 renderer（含
+     `stream_event` 细粒度流）；
+  2. `控制`：renderer → 主进程的 `interrupt / setPermissionMode / setModel / streamInput / close`；
+  3. `权限 RPC`：主进程 `canUseTool` 回调 → renderer 弹窗 → 用户决策回传（带 requestId
+     关联与超时兜底，超时默认 deny）。
+- 凭据只存主进程（安全存储），renderer 永不见 API key。
+- adapter 层雏形：`SDKMessage` → UI 消息模型的纯函数 reducer（见参考档 §6.1 底座辨析）。
+
+**验收**：无界面，用一个临时脚本经 IPC 发一句 prompt，能在日志里看到流式回包、
+一次工具调用的权限询问往返、以及 `interrupt` 生效。
+
+## M1 聊天核心：最小可信对话环
+
+**做**（对接表行号见参考档 §5）：
+- AppShell + 侧栏会话列表（`listSessions` / `resume` / `continue` / 改名 / 删除）
+- 消息流：流式打字机（`stream_event`）、markdown 渲染、思考块折叠、工具调用卡
+  （tool_use 挂起 → tool_result 填充）
+- Composer：发送 / **停止**（interrupt）、附件、模型选择、**权限模式五档切换**
+  （default / acceptEdits / plan / dontAsk / bypassPermissions——SDK 实有档位，无 auto）
+- **权限弹窗**（canUseTool RPC）：允许 / 拒绝 + 入参展示——这是「可信」的核心件
+- 错误与重试可见：`rate_limit_event` 倒计时条 / `api_retry` 状态条
+- UI 组件底座选型在此里程碑定死（assistant-ui 或 AI Elements，adapter 成本见参考档 §6.1）
+
+**验收**：日常真实使用一整天不需要打开 DevTools——对话、打断、换模式、看清每次
+工具调用与权限询问、断网重试可见。
+
+## M2 agent 透明化：把「它在干嘛」全部画出来
+
+**做**：
+- TodoWrite 任务清单件（三态列表）+ AskUserQuestion 选项卡（点选回流）
+- 子代理任务卡（`task_*` 四事件，注意消息边界排空的时序特性）
+- 转录密度三档（Normal / Verbose / Summary，纯前端过滤 `SDKMessage.type`——性价比最高的一件）
+- 上下文压缩指示条（`compact_boundary`）+ 用量 / 成本仪表（`result.metrics`）
+- 会话级权限审计列表（`permission_denials` 台账）
+
+**验收**：跑一个含子代理 + 十次以上工具调用的长任务，用户全程不困惑：能说出它正在哪一步、
+花了多少钱、哪些操作被拒过；切 Summary 档能一屏读完结果。
+
+## M3 工程面：工具与环境的管理界
+
+**做**：
+- MCP 面板：server 状态灯（`mcpServerStatus`）+ 配置 CRUD（配置文件由宿主管理）
+- 后台 shell 面板（`run_in_background` + BashOutput 增量 / KillShell；前端 xterm.js 级渲染可后置）
+- 文件检查点回滚 UI（「改坏一键回」）
+- 会话 fork / side-chat（`forkSession`——借上下文不回写主线，规格档模式 5）
+- Hook 审计面板（`includeHookEvents`，可选开关）
+
+**验收**：接一个真实 MCP server 全流程（配置 → 状态灯 → 工具调用 → 只读自动放行 /
+非只读弹窗）；跑一个后台任务并中途击杀；一次误编辑经检查点回滚。
+
+## M4 演进留位（不排期，按需启动）
+
+- 会话 = 一等资源化（多会话并行 + 状态过滤侧栏，向规格档 §5.2 靠拢）
+- pane 化工作区（dockview 类，MIT——装前复核）
+- Artifacts 级产物只读预览面板（按模式 11 给「可编辑画布」留布局位，不实现）
+- 计划模式专用视图、diff 审查面板
+- 斜杠命令菜单（需自建命令注册表，SDK `supportedCommands()` 为静态空）
+
+## 里程碑外的常备纪律
+
+- 每合入一个绿区组件，按参考档 §7 留版权头与 NOTICE；
+- 每个新 UI 件先查对接表有无现成 SDK 事件源，**没有数据源的件不做**（避免摆设件）；
+- 顶层导航全程可达（模式 12），新工作面一律与主界面同级。
+
+---
+
+*本档为草案（假设声明见头部）。守密人回填 BPT 前端现状（能跑的件 / 人力 / 最痛的三个问题）后升 r2 校准。*

--- a/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-structure-20260704-r2.md
+++ b/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-structure-20260704-r2.md
@@ -1,9 +1,10 @@
-# Claude Desktop UI 全结构设计文档（黑箱观察规格）
+# Claude Desktop UI 全结构设计文档（黑箱观察规格，r2）
 
-- **日期**：2026-07-04
+- **日期**：2026-07-04；**r2 修订 2026-07-05**（自洽审视回填：§7 模式 1 补「起步形态 vs
+  演进方向」调和句、§8 增 auto 模式落差行、§8 许可证表述补核验标签）
 - **对象版本**：Claude Desktop 三标签形态（Chat / Cowork / Code），官方文档标注部分能力需 v1.2581.0+
 - **定位**：银芯 → 黑池单向输出物，供 BPT Desktop 前端参考。姊妹档案：
-  `bpt-desktop-ui-reference-20260704.md`（开源许可证红绿灯 + UI↔SDK 消息流对接表）
+  `bpt-desktop-ui-reference-20260704-r2.md`（开源许可证红绿灯 + UI↔SDK 消息流对接表）
 - **方法与净室声明**：本档案为**自然语言黑箱观察规格**——全部内容来自公开文档 / 官方教程 /
   帮助中心 / 训练期公开知识的转写，**不含任何逆向代码、资产、提示词文本**。BPT 据此独立实现，
   法律路径与 bpt-agent-sdk 净室纪律（Compaq 金标准）完全一致。
@@ -297,6 +298,8 @@ Design 并入桌面应用后的社区批评（r/claude，高热帖）：入口**
 
 1. **会话 = 一等资源**：会话自带环境 + 工作区 + 变更集 + 上下文，侧栏是资源管理器而非聊天历史。
    比 BPT 现有「单对话窗」模型高一个维度，是 Code 标签一切并行能力的地基。
+   （与姊妹档案 §4 骨架**不矛盾**：那是起步形态——单活动会话 + 会话列表；本模式是演进方向，
+   起步骨架的 ConversationList 天然可升级为会话资源管理器，非两个互斥方案。）
 2. **权限渐进阶梯**：五档模式 + 会话中随时换挡 + 企业可锁档。BPT 有 SDK `permissionMode`
    现成对接（default/acceptEdits/plan/dontAsk/bypassPermissions 已实现，见姊妹档案对接表）。
 3. **计划先行**：Plan mode / Cowork 计划审批把「先给我看你要干嘛」做成一档模式而非一句提示词。
@@ -318,15 +321,16 @@ Design 并入桌面应用后的社区批评（r/claude，高热帖）：入口**
 
 ## §8 与 BPT/SDK 的落差清单（结构性差异，非逐件映射）
 
-逐件 UI↔SDK 对接表见姊妹档案 `bpt-desktop-ui-reference-20260704.md` §5。本节只列
+逐件 UI↔SDK 对接表见姊妹档案 `bpt-desktop-ui-reference-20260704-r2.md` §5。本节只列
 Code 标签新观察到、上一档未覆盖的映射：
 
 | Claude Desktop 结构 | BPT 对接可行性 |
 |--------------------|---------------|
-| pane 化工作区（八 pane 拖拽） | 纯前端工程（react-mosaic / dockview 类，均 MIT）；SDK 无涉 |
+| pane 化工作区（八 pane 拖拽） | 纯前端工程（react-mosaic / dockview 类，MIT——训练期知识，装前复核 LICENSE）；SDK 无涉 |
 | diff 视图 + 行级评论回灌 | SDK 侧文件检查点 + Read/Edit 已有；评论回灌 = 把评论拼成下一条 user 消息，纯前端 |
 | tasks pane | `task_started/progress/updated/notification`（v0.4 真发射）直接驱动 |
-| terminal pane | SDK v0.5 ShellManager（后台 shell + BashOutput/KillShell）是数据源，前端接 xterm.js（MIT） |
+| terminal pane | SDK v0.5 ShellManager（后台 shell + BashOutput/KillShell）是数据源，前端接 xterm.js（MIT——训练期知识，装前复核） |
+| 权限模式 **auto**（分类器，研究预览） | SDK 不提供（COMPAT：`auto` not offered）——BPT 选择器做 SDK 实有的五档（default / acceptEdits / plan / dontAsk / bypassPermissions），勿照抄 Desktop 含 auto 的六种形态 |
 | 视图模式三档 | `SDKMessage.type` 前端过滤即得 |
 | CI 状态条 / Auto-fix | SDK 无此内建；BPT 若要，走宿主层轮询 gh + 自动派新 query |
 | 用量环 | `result.metrics`（SDKRunMetrics）现成 |

--- a/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-wireframe-20260704.html
+++ b/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-wireframe-20260704.html
@@ -42,7 +42,7 @@
 </head>
 <body>
 <h1>Claude Desktop UI 结构线框图</h1>
-<div class="meta">黑箱观察规格配图 · 详细规格见同目录 claude-desktop-ui-structure-20260704.md · 灰框 = 结构占位，非视觉还原</div>
+<div class="meta">黑箱观察规格配图 · 详细规格见同目录 claude-desktop-ui-structure-20260704-r2.md · 灰框 = 结构占位，非视觉还原</div>
 
 <div class="tabs">
   <button class="on" data-t="chat">Chat</button>

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -170,17 +170,23 @@
   数字说话前不宣胜负。缓存 0% 已诊断为「前缀够不着 Haiku 2048 门槛、非 bug、不灌水」。组织级缓存红利设计留 host
   （多层注入 proposal 档）、SDK 只承接 `segments` 分段 seam。整条线综述见
   `Public-Info-Pool/Resource/repo-engineering/bpt-sdk-prompt-cache-milestone-20260704.md`
-- **Desktop UI 参考线（2026-07-04）**：BPT Desktop 前端参考情报档（守密人转交 GPT-5.5 搜索梗概 +
-  AnySearch 许可证逐项实锤 + UI 组件↔`SDKMessage` 流对接表）落
-  `Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-reference-20260704.md`——
+- **Desktop UI 参考线（2026-07-04，07-05 r2 修订 + 路线草案收口）**：BPT Desktop 前端参考情报档
+  （守密人转交 GPT-5.5 搜索梗概 + AnySearch 许可证逐项实锤 + UI 组件↔`SDKMessage` 流对接表）落
+  `Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-reference-20260704-r2.md`——
   绿区（MIT/Apache 可借码：assistant-ui / AI Elements / Goose / LibreChat 等）/ 黄区（Open WebUI 品牌条款、
   LobeChat 社区许可证）/ 红区（Cherry Studio AGPL 双许可、Chatbox GPLv3 只看不抄）三级红绿灯 +
   净室边界（Claude Desktop 逆向产物零复制）。**第二弹（同日）**：Claude Desktop 本体全结构黑箱观察规格
-  `Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-structure-20260704.md`（三标签 Chat/Cowork/Code
+  `Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-structure-20260704-r2.md`（三标签 Chat/Cowork/Code
   逐节结构；Code 标签为官方文档全文取证最高置信——会话/worktree 模型、权限五档、八 pane、diff 行评、
   CI 状态条、computer use 三档 app 权限、快捷键全表；附证据分级与残余盲区；同日修订融入
   **Claude Design** 节——Labs 视觉工作区双平面布局 / 画布编辑 / Export 交接 / 桌面集成反模式教训）
-  + 配套单文件线框图 `claude-desktop-ui-wireframe-20260704.html`（四线框：Chat/Cowork/Code/Design）
+  + 配套单文件线框图 `claude-desktop-ui-wireframe-20260704.html`（四线框：Chat/Cowork/Code/Design）。
+  **07-05 自洽审视后 r2**：两档 git mv 升 `-r2`（对接表补 TodoWrite/AskUserQuestion/compact_boundary/
+  thinking/斜杠命令五行、权限模式清单补全并标注 Desktop auto 档 SDK 不提供、底座三层辨析
+  ——引擎底座 bpt-agent-sdk / UI 组件底座 assistant-ui·AI Elements / Vercel AI SDK 不需引入仅涉 adapter）；
+  **第四弹落地路线草案** `Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-roadmap-20260705.md`
+  （M0 引擎接线与 IPC 契约 → M1 最小可信对话环 → M2 agent 透明化 → M3 工程面 → M4 演进留位，
+  每 M 带行为级验收；待守密人回填 BPT 现状后升 r2 校准）
 - **完成度（表面等价）**：对官方 SDK **0.3.199 基线**约 **89.5%**（v0.1 基线 68.3% → v0.2+v0.3 补齐后重算）。
   审计矩阵与逐行台账落 `Public-Info-Pool/Resource/repo-engineering/bpt-agent-sdk-completion-audit-20260703.md`
   + 同名 `-matrix-20260703.json`（146 行）


### PR DESCRIPTION
## 概述

Desktop UI 参考线第五弹（守密人「按审视建议执行」派发）：自洽审视发现的 3 处不一致 + 5 处遗漏全部回填，两份参考档经 git mv 升 `-r2`（单一正本、历史在 git，仓内先例 `repo-audit-20260603-r2`）；新增第四份产物——M0–M4 落地路线草案。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [x] 文档完善（CLAUDE.md / BIAV-SC.md / README.md / 子项目 CONTEXT.md）
- [ ] Bug 修复
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 其他（请说明）：Public-Info-Pool `repo-engineering` 两档 r2 修订 + 新路线档 + 线框图引用与状态档指针同步

---

## 来源声明

- [x] 本 PR 涉及的数据可在以下公开来源查到：

  ```
  修订内容全部源自本仓已核验档案的交叉对账：
  projects/bpt-agent-sdk/docs/COMPAT.md（TodoWrite / AskUserQuestion / compact_boundary /
  thinking / supportedCommands / permissionMode 契约行）
  + 前四弹已列公开来源（#424 / #425 / #427）
  ```

- [ ] 翻译类 PR：不适用

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**；不含任何逆向产物。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 纯文档变更，按 §7.6 免跑 pytest；全仓 grep 确认旧文件名零残留引用
- [x] 产物路径经 `scripts/deliverable_path.py` 生成（--rev 2 与新 topic 均过注册表守卫）
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案

---

## 关联 Issue

- Refs：无（守密人会话直接派发；前四弹见已合并 #424 / #425 / #427）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrLRxJdAj3DyXtHZQuw9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrLRxJdAj3DyXtHZQuw9U)_