### PR TITLE
feat(bpt-conformance): M1 — content-blind emulator + L1 stream-grammar differential

### DIFF
--- a/.github/workflows/bpt-agent-sdk.yml
+++ b/.github/workflows/bpt-agent-sdk.yml
@@ -105,6 +105,46 @@ jobs:
       - name: Test (keyless, includes emulator e2e)
         run: npm test
 
+  conformance-l1:
+    # Conformance suite M1 (design final 2026-07-05): the L1 stream-grammar
+    # differential. Keyless AND free — both engines talk only to a local
+    # content-blind emulator (zero api.anthropic.com traffic). The official
+    # arm installs the DUAL-PINNED packages transiently (--no-save, never a
+    # repo dependency; pins in tests/conformance/pins.json). M1 semantics:
+    # a DIVERGENT verdict is informational (M3 adds the ratchet gate); a
+    # BPT-arm check failure fails the job (our own engine regression).
+    # Clean-room: the emulator never reads request bodies (standing decision
+    # 2026-07-05 净室观测边界), and the runner self-audits its artifact.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            /*
+            !/Public-Info-Pool/Record/
+            !/Public-Info-Pool/Reference/
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Install pinned official arm (transient, --no-save, never a repo dep)
+        run: |
+          PINS=$(node -e "const p=require('./tests/conformance/pins.json');process.stdout.write('@anthropic-ai/claude-agent-sdk@'+p.agentSdk+' @anthropic-ai/claude-code@'+p.claudeCode)")
+          npm i --no-save $PINS
+      - name: L1 stream-grammar differential (content-blind emulator)
+        run: node tests/conformance/run-l1.mjs --out=conformance-l1.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: conformance-l1-matrix
+          path: projects/bpt-agent-sdk/conformance-l1.json
+          if-no-files-found: ignore
+
   live-smoke:
     # Real api.anthropic.com run. Manual only — spends API budget.
     if: github.event_name == 'workflow_dispatch'

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -192,6 +192,16 @@
   **第四弹落地路线草案** `Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-roadmap-20260705.md`
   （M0 引擎接线与 IPC 契约 → M1 最小可信对话环 → M2 agent 透明化 → M3 工程面 → M4 演进留位，
   每 M 带行为级验收；待守密人回填 BPT 现状后升 r2 校准）
+- **一致性测试套件（2026-07-05 拷问定稿开工，设计蓝图
+  `Public-Info-Pool/Resource/repo-engineering/bpt-sdk-conformance-suite-design-20260705.md`）**：
+  五层金字塔（L1 流语法 / L2 选项语义 / L3 工具差分 / L4 故障注入 / L5 端到端统计带，L6 行为指纹后置留痕）；
+  硬约束「净室观测边界」已录 decisions.md（对照物白名单 / 内容盲纪律 / 泄漏衍生禁引 claw-code 系）。
+  **spike 三断点全通**（官方臂无头 + localhost 仿真器 + 协议面极窄，$0，剖面档
+  `bpt-sdk-official-arm-protocol-profile-20260705.md`）→ 活体差分架构成立。
+  **M1 已落地**：`tests/conformance/`（内容盲仿真器正式版 + L1 差分 `run-l1.mjs` + 双包同钉 pins.json）
+  + CI `conformance-l1` 无钥零费常跑 + vitest 流语法回归锁；**首份矩阵 3/3 MATCH_WITH_KNOWN_DIFFS、
+  零未解释分歧**，KD-01~05 已知差异登记（KD-05 消息粒度 = 官方逐块/逐 tool_result 拆消息 vs 本 SDK 按轮合批，
+  引擎对齐候选）。708 单测全绿（+6）。M2-M4 待续（L2/L3 → L4/棘轮/漂移哨兵 → L5 五维任务库/乙门禁）
 - **完成度（表面等价）**：对官方 SDK **0.3.199 基线**约 **89.5%**（v0.1 基线 68.3% → v0.2+v0.3 补齐后重算）。
   审计矩阵与逐行台账落 `Public-Info-Pool/Resource/repo-engineering/bpt-agent-sdk-completion-audit-20260703.md`
   + 同名 `-matrix-20260703.json`（146 行）

--- a/projects/bpt-agent-sdk/.gitignore
+++ b/projects/bpt-agent-sdk/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 dist/
 *.tsbuildinfo
 .vitest-cache/
+conformance-l1.json
+ab-report-*.json

--- a/projects/bpt-agent-sdk/CONTEXT.md
+++ b/projects/bpt-agent-sdk/CONTEXT.md
@@ -169,6 +169,17 @@ shell（BashOutput 增量读 + 按行 filter / KillShell 击杀，进程组 SIGT
 repeat=1 便宜探针 ~$0.08）。验收标准=**净值**：v2 须成本持平/更省 + 质量/轮数改善才提拔，否则退回 v1。699 单测全绿（+6）。
 硬红线不变：只学公开材料、绝不读泄漏官方提示词文本。
 
+**一致性测试套件 M1（2026-07-05，设计定稿见
+`Public-Info-Pool/Resource/repo-engineering/bpt-sdk-conformance-suite-design-20260705.md`）**：
+`tests/conformance/` 落地——内容盲仿真器正式版（请求体零读取 + `assertContentBlind` 自审）、
+L1 流语法差分（`run-l1.mjs`，双臂活体对跑、归一化 token 序列 + KD 已知差异表比较）、
+双包同钉 `pins.json`（agent-sdk 0.3.199 + claude-code 2.1.201 分别锁死）、CI 作业
+`conformance-l1`（无钥零费常跑，官方臂 `--no-save` 临时装）。**首份矩阵：3/3
+MATCH_WITH_KNOWN_DIFFS、零未解释分歧**；KD-01~KD-05 五条已知差异全部登记在
+`normalize.mjs`（KD-05 = 消息粒度：官方按内容块/逐 tool_result 拆消息、本 SDK 按轮合批——
+未来引擎对齐候选，对逐消息渲染的 Desktop UI 可感知）。本 SDK 流语法另有 vitest 回归锁
+`tests/conformance-l1.test.ts`（无官方依赖、进常规 `npm test`）。
+
 进度以 `memory/project-status.md` 为唯一权威。
 
 ## v0.2 候选

--- a/projects/bpt-agent-sdk/tests/conformance-l1.test.ts
+++ b/projects/bpt-agent-sdk/tests/conformance-l1.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Conformance L1 - keyless regression lock for THIS SDK's stream grammar.
+ *
+ * Drives the same scenarios as tests/conformance/run-l1.mjs through the SDK
+ * (src build) against the content-blind emulator, and pins the exact
+ * normalized token sequence. If our grammar drifts, this fails in `npm test`
+ * without needing the official arm; the two-arm differential runs in the
+ * dedicated CI job (conformance-l1) and via run-l1.mjs.
+ *
+ * Also locks the emulator's own discipline: the content-blind self-audit and
+ * the comparator's known-divergence semantics (incl. KD-05 coalescing).
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { query } from '../src/index.js';
+import type { Query, SDKMessage } from '../src/types.js';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - plain-JS conformance modules (no d.ts by design)
+import { startEmulator, assertContentBlind } from './conformance/emulator.mjs';
+// @ts-ignore
+import { SCENARIOS } from './conformance/scenarios.mjs';
+// @ts-ignore
+import { normalizeStream, compareStreams } from './conformance/normalize.mjs';
+
+const DUMMY_KEY = 'sk-ant-api03-' + 'A'.repeat(95);
+
+/** Expected token sequence of OUR arm per scenario (the grammar lock). */
+const EXPECTED_TOKENS: Record<string, string[]> = {
+  'text-single-turn': ['system/init', 'user/echo', 'assistant', 'result/success'],
+  'tool-read-loop': ['system/init', 'user/echo', 'assistant', 'user/tool_result', 'assistant', 'result/success'],
+  'two-reads-one-turn': ['system/init', 'user/echo', 'assistant', 'user/tool_result', 'assistant', 'result/success'],
+};
+
+let cwd: string;
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'conf-lock-'));
+});
+
+afterEach(async () => {
+  await rm(cwd, { recursive: true, force: true });
+});
+
+async function runOurArm(scenario: (typeof SCENARIOS)[number]): Promise<SDKMessage[]> {
+  for (const [name, content] of Object.entries(scenario.fixtureFiles ?? {})) {
+    await writeFile(join(cwd, name), content as string);
+  }
+  await mkdir(join(cwd, '.sessions'), { recursive: true });
+  const emulator = await startEmulator(scenario.buildScripts(cwd));
+  const messages: SDKMessage[] = [];
+  try {
+    const q: Query = query({
+      prompt: scenario.prompt,
+      options: {
+        cwd,
+        maxTurns: 4,
+        sessionDir: join(cwd, '.sessions'),
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          ANTHROPIC_BASE_URL: emulator.url,
+          ANTHROPIC_API_KEY: DUMMY_KEY,
+        },
+      },
+    });
+    for await (const m of q) messages.push(m);
+  } finally {
+    await emulator.close();
+  }
+  return messages;
+}
+
+describe('conformance L1 - our stream grammar lock', () => {
+  for (const scenario of SCENARIOS) {
+    it(`${scenario.id}: token sequence and checks are pinned`, async () => {
+      const messages = await runOurArm(scenario);
+      const { tokens, checks } = normalizeStream(messages);
+      expect(tokens).toEqual(EXPECTED_TOKENS[scenario.id]);
+      expect(checks.resultSubtype).toBe(scenario.expect.resultSubtype);
+      expect(checks.toolResults).toBe(scenario.expect.toolResults);
+      expect(checks.resultText).toContain(scenario.expect.resultText);
+    });
+  }
+});
+
+describe('conformance comparator semantics', () => {
+  it('KD-05 coalescing: per-block splits match per-turn batches as a KNOWN diff', () => {
+    const official = ['system/init', 'assistant', 'assistant', 'user/tool_result', 'user/tool_result', 'assistant', 'result/success'];
+    const ours = ['system/init', 'user/echo', 'assistant', 'user/tool_result', 'assistant', 'result/success'];
+    const r = compareStreams(official, ours);
+    expect(r.verdict).toBe('MATCH_WITH_KNOWN_DIFFS');
+    expect(r.knownDiffs).toContain('KD-05');
+    expect(r.knownDiffs).toContain('KD-04');
+    expect(r.divergences).toEqual([]);
+  });
+
+  it('an unlisted difference stays DIVERGENT (allowlist cannot hide novelty)', () => {
+    const official = ['system/init', 'assistant', 'brand_new_variant', 'result/success'];
+    const ours = ['system/init', 'assistant', 'result/success'];
+    const r = compareStreams(official, ours);
+    expect(r.verdict).toBe('DIVERGENT');
+    expect(r.divergences.length).toBeGreaterThan(0);
+  });
+
+  it('content-blind self-audit rejects body-derived markers', () => {
+    expect(() => assertContentBlind('{"tokens":["assistant"]}')).not.toThrow();
+    expect(() => assertContentBlind('{"system":"leaked prompt text"}')).toThrow(/self-audit FAILED/);
+  });
+});

--- a/projects/bpt-agent-sdk/tests/conformance/arm.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/arm.mjs
@@ -1,0 +1,91 @@
+/**
+ * Shared arm driver: run one scenario through EITHER engine against a fresh
+ * content-blind emulator instance, and return the normalized stream.
+ *
+ * armKind 'bpt'      -> this SDK's built dist (npm run build first)
+ * armKind 'official' -> @anthropic-ai/claude-agent-sdk, installed transiently
+ *                       (`npm i --no-save` per tests/conformance/pins.json);
+ *                       its spawned claude-code engine follows
+ *                       ANTHROPIC_BASE_URL to the emulator (spike-proven).
+ *
+ * Both arms receive identical prompt/cwd/env. Observation stays inside the
+ * standing clean-room boundary: the public SDKMessage stream only.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startEmulator } from './emulator.mjs';
+import { normalizeStream } from './normalize.mjs';
+
+const DUMMY_KEY = 'sk-ant-api03-' + 'A'.repeat(95);
+
+async function loadQuery(armKind) {
+  if (armKind === 'bpt') {
+    const mod = await import('../../dist/index.js');
+    return mod.query;
+  }
+  const mod = await import('@anthropic-ai/claude-agent-sdk');
+  return mod.query;
+}
+
+export async function runScenario(armKind, scenario, { timeoutMs = 120_000 } = {}) {
+  const query = await loadQuery(armKind);
+  const cwd = mkdtempSync(join(tmpdir(), `conf-${armKind}-`));
+  for (const [name, content] of Object.entries(scenario.fixtureFiles ?? {})) {
+    writeFileSync(join(cwd, name), content);
+  }
+  // Scenario fixture paths are built against the run cwd by the caller.
+  const scripts = scenario.buildScripts ? scenario.buildScripts(cwd) : scenario.scripts;
+  const emulator = await startEmulator(scripts);
+
+  const env = {
+    ...process.env,
+    ANTHROPIC_BASE_URL: emulator.url,
+    ANTHROPIC_API_KEY: DUMMY_KEY,
+    ANTHROPIC_AUTH_TOKEN: '',
+    ANTHROPIC_MODEL: '',
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+    DISABLE_TELEMETRY: '1',
+    DISABLE_ERROR_REPORTING: '1',
+  };
+
+  const messages = [];
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  let error;
+  try {
+    const q = query({
+      prompt: scenario.prompt,
+      options: {
+        abortController: ac,
+        cwd,
+        maxTurns: 4,
+        env,
+        // Session persistence is engine-internal state, not stream grammar;
+        // keep this SDK's store inside the throwaway cwd.
+        ...(armKind === 'bpt' ? { sessionDir: join(cwd, '.sessions') } : {}),
+      },
+    });
+    for await (const m of q) messages.push(m);
+  } catch (err) {
+    error = String(err?.message ?? err).slice(0, 300);
+  } finally {
+    clearTimeout(timer);
+    await emulator.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }
+
+  const normalized = normalizeStream(messages);
+  return {
+    arm: armKind,
+    scenario: scenario.id,
+    error,
+    ...normalized,
+    emulatorProfile: {
+      requests: emulator.profile.requests,
+      otherEndpoints: emulator.profile.otherEndpoints,
+      unscriptedCalls: emulator.profile.unscriptedCalls,
+    },
+  };
+}

--- a/projects/bpt-agent-sdk/tests/conformance/emulator.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/emulator.mjs
@@ -1,0 +1,159 @@
+/**
+ * Content-blind Messages-API emulator - the heart of the conformance suite.
+ *
+ * Both engines (this SDK and the official @anthropic-ai/claude-agent-sdk,
+ * whose spawned claude-code CLI honors ANTHROPIC_BASE_URL - proven by the
+ * 2026-07-05 spike, see Public-Info-Pool/Resource/repo-engineering/
+ * bpt-sdk-official-arm-protocol-profile-20260705.md) are pointed at this
+ * local server. The model side becomes a deterministic shared script, so any
+ * difference in the emitted SDKMessage stream is a real engine difference.
+ *
+ * CLEAN-ROOM / CONTENT-BLIND DISCIPLINE (standing decision, memory/
+ * decisions.md 2026-07-05 "净室观测边界"): the official arm's request bodies
+ * carry the proprietary system prompt. This server NEVER reads request
+ * bodies - `req.resume()` drains them unbuffered - routes purely by
+ * (method, path, arrival order), logs header NAMES only, and whitelists just
+ * four protocol-metadata header values. `assertContentBlind()` is the
+ * mandatory self-audit every consumer must run over its own outputs.
+ *
+ * Protocol surface implemented per the spike profile: POST /v1/messages
+ * (SSE) only; every other path gets a tolerated 404. Fault injection:
+ * http429 and sse-truncated script kinds.
+ */
+
+import { createServer } from 'node:http';
+
+const HEADER_VALUE_WHITELIST = new Set([
+  'anthropic-version',
+  'anthropic-beta',
+  'content-type',
+  'accept',
+]);
+
+/** Serialize scripted stream events as SSE wire frames. */
+function sse(events) {
+  return events.map((e) => `event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`).join('');
+}
+
+/** Standard event sequence for a scripted plain-text assistant reply. */
+export function textReply(text, { stopReason = 'end_turn', id = 'msg_conf_text' } = {}) {
+  return [
+    { type: 'message_start', message: { id, type: 'message', role: 'assistant', model: 'claude-conformance-1', content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 10, output_tokens: 1 } } },
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } },
+    { type: 'content_block_stop', index: 0 },
+    { type: 'message_delta', delta: { stop_reason: stopReason, stop_sequence: null }, usage: { output_tokens: 5 } },
+    { type: 'message_stop' },
+  ];
+}
+
+/**
+ * Scripted assistant turn issuing one or more tool_use blocks.
+ * calls: Array<{ name, input }> - input is OUR scripted content (safe).
+ */
+export function toolUseReply(calls, { id = 'msg_conf_tool' } = {}) {
+  const events = [
+    { type: 'message_start', message: { id, type: 'message', role: 'assistant', model: 'claude-conformance-1', content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 10, output_tokens: 1 } } },
+  ];
+  calls.forEach((call, i) => {
+    events.push(
+      { type: 'content_block_start', index: i, content_block: { type: 'tool_use', id: `toolu_conf_${i + 1}`, name: call.name, input: {} } },
+      { type: 'content_block_delta', index: i, delta: { type: 'input_json_delta', partial_json: JSON.stringify(call.input) } },
+      { type: 'content_block_stop', index: i },
+    );
+  });
+  events.push(
+    { type: 'message_delta', delta: { stop_reason: 'tool_use', stop_sequence: null }, usage: { output_tokens: 20 } },
+    { type: 'message_stop' },
+  );
+  return events;
+}
+
+/**
+ * Start the emulator with a per-run script queue.
+ *
+ * scripts: consumed one per POST /v1/messages, each one of
+ *   { kind: 'sse', events }            - full SSE reply
+ *   { kind: 'sse-truncated', events }  - stream cut before message_stop
+ *   { kind: 'http429' }                - 429 + retry-after: 1
+ *
+ * Returns { url, port, profile, close }.
+ */
+export function startEmulator(scripts) {
+  const profile = {
+    requests: [], // "METHOD /path" in arrival order - never content
+    otherEndpoints: {},
+    headerNames: new Set(),
+    protocolMeta: {},
+    unscriptedCalls: 0,
+  };
+  let messagesCalls = 0;
+
+  const server = createServer((req, res) => {
+    req.resume(); // content-blind: drain the body without buffering a byte
+    for (const name of Object.keys(req.headers)) {
+      profile.headerNames.add(name);
+      if (HEADER_VALUE_WHITELIST.has(name)) profile.protocolMeta[name] = req.headers[name];
+    }
+    const path = (req.url ?? '/').split('?')[0];
+    profile.requests.push(`${req.method} ${path}`);
+
+    if (req.method === 'POST' && path === '/v1/messages') {
+      const script = scripts[messagesCalls++];
+      if (!script) {
+        profile.unscriptedCalls += 1;
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message: 'conformance emulator: script queue exhausted' } }));
+        return;
+      }
+      if (script.kind === 'http429') {
+        res.writeHead(429, { 'content-type': 'application/json', 'retry-after': '1' });
+        res.end(JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'emulated rate limit' } }));
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+      const body = sse(script.events);
+      if (script.kind === 'sse-truncated') {
+        const cut = body.lastIndexOf('event: message_stop');
+        res.write(body.slice(0, cut === -1 ? body.length : cut));
+        setTimeout(() => res.destroy(), 100);
+      } else {
+        res.end(body);
+      }
+      return;
+    }
+
+    // Any other endpoint: profile it and 404 (tolerated per the spike).
+    profile.otherEndpoints[`${req.method} ${path}`] =
+      (profile.otherEndpoints[`${req.method} ${path}`] ?? 0) + 1;
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: 'conformance emulator: unknown endpoint' } }));
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        port,
+        profile,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+/**
+ * Mandatory self-audit (standing-decision clause 2): assert a serialized
+ * output artifact contains no request-body-derived content. We never read
+ * bodies, so the strongest structural markers of a leak are the system/
+ * messages fields of a Messages API request. Throws on failure.
+ */
+export function assertContentBlind(artifactJsonString) {
+  const markers = ['"system":', '"messages":', 'You are Claude'];
+  const hits = markers.filter((m) => artifactJsonString.includes(m));
+  if (hits.length > 0) {
+    throw new Error(`content-blind self-audit FAILED: found ${hits.join(', ')} in output artifact`);
+  }
+  return true;
+}

--- a/projects/bpt-agent-sdk/tests/conformance/normalize.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/normalize.mjs
@@ -1,0 +1,130 @@
+/**
+ * Stream normalization + comparison for the L1 differential.
+ *
+ * normalizeStream() reduces an arm's SDKMessage sequence to shape tokens -
+ * volatile identity (uuid / session_id / timings / cost) is dropped, only
+ * grammar remains. compareStreams() aligns the two token sequences under the
+ * KNOWN_DIVERGENCES allowlist: every allowlisted difference is reported (not
+ * hidden), anything NOT allowlisted makes the scenario DIVERGENT.
+ *
+ * Verdicts: MATCH | MATCH_WITH_KNOWN_DIFFS | DIVERGENT.
+ */
+
+/** One SDKMessage -> one shape token. */
+export function tokenOf(msg) {
+  const type = msg?.type ?? 'unknown';
+  if (type === 'system') return `system/${msg.subtype ?? '?'}`;
+  if (type === 'result') return `result/${msg.subtype ?? '?'}`;
+  if (type === 'user') {
+    const content = msg.message?.content;
+    const hasToolResult =
+      Array.isArray(content) && content.some((b) => b?.type === 'tool_result');
+    return hasToolResult ? 'user/tool_result' : 'user/echo';
+  }
+  return type;
+}
+
+export function normalizeStream(messages) {
+  const tokens = messages.map(tokenOf);
+  const resultMsg = messages.filter((m) => m?.type === 'result').pop();
+  const toolResults = messages
+    .filter((m) => m?.type === 'user')
+    .flatMap((m) => (Array.isArray(m.message?.content) ? m.message.content : []))
+    .filter((b) => b?.type === 'tool_result').length;
+  return {
+    tokens,
+    checks: {
+      resultSubtype: resultMsg?.subtype ?? null,
+      resultText: typeof resultMsg?.result === 'string' ? resultMsg.result : null,
+      toolResults,
+    },
+  };
+}
+
+/**
+ * Known divergences between the official arm and this SDK, each observed
+ * live (spike 2026-07-05) or documented in COMPAT.md. Three kinds:
+ *   official-only token  -> { official: token }
+ *   ours-only token      -> { ours: token }
+ *   alias (same event, different wire shape) -> { official, ours, alias: true }
+ * The comparator consumes matching tokens per this table and REPORTS every
+ * consumption - allowlisted means "known and documented", never "invisible".
+ */
+export const KNOWN_DIVERGENCES = [
+  { id: 'KD-01', official: 'active_goal', note: 'official-only status variant (engine 2.1.x); outside the pinned 0.3.199 type surface, typed-not-emitted here' },
+  { id: 'KD-02', official: 'rate_limit_event', note: 'official broadcasts rate-limit STATUS even on success; this SDK emits rate_limit_event only on an actual 429' },
+  { id: 'KD-03', official: 'system/api_retry', ours: 'api_retry', alias: true, note: 'same retry event; official wire shape is system+subtype, ours is a top-level discriminator (official docs are internally inconsistent here - see COMPAT observability note)' },
+  { id: 'KD-04', ours: 'user/echo', note: 'this SDK yields a prompt-echo user message for string prompts; the official arm does not (spike S1 observation)' },
+  { id: 'KD-05', granularity: true, note: 'message granularity: the official arm splits one assistant turn into one SDKMessage per content block and yields one user message per tool_result; this SDK batches per turn (one assistant message, one user message carrying all tool_results). End state equal - alignment candidate for a future surface batch, since per-message UI renderers see chunkier updates on the official engine (first caught live by two-reads-one-turn, 2026-07-05)' },
+];
+
+/** Collapse consecutive identical tokens; reports whether anything collapsed
+ *  so the KD-05 granularity divergence is recorded, never hidden. */
+function coalesce(tokens) {
+  const out = [];
+  let collapsed = false;
+  for (const t of tokens) {
+    if (out[out.length - 1] === t) collapsed = true;
+    else out.push(t);
+  }
+  return { tokens: out, collapsed };
+}
+
+export function compareStreams(rawOfficialTokens, rawOursTokens) {
+  // KD-05 granularity normalization: compare at turn granularity by
+  // coalescing consecutive identical tokens on both sides.
+  const a = coalesce(rawOfficialTokens);
+  const b = coalesce(rawOursTokens);
+  const officialTokens = a.tokens;
+  const oursTokens = b.tokens;
+
+  const officialOnly = new Map(
+    KNOWN_DIVERGENCES.filter((d) => d.official && !d.alias).map((d) => [d.official, d]),
+  );
+  const oursOnly = new Map(
+    KNOWN_DIVERGENCES.filter((d) => d.ours && !d.alias).map((d) => [d.ours, d]),
+  );
+  const aliases = KNOWN_DIVERGENCES.filter((d) => d.alias);
+
+  const knownDiffsHit = new Set();
+  if (a.collapsed || b.collapsed) knownDiffsHit.add('KD-05');
+  const divergences = [];
+  let i = 0;
+  let j = 0;
+  while (i < officialTokens.length || j < oursTokens.length) {
+    const a = officialTokens[i];
+    const b = oursTokens[j];
+    if (a !== undefined && b !== undefined && a === b) {
+      i += 1; j += 1;
+      continue;
+    }
+    const alias = aliases.find((d) => d.official === a && d.ours === b);
+    if (alias) {
+      knownDiffsHit.add(alias.id);
+      i += 1; j += 1;
+      continue;
+    }
+    if (a !== undefined && officialOnly.has(a)) {
+      knownDiffsHit.add(officialOnly.get(a).id);
+      i += 1;
+      continue;
+    }
+    if (b !== undefined && oursOnly.has(b)) {
+      knownDiffsHit.add(oursOnly.get(b).id);
+      j += 1;
+      continue;
+    }
+    divergences.push({ atOfficial: i, atOurs: j, official: a ?? '(end)', ours: b ?? '(end)' });
+    // Advance both to keep producing signal instead of cascading one offset.
+    if (a !== undefined) i += 1;
+    if (b !== undefined) j += 1;
+  }
+
+  const verdict =
+    divergences.length > 0
+      ? 'DIVERGENT'
+      : knownDiffsHit.size > 0
+        ? 'MATCH_WITH_KNOWN_DIFFS'
+        : 'MATCH';
+  return { verdict, knownDiffs: [...knownDiffsHit].sort(), divergences };
+}

--- a/projects/bpt-agent-sdk/tests/conformance/pins.json
+++ b/projects/bpt-agent-sdk/tests/conformance/pins.json
@@ -1,0 +1,5 @@
+{
+  "comment": "Dual-package pin for the conformance suite (design final 2026-07-05 §1): the official agent-sdk AND the claude-code engine it spawns are pinned SEPARATELY - the engine is otherwise a moving target that drifts the baseline (observed: CLI 2.1.201 emits variants outside the 0.3.199 type surface). Installed at run time with `npm i --no-save`; never a repo dependency (clean-room discipline).",
+  "agentSdk": "0.3.199",
+  "claudeCode": "2.1.201"
+}

--- a/projects/bpt-agent-sdk/tests/conformance/run-l1.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/run-l1.mjs
@@ -1,0 +1,107 @@
+/**
+ * L1 stream-grammar differential runner (conformance suite M1).
+ *
+ * Replays every scenario through BOTH arms against the content-blind
+ * emulator, compares normalized streams under the known-divergence
+ * allowlist, and emits the conformance matrix (JSON + markdown summary).
+ *
+ * Usage:
+ *   node tests/conformance/run-l1.mjs [--arm=both|bpt|official] [--out=path.json]
+ *
+ * Prereqs: `npm run build` (bpt arm); for the official arm, install the
+ * PINNED packages transiently first (never into package.json):
+ *   node -e "const p=require('./tests/conformance/pins.json'); \
+ *     console.log(\`@anthropic-ai/claude-agent-sdk@\${p.agentSdk} @anthropic-ai/claude-code@\${p.claudeCode}\`)" \
+ *     | xargs npm i --no-save
+ *
+ * M1 exit semantics: informational - exit 0 unless the runner itself broke
+ * or a scenario check failed on the BPT arm (that is a regression in OUR
+ * engine regardless of the official arm). DIVERGENT verdicts print loudly;
+ * the M3 ratchet will turn them into a gate.
+ */
+
+import { writeFileSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SCENARIOS } from './scenarios.mjs';
+import { runScenario } from './arm.mjs';
+import { compareStreams, KNOWN_DIVERGENCES } from './normalize.mjs';
+import { assertContentBlind } from './emulator.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const m = a.match(/^--([^=]+)(?:=(.*))?$/);
+    return m ? [m[1], m[2] ?? true] : [a, true];
+  }),
+);
+const armMode = args.arm ?? 'both';
+const outPath = typeof args.out === 'string' ? args.out : join(HERE, '..', '..', 'conformance-l1.json');
+
+function checksVerdict(expected, checks) {
+  const failures = [];
+  if (checks.resultSubtype !== expected.resultSubtype) failures.push(`resultSubtype ${checks.resultSubtype} != ${expected.resultSubtype}`);
+  if (expected.resultText !== undefined && checks.resultText !== null && !checks.resultText.includes(expected.resultText)) {
+    failures.push(`resultText missing "${expected.resultText}"`);
+  }
+  if (checks.toolResults !== expected.toolResults) failures.push(`toolResults ${checks.toolResults} != ${expected.toolResults}`);
+  return failures;
+}
+
+const pins = JSON.parse(readFileSync(join(HERE, 'pins.json'), 'utf8'));
+const matrix = {
+  generated_for: 'bpt-agent-sdk conformance L1 (stream grammar)',
+  pins: { agentSdk: pins.agentSdk, claudeCode: pins.claudeCode },
+  armMode,
+  scenarios: [],
+  knownDivergenceTable: KNOWN_DIVERGENCES,
+};
+
+let bptCheckFailures = 0;
+let divergent = 0;
+
+for (const scenario of SCENARIOS) {
+  const row = { id: scenario.id };
+  if (armMode !== 'official') {
+    const r = await runScenario('bpt', scenario);
+    row.bpt = { tokens: r.tokens, checks: r.checks, error: r.error, checkFailures: checksVerdict(scenario.expect, r.checks) };
+    bptCheckFailures += row.bpt.checkFailures.length + (r.error ? 1 : 0);
+  }
+  if (armMode !== 'bpt') {
+    try {
+      const r = await runScenario('official', scenario);
+      row.official = { tokens: r.tokens, checks: r.checks, error: r.error, checkFailures: checksVerdict(scenario.expect, r.checks) };
+    } catch (err) {
+      row.official = { unavailable: String(err?.message ?? err).slice(0, 200) };
+    }
+  }
+  if (row.bpt && row.official && !row.official.unavailable) {
+    row.compare = compareStreams(row.official.tokens, row.bpt.tokens);
+    if (row.compare.verdict === 'DIVERGENT') divergent += 1;
+  }
+  matrix.scenarios.push(row);
+  console.log(`[${scenario.id}] ${row.compare ? row.compare.verdict : 'single-arm'}${row.bpt?.checkFailures?.length ? ` | BPT CHECK FAIL: ${row.bpt.checkFailures.join('; ')}` : ''}`);
+}
+
+// Mandatory self-audit before the artifact leaves the process (standing
+// decision clause 2): no request-body-derived content in the matrix.
+const serialized = JSON.stringify(matrix, null, 2);
+assertContentBlind(serialized);
+writeFileSync(outPath, serialized);
+
+console.log('\n| scenario | verdict | known diffs | divergences |');
+console.log('|---|---|---|---|');
+for (const row of matrix.scenarios) {
+  console.log(`| ${row.id} | ${row.compare?.verdict ?? (row.official?.unavailable ? 'OFFICIAL-ARM-UNAVAILABLE' : 'single-arm')} | ${row.compare?.knownDiffs?.join(' ') ?? ''} | ${row.compare?.divergences?.length ?? ''} |`);
+}
+console.log(`\nmatrix: ${outPath}`);
+console.log(`content-blind self-audit: PASS`);
+
+if (bptCheckFailures > 0) {
+  console.error(`\nFAIL: ${bptCheckFailures} check failure(s) on the BPT arm (engine regression independent of the official arm)`);
+  process.exit(1);
+}
+if (divergent > 0) {
+  console.error(`\nINFO (M1, not gating): ${divergent} DIVERGENT scenario(s) - inspect the matrix; the M3 ratchet will gate these`);
+}
+process.exit(0);

--- a/projects/bpt-agent-sdk/tests/conformance/scenarios.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/scenarios.mjs
@@ -1,0 +1,49 @@
+/**
+ * L1 stream-grammar scenarios.
+ *
+ * Each scenario is one deterministic conversation both arms replay against
+ * the content-blind emulator. `buildScripts(cwd)` produces the shared
+ * model-side script against the arm's own throwaway cwd (each arm gets a
+ * fresh one, so fixture paths are computed per run). `expect` is asserted
+ * identically on both arms: a check failing on ONE arm is an engine
+ * difference, failing on BOTH is a scenario bug.
+ */
+
+import { join } from 'node:path';
+import { textReply, toolUseReply } from './emulator.mjs';
+
+export const SCENARIOS = [
+  {
+    id: 'text-single-turn',
+    prompt: 'Say OK.',
+    fixtureFiles: {},
+    buildScripts: () => [{ kind: 'sse', events: textReply('CONFORMANCE TEXT OK') }],
+    expect: { resultSubtype: 'success', resultText: 'CONFORMANCE TEXT OK', toolResults: 0 },
+  },
+  {
+    id: 'tool-read-loop',
+    prompt: 'Read hello.txt and repeat the magic word.',
+    fixtureFiles: { 'hello.txt': 'the magic word is PINEAPPLE\n' },
+    buildScripts: (cwd) => [
+      { kind: 'sse', events: toolUseReply([{ name: 'Read', input: { file_path: join(cwd, 'hello.txt') } }]) },
+      { kind: 'sse', events: textReply('TOOL LOOP DONE') },
+    ],
+    expect: { resultSubtype: 'success', resultText: 'TOOL LOOP DONE', toolResults: 1 },
+  },
+  {
+    id: 'two-reads-one-turn',
+    prompt: 'Read hello.txt and notes.txt.',
+    fixtureFiles: { 'hello.txt': 'alpha content\n', 'notes.txt': 'beta content\n' },
+    buildScripts: (cwd) => [
+      {
+        kind: 'sse',
+        events: toolUseReply([
+          { name: 'Read', input: { file_path: join(cwd, 'hello.txt') } },
+          { name: 'Read', input: { file_path: join(cwd, 'notes.txt') } },
+        ]),
+      },
+      { kind: 'sse', events: textReply('TWO READS DONE') },
+    ],
+    expect: { resultSubtype: 'success', resultText: 'TWO READS DONE', toolResults: 2 },
+  },
+];


### PR DESCRIPTION
Conformance suite M1 per the 2026-07-05 design final (#434).

- `tests/conformance/emulator.mjs` — production content-blind Messages-API emulator: request bodies drained unread, header-name-only profiling, mandatory `assertContentBlind` self-audit
- `tests/conformance/{scenarios,arm,normalize,run-l1}.mjs` — three L1 scenarios replayed live through BOTH engines (this SDK's dist + the official agent-sdk with its spawned claude-code engine, pointed at the same local emulator); normalized token streams compared under a reported-never-hidden known-divergence allowlist
- `tests/conformance/pins.json` — dual-package pin (agent-sdk 0.3.199 + claude-code 2.1.201, locked separately); official arm installed `npm i --no-save` at run time only, never a repo dependency
- CI job `conformance-l1` — keyless, zero API cost, runs on every SDK change; matrix uploaded as artifact. BPT-arm check failures gate; DIVERGENT verdicts informational until the M3 ratchet
- `tests/conformance-l1.test.ts` — vitest lock for OUR stream grammar + comparator semantics (no official dependency, runs in `npm test`)

**First live matrix: 3/3 MATCH_WITH_KNOWN_DIFFS, zero unexplained divergences.** KD-01..KD-05 recorded in `normalize.mjs`; KD-05 is a real catch — message granularity: the official arm emits one SDKMessage per content block and one user message per tool_result, this SDK batches per turn; end state identical. Flagged as an engine alignment candidate (per-message UI renderers see chunkier updates on the official engine).

Verification: 754 unit tests green on the rebased base (27 files), `tsc` + build clean, L1 rerun green post-rebase.

Note for the keeper: this session also detected a cross-session tension between the 净室观测边界 standing decision (#432, this session) and the 公开信息再现 pivot (#421, parallel session) — reported separately in chat for a ruling; the emulator's content-blind design is compatible with both readings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ4YLu2UNyU2ud5hPDD9sD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJ4YLu2UNyU2ud5hPDD9sD)_