### PR TITLE
test(bpt-sdk): L5 测试用例层加固 — 散落物清扫 + 按臂度量聚合 + KD 表

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -241,6 +241,13 @@
   修复方案：Fix-1 claude_code preset 默认开 thinking（budget 4096 起步，管线 computeThinking 已就绪；预算值不可知——读官方请求体越
   内容盲边界，登记 KD）/ Fix-2 L5 双臂 maxThinkingTokens 显式同参拆变量；退出标准 chat-03 ≥2/3、code-01 ≥官方−1、乙门禁保 PASS。
   顺手实锤 B②规格：官方 Write 读前写门仅拦已存在文件、新建不拦。
+  **L5 测试用例层加固已落（2026-07-05，解剖挂账三项 + 附带新 KD）**：① S2 污染面封堵——任务库 11 个带档案产物任务加 `strays`
+  声明（任务自有文件名白名单），runner 每 run 前后在 tmpdir 根定点清扫（pre 恢复 ENOENT 自救信号 / post 把「本 run 写歪了」升为
+  行级观测字段 `strayArtifacts`，判分语义零变动）；② M1 度量修正——双臂流式多轮均逐轮发 result，按臂聚合（官方 num_turns/usage
+  逐 result 求和、cost/apiMs 取累计末值；我方全字段累计取末值、apiMs 逐 run 求和）；③ KD 表 `L5_KNOWN_DIFFERENCES` 落任务库并
+  透传报告 per-task 汇总（KD-L5-01 官方 /tmp 锚定 / KD-L5-02 官方注入误判方差 / KD-L5-03 思考不对称）。**附带发现 KD-L5-04**：
+  两引擎 result 累计口径本身分歧（官方 num_turns/usage 逐 result vs 我方 finding #33 全字段会话累计）——drop-in 面引擎对齐候选。
+  `--smoke` 3/3 绿 + 预置散落物清扫实测 + `npx vitest run` 981 全绿。
   （首轮 run 28735894053 因预算护栏冷启动外推误停 2/180，护栏已修 #447）。**一致性验证体系 M1-M4 全部封顶**
 - **完成度（表面等价）**：对官方 SDK **0.3.199 基线**约 **89.5%**（v0.1 基线 68.3% → v0.2+v0.3 补齐后重算）。
   审计矩阵与逐行台账落 `Public-Info-Pool/Resource/repo-engineering/bpt-agent-sdk-completion-audit-20260703.md`

--- a/projects/bpt-agent-sdk/package-lock.json
+++ b/projects/bpt-agent-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bpt-agent-sdk",
-      "version": "0.3.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/bpt-agent-sdk/tests/conformance/l5-tasks.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/l5-tasks.mjs
@@ -49,6 +49,23 @@
  *
  * estTurns is the nominal per-repeat assistant-turn load used by the
  * blueprint budget estimate (~42 turns/engine/repeat total).
+ *
+ * strays: task-owned file basenames the model may misplace at the tmpdir
+ * ROOT instead of the sandbox cwd. First real round (run 28736460533,
+ * dissected in Public-Info-Pool/Resource/repo-engineering/
+ * bpt-sdk-l5-failure-dissection-20260705.md, S2): the official arm's Write
+ * requires absolute paths and Haiku guessed /tmp/<name>; the repeat-1
+ * leftover then steered repeats 2-3 into verifying at the wrong location
+ * (the read-before-write gate plus a pre-existing correct file removed the
+ * ENOENT self-rescue signal repeat 1 recovered on). run-l5.mjs sweeps these
+ * exact basenames at the tmpdir root before and after every run - restoring
+ * per-run independence without touching any pass semantics. Listed for
+ * every task that names a concrete artifact file (created or edited).
+ *
+ * kd: L5 known-difference tags (table: L5_KNOWN_DIFFERENCES below) carried
+ * into the report's per-task summaries so a reader of per-task pass counts
+ * sees the standing explanation next to the number instead of rediscovering
+ * it from traces.
  */
 
 import fs from 'node:fs';
@@ -87,6 +104,56 @@ function importFresh(dir, rel) {
   );
 }
 
+/**
+ * L5 known differences - task-level, REPORT-ONLY (gate B stays aggregate).
+ * Source: first real round run 28736460533 dissection (2026-07-05),
+ * Public-Info-Pool/Resource/repo-engineering/bpt-sdk-l5-failure-dissection-20260705.md.
+ * Every entry is grounded in L6 official-arm public-stream traces - the
+ * legal observation surface (净室观测边界 r2); request bodies were never read.
+ */
+export const L5_KNOWN_DIFFERENCES = {
+  'KD-L5-01': {
+    arm: 'official',
+    title: 'tmpdir-root path anchoring on new-file writes',
+    note:
+      'Official Write requires absolute paths; Haiku guesses /tmp/<name> instead of ' +
+      'the sandbox cwd. Recoverable via the ENOENT self-rescue signal on a clean ' +
+      'tmpdir (code-03 r1); the strays sweep keeps the signal available every run.',
+  },
+  'KD-L5-02': {
+    arm: 'official',
+    title: 'injection-suspicion refusal variance on benign multi-turn remember-X (zh)',
+    note:
+      'The official system prompt\'s injection wariness + Haiku sometimes judges ' +
+      '"记住：甲的值是 12。只需确认" as a prompt-injection attempt and refuses from ' +
+      'turn 1 (longconv-02 r1/r2 of run 28736460533). Model-level posture, not an ' +
+      'engine defect on either side; per-task numbers for longconv-02 are noisy.',
+  },
+  'KD-L5-03': {
+    arm: 'bpt',
+    title: 'thinking asymmetry: official CLI defaults extended thinking ON, our engine OFF',
+    note:
+      '54/54 official traces carry thinking_tokens events; our claude_code preset ' +
+      'sends no thinking block. Costs us pre-answer computation on chat-03 (reverse ' +
+      'alphabetical) and diligence probability on code-01 (even-length median). ' +
+      'Alignment candidates: engine Fix-1 (preset default-on thinking) and/or ' +
+      'harness Fix-2 (explicit equal maxThinkingTokens on both arms).',
+  },
+  'KD-L5-04': {
+    arm: 'both',
+    title: 'per-result cumulative semantics diverge between engines on streamed multi-turn input',
+    note:
+      'Both engines emit one result per streamed user turn, but the official arm ' +
+      'reports num_turns and usage PER RESULT with total_cost_usd/duration_api_ms ' +
+      'session-cumulative (verified from run 28736460533 longconv traces: ' +
+      'num_turns 1,1,2; costs strictly increasing with exact per-run deltas), while ' +
+      'our SDK rewrites EVERY field session-cumulative on every result except ' +
+      'duration_api_ms which stays per-run (query.ts finding #33 rewriteResult). ' +
+      'run-l5 aggregates per-arm accordingly. Engine alignment candidate: match ' +
+      'the official per-result semantics on the drop-in surface.',
+  },
+};
+
 export const L5_TASKS = [
   // --- chat: pure dialogue, zero tools --------------------------------------
   {
@@ -124,6 +191,7 @@ export const L5_TASKS = [
     zh: false,
     repeatOverride: 3,
     estTurns: 1,
+    kd: ['KD-L5-03'],
     prompt:
       'Without using any tools: list the three classical states of matter ' +
       '(solid, liquid, gas) in REVERSE alphabetical order, comma-separated, ' +
@@ -278,6 +346,7 @@ export const L5_TASKS = [
     zh: false,
     repeatOverride: 3,
     estTurns: 2,
+    strays: ['toc.md'],
     fixture(dir) {
       const body = (label, n) =>
         Array.from(
@@ -324,6 +393,7 @@ export const L5_TASKS = [
     zh: false,
     repeatOverride: 3,
     estTurns: 2,
+    strays: ['tasks.md'],
     fixture(dir) {
       seed(
         dir,
@@ -358,6 +428,7 @@ export const L5_TASKS = [
     zh: true,
     repeatOverride: 3,
     estTurns: 2,
+    strays: ['announcement_zh.md'],
     fixture(dir) {
       seed(
         dir,
@@ -399,6 +470,7 @@ export const L5_TASKS = [
     zh: false,
     repeatOverride: 3,
     estTurns: 2,
+    strays: ['RELEASES.md'],
     fixture(dir) {
       // Interleaved versions (a: 1.0.0 + 1.2.0, b: 1.1.0) force a real
       // ordering merge - plain concatenation in either order fails.
@@ -439,6 +511,8 @@ export const L5_TASKS = [
     dimension: 'code',
     zh: false,
     estTurns: 3,
+    strays: ['stats.mjs'],
+    kd: ['KD-L5-03'],
     options: { maxTurns: 12 },
     fixture(dir) {
       // BUG: indexes the middle of the UNSORTED input - median([3,1,2])
@@ -474,6 +548,7 @@ export const L5_TASKS = [
     dimension: 'code',
     zh: false,
     estTurns: 3,
+    strays: ['slug.mjs'],
     options: { maxTurns: 12 },
     prompt:
       'Create slug.mjs exporting slugify(s): lowercase the string, replace ' +
@@ -497,6 +572,8 @@ export const L5_TASKS = [
     dimension: 'code',
     zh: false,
     estTurns: 4,
+    strays: ['fizz.mjs'],
+    kd: ['KD-L5-01'],
     options: { maxTurns: 12 },
     prompt:
       'Create fizz.mjs exporting classify(n): return \'FizzBuzz\' if n is ' +
@@ -523,6 +600,7 @@ export const L5_TASKS = [
     dimension: 'code',
     zh: true,
     estTurns: 3,
+    strays: ['a.mjs', 'b.mjs'],
     options: { maxTurns: 12 },
     fixture(dir) {
       seed(dir, 'b.mjs', 'export function getData() {\n  return 42;\n}\n');
@@ -551,6 +629,7 @@ export const L5_TASKS = [
     dimension: 'code',
     zh: false,
     estTurns: 2,
+    strays: ['result.txt'],
     options: { maxTurns: 12 },
     prompt:
       'Using Bash, compute the sum of the integers from 1 to 100 (do not ' +
@@ -571,6 +650,7 @@ export const L5_TASKS = [
     dimension: 'long-conversation',
     zh: false,
     estTurns: 4,
+    strays: ['note.txt'],
     options: { maxTurns: 10 },
     // The runner wraps `turns` in an async generator; each turn is released
     // only after the previous turn's completion (result / end_turn) shows up
@@ -593,6 +673,8 @@ export const L5_TASKS = [
     dimension: 'long-conversation',
     zh: true,
     estTurns: 4,
+    strays: ['sum.txt'],
+    kd: ['KD-L5-01', 'KD-L5-02'],
     options: { maxTurns: 10 },
     turns: [
       '记住：甲的值是 12。只需确认，不要做别的。',

--- a/projects/bpt-agent-sdk/tests/conformance/run-l5.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/run-l5.mjs
@@ -60,11 +60,11 @@
  * the streaming turn-release barrier are loud-fail settle barriers only.
  */
 
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { L5_TASKS } from './l5-tasks.mjs';
+import { L5_TASKS, L5_KNOWN_DIFFERENCES } from './l5-tasks.mjs';
 import { startEmulator, textReply, assertContentBlind } from './emulator.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -310,16 +310,49 @@ function smokeEnv(emulatorUrl) {
 // --- Single run -------------------------------------------------------------------
 
 /**
+ * S2 stray-artifact sweep (first-round dissection, KD-L5-01): the official
+ * arm sometimes anchors task-artifact writes at the tmpdir ROOT
+ * (/tmp/<name>) instead of the sandbox cwd. A leftover from repeat N then
+ * steers repeat N+1 into verifying at the wrong location - the
+ * read-before-write gate plus a pre-existing correct file removes the
+ * ENOENT self-rescue signal a clean tmpdir provides. Sweeping the
+ * task-declared basenames before AND after every run restores per-run
+ * independence; only exact, task-owned basenames are ever touched, and
+ * pass semantics stay byte-identical (checks still read only the sandbox).
+ */
+function sweepStrays(task) {
+  const removed = [];
+  for (const name of task.strays ?? []) {
+    const p = join(tmpdir(), name);
+    try {
+      if (statSync(p, { throwIfNoEntry: false })?.isFile()) {
+        rmSync(p, { force: true });
+        removed.push(p);
+      }
+    } catch {
+      // A sweep that cannot stat/remove must never fail the run - the worst
+      // case is the pre-fix behavior (a stray survives), which the post-run
+      // row surfaces via strayArtifacts on the NEXT run's pre-sweep.
+    }
+  }
+  return removed;
+}
+
+/**
  * One (arm, task, repeat) run in a throwaway mkdtemp cwd. Returns metrics +
  * the raw PUBLIC message array (for L6 retention; the caller drops it before
  * the row enters the report). The pass decision runs BEFORE cleanup because
  * fs-decidable checks read the sandbox.
  */
 async function runOne(arm, task) {
+  const preStrays = sweepStrays(task);
+  if (preStrays.length > 0)
+    console.warn(`run-l5: pre-run sweep removed stray artifact(s): ${preStrays.join(', ')}`);
   const dir = mkdtempSync(join(tmpdir(), `l5-${SMOKE ? 'smoke-' : ''}${arm}-${task.id}-`));
   if (typeof task.fixture === 'function') task.fixture(dir);
 
   const messages = [];
+  const resultMsgs = [];
   const sync = makeTurnSync(SMOKE ? 60_000 : 240_000);
   const ac = new AbortController();
   // Loud-fail run barrier only - never asserted on (deterministic-test
@@ -375,6 +408,7 @@ async function runOne(arm, task) {
         if (t.length > 0) finalText = t;
       } else if (msg.type === 'result') {
         lastResult = msg;
+        resultMsgs.push(msg);
       }
     }
     // Code tasks execute the produced module - must run while the sandbox
@@ -411,7 +445,29 @@ async function runOne(arm, task) {
     rmSync(dir, { recursive: true, force: true });
   }
 
-  const usage = lastResult?.usage ?? {};
+  // Post-run sweep doubles as an observation: anything removed here is
+  // positive evidence THIS run wrote a task artifact at the tmpdir root
+  // (the KD-L5-01 anchoring behavior), surfaced on the row instead of
+  // silently poisoning the next repeat.
+  const strayArtifacts = sweepStrays(task);
+  if (strayArtifacts.length > 0)
+    console.warn(`run-l5: [${arm}] ${task.id} left stray artifact(s) at tmpdir root (KD-L5-01): ${strayArtifacts.join(', ')}`);
+
+  // Multi-result aggregation (M1 metric-artifact fix, first-round
+  // dissection): BOTH engines emit one result per streamed user turn, so
+  // lastResult-only metrics under-reported official multi-turn runs
+  // (longconv showed turns=1 - misread as early termination). The two
+  // engines' per-result cumulative semantics DIVERGE (KD-L5-04, verified
+  // from run 28736460533 L6 traces + query.ts finding #33):
+  //   official: num_turns/usage PER-RESULT (sum), total_cost_usd and
+  //             duration_api_ms session-cumulative (take last);
+  //   bpt:      num_turns/usage/total_cost_usd session-cumulative on every
+  //             result (take last), duration_api_ms per-run (sum).
+  // Single-result runs are unchanged by construction either way.
+  const sumOf = (get) => resultMsgs.reduce((s, r) => s + (get(r) ?? 0), 0);
+  const lastOf = (get) => (lastResult ? (get(lastResult) ?? 0) : 0);
+  const perResultArm = arm === 'official';
+  const usageOf = (k) => (perResultArm ? sumOf((r) => r.usage?.[k]) : lastOf((r) => r.usage?.[k]));
   return {
     arm,
     task: task.id,
@@ -419,15 +475,17 @@ async function runOne(arm, task) {
     passed,
     subtype: lastResult?.subtype ?? 'no-result',
     error,
-    turns: lastResult?.num_turns ?? 0,
-    costUsd: lastResult?.total_cost_usd ?? 0,
-    inputTokens: usage.input_tokens ?? 0,
-    outputTokens: usage.output_tokens ?? 0,
-    cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
-    cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+    turns: perResultArm ? sumOf((r) => r.num_turns) : lastOf((r) => r.num_turns),
+    results: resultMsgs.length,
+    costUsd: lastOf((r) => r.total_cost_usd),
+    inputTokens: usageOf('input_tokens'),
+    outputTokens: usageOf('output_tokens'),
+    cacheCreationTokens: usageOf('cache_creation_input_tokens'),
+    cacheReadTokens: usageOf('cache_read_input_tokens'),
     wallMs: Date.now() - started,
-    apiMs: lastResult?.duration_api_ms ?? 0,
+    apiMs: perResultArm ? lastOf((r) => r.duration_api_ms) : sumOf((r) => r.duration_api_ms),
     finalTextHead: finalText.slice(0, 160),
+    ...(strayArtifacts.length > 0 ? { strayArtifacts } : {}),
     messages, // dropped by the caller after L6 retention
   };
 }
@@ -626,6 +684,10 @@ const taskSummaries = selected.map((task) => {
     zh: task.zh === true,
     repeats: effRepeat(task),
     estTurns: task.estTurns,
+    // Standing per-task explanations (L5_KNOWN_DIFFERENCES) ride next to the
+    // pass counts so a report reader never mistakes a documented KD for a
+    // fresh regression. Report-only - gate B ignores them.
+    ...(Array.isArray(task.kd) && task.kd.length > 0 ? { kd: task.kd } : {}),
     arms: perArm,
   };
 });
@@ -677,6 +739,7 @@ const report = {
     aborted: budgetAborted,
   },
   aggregate,
+  knownDifferences: L5_KNOWN_DIFFERENCES,
   tasks: taskSummaries,
   runs: rows,
   cache,


### PR DESCRIPTION
## 概要

回到测试用例本身的开发：把首轮 L5 解剖（`bpt-sdk-l5-failure-dissection-20260705.md`，PR #452）挂账的三项测试用例层修缮全部落地，并附带发现一条新 KD。

## 改动

### ① S2 污染面封堵（`l5-tasks.mjs` + `run-l5.mjs`）
- 11 个带档案产物的任务声明 `strays` 字段（任务自有文件 basename 白名单：fizz.mjs / sum.txt / stats.mjs / toc.md 等）。
- runner 每 run **前后**在 tmpdir 根定点清扫这些确切文件名：pre-run 清扫恢复官方臂 code-03 r1 赖以自救的 ENOENT 信号；post-run 清扫把「本 run 把档案写歪到 /tmp 根」升格为行级观测字段 `strayArtifacts`（KD-L5-01 的正面证据），不再静默毒害下一个 repeat。
- 判分语义零变动：check/verify 仍只读沙箱目录。

### ② M1 度量伪影修正（`run-l5.mjs`）
- 双臂对流式多轮**均**逐用户轮发 result；旧逻辑只取 lastResult，官方多轮任务 turns/usage 被低报（longconv 报 turns=1 曾被误读为提前终局）。
- 聚合改为**按臂**，因为两引擎累计口径本身分歧（见 KD-L5-04）：官方 num_turns/usage 逐 result 求和、cost/apiMs 取累计末值；我方全字段累计取末值、apiMs 逐 run 求和。口径均从 run 28736460533 留痕 + `query.ts` finding #33 实证。

### ③ KD 表落库并透传报告（`l5-tasks.mjs` → 报告）
- `L5_KNOWN_DIFFERENCES`：KD-L5-01（官方 /tmp 锚定）/ KD-L5-02（官方注入误判拒绝方差）/ KD-L5-03（思考不对称）。
- 任务级 `kd` 标签跟随 per-task 汇总进报告，读数的人在通过率旁边直接看到既有解释，不再需要重新解剖。

### 附带发现 KD-L5-04（新）
两引擎 result 消息的累计口径本身不同：官方 `num_turns`/`usage` 逐 result、`total_cost_usd`/`duration_api_ms` 会话累计；我方（finding #33 设计）除 per-run 的 `duration_api_ms` 外全字段每 result 报会话累计。已登记为 drop-in 面引擎对齐候选。

### 其他
- `package-lock.json` 版本字段对账 0.3.0 → 0.6.0（滞后于 package.json）。

## 验证

- `node tests/conformance/run-l5.mjs --smoke`：3/3 绿，content-blind 自审 PASS。
- 预置散落物实测：植入 `/tmp/note.txt` 后跑冒烟，pre-run 清扫检出、警告并移除。
- `npx vitest run`：**981/981 全绿**（33 文件）。
- L5 不在棘轮 baseline.json 与 vitest 锁定面内，无回归锁需更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_