### PR TITLE
test(bpt-sdk): 测试用例完备性全面推进 — 网关方言轴 + MCP 差分首批 + Fix-2 + 聚合自证

### DIFF
--- a/.github/workflows/bpt-agent-sdk.yml
+++ b/.github/workflows/bpt-agent-sdk.yml
@@ -76,6 +76,10 @@ on:
         description: 'L5 repeats per task per engine (blueprint nominal 5; gate B takes the aggregate)'
         required: false
         default: '5'
+      l5_thinking:
+        description: 'Fix-2 variable isolation: pin maxThinkingTokens to this SAME budget on BOTH arms (empty = each engine its own default)'
+        required: false
+        default: ''
 
 concurrency:
   group: bpt-agent-sdk-${{ github.ref }}
@@ -379,7 +383,7 @@ jobs:
       - name: L5 dual-arm real-API round (gate B enforced)
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: node tests/conformance/run-l5.mjs --gate "--model=${{ github.event.inputs.model }}" "--repeat=${{ github.event.inputs.l5_repeat }}"
+        run: node tests/conformance/run-l5.mjs --gate "--model=${{ github.event.inputs.model }}" "--repeat=${{ github.event.inputs.l5_repeat }}" ${{ github.event.inputs.l5_thinking != '' && format('--thinking={0}', github.event.inputs.l5_thinking) || '' }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -261,6 +261,19 @@
   ② stop 前无 event 名非 JSON 帧跳过（debug 留片段）③ 有 event 名坏帧照抛且带现场（前 120 字符 + 已解析帧数
   ——交接单 **E6b 就地落地**，交接档 r2 已注记引擎侧勿重做）。5 条回归测试；`npx vitest run` **1030 全绿（35 文件）**、
   `tsc` + build exit 0。BPT 侧只需装新 build 验证。
+  **测试用例完备性全面推进已落（2026-07-05，守密人「全面推进」裁定，四缺口一批清）**：
+  ① **环境保真轴建轴**——仿真器加 `sse-gateway` 脚本类（`[DONE]` 尾卡 / 无 event 名帧，复刻 idealab 原始字节形状），
+  L4 新增 3 场景双臂差分：`[DONE]` 尾卡（文本轮 + 工具链轮）**双臂全绿**（#461 修复差分成立）；无名错误帧抓到**真发现
+  KD-L4-05**（两轮稳定）：官方 2.1.201 不认无名错误帧、当「空/畸形响应」**重试一次**并把失败编码成 assistant 文本 +
+  result/success——对 BPT 产线的实义：官方客户端在 idealab 后面会重试并 success 化 API 错误、我方快速失败带真错误类型；
+  ② **MCP 差分首批（L3 扩容）**——arm.mjs `buildOptions` 加每臂 SDK 句柄（各臂用自家 `tool()`/`createSdkMcpServer`
+  建进程内服务器），4 场景：ping/软失败 isError **双臂 CONTENT_MATCH**（结果编码逐字一致），抛异常/未注册工具措辞差
+  两轮稳定入 KD-L3-22/23（zod schema 语义留第二批）；③ **Fix-2 落地**——run-l5 `--thinking=N` 双臂同预算钉死
+  （拆引擎差 vs 思考差），workflow 加 `l5_thinking` dispatch 输入；④ **聚合自证**——runner 度量规则抽成
+  `l5-aggregate.mjs`，vitest 喂 run 28736460533 真实官方 result 序列锁定（多 result 求和/取末值、空跑、缺字段防 NaN）。
+  棘轮基线 +7 行全改进项锁入；L1-L4 双臂全跑收敛（L4 12/12、L3 零发散、零未分诊候选）；`npx vitest run` **1060 全绿**。
+  剩余挂账：MCP 差分第二批（schema 语义/annotations/stdio-http 传输）、子代理/hook 差分（L3.5，大活）、
+  E1 后首轮真 L5 复测（退出标准 chat-03 ≥2/3、code-01 ≥官方−1）。
   （首轮 run 28735894053 因预算护栏冷启动外推误停 2/180，护栏已修 #447）。**一致性验证体系 M1-M4 全部封顶**
 - **完成度（表面等价）**：对官方 SDK **0.3.199 基线**约 **89.5%**（v0.1 基线 68.3% → v0.2+v0.3 补齐后重算）。
   审计矩阵与逐行台账落 `Public-Info-Pool/Resource/repo-engineering/bpt-agent-sdk-completion-audit-20260703.md`

--- a/projects/bpt-agent-sdk/tests/conformance-l5-aggregate.test.ts
+++ b/projects/bpt-agent-sdk/tests/conformance-l5-aggregate.test.ts
@@ -1,0 +1,94 @@
+/**
+ * L5 multi-result aggregation self-test (gap 4 of the completeness push,
+ * 2026-07-05): the runner's metric rule previously had no test of its own -
+ * the multi-result sum path was first executed inside a paid real round.
+ *
+ * The multi-result fixture below is the REAL official-arm result sequence
+ * from run 28736460533 longconv-02 r1 (L6 public-stream trace retention):
+ * three streamed user turns -> three result messages, num_turns/usage
+ * per-result, total_cost_usd and duration_api_ms session-cumulative.
+ */
+
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error - plain-JS conformance module without type declarations
+import { aggregateRunMetrics } from './conformance/l5-aggregate.mjs';
+
+/** Real sequence: run 28736460533, official arm, longconv-02 repeat 1. */
+const OFFICIAL_LONGCONV_R1 = [
+  {
+    type: 'result',
+    subtype: 'success',
+    num_turns: 1,
+    total_cost_usd: 0.0067209999999999995,
+    duration_api_ms: 3576,
+    usage: { input_tokens: 4, output_tokens: 259, cache_creation_input_tokens: 253, cache_read_input_tokens: 5000 },
+  },
+  {
+    type: 'result',
+    subtype: 'success',
+    num_turns: 1,
+    total_cost_usd: 0.00989985,
+    duration_api_ms: 7090,
+    usage: { input_tokens: 3, output_tokens: 211, cache_creation_input_tokens: 0, cache_read_input_tokens: 6000 },
+  },
+  {
+    type: 'result',
+    subtype: 'success',
+    num_turns: 1,
+    total_cost_usd: 0.0137899,
+    duration_api_ms: 10479,
+    usage: { input_tokens: 3, output_tokens: 356, cache_creation_input_tokens: 0, cache_read_input_tokens: 6838 },
+  },
+];
+
+describe('aggregateRunMetrics', () => {
+  it('multi-result (real official longconv trace): turns/usage summed, cost/apiMs last-cumulative', () => {
+    const m = aggregateRunMetrics(OFFICIAL_LONGCONV_R1);
+    expect(m.results).toBe(3);
+    expect(m.turns).toBe(3); // 1+1+1, NOT the lastResult-only 1 that misread as early termination
+    expect(m.costUsd).toBeCloseTo(0.0137899, 10); // cumulative -> last, never summed
+    expect(m.apiMs).toBe(10479); // cumulative -> last
+    expect(m.outputTokens).toBe(259 + 211 + 356); // per-result -> summed
+    expect(m.inputTokens).toBe(4 + 3 + 3);
+    expect(m.cacheCreationTokens).toBe(253);
+    expect(m.cacheReadTokens).toBe(5000 + 6000 + 6838);
+    expect(m.subtype).toBe('success');
+  });
+
+  it('single-result run is unchanged by construction (sum-of-one == last-of-one)', () => {
+    const only = OFFICIAL_LONGCONV_R1[2];
+    const m = aggregateRunMetrics([only]);
+    expect(m.results).toBe(1);
+    expect(m.turns).toBe(1);
+    expect(m.costUsd).toBeCloseTo(0.0137899, 10);
+    expect(m.outputTokens).toBe(356);
+    expect(m.apiMs).toBe(10479);
+  });
+
+  it('no result messages (harness abort / dead run): zeroed metrics, subtype no-result', () => {
+    const m = aggregateRunMetrics([]);
+    expect(m).toEqual({
+      subtype: 'no-result',
+      turns: 0,
+      results: 0,
+      costUsd: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      apiMs: 0,
+    });
+  });
+
+  it('missing usage/num_turns fields default to 0 instead of NaN-poisoning the report', () => {
+    const m = aggregateRunMetrics([
+      { type: 'result', subtype: 'error_during_execution', total_cost_usd: 0.01 },
+      { type: 'result', subtype: 'success', num_turns: 2, usage: { output_tokens: 5 }, total_cost_usd: 0.02, duration_api_ms: 100 },
+    ]);
+    expect(m.turns).toBe(2);
+    expect(m.outputTokens).toBe(5);
+    expect(m.costUsd).toBeCloseTo(0.02, 10);
+    expect(Number.isNaN(m.inputTokens)).toBe(false);
+    expect(m.subtype).toBe('success');
+  });
+});

--- a/projects/bpt-agent-sdk/tests/conformance/arm.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/arm.mjs
@@ -27,7 +27,7 @@
  *     Discipline: a dynamic entry must not depend on the message emitted by
  *     the turn IMMEDIATELY before it (stdout delivery can race the next HTTP
  *     request); scenarios insert a settle-barrier turn in between.
- *   scenario.options / scenario.buildOptions(cwd, ctx) - extra Options merged
+ *   scenario.options / scenario.buildOptions(cwd, ctx, { armKind, sdk }) - extra Options merged
  *     into the query (e.g. allowedTools so both arms auto-approve write tools;
  *     preferred over bypassPermissions, which claude-code refuses when running
  *     as root without IS_SANDBOX=1 - a real CI risk).
@@ -56,13 +56,14 @@ import { normalizeStream } from './normalize.mjs';
 
 const DUMMY_KEY = 'sk-ant-api03-' + 'A'.repeat(95);
 
+async function loadSdk(armKind) {
+  return armKind === 'bpt'
+    ? import('../../dist/index.js')
+    : import('@anthropic-ai/claude-agent-sdk');
+}
+
 async function loadQuery(armKind) {
-  if (armKind === 'bpt') {
-    const mod = await import('../../dist/index.js');
-    return mod.query;
-  }
-  const mod = await import('@anthropic-ai/claude-agent-sdk');
-  return mod.query;
+  return (await loadSdk(armKind)).query;
 }
 
 /**
@@ -156,7 +157,8 @@ function safeRealpath(p) {
 }
 
 export async function runScenario(armKind, scenario, { timeoutMs = 120_000 } = {}) {
-  const query = await loadQuery(armKind);
+  const sdk = await loadSdk(armKind);
+  const query = sdk.query;
   const cwd = mkdtempSync(join(tmpdir(), `conf-${armKind}-`));
   const realCwd = safeRealpath(cwd);
   writeFixtures(cwd, scenario.fixtureFiles);
@@ -189,8 +191,11 @@ export async function runScenario(armKind, scenario, { timeoutMs = 120_000 } = {
     DISABLE_ERROR_REPORTING: '1',
   };
 
+  // Third arg gives per-arm construction access (L3-MCP tranche): in-process
+  // MCP servers must be built with EACH ARM'S OWN tool()/createSdkMcpServer,
+  // so the scenario factory receives { armKind, sdk }.
   const extraOptions = scenario.buildOptions
-    ? scenario.buildOptions(cwd, ctx)
+    ? scenario.buildOptions(cwd, ctx, { armKind, sdk })
     : (scenario.options ?? {});
 
   const ac = new AbortController();

--- a/projects/bpt-agent-sdk/tests/conformance/baseline.json
+++ b/projects/bpt-agent-sdk/tests/conformance/baseline.json
@@ -273,6 +273,30 @@
         ],
         "engineFinding": false
       },
+      "L3-MCP-01": {
+        "verdict": "CONTENT_MATCH",
+        "kdIds": [],
+        "engineFinding": false
+      },
+      "L3-MCP-02": {
+        "verdict": "CONTENT_MATCH",
+        "kdIds": [],
+        "engineFinding": false
+      },
+      "L3-MCP-03": {
+        "verdict": "CONTENT_KNOWN_DIFF",
+        "kdIds": [
+          "KD-L3-22"
+        ],
+        "engineFinding": false
+      },
+      "L3-MCP-04": {
+        "verdict": "CONTENT_KNOWN_DIFF",
+        "kdIds": [
+          "KD-L3-23"
+        ],
+        "engineFinding": false
+      },
       "L3-READ-01": {
         "verdict": "CONTENT_KNOWN_DIFF",
         "kdIds": [
@@ -354,6 +378,33 @@
           "KD-04",
           "KD-05",
           "KD-12"
+        ],
+        "engineFinding": false
+      },
+      "l4-gateway-done-appendix": {
+        "verdict": "FAULT_KNOWN_DIFF",
+        "kdIds": [
+          "KD-01",
+          "KD-02",
+          "KD-04"
+        ],
+        "engineFinding": false
+      },
+      "l4-gateway-done-tool-chain": {
+        "verdict": "FAULT_KNOWN_DIFF",
+        "kdIds": [
+          "KD-01",
+          "KD-02",
+          "KD-04"
+        ],
+        "engineFinding": false
+      },
+      "l4-gateway-eventless-error-frame": {
+        "verdict": "FAULT_KNOWN_DIFF",
+        "kdIds": [
+          "KD-01",
+          "KD-04",
+          "KD-L4-05"
         ],
         "engineFinding": false
       },

--- a/projects/bpt-agent-sdk/tests/conformance/emulator.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/emulator.mjs
@@ -90,6 +90,16 @@ export function toolUseReply(calls, { id = 'msg_conf_tool' } = {}) {
  *     hangAfter event type (default 'message_start'), then the connection is
  *     held open forever: no end(), no further writes. close() destroys the
  *     registered hung sockets so shutdown cannot deadlock.
+ *   { kind: 'sse-gateway', events, eventless?, appendDone? } - OpenAI-dialect
+ *     framing quirks of a TRANSLATING GATEWAY's /api/anthropic endpoint,
+ *     reproduced from the 2026-07-05 BPT production capture (raw curl -N
+ *     bytes): `eventless: true` serializes frames as bare `data:` lines with
+ *     NO `event:` name (the gateway's error-frame shape); `appendDone`
+ *     (default true) terminates the stream with the OpenAI-style
+ *     `data: [DONE]` appendix - not valid JSON, present after message_stop
+ *     on every gateway response. Environment-fidelity axis: engines that
+ *     pass L1-L4 against clean framing can still differ behind such a
+ *     gateway, which is exactly where BPT runs in production.
  *
  * Returns { url, port, profile, close }.
  */
@@ -149,6 +159,18 @@ export function startEmulator(scripts) {
         res.write(sse(script.events.slice(0, upTo === -1 ? script.events.length : upTo + 1)));
         hungResponses.add(res);
         res.on('close', () => hungResponses.delete(res));
+        return;
+      }
+      if (script.kind === 'sse-gateway') {
+        const frames = script.events.map((e) =>
+          script.eventless === true
+            ? `data: ${JSON.stringify(e)}\n\n`
+            : `event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`,
+        );
+        let body = frames.join('');
+        if (script.appendDone !== false) body += 'data: [DONE]\n\n';
+        res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+        res.end(body);
         return;
       }
       const body = sse(script.events);

--- a/projects/bpt-agent-sdk/tests/conformance/l5-aggregate.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/l5-aggregate.mjs
@@ -1,0 +1,38 @@
+/**
+ * L5 multi-result metric aggregation - extracted from run-l5.mjs runOne so
+ * the rule is unit-testable against REAL result sequences (the runner logic
+ * itself previously had no self-test: the official-arm sum path was first
+ * executed in a paid real round - a test tool without a test).
+ *
+ * Semantics (M1 metric-artifact fix + E2 alignment, both 2026-07-05): BOTH
+ * engines emit one `result` message per streamed user turn and share the
+ * official per-result field semantics -
+ *   num_turns / usage        PER-RESULT      -> summed across results
+ *   total_cost_usd           session-cumulative -> last result's value
+ *   duration_api_ms          session-cumulative -> last result's value
+ * Single-result runs are unchanged by construction (sum-of-one == last).
+ * Verified against run 28736460533 L6 official traces (longconv-02: turns
+ * 1,1,2; costs strictly increasing with exact per-run deltas).
+ */
+
+/**
+ * Aggregate a run's result-message sequence into report metrics.
+ * resultMsgs: SDKResultMessage[] in stream order (possibly empty).
+ */
+export function aggregateRunMetrics(resultMsgs) {
+  const lastResult = resultMsgs.length > 0 ? resultMsgs[resultMsgs.length - 1] : undefined;
+  const sumOf = (get) => resultMsgs.reduce((s, r) => s + (get(r) ?? 0), 0);
+  const lastOf = (get) => (lastResult ? (get(lastResult) ?? 0) : 0);
+  const usageOf = (k) => sumOf((r) => r.usage?.[k]);
+  return {
+    subtype: lastResult?.subtype ?? 'no-result',
+    turns: sumOf((r) => r.num_turns),
+    results: resultMsgs.length,
+    costUsd: lastOf((r) => r.total_cost_usd),
+    inputTokens: usageOf('input_tokens'),
+    outputTokens: usageOf('output_tokens'),
+    cacheCreationTokens: usageOf('cache_creation_input_tokens'),
+    cacheReadTokens: usageOf('cache_read_input_tokens'),
+    apiMs: lastOf((r) => r.duration_api_ms),
+  };
+}

--- a/projects/bpt-agent-sdk/tests/conformance/normalize-l3.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/normalize-l3.mjs
@@ -288,6 +288,31 @@ export const KNOWN_TOOL_DIVERGENCES = [
       return t !== u && t === o;
     },
   },
+
+  {
+    id: 'KD-L3-22',
+    tool: 'mcp (sdk server)',
+    note:
+      'thrown MCP handler wording: official 2.1.201 relays the bare handler error message as the ' +
+      "error tool_result text; ours wraps it as \"Tool '<name>' failed: <msg>\" (registry " +
+      'encoding). Semantics identical: is_error true, handler message carried verbatim inside. ' +
+      'Stable across 2 runs (2026-07-05, L3-MCP tranche 1).',
+    applies: (o, u) => /^Tool '[^']+' failed: /.test(u) && u.endsWith(o),
+  },
+  {
+    id: 'KD-L3-23',
+    tool: 'mcp (sdk server)',
+    note:
+      'unknown-MCP-tool wording: official 2.1.201 emits "<tool_use_error>Error: No such tool ' +
+      'available: <name></tool_use_error>"; ours emits "No such tool: <name>" (no XMLish wrapper, ' +
+      'registry wording). Semantics identical: is_error true, refused without execution, tool ' +
+      'name carried. Stable across 2 runs (2026-07-05, L3-MCP tranche 1).',
+    applies: (o, u) => {
+      const om = o.match(/^<tool_use_error>Error: No such tool available: (.+)<\/tool_use_error>$/);
+      const um = u.match(/^No such tool: (.+)$/);
+      return om !== null && um !== null && om[1] === um[1];
+    },
+  },
 ];
 
 /** First `max` differing line pairs between two normalized texts. */

--- a/projects/bpt-agent-sdk/tests/conformance/run-l4.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/run-l4.mjs
@@ -104,6 +104,23 @@ export const KD_L4 = [
   // COMPLETE tool_use blocks as actionable (execute, 2nd POST for the
   // tool_result, result/success) at either cut depth - every facet converged
   // in the dual-arm run, the engineFinding cleared. Id kept out of circulation.
+  {
+    id: 'KD-L4-05',
+    scenarios: ['l4-gateway-eventless-error-frame'],
+    facets: ['postCount', 'resultSubtype', 'errorPresent'],
+    coversTokens: true,
+    note:
+      'gateway-dialect EVENT-LESS error frame (bare `data: {error json}` + [DONE], the 2026-07-05 ' +
+      'production capture shape): official 2.1.201 does not recognize the frame as an error event ' +
+      'at all - it reports "API returned an empty or malformed response (HTTP 200) - check for a ' +
+      'proxy or gateway intercepting the request", RETRIES once (postCount 2; the retry response ' +
+      'never surfaces on its stream), then encodes the failure AS ASSISTANT TEXT with ' +
+      'result/success + a post-result iterator throw (the KD-L4-01 quirk family). This SDK maps ' +
+      'the error payload via isErrorPayload -> APIStatusError(400) -> clean ' +
+      'result/error_during_execution, NO retry (postCount 1). Stable across 2 runs. Practical ' +
+      'consequence for BPT production: behind such a gateway the official client retries and ' +
+      'success-encodes API errors; ours fails fast with the real error type.',
+  },
 ];
 
 async function loadQuery(armKind) {

--- a/projects/bpt-agent-sdk/tests/conformance/run-l5.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/run-l5.mjs
@@ -17,7 +17,7 @@
  *   ANTHROPIC_API_KEY=... node tests/conformance/run-l5.mjs \
  *     [--model=claude-haiku-4-5-20251001] [--repeat=5] [--budget-usd=1.5] \
  *     [--gate] [--econ] [--tasks=chat-01,code-03|--tasks=code] \
- *     [--traces-bpt] [--out=path.json]
+ *     [--thinking=4096] [--traces-bpt] [--out=path.json]
  *
  * Keyless smoke (this is the only mode runnable without a key - proves the
  * harness end-to-end against the M1 content-blind emulator, zero spend):
@@ -65,6 +65,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { L5_TASKS, L5_KNOWN_DIFFERENCES } from './l5-tasks.mjs';
+import { aggregateRunMetrics } from './l5-aggregate.mjs';
 import { startEmulator, textReply, assertContentBlind } from './emulator.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -90,6 +91,14 @@ if (GATE && typeof args.tasks === 'string' && args['gate-shard'] !== true) {
   process.exit(1);
 }
 const ECON = args.econ === true;
+// Fix-2 (dissection 2026-07-05, KD-L5-03 variable isolation): --thinking=N
+// pins maxThinkingTokens to the SAME explicit budget on BOTH arms, so a
+// correctness delta can no longer hide behind the engines' different
+// thinking DEFAULTS (official CLI: on, undisclosed budget; ours since E1:
+// on, 4096 under the claude_code preset). Unset = each engine's own default
+// (the product-realistic comparison). Real mode only - smoke is scripted.
+const THINKING = Number.parseInt(args.thinking, 10);
+const THINKING_SET = Number.isFinite(THINKING) && THINKING >= 0;
 const TRACE_BPT = args['traces-bpt'] === true;
 const OUT = typeof args.out === 'string' ? args.out : join(HERE, '..', '..', 'conformance-l5.json');
 const TRACE_ROOT = join(HERE, '..', '..', 'l5-traces');
@@ -384,6 +393,8 @@ async function runOne(arm, task) {
         allowDangerouslySkipPermissions: true,
         persistSession: false,
         ...(arm === 'bpt' ? { systemPrompt: { type: 'preset', preset: 'claude_code' } } : {}),
+        // Fix-2: identical explicit thinking budget on BOTH arms when set.
+        ...(THINKING_SET ? { maxThinkingTokens: THINKING } : {}),
       };
     }
     const q = queryOf(arm)({
@@ -453,34 +464,18 @@ async function runOne(arm, task) {
   if (strayArtifacts.length > 0)
     console.warn(`run-l5: [${arm}] ${task.id} left stray artifact(s) at tmpdir root (KD-L5-01): ${strayArtifacts.join(', ')}`);
 
-  // Multi-result aggregation (M1 metric-artifact fix, first-round
-  // dissection): BOTH engines emit one result per streamed user turn, so
-  // lastResult-only metrics under-reported official multi-turn runs
-  // (longconv showed turns=1 - misread as early termination). Since E2
-  // (2026-07-05) BOTH arms share the official per-result semantics -
-  // num_turns/usage PER-RESULT (sum across results), total_cost_usd and
-  // duration_api_ms session-cumulative (take last) - so the former per-arm
-  // aggregation split (KD-L5-04, retired) collapses to one rule. Single-
-  // result runs are unchanged by construction.
-  const sumOf = (get) => resultMsgs.reduce((s, r) => s + (get(r) ?? 0), 0);
-  const lastOf = (get) => (lastResult ? (get(lastResult) ?? 0) : 0);
-  const usageOf = (k) => sumOf((r) => r.usage?.[k]);
+  // Multi-result aggregation: the rule lives in l5-aggregate.mjs (extracted
+  // 2026-07-05 so it is unit-tested against REAL trace sequences in
+  // tests/conformance-l5-aggregate.test.ts - the runner logic itself gets a
+  // self-test instead of first executing its sum path in a paid round).
   return {
     arm,
     task: task.id,
     dimension: task.dimension,
     passed,
-    subtype: lastResult?.subtype ?? 'no-result',
     error,
-    turns: sumOf((r) => r.num_turns),
-    results: resultMsgs.length,
-    costUsd: lastOf((r) => r.total_cost_usd),
-    inputTokens: usageOf('input_tokens'),
-    outputTokens: usageOf('output_tokens'),
-    cacheCreationTokens: usageOf('cache_creation_input_tokens'),
-    cacheReadTokens: usageOf('cache_read_input_tokens'),
+    ...aggregateRunMetrics(resultMsgs),
     wallMs: Date.now() - started,
-    apiMs: lastOf((r) => r.duration_api_ms),
     finalTextHead: finalText.slice(0, 160),
     ...(strayArtifacts.length > 0 ? { strayArtifacts } : {}),
     messages, // dropped by the caller after L6 retention
@@ -526,6 +521,7 @@ const runsPlanned = selected.reduce((s, t) => s + effRepeat(t), 0) * ARMS.length
 console.log(
   `run-l5 [${SMOKE ? 'SMOKE (emulator, zero spend)' : 'REAL API'}] model=${MODEL} ` +
     `tasks=${selected.length} arms=${ARMS.join('+')} plannedRuns=${runsPlanned}` +
+    (THINKING_SET ? ` thinking=${THINKING} (both arms pinned)` : '') +
     (SMOKE ? '' : ` repeat=${REPEAT}${ECON ? ' (econ overrides on)' : ''} budget=$${BUDGET_USD}`),
 );
 
@@ -719,6 +715,8 @@ const report = {
   model: MODEL,
   repeat: REPEAT,
   econ: ECON,
+  // Fix-2 audit trail: null = engines ran their own thinking defaults.
+  thinkingBudget: THINKING_SET ? THINKING : null,
   taskFilter: typeof args.tasks === 'string' ? args.tasks : null,
   gate: {
     rule: 'aggregate pass-rate over all task-repeats: bpt >= official - 5pp (single tasks may trade wins)',

--- a/projects/bpt-agent-sdk/tests/conformance/scenarios-l3.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/scenarios-l3.mjs
@@ -740,6 +740,154 @@ export const L3_SCENARIOS = [
       },
     ],
   },
+
+  // --- MCP (in-process sdk server) - differential tranche 1 -------------------
+  // Completeness-push gap 2 (2026-07-05): L3 previously differentialized only
+  // the six built-in tools; the MCP tool chain (registration -> scripted
+  // tool_use -> handler -> tool_result encoding) had unit tests but ZERO
+  // official-arm comparison. Each arm builds the server with ITS OWN
+  // tool()/createSdkMcpServer via buildOptions(cwd, ctx, { sdk }) - the
+  // official arm bridges handlers over its control protocol, ours dispatches
+  // in-process; the tool_result text is the shared observable. Tranche 1 uses
+  // no-arg fixed-output tools only (zod schema-coercion semantics deferred to
+  // tranche 2 - a different failure axis).
+  {
+    id: 'L3-MCP-01',
+    tool: 'mcp__conf__ping',
+    prompt: 'Call the ping tool.',
+    buildOptions: (_cwd, _ctx, { sdk }) => ({
+      allowedTools: [...ALLOWED_TOOLS, 'mcp__conf__ping'],
+      mcpServers: {
+        conf: sdk.createSdkMcpServer({
+          name: 'conf',
+          version: '1.0.0',
+          tools: [
+            sdk.tool('ping', 'Return a fixed marker.', {}, async () => ({
+              content: [{ type: 'text', text: 'MCP-PING-OK' }],
+            })),
+          ],
+        }),
+      },
+    }),
+    fixtureFiles: {},
+    buildScripts: () => [
+      toolTurn(1, [{ name: 'mcp__conf__ping', input: {} }]),
+      { kind: 'sse', events: textReply('L3 MCP-01 DONE') },
+    ],
+    steps: [
+      {
+        tool: 'mcp__conf__ping',
+        isError: false,
+        locks: [/MCP-PING-OK/],
+      },
+    ],
+  },
+  {
+    id: 'L3-MCP-02',
+    tool: 'mcp__conf__fail_soft',
+    prompt: 'Call the failing tool.',
+    buildOptions: (_cwd, _ctx, { sdk }) => ({
+      allowedTools: [...ALLOWED_TOOLS, 'mcp__conf__fail_soft'],
+      mcpServers: {
+        conf: sdk.createSdkMcpServer({
+          name: 'conf',
+          version: '1.0.0',
+          tools: [
+            sdk.tool('fail_soft', 'Return an isError tool result.', {}, async () => ({
+              content: [{ type: 'text', text: 'MCP-SOFT-FAILURE' }],
+              isError: true,
+            })),
+          ],
+        }),
+      },
+    }),
+    fixtureFiles: {},
+    buildScripts: () => [
+      toolTurn(1, [{ name: 'mcp__conf__fail_soft', input: {} }]),
+      { kind: 'sse', events: textReply('L3 MCP-02 DONE') },
+    ],
+    steps: [
+      {
+        // The MCP protocol's soft-failure channel: handler returns
+        // isError: true. How each engine maps that onto the Messages API
+        // tool_result is_error flag is the differential payload.
+        tool: 'mcp__conf__fail_soft',
+        isError: true,
+        locks: [/MCP-SOFT-FAILURE/],
+      },
+    ],
+  },
+  {
+    id: 'L3-MCP-03',
+    tool: 'mcp__conf__crash',
+    prompt: 'Call the crashing tool.',
+    buildOptions: (_cwd, _ctx, { sdk }) => ({
+      allowedTools: [...ALLOWED_TOOLS, 'mcp__conf__crash'],
+      mcpServers: {
+        conf: sdk.createSdkMcpServer({
+          name: 'conf',
+          version: '1.0.0',
+          tools: [
+            sdk.tool('crash', 'Throw from the handler.', {}, async () => {
+              throw new Error('MCP-HANDLER-CRASH');
+            }),
+          ],
+        }),
+      },
+    }),
+    fixtureFiles: {},
+    buildScripts: () => [
+      toolTurn(1, [{ name: 'mcp__conf__crash', input: {} }]),
+      { kind: 'sse', events: textReply('L3 MCP-03 DONE') },
+    ],
+    steps: [
+      {
+        // A THROWN handler (vs the soft isError channel above): must surface
+        // as an error tool_result carrying the message - never a crashed run.
+        tool: 'mcp__conf__crash',
+        isError: true,
+        locks: [/MCP-HANDLER-CRASH/],
+        kd: ['KD-L3-22'],
+      },
+    ],
+  },
+  {
+    id: 'L3-MCP-04',
+    tool: 'mcp__conf__nope (unregistered)',
+    prompt: 'Call a tool that does not exist.',
+    buildOptions: (_cwd, _ctx, { sdk }) => ({
+      // The server registers ONLY ping; the script calls mcp__conf__nope.
+      allowedTools: [...ALLOWED_TOOLS, 'mcp__conf__nope'],
+      mcpServers: {
+        conf: sdk.createSdkMcpServer({
+          name: 'conf',
+          version: '1.0.0',
+          tools: [
+            sdk.tool('ping', 'Return a fixed marker.', {}, async () => ({
+              content: [{ type: 'text', text: 'MCP-PING-OK' }],
+            })),
+          ],
+        }),
+      },
+    }),
+    fixtureFiles: {},
+    buildScripts: () => [
+      toolTurn(1, [{ name: 'mcp__conf__nope', input: {} }]),
+      { kind: 'sse', events: textReply('L3 MCP-04 DONE') },
+    ],
+    steps: [
+      {
+        // Unknown-tool encoding is a discovery objective: both engines must
+        // refuse via an error tool_result (never execute, never crash the
+        // run); the wording is expected to differ and will be KD-triaged
+        // after first observation.
+        tool: 'mcp__conf__nope',
+        isError: true,
+        locks: [/nope|not found|unknown|no such|not available/i],
+        kd: ['KD-L3-23'],
+      },
+    ],
+  },
 ];
 
 /**

--- a/projects/bpt-agent-sdk/tests/conformance/scenarios-l4.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/scenarios-l4.mjs
@@ -402,4 +402,141 @@ export const SCENARIOS_L4 = [
       'Mirrors l4-http400 mid-session; a stable encoding split shares KD-L4-01 (one KD covers ' +
       'both 400 positions).',
   },
+
+  // --- Gateway-dialect fidelity (2026-07-05 BPT production incident) -------------
+  // BPT runs behind a translating corporate gateway whose /api/anthropic
+  // endpoint keeps OpenAI framing habits: every response ends with a
+  // `data: [DONE]` appendix, and error frames arrive as bare `data:` lines
+  // with no event: name (raw curl -N capture). The three cases below replay
+  // that dialect through BOTH arms - the environment-fidelity axis L1-L4
+  // previously never exercised (clean framing only).
+  {
+    id: 'l4-gateway-done-appendix',
+    fault: "text turn followed by the gateway's OpenAI-style `data: [DONE]` appendix (not JSON)",
+    prompt: 'Say OK.',
+    timeoutMs: 45_000,
+    buildScripts: () => [
+      { kind: 'sse-gateway', events: textReply('GATEWAY APPENDIX OK') },
+      // Sentinel: a retry/re-request provoked by the appendix would consume it.
+      { kind: 'sse', events: textReply('UNEXPECTED GATEWAY RETRY') },
+    ],
+    sentinels: ['GATEWAY APPENDIX OK', 'UNEXPECTED GATEWAY RETRY'],
+    invariants: (run) => {
+      const f = [];
+      if (run.postCount !== 1) f.push(`postCount ${run.postCount} != 1 (appendix provoked a re-request)`);
+      if (run.unscriptedCalls !== 0) f.push(`unscriptedCalls ${run.unscriptedCalls} != 0`);
+      if (run.checks.resultSubtype !== 'success') f.push(`resultSubtype ${run.checks.resultSubtype} != success`);
+      if (!streamHas(run, 'GATEWAY APPENDIX OK')) f.push('resultText missing "GATEWAY APPENDIX OK"');
+      if (streamHas(run, 'UNEXPECTED GATEWAY RETRY')) f.push('retry sentinel leaked into the stream');
+      return f;
+    },
+    bptOnly: (run) => {
+      // #461 contract: message_stop ends consumption, the appendix is never
+      // parsed - the run must be CLEAN (no thrown error, no non-fatal notes).
+      const f = [];
+      if (run.error) f.push(`unexpected thrown error: ${run.error}`);
+      if ((run.resultErrors ?? []).length > 0) {
+        f.push(`unexpected result.errors notes: ${JSON.stringify(run.resultErrors)}`);
+      }
+      return f;
+    },
+    engineFindingIf: (bpt, off) =>
+      off.resultSubtype === 'success' && bpt.resultSubtype !== 'success'
+        ? 'gateway [DONE] appendix: official completes clean while our engine fails the run - ' +
+          'our tolerance regression (the exact 2026-07-05 production incident shape)'
+        : null,
+    notes:
+      'The exact production-incident shape: a full healthy reply that only differs from clean ' +
+      'framing by the trailing non-JSON appendix.',
+  },
+  {
+    id: 'l4-gateway-done-tool-chain',
+    fault: '[DONE] appendix on EVERY response across a tool chain (gateway appends unconditionally)',
+    prompt: 'Write the file.',
+    timeoutMs: 45_000,
+    options: { allowedTools: ['Write'] },
+    captureFiles: ['gw-out.txt'],
+    buildScripts: (cwd) => [
+      {
+        kind: 'sse-gateway',
+        events: toolUseReply([
+          { name: 'Write', input: { file_path: join(cwd, 'gw-out.txt'), content: 'GW-CHAIN' } },
+        ]),
+      },
+      { kind: 'sse-gateway', events: textReply('GATEWAY CHAIN DONE') },
+    ],
+    sentinels: ['GATEWAY CHAIN DONE'],
+    invariants: (run) => {
+      const f = [];
+      if (run.postCount !== 2) f.push(`postCount ${run.postCount} != 2 (tool_result delivery turn)`);
+      if (run.unscriptedCalls !== 0) f.push(`unscriptedCalls ${run.unscriptedCalls} != 0`);
+      if (run.checks.resultSubtype !== 'success') f.push(`resultSubtype ${run.checks.resultSubtype} != success`);
+      if (run.files['gw-out.txt'] !== 'GW-CHAIN') f.push('tool did not execute behind the gateway dialect');
+      if (!streamHas(run, 'GATEWAY CHAIN DONE')) f.push('final turn missing "GATEWAY CHAIN DONE"');
+      return f;
+    },
+    bptOnly: (run) => {
+      const f = [];
+      if (run.error) f.push(`unexpected thrown error: ${run.error}`);
+      if ((run.resultErrors ?? []).length > 0) {
+        f.push(`unexpected result.errors notes: ${JSON.stringify(run.resultErrors)}`);
+      }
+      return f;
+    },
+    engineFindingIf: (bpt, off) =>
+      (off.files['gw-out.txt'] === 'GW-CHAIN' && bpt.files['gw-out.txt'] !== 'GW-CHAIN') ||
+      (off.resultSubtype === 'success' && bpt.resultSubtype !== 'success')
+        ? 'gateway appendix across a tool chain: official survives while our engine drops the ' +
+          'chain - our tolerance regression'
+        : null,
+    notes:
+      'A realistic gateway appends [DONE] to every response, so the agent loop must survive it ' +
+      'on the tool_result delivery turn too, not just the final turn.',
+  },
+  {
+    id: 'l4-gateway-eventless-error-frame',
+    fault:
+      'gateway error dialect: a bare `data: {error json}` frame with NO event: name, then the ' +
+      '[DONE] appendix (byte-shape of the 2026-07-05 invalid-key capture)',
+    prompt: 'Say OK.',
+    timeoutMs: 30_000,
+    buildScripts: () => [
+      {
+        kind: 'sse-gateway',
+        eventless: true,
+        events: [
+          { type: 'error', error: { type: 'invalid_request_error', message: 'gateway: invalid api key' } },
+        ],
+      },
+      // Retry sentinel, same rationale as l4-http400.
+      { kind: 'sse', events: textReply('MUST NEVER BE REQUESTED GW') },
+    ],
+    sentinels: ['MUST NEVER BE REQUESTED GW'],
+    invariants: (run) => {
+      const f = [];
+      if (run.postCount !== 1) f.push(`postCount ${run.postCount} != 1 (an arm retried the in-stream error)`);
+      if (streamHas(run, 'MUST NEVER BE REQUESTED GW')) f.push('retry sentinel leaked into the stream');
+      if (run.checks.resultSubtype === 'success') f.push('resultSubtype success over an unrecovered gateway error');
+      return f;
+    },
+    // Observed stable across 2 runs (2026-07-05): official mis-parses the
+    // event-less error frame as an empty response, retries once and
+    // success-encodes the failure - triaged as KD-L4-05.
+    officialInvariantKd: 'KD-L4-05',
+    bptOnly: (run) => {
+      // Engine contract: isErrorPayload catches the event-less error JSON ->
+      // APIStatusError(400) -> engine wraps into result/error_during_execution
+      // (same encoding as the HTTP-400 family), query() does not throw.
+      const f = [];
+      if (run.checks.resultSubtype !== 'error_during_execution') {
+        f.push(`expected result/error_during_execution, got ${run.checks.resultSubtype}`);
+      }
+      if (run.error) f.push(`unexpected thrown error: ${run.error}`);
+      return f;
+    },
+    notes:
+      'Reproduces the raw idealab capture shape. Official terminal encoding under this dialect ' +
+      'is a discovery objective - if it lands in the KD-L4-01 success-subtype family, triage ' +
+      'extends that KD after 2-run stability.',
+  },
 ];


### PR DESCRIPTION
## 概要

守密人裁定「全面推进」：完备性评估的四条缺口一批清零，全程零真实 API 开销（全部走内容盲仿真器双臂差分）。

## 缺口一：环境保真轴（从无到有）

仿真器新增 `sse-gateway` 脚本类，逐字节复刻 idealab 抓包形状（`data: [DONE]` 尾卡 / 无 event 名帧）。L4 新增 3 场景双臂对跑：

- `[DONE]` 尾卡（文本轮 + 工具链轮）：**双臂全绿**——#461 容错修复在差分下成立，含工具链中每个响应都带尾卡的真实网关形态；
- 无名错误帧：**真发现 KD-L4-05**（两轮稳定）——官方 2.1.201 不认无名错误帧，报「empty or malformed response (HTTP 200)」并**重试一次**，然后把失败编码成 assistant 文本 + `result/success`（KD-L4-01 怪癖同族）。我方 `isErrorPayload` → `APIStatusError(400)` → 干净 `error_during_execution` 零重试。**产线实义：官方客户端在 idealab 后面会重试并 success 化 API 错误，我方快速失败带真错误类型。**

## 缺口二：MCP 差分首批（L3 扩容）

`arm.mjs` 的 `buildOptions` 增加 `{ armKind, sdk }` 第三参——各臂用**自家的** `tool()`/`createSdkMcpServer` 建进程内服务器。4 场景：ping / 软失败 isError **双臂 CONTENT_MATCH**（tool_result 编码逐字一致）；抛异常 / 未注册工具为措辞级差异，两轮稳定登记 KD-L3-22/23。zod schema 语义留第二批。

## 缺口三：Fix-2 思考同参

`run-l5.mjs --thinking=N` 把 `maxThinkingTokens` 双臂钉同值（不设 = 各引擎自家默认，产品真实对比），拆开「引擎差」与「思考差」两变量；workflow 加 `l5_thinking` dispatch 输入。

## 缺口四：runner 度量规则自证

聚合规则抽成 `l5-aggregate.mjs`，vitest 用 run 28736460533 官方臂**真实 result 序列**锁定（多 result 求和/取末值、空跑、缺字段防 NaN）——求和路径不再第一次执行就发生在付费轮里。

## 验证

- run-l1/l2/l3/l4 双臂本地全跑收敛：L4 **12/12 FAULT_KNOWN_DIFF**、L3 零发散、**零未分诊候选**；
- 棘轮基线 +7 行**全部改进类**，`--update` 锁入；
- `run-l5 --smoke` 绿（官方臂本地在位、双臂 6 跑）；
- `npx vitest run` **1060 通过 / 2 跳过**；`tsc` + build 干净。

## 剩余挂账（记入 project-status）

MCP 差分第二批（schema 语义 / annotations / stdio+http 传输）、子代理/hook 差分（L3.5 大活）、E1 后首轮真 L5 复测（退出标准 chat-03 ≥2/3、code-01 ≥官方−1）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_