### PR TITLE
test(bpt-sdk): 白盒接口覆盖计划 — 覆盖守卫 + 首批 7 个导出缺口补齐

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -273,6 +273,16 @@
   `l5-aggregate.mjs`，vitest 喂 run 28736460533 真实官方 result 序列锁定（多 result 求和/取末值、空跑、缺字段防 NaN）。
   棘轮基线 +7 行全改进项锁入；L1-L4 双臂全跑收敛（L4 12/12、L3 零发散、零未分诊候选）；`npx vitest run` **1060 全绿**。
   剩余挂账：MCP 差分第二批（schema 语义/annotations/stdio-http 传输）、子代理/hook 差分（L3.5，大活）。
+  **白盒接口覆盖计划已立（2026-07-05，守密人「针对每个接口白盒测试」裁定）**：现状厘清——黑盒差分（L1-L5）是官方臂
+  内容盲边界下的必然形态，我方自身侧本就有千余条白盒单测，但**测试随功能长、没人逐接口对过账**。对账结果：公开面
+  66 导出 + 48 Options 字段 + 17 Query 方法中，**15 个接口点全测试树零覆盖**。处置：① 7 个导出缺口当批补齐
+  （`tests/api-surface-gaps.test.ts`：NotImplementedError / COMMAND_INJECTION_TOKEN 哨兵契约 / DEFAULT_UTILITY_MODEL /
+  resolveUtilityTransport 注入席位 / runVerification fail-closed / renderCatalog / buildSelectorUserTurn）；
+  ② **永久性覆盖守卫**（`tests/api-surface-coverage.test.ts`）：枚举导出+Options+Query 三面对账全测试树，
+  新接口不带测试即红、白名单只减不增（陈旧条目自动红）——覆盖率地板制度化；③ 剩余 8 点挂守卫白名单可见化
+  （4 Options 字段 includeEnvironmentContext/onElicitation/sessionStoreFlush/toolSearch + 4 Query 方法
+  reconnectMcpServer/toggleMcpServer/setMcpServers/streamInput，各标欠账原因）= **白盒补齐 batch 2**。
+  `npx vitest run` **1079 全绿（37 文件，+19）**。
   **E1 后验收轮真 L5 已收官（2026-07-05，run 28741914245，repeat=3，108/108，$1.156 < $1.5 帽，双引擎各自默认）**：
   **乙门禁 PASS 且首次正向拉开——我方 50/54（92.6%）vs 官方 43/54（79.6%），差值 +13.0pp**（首轮为 88.9% 打平）。
   退出标准三过一未过：**chat-03 0/3→3/3 兑现**（E1 思考直接修复，KD-L5-03 的答前计算半边正式 RESOLVED）；econ 轴我方

--- a/projects/bpt-agent-sdk/tests/api-surface-coverage.test.ts
+++ b/projects/bpt-agent-sdk/tests/api-surface-coverage.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Interface-coverage guard (2026-07-05, keeper directive: per-interface
+ * white-box testing). Enumerates the PUBLIC surface - runtime exports of
+ * src/index.ts, Options fields, Query methods - and asserts every name is
+ * word-boundary-mentioned somewhere under tests/ (this file excluded), or
+ * sits on the explicit KNOWN_UNTESTED allowlist.
+ *
+ * Contract (shrink-only ratchet, mirrors the conformance baseline):
+ *   - a NEW export/field/method with no test and no allowlist entry -> RED;
+ *   - an allowlist entry that HAS gained coverage -> RED (stale entry must
+ *     be deleted, so the list only shrinks);
+ *   - the allowlist documents WHY each gap is deferred.
+ *
+ * Honest limits: "mentioned in a test file" is a coverage FLOOR, not proof
+ * of semantic depth - it catches wholly-untested interfaces (13 found on
+ * 2026-07-05, of which 7 were filled by api-surface-gaps.test.ts), not
+ * shallow tests. Depth stays a review concern.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import * as api from '../src/index.js';
+
+const TESTS_DIR = join(__dirname);
+const SELF = basename(__filename);
+
+/** Every test-ish source under tests/, this guard excluded. */
+function collectTestFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) {
+      if (name === 'fixtures' || name === 'node_modules') continue;
+      out.push(...collectTestFiles(p));
+    } else if (/\.(test\.ts|ts|mjs)$/.test(name) && name !== SELF) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+const corpus = collectTestFiles(TESTS_DIR).map((p) => readFileSync(p, 'utf8'));
+
+function covered(name: string): boolean {
+  const re = new RegExp(`\\b${name}\\b`);
+  return corpus.some((text) => re.test(text));
+}
+
+/**
+ * Deferred gaps - each entry names the follow-up batch that owns it.
+ * DELETE the entry when its test lands (the guard reds out stale entries).
+ */
+const KNOWN_UNTESTED: Record<string, string> = {
+  // Options fields - white-box batch 2 (engine-level harness required):
+  includeEnvironmentContext: 'engine option; needs a mock-transport request-shape probe',
+  onElicitation: 'MCP elicitation host callback; needs an in-process server driving elicitation',
+  sessionStoreFlush: 'external-session-store flush hook; needs a store spy fixture',
+  toolSearch: 'deferred-tool search surface; needs a registry fixture with deferred tools',
+  // Query control methods - white-box batch 2 (runtime MCP control):
+  reconnectMcpServer: 'runtime MCP control; needs a restartable in-process server fixture',
+  toggleMcpServer: 'runtime MCP control; same fixture as reconnectMcpServer',
+  setMcpServers: 'runtime MCP reconfiguration; same fixture family',
+  streamInput: 'streaming-input push method; needs an open-ended AsyncIterable harness',
+};
+
+function parseBlock(source: string, re: RegExp): string {
+  const m = source.match(re);
+  if (!m) throw new Error(`api-surface-coverage: anchor not found: ${re}`);
+  return m[0];
+}
+
+const typesSource = readFileSync(join(__dirname, '..', 'src', 'types.ts'), 'utf8');
+const optionsFields = [
+  ...parseBlock(typesSource, /export (?:interface|type) Options[\s\S]*?\n\}/).matchAll(
+    /^\s{2}(\w+)\??:/gm,
+  ),
+].map((m) => m[1]);
+const queryMethods = [
+  ...parseBlock(typesSource, /export interface Query[\s\S]*?\n\}/).matchAll(/^\s{2}(\w+)\(/gm),
+].map((m) => m[1]);
+
+describe('public interface coverage floor', () => {
+  it('sanity: surface enumeration is non-trivial', () => {
+    expect(Object.keys(api).length).toBeGreaterThan(50);
+    expect(optionsFields.length).toBeGreaterThan(30);
+    expect(queryMethods.length).toBeGreaterThan(10);
+  });
+
+  it('every runtime export is tested or allowlisted', () => {
+    const gaps = Object.keys(api).filter((n) => !covered(n) && !(n in KNOWN_UNTESTED));
+    expect(gaps, `untested exports (add tests, or allowlist with a reason): ${gaps.join(', ')}`)
+      .toEqual([]);
+  });
+
+  it('every Options field is tested or allowlisted', () => {
+    const gaps = optionsFields.filter((n) => !covered(n) && !(n in KNOWN_UNTESTED));
+    expect(gaps, `untested Options fields: ${gaps.join(', ')}`).toEqual([]);
+  });
+
+  it('every Query method is tested or allowlisted', () => {
+    const gaps = queryMethods.filter((n) => !covered(n) && !(n in KNOWN_UNTESTED));
+    expect(gaps, `untested Query methods: ${gaps.join(', ')}`).toEqual([]);
+  });
+
+  it('the allowlist only shrinks: entries that gained coverage must be deleted', () => {
+    const stale = Object.keys(KNOWN_UNTESTED).filter((n) => covered(n));
+    expect(stale, `stale allowlist entries (now covered - delete them): ${stale.join(', ')}`)
+      .toEqual([]);
+  });
+});

--- a/projects/bpt-agent-sdk/tests/api-surface-gaps.test.ts
+++ b/projects/bpt-agent-sdk/tests/api-surface-gaps.test.ts
@@ -1,0 +1,124 @@
+/**
+ * White-box tests for the public exports the interface-coverage audit
+ * (2026-07-05, keeper directive: per-interface white-box testing) found with
+ * ZERO mentions anywhere under tests/. Each block tests the export's OWN
+ * contract - not a differential observation, not a side effect of some other
+ * feature's test. The companion guard (api-surface-coverage.test.ts) keeps
+ * the audit permanent: a new export without a test fails CI.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  COMMAND_INJECTION_TOKEN,
+  DEFAULT_UTILITY_MODEL,
+  NotImplementedError,
+  buildSelectorUserTurn,
+  parseCommandPrefix,
+  renderCatalog,
+  resolveUtilityTransport,
+  runVerification,
+  runUtilityCall,
+  VERIFIER_DEFAULT_MODEL,
+} from '../src/index.js';
+import { AnthropicTransport } from '../src/transport/anthropic.js';
+import { MockTransport, textReplyEvents } from './helpers/mock-transport.js';
+
+describe('NotImplementedError', () => {
+  it('carries the house message shape with the feature name', () => {
+    const e = new NotImplementedError('someFeature');
+    expect(e.name).toBe('NotImplementedError');
+    expect(e.message).toBe('bpt-agent-sdk: someFeature is not implemented in this version');
+    expect(e).toBeInstanceOf(Error);
+  });
+  it('appends the hint when provided', () => {
+    const e = new NotImplementedError('x', 'Use y instead.');
+    expect(e.message).toBe('bpt-agent-sdk: x is not implemented in this version. Use y instead.');
+  });
+});
+
+describe('COMMAND_INJECTION_TOKEN', () => {
+  it('is the pinned fail-closed sentinel value', () => {
+    // The value is a WIRE CONTRACT with the faithful prefix-detection prompt:
+    // the model is instructed to answer exactly this string on suspected
+    // injection - changing it desynchronizes prompt and parser.
+    expect(COMMAND_INJECTION_TOKEN).toBe('command_injection_detected');
+  });
+  it('parseCommandPrefix maps the sentinel to the injection verdict', () => {
+    expect(parseCommandPrefix(COMMAND_INJECTION_TOKEN)).toEqual({ kind: 'injection' });
+  });
+});
+
+describe('DEFAULT_UTILITY_MODEL', () => {
+  it('is the cheap utility tier (haiku), distinct from the verifier default only if overridden', () => {
+    expect(DEFAULT_UTILITY_MODEL).toContain('haiku');
+    expect(VERIFIER_DEFAULT_MODEL).toContain('haiku');
+  });
+  it('runUtilityCall resolves it as the wire model when no override is given', async () => {
+    const t = new MockTransport([textReplyEvents('ok')]);
+    await runUtilityCall('system', 'user', { transport: t }, 128);
+    expect(t.requests[0]?.model).toContain('haiku');
+  });
+});
+
+describe('resolveUtilityTransport', () => {
+  it('returns the injected transport by identity (offline-unit-test seam)', () => {
+    const t = new MockTransport([]);
+    expect(resolveUtilityTransport({ transport: t })).toBe(t);
+  });
+  it('builds a real AnthropicTransport when none is injected', () => {
+    const t = resolveUtilityTransport({ provider: { apiKey: 'k' }, env: {} });
+    expect(t).toBeInstanceOf(AnthropicTransport);
+  });
+});
+
+describe('runVerification', () => {
+  it('returns the typed verdict over a mock transport (the adversarialVerify base)', async () => {
+    const t = new MockTransport([
+      textReplyEvents('{"verdict":"CONFIRMED","quote":"q","rationale":"r"}'),
+    ]);
+    const r = await runVerification({ summary: 's', context: 'c' }, { transport: t });
+    expect(r.verdict).toBe('CONFIRMED');
+    expect(r.keep).toBe(true);
+  });
+  it('fails closed on a garbage reply (REFUTED, keep false)', async () => {
+    const t = new MockTransport([textReplyEvents('!!! not a verdict !!!')]);
+    const r = await runVerification({ summary: 's' }, { transport: t });
+    expect(r.verdict).toBe('REFUTED');
+    expect(r.keep).toBe(false);
+  });
+});
+
+describe('renderCatalog', () => {
+  it('renders one feature_id/action/situation block per situation, newline-joined', () => {
+    const out = renderCatalog([
+      { featureId: 'f1', action: 'do a', situation: 'when x' },
+      { featureId: 'f2', action: 'do b', situation: 'when y' },
+    ]);
+    expect(out).toBe(
+      '- feature_id: f1\n  action: do a\n  situation: when x\n' +
+        '- feature_id: f2\n  action: do b\n  situation: when y',
+    );
+  });
+  it('renders an empty catalog to an empty string', () => {
+    expect(renderCatalog([])).toBe('');
+  });
+});
+
+describe('buildSelectorUserTurn', () => {
+  it('assembles transcript, eligibility sets and metadata into the selector turn', () => {
+    const turn = buildSelectorUserTurn({
+      transcript: 'T-LINE',
+      eligibleIds: ['a', 'b'],
+      ineligibleIds: ['c'],
+      sessionMetadata: { numStartups: 7 },
+    });
+    expect(turn).toContain('Transcript:\nT-LINE');
+    expect(turn).toContain('<eligible_ids>a, b</eligible_ids>');
+    expect(turn).toContain('<ineligible_ids>c</ineligible_ids>');
+    expect(turn).toContain('numStartups: 7');
+  });
+  it('omitted ineligible ids render as an empty set, not a crash', () => {
+    const turn = buildSelectorUserTurn({ transcript: 't', eligibleIds: ['a'] });
+    expect(turn).toContain('<ineligible_ids></ineligible_ids>');
+  });
+});


### PR DESCRIPTION
## 概要

守密人裁定「针对每个接口白盒测试」。先厘清：黑盒差分（L1–L5）是官方臂内容盲边界下的必然形态，我方自身侧本有千余条白盒单测——但**测试随功能长、没人逐接口对过账**。对账公开面（66 运行时导出 + 48 Options 字段 + 17 Query 方法），发现 **15 个接口点全测试树零覆盖**。

## 改动

- **`tests/api-surface-gaps.test.ts`**（14 用例）：补齐 7 个导出缺口的契约测试——`NotImplementedError` 消息形状 / `COMMAND_INJECTION_TOKEN` 哨兵值作为提示词↔解析器线缆契约（含 `parseCommandPrefix` 接线）/ `DEFAULT_UTILITY_MODEL` 落线解析 / `resolveUtilityTransport` 注入席位 + 真传输回退 / `runVerification` 判词与 fail-closed / `renderCatalog` 格式 / `buildSelectorUserTurn` 装配。
- **`tests/api-surface-coverage.test.ts`**（永久守卫，5 断言）：枚举三面接口对账全测试树——每个名字要么被词界覆盖、要么在 `KNOWN_UNTESTED` 白名单上；**新接口不带测试即红**；**白名单只减不增**（条目一旦获得覆盖必须删除，否则红）。诚实边界已写进头注：「被测试文件提及」是覆盖率**地板**而非语义深度证明。
- 剩余 8 点挂白名单可见化（各标欠账原因与归属批次）= **白盒补齐 batch 2**：4 个 Options 字段（includeEnvironmentContext / onElicitation / sessionStoreFlush / toolSearch）+ 4 个 Query 方法（reconnectMcpServer / toggleMcpServer / setMcpServers / streamInput），均需较重 fixture（进程内 MCP 可重启服务器 / 外部会话存储 spy / 流式输入 harness）。

## 验证

`npx vitest run` **1079 通过 / 2 跳过（37 文件，+19）**全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_