### PR TITLE
test(bpt-sdk): 逐接口全覆盖线缆差分 + 官方参考目标固化

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -276,6 +276,15 @@
   引擎对齐候选=claude_code 默认改自适应思考（可能顺带移动 code-01 残余，比固定 --thinking 探针更干净）；另官方工具 cache_control
   断点 0 vs 我方 1（缓存策略差）。工具集 34 vs 13 归「预期表面差」（CLI 自带 Cron*/Task*/Workflow/Skills 等产品工具、SDK 不发）。
   `tsc` + `npx vitest run` **1085 全绿**。
+  **逐接口全覆盖 + 参考目标固化（2026-07-05 续，守密人「对着接口全部测试一轮、作为参考目标」裁定）**：run-wire 扩为
+  **场景矩阵**（`scenarios-wire.mjs` 5 场景：default / thinking-off / thinking-4096 / cache-off / mcp-added）+ **逐工具
+  input_schema 差分**（`diffToolSchemas`，比对两臂共有工具的参数/必填集——「每个接口」的真信号）。官方结构指纹固化为
+  **参考目标** `tests/conformance/wire-reference.json`（`--update-reference` 刷新，纯结构无提示词正文）；our-arm 回归锁
+  升级为**参考目标棘轮**（`conformance-wire.test.ts` 12 用例：实际缺口须精确等于登记缺口，新漂移即红 / 缺口修复须删条目）。
+  **全覆盖新发现——我方工具 schema 落后官方当前参数**（引擎对齐候选，交引擎团队）：Agent 缺 `isolation`/`model` 且必填集不同、
+  Bash 缺 `dangerouslyDisableSandbox`、Read 缺 `pages`（PDF 页范围）——五场景一致稳定。连同 thinking 自适应 + 工具缓存断点，
+  构成引擎侧「对齐官方线缆」清单。cache-off 系统分段差属 bpt-only 选项非对称（官方忽略 promptCaching:false）已标注不追。
+  `tsc` + `npx vitest run` **1091 全绿（+6）**。
   **SSE 网关方言容错已落（2026-07-05，BPT 产线故障闭环）**：BPT 实测「Malformed SSE payload for event "(none)"」
   经双侧协作定型——BPT `curl -N` 抓原始字节实锤 idealab 网关 `/api/anthropic` 端点带 OpenAI 方言遗留
   （流尾追加 `data: [DONE]`、错误帧无 event 行）；官方客户端 message_stop 即收工不碰尾卡、我方读到流关闭才撞上。

--- a/projects/bpt-agent-sdk/tests/conformance-wire.test.ts
+++ b/projects/bpt-agent-sdk/tests/conformance-wire.test.ts
@@ -13,10 +13,13 @@ import { mkdtemp, rm, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { query, type Query } from '../src/index.js';
 import { startEmulator, textReply } from './conformance/emulator.mjs';
 // @ts-expect-error - plain-JS conformance module without type declarations
-import { fingerprintRequestBody, diffFingerprints } from './conformance/wire-fingerprint.mjs';
+import { fingerprintRequestBody, diffFingerprints, diffToolSchemas } from './conformance/wire-fingerprint.mjs';
+// @ts-expect-error - plain-JS conformance module without type declarations
+import { WIRE_SCENARIOS } from './conformance/scenarios-wire.mjs';
 
 const DUMMY_KEY = 'sk-ant-api03-' + 'A'.repeat(95);
 let cwd: string;
@@ -118,4 +121,109 @@ describe('fingerprint + diff', () => {
     expect(fingerprintRequestBody({ __unparsed: 'garbage' })).toEqual({ present: false });
     expect(fingerprintRequestBody(undefined)).toEqual({ present: false });
   });
+});
+
+// ---------------------------------------------------------------------------
+// Reference-target regression (keeper directive: "对着接口全部测试一轮,然后
+// 作为参考目标"). The official arm's structural wire fingerprints per scenario
+// live in wire-reference.json (refreshed by run-wire.mjs --update-reference
+// with the official pkg installed). This block drives OUR arm keyless per
+// scenario and asserts the diff-against-reference EXACTLY equals the
+// documented alignment gaps - a shrink-only ratchet:
+//   - a NEW gap (our wire drifted, or a new reference facet) -> RED;
+//   - a gap that CLOSED (engine aligned to the target) but is still listed
+//     -> RED (stale entry must be deleted).
+// Tool-set size/name gaps are expected-surface (CLI product tools the SDK
+// omits) and excluded from the alignment comparison, matching the runner.
+// ---------------------------------------------------------------------------
+
+const EXPECTED_SURFACE = new Set(['toolNames', 'toolCount']);
+
+/**
+ * Documented wire-alignment gaps vs the official reference target. Each is a
+ * concrete engine-alignment candidate handed to the engine team; DELETE the
+ * entry when the engine closes it (the ratchet reds a stale entry).
+ *   thinking            - official sends {type:'adaptive'}; ours enabled/fixed (KD-L5-03)
+ *   toolCacheBreakpoints- official 0 on tools; ours 1 (cache-strategy divergence)
+ *   Agent/Bash/Read     - our tool input_schemas lag the official current params
+ *                         (Agent: isolation/model + required set; Bash:
+ *                         dangerouslyDisableSandbox; Read: pages)
+ *   cache-off system*   - promptCaching:false is a bpt-only option the official
+ *                         arm ignores, so its reference stays cache-on: the
+ *                         system-segmentation delta there is an artifact of the
+ *                         asymmetric option, documented not chased.
+ */
+const WIRE_ALIGNMENT_GAPS: Record<string, { facets: string[]; tools: string[] }> = {
+  default: { facets: ['thinking', 'toolCacheBreakpoints'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
+  'thinking-off': { facets: ['thinking', 'toolCacheBreakpoints'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
+  'thinking-4096': { facets: ['thinking', 'toolCacheBreakpoints'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
+  'cache-off': { facets: ['systemBlocks', 'systemCacheBreakpoints', 'systemKind', 'thinking'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
+  'mcp-added': { facets: ['thinking', 'toolCacheBreakpoints'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
+};
+
+interface WireScenario {
+  id: string;
+  options?: Record<string, unknown>;
+  buildOptions?: (ctx: { sdk: unknown }) => Record<string, unknown>;
+}
+
+async function ourFingerprint(scenario: WireScenario) {
+  await mkdir(join(cwd, '.sessions'), { recursive: true });
+  const emulator = await startEmulator([{ kind: 'sse', events: textReply('WIRE OK') }], {
+    captureBodies: true,
+  });
+  const sdk = await import('../src/index.js');
+  const extra = scenario.buildOptions ? scenario.buildOptions({ sdk }) : (scenario.options ?? {});
+  try {
+    const q: Query = query({
+      prompt: 'Say OK.',
+      options: {
+        cwd,
+        maxTurns: 2,
+        sessionDir: join(cwd, '.sessions'),
+        sandbox: false,
+        systemPrompt: { type: 'preset', preset: 'claude_code' },
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          ANTHROPIC_BASE_URL: emulator.url,
+          ANTHROPIC_API_KEY: DUMMY_KEY,
+        },
+        ...extra,
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of q) void _;
+  } finally {
+    await emulator.close();
+  }
+  return fingerprintRequestBody(emulator.profile.requestBodies[0]);
+}
+
+describe('wire reference-target ratchet (our arm vs official reference)', () => {
+  const ref = JSON.parse(
+    readFileSync(join(__dirname, 'conformance', 'wire-reference.json'), 'utf8'),
+  ).scenarios as Record<string, unknown>;
+
+  it('reference file covers every scenario', () => {
+    for (const sc of WIRE_SCENARIOS as WireScenario[]) {
+      expect(ref[sc.id], `reference missing scenario ${sc.id}`).toBeTruthy();
+    }
+  });
+
+  for (const scenario of WIRE_SCENARIOS as WireScenario[]) {
+    it(`${scenario.id}: alignment gaps vs reference exactly match the documented set`, async () => {
+      const ours = await ourFingerprint(scenario);
+      const facetGaps = (diffFingerprints(ref[scenario.id], ours) as { facet: string }[])
+        .filter((d) => !EXPECTED_SURFACE.has(d.facet))
+        .map((d) => d.facet)
+        .sort();
+      const toolGaps = (diffToolSchemas(ref[scenario.id], ours) as { tool: string; diffs: { facet: string }[] }[])
+        .map((s) => `${s.tool}:${s.diffs.map((d) => d.facet).join('+')}`)
+        .sort();
+      const expected = WIRE_ALIGNMENT_GAPS[scenario.id];
+      expect(facetGaps, `facet gaps drifted for ${scenario.id}`).toEqual([...expected.facets].sort());
+      expect(toolGaps, `tool-schema gaps drifted for ${scenario.id}`).toEqual([...expected.tools].sort());
+    });
+  }
 });

--- a/projects/bpt-agent-sdk/tests/conformance/run-wire.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/run-wire.mjs
@@ -1,23 +1,22 @@
 /**
- * Request-body wire differential (conformance input-axis, enabled by
+ * Request-body wire differential (conformance INPUT axis, enabled by
  * decisions.md 2026-07-05 净室观测边界 r3 - clause ② content-blind LIFTED).
  *
- * Points BOTH arms at a capturing emulator, drives one scripted turn each,
- * captures what each engine puts ON THE WIRE (the Messages API request body),
- * and compares the STRUCTURAL fingerprint (system segmentation, cache
- * breakpoints, tool set, thinking config). L1-L5 observe outputs; this
- * observes inputs - the other half of the differential the clean-room rule
- * previously forbade.
+ * Iterates WIRE_SCENARIOS: for each, points BOTH arms at a capturing emulator,
+ * drives one scripted turn, captures each engine's first Messages API request
+ * body, and compares STRUCTURAL fingerprints (system segmentation, cache
+ * breakpoints, tool set, thinking config) plus PER-TOOL input_schema for the
+ * shared tool set. L1-L5 observe outputs; this observes inputs - the half the
+ * clean-room rule previously forbade. The official arm's fingerprints are the
+ * REFERENCE TARGET (--update-reference writes wire-reference.json).
  *
  * Usage:
- *   node tests/conformance/run-wire.mjs [--arm=both|bpt] [--out=path.json]
+ *   node tests/conformance/run-wire.mjs [--arm=both|bpt] [--update-reference] [--out=path.json]
  *
  * Prereqs: dist/ built; official pkg installed transiently per pins.json
- * (`npm i --no-save`, never a repo dependency). Keyless - the emulator
- * scripts a fixed reply, so no real API is hit.
+ * (`npm i --no-save`, never a repo dependency). Keyless - scripted reply.
  *
- * Exit: 0 always (report-only, like the pre-ratchet M2/M3 runners); the
- * structural differences are the finding, triaged into the report.
+ * Exit: 0 always (report-only; the structural diffs are the finding).
  */
 
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
@@ -25,10 +24,12 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { startEmulator, textReply, assertContentBlind } from './emulator.mjs';
-import { fingerprintRequestBody, diffFingerprints } from './wire-fingerprint.mjs';
+import { fingerprintRequestBody, diffFingerprints, diffToolSchemas } from './wire-fingerprint.mjs';
+import { WIRE_SCENARIOS } from './scenarios-wire.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const DUMMY_KEY = 'sk-ant-api03-' + 'A'.repeat(95);
+const REFERENCE_PATH = join(HERE, 'wire-reference.json');
 const args = Object.fromEntries(
   process.argv.slice(2).map((a) => {
     const m = a.match(/^--([^=]+)(?:=(.*))?$/);
@@ -36,11 +37,19 @@ const args = Object.fromEntries(
   }),
 );
 const armMode = args.arm ?? 'both';
+const updateReference = args['update-reference'] === true;
 const outPath = typeof args.out === 'string' ? args.out : join(HERE, '..', '..', 'conformance-wire.json');
+
+// Tool-set size/name gaps are EXPECTED-SURFACE: the CLI advertises its own
+// product tools (Cron*/Task*/Workflow/Skills/...) the SDK deliberately omits.
+const EXPECTED_SURFACE = new Set(['toolNames', 'toolCount']);
 
 async function loadQuery(armKind) {
   const mod = armKind === 'bpt' ? await import('../../dist/index.js') : await import('@anthropic-ai/claude-agent-sdk');
   return mod.query;
+}
+async function loadSdk(armKind) {
+  return armKind === 'bpt' ? import('../../dist/index.js') : import('@anthropic-ai/claude-agent-sdk');
 }
 
 function baseEnv(url) {
@@ -60,15 +69,17 @@ function baseEnv(url) {
   return env;
 }
 
-/** Drive one arm one scripted turn against a capturing emulator; fingerprint the first POST body. */
-async function captureArm(armKind) {
+/** Drive one arm through one scenario; fingerprint the first captured POST body. */
+async function captureArm(armKind, scenario) {
   const query = await loadQuery(armKind);
+  const sdk = await loadSdk(armKind);
   const cwd = mkdtempSync(join(tmpdir(), `conf-wire-${armKind}-`));
   const emulator = await startEmulator([{ kind: 'sse', events: textReply('WIRE OK') }], {
     captureBodies: true,
   });
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), 60_000);
+  const extra = scenario.buildOptions ? scenario.buildOptions({ sdk }) : (scenario.options ?? {});
   try {
     const q = query({
       prompt: 'Say OK.',
@@ -77,7 +88,10 @@ async function captureArm(armKind) {
         cwd,
         maxTurns: 2,
         env: baseEnv(emulator.url),
-        ...(armKind === 'bpt' ? { sessionDir: join(cwd, '.sessions'), systemPrompt: { type: 'preset', preset: 'claude_code' } } : {}),
+        ...(armKind === 'bpt'
+          ? { sessionDir: join(cwd, '.sessions'), systemPrompt: { type: 'preset', preset: 'claude_code' } }
+          : {}),
+        ...extra,
       },
     });
     for await (const _m of q) void _m;
@@ -88,8 +102,7 @@ async function captureArm(armKind) {
     await emulator.close();
     rmSync(cwd, { recursive: true, force: true });
   }
-  const body = emulator.profile.requestBodies[0];
-  return { arm: armKind, fingerprint: fingerprintRequestBody(body), posts: emulator.profile.requestBodies.length };
+  return fingerprintRequestBody(emulator.profile.requestBodies[0]);
 }
 
 const pins = JSON.parse(readFileSync(join(HERE, 'pins.json'), 'utf8'));
@@ -97,46 +110,65 @@ const report = {
   generated_for: 'bpt-agent-sdk conformance request-body wire differential (input axis, r3)',
   pins: { agentSdk: pins.agentSdk, claudeCode: pins.claudeCode },
   boundary:
-    'content-blind clause LIFTED (decisions.md 2026-07-05 r3); request bodies read for the input differential. Fingerprints are STRUCTURAL (no prompt prose dumped).',
+    'content-blind clause LIFTED (decisions.md 2026-07-05 r3); request bodies read for the input differential. Fingerprints are STRUCTURAL (no prompt prose).',
   armMode,
+  scenarios: [],
 };
+const referenceOut = {};
 
-const bpt = await captureArm('bpt');
-report.bpt = bpt;
-console.log(`[bpt] tools=${bpt.fingerprint.toolCount} systemKind=${bpt.fingerprint.systemKind} sysCache=${bpt.fingerprint.systemCacheBreakpoints} thinking=${JSON.stringify(bpt.fingerprint.thinking)}`);
-
-if (armMode !== 'bpt') {
-  try {
-    const official = await captureArm('official');
-    report.official = official;
-    console.log(`[official] tools=${official.fingerprint.toolCount} systemKind=${official.fingerprint.systemKind} sysCache=${official.fingerprint.systemCacheBreakpoints} thinking=${JSON.stringify(official.fingerprint.thinking)}`);
-    const diff = diffFingerprints(official.fingerprint, bpt.fingerprint);
-    // Triage: the CLI advertises its own PRODUCT tool surface (Cron*, Task*,
-    // Workflow, Skills, Plugins, ...) that the SDK deliberately does not ship,
-    // so tool-set size/name gaps are EXPECTED-SURFACE, not alignment defects.
-    // Everything else (thinking config, cache-breakpoint strategy, system
-    // segmentation) is an ALIGNMENT-CANDIDATE the engine can act on - now
-    // observable because clause ② was lifted.
-    const EXPECTED_SURFACE = new Set(['toolNames', 'toolCount']);
-    for (const d of diff) d.kind = EXPECTED_SURFACE.has(d.facet) ? 'expected-surface' : 'alignment-candidate';
-    report.diff = diff;
-    const candidates = diff.filter((d) => d.kind === 'alignment-candidate');
-    report.alignmentCandidates = candidates.map((d) => d.facet);
-    report.verdict = diff.length === 0 ? 'WIRE_MATCH' : candidates.length === 0 ? 'WIRE_KNOWN_DIFF' : 'WIRE_DIFF';
-    console.log(`\nwire diff (official vs bpt): ${diff.length} facet(s), ${candidates.length} alignment-candidate(s)`);
-    for (const d of diff) console.log(`   [${d.kind}]`, JSON.stringify(d));
-  } catch (err) {
-    report.official = { unavailable: String(err?.message ?? err).slice(0, 200) };
-    report.verdict = 'OFFICIAL-ARM-UNAVAILABLE';
-    console.log(`[official] unavailable: ${report.official.unavailable}`);
+for (const scenario of WIRE_SCENARIOS) {
+  const bpt = await captureArm('bpt', scenario);
+  const row = { id: scenario.id, notes: scenario.notes, bpt };
+  if (armMode !== 'bpt') {
+    try {
+      const official = await captureArm('official', scenario);
+      row.official = official;
+      referenceOut[scenario.id] = official;
+      const facetDiff = diffFingerprints(official, bpt).map((d) => ({
+        ...d,
+        kind: EXPECTED_SURFACE.has(d.facet) ? 'expected-surface' : 'alignment-candidate',
+      }));
+      const schemaDiff = diffToolSchemas(official, bpt);
+      row.facetDiff = facetDiff;
+      row.toolSchemaDiff = schemaDiff;
+      const candidates = facetDiff.filter((d) => d.kind === 'alignment-candidate');
+      row.verdict =
+        facetDiff.length === 0 && schemaDiff.length === 0
+          ? 'WIRE_MATCH'
+          : candidates.length === 0 && schemaDiff.length === 0
+            ? 'WIRE_KNOWN_DIFF'
+            : 'WIRE_DIFF';
+      console.log(
+        `[${scenario.id}] ${row.verdict} | facets:${facetDiff.length}(cand ${candidates.length}) toolSchema:${schemaDiff.length}` +
+          (candidates.length ? ` | ${candidates.map((c) => c.facet).join(',')}` : ''),
+      );
+      for (const s of schemaDiff) console.log(`    tool ${s.tool}: ${JSON.stringify(s.diffs)}`);
+    } catch (err) {
+      row.official = { unavailable: String(err?.message ?? err).slice(0, 200) };
+      row.verdict = 'OFFICIAL-ARM-UNAVAILABLE';
+      console.log(`[${scenario.id}] official unavailable: ${row.official.unavailable}`);
+    }
+  } else {
+    row.verdict = 'single-arm';
+    console.log(`[${scenario.id}] single-arm (bpt) tools=${bpt.toolCount} thinking=${JSON.stringify(bpt.thinking)}`);
   }
-} else {
-  report.verdict = 'single-arm';
+  report.scenarios.push(row);
 }
 
 const serialized = JSON.stringify(report, null, 2);
-assertContentBlind(serialized); // fingerprints are structural, so this still passes
+assertContentBlind(serialized); // structural fingerprints carry no prompt prose
 writeFileSync(outPath, serialized);
 console.log(`\nreport: ${outPath}`);
-console.log('content-blind self-audit: PASS (structural fingerprints carry no prompt prose)');
+
+if (updateReference && armMode !== 'bpt' && Object.keys(referenceOut).length > 0) {
+  const ref = {
+    generated_for: 'official-arm request-body wire reference targets (structural fingerprints)',
+    pins: { agentSdk: pins.agentSdk, claudeCode: pins.claudeCode },
+    note: 'The official engine wire shape our engine aims to match (minus expected-surface tool-set gaps). Refresh via `node run-wire.mjs --update-reference`.',
+    scenarios: referenceOut,
+  };
+  writeFileSync(REFERENCE_PATH, JSON.stringify(ref, null, 2));
+  console.log(`reference targets written: ${REFERENCE_PATH}`);
+}
+console.log('content-blind self-audit: PASS (structural fingerprints, no prompt prose)');
 process.exit(0);

--- a/projects/bpt-agent-sdk/tests/conformance/scenarios-wire.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/scenarios-wire.mjs
@@ -1,0 +1,59 @@
+/**
+ * Request-body wire scenarios (conformance input axis, r3). Each scenario
+ * pins an OPTION set applied to both arms; the runner captures each engine's
+ * first Messages API request body and fingerprints it. The official arm's
+ * fingerprint becomes the committed reference target (wire-reference.json);
+ * our arm is regression-checked against it (minus documented alignment gaps).
+ *
+ * Scope note: the request body is determined by OPTIONS + registered TOOLS,
+ * not by what the model does - so the scenarios vary the option surface
+ * (thinking, cache, tool set) rather than task content. One scripted reply
+ * per scenario keeps it keyless and deterministic.
+ *
+ * Scenario shape:
+ *   id                         - stable key (also the reference-target key)
+ *   options                    - Options merged into BOTH arms
+ *   buildOptions(sdk)          - per-arm option builder (MCP needs each arm's
+ *                                own tool()/createSdkMcpServer); takes { sdk }
+ *   notes                      - what this scenario probes
+ */
+
+export const WIRE_SCENARIOS = [
+  {
+    id: 'default',
+    options: {},
+    notes: 'shipped defaults: builtin tool set, engine-default thinking, caching on',
+  },
+  {
+    id: 'thinking-off',
+    options: { maxThinkingTokens: 0 },
+    notes: 'thinking explicitly disabled - both arms should send no thinking block (or type off)',
+  },
+  {
+    id: 'thinking-4096',
+    options: { maxThinkingTokens: 4096 },
+    notes: 'thinking pinned to an equal fixed budget on both arms (Fix-2 wire view)',
+  },
+  {
+    id: 'cache-off',
+    options: { provider: { promptCaching: false } },
+    notes: 'prompt caching disabled - cache_control breakpoints should vanish from both arms',
+  },
+  {
+    id: 'mcp-added',
+    buildOptions: ({ sdk }) => ({
+      mcpServers: {
+        conf: sdk.createSdkMcpServer({
+          name: 'conf',
+          version: '1.0.0',
+          tools: [
+            sdk.tool('ping', 'Return a fixed marker.', {}, async () => ({
+              content: [{ type: 'text', text: 'MCP-PING-OK' }],
+            })),
+          ],
+        }),
+      },
+    }),
+    notes: 'an in-process MCP server adds mcp__conf__ping to the advertised tool surface',
+  },
+];

--- a/projects/bpt-agent-sdk/tests/conformance/wire-fingerprint.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/wire-fingerprint.mjs
@@ -19,6 +19,51 @@ function cacheBreakpoints(blocks) {
 }
 
 /**
+ * Per-tool input_schema fingerprint: { toolName: { params:sorted, required:sorted,
+ * hasDescription } }. STRUCTURAL - captures whether each tool advertises the same
+ * parameter surface, not the prose description (kept out of the diff for
+ * signal/noise; descriptions are compared elsewhere by the corpus-sync guard).
+ */
+function toolSchemaFingerprints(tools) {
+  const out = {};
+  for (const t of tools) {
+    if (!t || typeof t.name !== 'string') continue;
+    const schema = t.input_schema ?? {};
+    const props = schema.properties && typeof schema.properties === 'object' ? schema.properties : {};
+    out[t.name] = {
+      params: Object.keys(props).sort(),
+      required: Array.isArray(schema.required) ? [...schema.required].sort() : [],
+      hasDescription: typeof t.description === 'string' && t.description.length > 0,
+    };
+  }
+  return out;
+}
+
+/**
+ * Compare per-tool schemas for tools BOTH arms ship (shared set). Returns one
+ * entry per shared tool whose param/required surface differs - the "each
+ * interface" reference-target check. Tools unique to one arm are NOT reported
+ * here (that is the toolNames facet's job / expected-surface).
+ */
+export function diffToolSchemas(aFp, bFp) {
+  const a = aFp?.toolSchemas ?? {};
+  const b = bFp?.toolSchemas ?? {};
+  const shared = Object.keys(a).filter((n) => n in b);
+  const out = [];
+  for (const name of shared.sort()) {
+    const diffs = [];
+    if (JSON.stringify(a[name].params) !== JSON.stringify(b[name].params)) {
+      diffs.push({ facet: 'params', a: a[name].params, b: b[name].params });
+    }
+    if (JSON.stringify(a[name].required) !== JSON.stringify(b[name].required)) {
+      diffs.push({ facet: 'required', a: a[name].required, b: b[name].required });
+    }
+    if (diffs.length > 0) out.push({ tool: name, diffs });
+  }
+  return out;
+}
+
+/**
  * Reduce one request body to its structural fingerprint. Tolerates a missing
  * or unparsed body (returns a marker fingerprint rather than throwing).
  */
@@ -40,6 +85,7 @@ export function fingerprintRequestBody(body) {
       .sort(),
     toolCount: tools.length,
     toolCacheBreakpoints: cacheBreakpoints(tools),
+    toolSchemas: toolSchemaFingerprints(tools),
     thinking:
       body.thinking && typeof body.thinking === 'object'
         ? { type: body.thinking.type ?? null, budget_tokens: body.thinking.budget_tokens ?? null }

--- a/projects/bpt-agent-sdk/tests/conformance/wire-reference.json
+++ b/projects/bpt-agent-sdk/tests/conformance/wire-reference.json
@@ -1,0 +1,2095 @@
+{
+  "generated_for": "official-arm request-body wire reference targets (structural fingerprints)",
+  "pins": {
+    "agentSdk": "0.3.199",
+    "claudeCode": "2.1.201"
+  },
+  "note": "The official engine wire shape our engine aims to match (minus expected-surface tool-set gaps). Refresh via `node run-wire.mjs --update-reference`.",
+  "scenarios": {
+    "default": {
+      "present": true,
+      "systemKind": "blocks",
+      "systemBlocks": 2,
+      "systemCacheBreakpoints": 1,
+      "toolNames": [
+        "Agent",
+        "Bash",
+        "CronCreate",
+        "CronDelete",
+        "CronList",
+        "Edit",
+        "EnterWorktree",
+        "ExitWorktree",
+        "ListConnectors",
+        "ListPlugins",
+        "ListSkills",
+        "NotebookEdit",
+        "Read",
+        "ReportFindings",
+        "ScheduleWakeup",
+        "SearchMcpRegistry",
+        "SearchPlugins",
+        "SearchSkills",
+        "SendMessage",
+        "ShowOnboardingRolePicker",
+        "Skill",
+        "SuggestConnectors",
+        "SuggestPluginInstall",
+        "SuggestSkills",
+        "TaskCreate",
+        "TaskGet",
+        "TaskList",
+        "TaskOutput",
+        "TaskStop",
+        "TaskUpdate",
+        "WebFetch",
+        "WebSearch",
+        "Workflow",
+        "Write"
+      ],
+      "toolCount": 34,
+      "toolCacheBreakpoints": 0,
+      "toolSchemas": {
+        "Agent": {
+          "params": [
+            "description",
+            "isolation",
+            "model",
+            "prompt",
+            "run_in_background",
+            "subagent_type"
+          ],
+          "required": [
+            "description",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "Bash": {
+          "params": [
+            "command",
+            "dangerouslyDisableSandbox",
+            "description",
+            "run_in_background",
+            "timeout"
+          ],
+          "required": [
+            "command"
+          ],
+          "hasDescription": true
+        },
+        "CronCreate": {
+          "params": [
+            "cron",
+            "durable",
+            "prompt",
+            "recurring"
+          ],
+          "required": [
+            "cron",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "CronDelete": {
+          "params": [
+            "id"
+          ],
+          "required": [
+            "id"
+          ],
+          "hasDescription": true
+        },
+        "CronList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Edit": {
+          "params": [
+            "file_path",
+            "new_string",
+            "old_string",
+            "replace_all"
+          ],
+          "required": [
+            "file_path",
+            "new_string",
+            "old_string"
+          ],
+          "hasDescription": true
+        },
+        "EnterWorktree": {
+          "params": [
+            "name",
+            "path"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ExitWorktree": {
+          "params": [
+            "action",
+            "discard_changes"
+          ],
+          "required": [
+            "action"
+          ],
+          "hasDescription": true
+        },
+        "ListConnectors": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "NotebookEdit": {
+          "params": [
+            "cell_id",
+            "cell_type",
+            "edit_mode",
+            "new_source",
+            "notebook_path"
+          ],
+          "required": [
+            "new_source",
+            "notebook_path"
+          ],
+          "hasDescription": true
+        },
+        "Read": {
+          "params": [
+            "file_path",
+            "limit",
+            "offset",
+            "pages"
+          ],
+          "required": [
+            "file_path"
+          ],
+          "hasDescription": true
+        },
+        "ReportFindings": {
+          "params": [
+            "findings",
+            "level"
+          ],
+          "required": [
+            "findings"
+          ],
+          "hasDescription": true
+        },
+        "ScheduleWakeup": {
+          "params": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "required": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "hasDescription": true
+        },
+        "SearchMcpRegistry": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SendMessage": {
+          "params": [
+            "message",
+            "summary",
+            "to"
+          ],
+          "required": [
+            "message",
+            "to"
+          ],
+          "hasDescription": true
+        },
+        "ShowOnboardingRolePicker": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Skill": {
+          "params": [
+            "args",
+            "skill"
+          ],
+          "required": [
+            "skill"
+          ],
+          "hasDescription": true
+        },
+        "SuggestConnectors": {
+          "params": [
+            "uuids"
+          ],
+          "required": [
+            "uuids"
+          ],
+          "hasDescription": true
+        },
+        "SuggestPluginInstall": {
+          "params": [
+            "contextLabel",
+            "plugins"
+          ],
+          "required": [
+            "contextLabel",
+            "plugins"
+          ],
+          "hasDescription": true
+        },
+        "SuggestSkills": {
+          "params": [
+            "contextLabel",
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "TaskCreate": {
+          "params": [
+            "activeForm",
+            "description",
+            "metadata",
+            "subject"
+          ],
+          "required": [
+            "description",
+            "subject"
+          ],
+          "hasDescription": true
+        },
+        "TaskGet": {
+          "params": [
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "TaskList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskOutput": {
+          "params": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "required": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "hasDescription": true
+        },
+        "TaskStop": {
+          "params": [
+            "shell_id",
+            "task_id"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskUpdate": {
+          "params": [
+            "activeForm",
+            "addBlockedBy",
+            "addBlocks",
+            "description",
+            "metadata",
+            "owner",
+            "status",
+            "subject",
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "WebFetch": {
+          "params": [
+            "prompt",
+            "url"
+          ],
+          "required": [
+            "prompt",
+            "url"
+          ],
+          "hasDescription": true
+        },
+        "WebSearch": {
+          "params": [
+            "allowed_domains",
+            "blocked_domains",
+            "query"
+          ],
+          "required": [
+            "query"
+          ],
+          "hasDescription": true
+        },
+        "Workflow": {
+          "params": [
+            "args",
+            "description",
+            "name",
+            "resumeFromRunId",
+            "script",
+            "scriptPath",
+            "title"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "Write": {
+          "params": [
+            "content",
+            "file_path"
+          ],
+          "required": [
+            "content",
+            "file_path"
+          ],
+          "hasDescription": true
+        }
+      },
+      "thinking": {
+        "type": "adaptive",
+        "budget_tokens": null
+      },
+      "hasTemperature": false,
+      "stream": true,
+      "topLevelKeys": [
+        "context_management",
+        "max_tokens",
+        "messages",
+        "metadata",
+        "model",
+        "output_config",
+        "stream",
+        "system",
+        "thinking",
+        "tools"
+      ]
+    },
+    "thinking-off": {
+      "present": true,
+      "systemKind": "blocks",
+      "systemBlocks": 2,
+      "systemCacheBreakpoints": 1,
+      "toolNames": [
+        "Agent",
+        "Bash",
+        "CronCreate",
+        "CronDelete",
+        "CronList",
+        "Edit",
+        "EnterWorktree",
+        "ExitWorktree",
+        "ListConnectors",
+        "ListPlugins",
+        "ListSkills",
+        "NotebookEdit",
+        "Read",
+        "ReportFindings",
+        "ScheduleWakeup",
+        "SearchMcpRegistry",
+        "SearchPlugins",
+        "SearchSkills",
+        "SendMessage",
+        "ShowOnboardingRolePicker",
+        "Skill",
+        "SuggestConnectors",
+        "SuggestPluginInstall",
+        "SuggestSkills",
+        "TaskCreate",
+        "TaskGet",
+        "TaskList",
+        "TaskOutput",
+        "TaskStop",
+        "TaskUpdate",
+        "WebFetch",
+        "WebSearch",
+        "Workflow",
+        "Write"
+      ],
+      "toolCount": 34,
+      "toolCacheBreakpoints": 0,
+      "toolSchemas": {
+        "Agent": {
+          "params": [
+            "description",
+            "isolation",
+            "model",
+            "prompt",
+            "run_in_background",
+            "subagent_type"
+          ],
+          "required": [
+            "description",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "Bash": {
+          "params": [
+            "command",
+            "dangerouslyDisableSandbox",
+            "description",
+            "run_in_background",
+            "timeout"
+          ],
+          "required": [
+            "command"
+          ],
+          "hasDescription": true
+        },
+        "CronCreate": {
+          "params": [
+            "cron",
+            "durable",
+            "prompt",
+            "recurring"
+          ],
+          "required": [
+            "cron",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "CronDelete": {
+          "params": [
+            "id"
+          ],
+          "required": [
+            "id"
+          ],
+          "hasDescription": true
+        },
+        "CronList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Edit": {
+          "params": [
+            "file_path",
+            "new_string",
+            "old_string",
+            "replace_all"
+          ],
+          "required": [
+            "file_path",
+            "new_string",
+            "old_string"
+          ],
+          "hasDescription": true
+        },
+        "EnterWorktree": {
+          "params": [
+            "name",
+            "path"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ExitWorktree": {
+          "params": [
+            "action",
+            "discard_changes"
+          ],
+          "required": [
+            "action"
+          ],
+          "hasDescription": true
+        },
+        "ListConnectors": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "NotebookEdit": {
+          "params": [
+            "cell_id",
+            "cell_type",
+            "edit_mode",
+            "new_source",
+            "notebook_path"
+          ],
+          "required": [
+            "new_source",
+            "notebook_path"
+          ],
+          "hasDescription": true
+        },
+        "Read": {
+          "params": [
+            "file_path",
+            "limit",
+            "offset",
+            "pages"
+          ],
+          "required": [
+            "file_path"
+          ],
+          "hasDescription": true
+        },
+        "ReportFindings": {
+          "params": [
+            "findings",
+            "level"
+          ],
+          "required": [
+            "findings"
+          ],
+          "hasDescription": true
+        },
+        "ScheduleWakeup": {
+          "params": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "required": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "hasDescription": true
+        },
+        "SearchMcpRegistry": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SendMessage": {
+          "params": [
+            "message",
+            "summary",
+            "to"
+          ],
+          "required": [
+            "message",
+            "to"
+          ],
+          "hasDescription": true
+        },
+        "ShowOnboardingRolePicker": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Skill": {
+          "params": [
+            "args",
+            "skill"
+          ],
+          "required": [
+            "skill"
+          ],
+          "hasDescription": true
+        },
+        "SuggestConnectors": {
+          "params": [
+            "uuids"
+          ],
+          "required": [
+            "uuids"
+          ],
+          "hasDescription": true
+        },
+        "SuggestPluginInstall": {
+          "params": [
+            "contextLabel",
+            "plugins"
+          ],
+          "required": [
+            "contextLabel",
+            "plugins"
+          ],
+          "hasDescription": true
+        },
+        "SuggestSkills": {
+          "params": [
+            "contextLabel",
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "TaskCreate": {
+          "params": [
+            "activeForm",
+            "description",
+            "metadata",
+            "subject"
+          ],
+          "required": [
+            "description",
+            "subject"
+          ],
+          "hasDescription": true
+        },
+        "TaskGet": {
+          "params": [
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "TaskList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskOutput": {
+          "params": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "required": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "hasDescription": true
+        },
+        "TaskStop": {
+          "params": [
+            "shell_id",
+            "task_id"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskUpdate": {
+          "params": [
+            "activeForm",
+            "addBlockedBy",
+            "addBlocks",
+            "description",
+            "metadata",
+            "owner",
+            "status",
+            "subject",
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "WebFetch": {
+          "params": [
+            "prompt",
+            "url"
+          ],
+          "required": [
+            "prompt",
+            "url"
+          ],
+          "hasDescription": true
+        },
+        "WebSearch": {
+          "params": [
+            "allowed_domains",
+            "blocked_domains",
+            "query"
+          ],
+          "required": [
+            "query"
+          ],
+          "hasDescription": true
+        },
+        "Workflow": {
+          "params": [
+            "args",
+            "description",
+            "name",
+            "resumeFromRunId",
+            "script",
+            "scriptPath",
+            "title"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "Write": {
+          "params": [
+            "content",
+            "file_path"
+          ],
+          "required": [
+            "content",
+            "file_path"
+          ],
+          "hasDescription": true
+        }
+      },
+      "thinking": {
+        "type": "disabled",
+        "budget_tokens": null
+      },
+      "hasTemperature": false,
+      "stream": true,
+      "topLevelKeys": [
+        "max_tokens",
+        "messages",
+        "metadata",
+        "model",
+        "output_config",
+        "stream",
+        "system",
+        "thinking",
+        "tools"
+      ]
+    },
+    "thinking-4096": {
+      "present": true,
+      "systemKind": "blocks",
+      "systemBlocks": 2,
+      "systemCacheBreakpoints": 1,
+      "toolNames": [
+        "Agent",
+        "Bash",
+        "CronCreate",
+        "CronDelete",
+        "CronList",
+        "Edit",
+        "EnterWorktree",
+        "ExitWorktree",
+        "ListConnectors",
+        "ListPlugins",
+        "ListSkills",
+        "NotebookEdit",
+        "Read",
+        "ReportFindings",
+        "ScheduleWakeup",
+        "SearchMcpRegistry",
+        "SearchPlugins",
+        "SearchSkills",
+        "SendMessage",
+        "ShowOnboardingRolePicker",
+        "Skill",
+        "SuggestConnectors",
+        "SuggestPluginInstall",
+        "SuggestSkills",
+        "TaskCreate",
+        "TaskGet",
+        "TaskList",
+        "TaskOutput",
+        "TaskStop",
+        "TaskUpdate",
+        "WebFetch",
+        "WebSearch",
+        "Workflow",
+        "Write"
+      ],
+      "toolCount": 34,
+      "toolCacheBreakpoints": 0,
+      "toolSchemas": {
+        "Agent": {
+          "params": [
+            "description",
+            "isolation",
+            "model",
+            "prompt",
+            "run_in_background",
+            "subagent_type"
+          ],
+          "required": [
+            "description",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "Bash": {
+          "params": [
+            "command",
+            "dangerouslyDisableSandbox",
+            "description",
+            "run_in_background",
+            "timeout"
+          ],
+          "required": [
+            "command"
+          ],
+          "hasDescription": true
+        },
+        "CronCreate": {
+          "params": [
+            "cron",
+            "durable",
+            "prompt",
+            "recurring"
+          ],
+          "required": [
+            "cron",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "CronDelete": {
+          "params": [
+            "id"
+          ],
+          "required": [
+            "id"
+          ],
+          "hasDescription": true
+        },
+        "CronList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Edit": {
+          "params": [
+            "file_path",
+            "new_string",
+            "old_string",
+            "replace_all"
+          ],
+          "required": [
+            "file_path",
+            "new_string",
+            "old_string"
+          ],
+          "hasDescription": true
+        },
+        "EnterWorktree": {
+          "params": [
+            "name",
+            "path"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ExitWorktree": {
+          "params": [
+            "action",
+            "discard_changes"
+          ],
+          "required": [
+            "action"
+          ],
+          "hasDescription": true
+        },
+        "ListConnectors": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "NotebookEdit": {
+          "params": [
+            "cell_id",
+            "cell_type",
+            "edit_mode",
+            "new_source",
+            "notebook_path"
+          ],
+          "required": [
+            "new_source",
+            "notebook_path"
+          ],
+          "hasDescription": true
+        },
+        "Read": {
+          "params": [
+            "file_path",
+            "limit",
+            "offset",
+            "pages"
+          ],
+          "required": [
+            "file_path"
+          ],
+          "hasDescription": true
+        },
+        "ReportFindings": {
+          "params": [
+            "findings",
+            "level"
+          ],
+          "required": [
+            "findings"
+          ],
+          "hasDescription": true
+        },
+        "ScheduleWakeup": {
+          "params": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "required": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "hasDescription": true
+        },
+        "SearchMcpRegistry": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SendMessage": {
+          "params": [
+            "message",
+            "summary",
+            "to"
+          ],
+          "required": [
+            "message",
+            "to"
+          ],
+          "hasDescription": true
+        },
+        "ShowOnboardingRolePicker": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Skill": {
+          "params": [
+            "args",
+            "skill"
+          ],
+          "required": [
+            "skill"
+          ],
+          "hasDescription": true
+        },
+        "SuggestConnectors": {
+          "params": [
+            "uuids"
+          ],
+          "required": [
+            "uuids"
+          ],
+          "hasDescription": true
+        },
+        "SuggestPluginInstall": {
+          "params": [
+            "contextLabel",
+            "plugins"
+          ],
+          "required": [
+            "contextLabel",
+            "plugins"
+          ],
+          "hasDescription": true
+        },
+        "SuggestSkills": {
+          "params": [
+            "contextLabel",
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "TaskCreate": {
+          "params": [
+            "activeForm",
+            "description",
+            "metadata",
+            "subject"
+          ],
+          "required": [
+            "description",
+            "subject"
+          ],
+          "hasDescription": true
+        },
+        "TaskGet": {
+          "params": [
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "TaskList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskOutput": {
+          "params": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "required": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "hasDescription": true
+        },
+        "TaskStop": {
+          "params": [
+            "shell_id",
+            "task_id"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskUpdate": {
+          "params": [
+            "activeForm",
+            "addBlockedBy",
+            "addBlocks",
+            "description",
+            "metadata",
+            "owner",
+            "status",
+            "subject",
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "WebFetch": {
+          "params": [
+            "prompt",
+            "url"
+          ],
+          "required": [
+            "prompt",
+            "url"
+          ],
+          "hasDescription": true
+        },
+        "WebSearch": {
+          "params": [
+            "allowed_domains",
+            "blocked_domains",
+            "query"
+          ],
+          "required": [
+            "query"
+          ],
+          "hasDescription": true
+        },
+        "Workflow": {
+          "params": [
+            "args",
+            "description",
+            "name",
+            "resumeFromRunId",
+            "script",
+            "scriptPath",
+            "title"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "Write": {
+          "params": [
+            "content",
+            "file_path"
+          ],
+          "required": [
+            "content",
+            "file_path"
+          ],
+          "hasDescription": true
+        }
+      },
+      "thinking": {
+        "type": "adaptive",
+        "budget_tokens": null
+      },
+      "hasTemperature": false,
+      "stream": true,
+      "topLevelKeys": [
+        "context_management",
+        "max_tokens",
+        "messages",
+        "metadata",
+        "model",
+        "output_config",
+        "stream",
+        "system",
+        "thinking",
+        "tools"
+      ]
+    },
+    "cache-off": {
+      "present": true,
+      "systemKind": "blocks",
+      "systemBlocks": 2,
+      "systemCacheBreakpoints": 1,
+      "toolNames": [
+        "Agent",
+        "Bash",
+        "CronCreate",
+        "CronDelete",
+        "CronList",
+        "Edit",
+        "EnterWorktree",
+        "ExitWorktree",
+        "ListConnectors",
+        "ListPlugins",
+        "ListSkills",
+        "NotebookEdit",
+        "Read",
+        "ReportFindings",
+        "ScheduleWakeup",
+        "SearchMcpRegistry",
+        "SearchPlugins",
+        "SearchSkills",
+        "SendMessage",
+        "ShowOnboardingRolePicker",
+        "Skill",
+        "SuggestConnectors",
+        "SuggestPluginInstall",
+        "SuggestSkills",
+        "TaskCreate",
+        "TaskGet",
+        "TaskList",
+        "TaskOutput",
+        "TaskStop",
+        "TaskUpdate",
+        "WebFetch",
+        "WebSearch",
+        "Workflow",
+        "Write"
+      ],
+      "toolCount": 34,
+      "toolCacheBreakpoints": 0,
+      "toolSchemas": {
+        "Agent": {
+          "params": [
+            "description",
+            "isolation",
+            "model",
+            "prompt",
+            "run_in_background",
+            "subagent_type"
+          ],
+          "required": [
+            "description",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "Bash": {
+          "params": [
+            "command",
+            "dangerouslyDisableSandbox",
+            "description",
+            "run_in_background",
+            "timeout"
+          ],
+          "required": [
+            "command"
+          ],
+          "hasDescription": true
+        },
+        "CronCreate": {
+          "params": [
+            "cron",
+            "durable",
+            "prompt",
+            "recurring"
+          ],
+          "required": [
+            "cron",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "CronDelete": {
+          "params": [
+            "id"
+          ],
+          "required": [
+            "id"
+          ],
+          "hasDescription": true
+        },
+        "CronList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Edit": {
+          "params": [
+            "file_path",
+            "new_string",
+            "old_string",
+            "replace_all"
+          ],
+          "required": [
+            "file_path",
+            "new_string",
+            "old_string"
+          ],
+          "hasDescription": true
+        },
+        "EnterWorktree": {
+          "params": [
+            "name",
+            "path"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ExitWorktree": {
+          "params": [
+            "action",
+            "discard_changes"
+          ],
+          "required": [
+            "action"
+          ],
+          "hasDescription": true
+        },
+        "ListConnectors": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "NotebookEdit": {
+          "params": [
+            "cell_id",
+            "cell_type",
+            "edit_mode",
+            "new_source",
+            "notebook_path"
+          ],
+          "required": [
+            "new_source",
+            "notebook_path"
+          ],
+          "hasDescription": true
+        },
+        "Read": {
+          "params": [
+            "file_path",
+            "limit",
+            "offset",
+            "pages"
+          ],
+          "required": [
+            "file_path"
+          ],
+          "hasDescription": true
+        },
+        "ReportFindings": {
+          "params": [
+            "findings",
+            "level"
+          ],
+          "required": [
+            "findings"
+          ],
+          "hasDescription": true
+        },
+        "ScheduleWakeup": {
+          "params": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "required": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "hasDescription": true
+        },
+        "SearchMcpRegistry": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SendMessage": {
+          "params": [
+            "message",
+            "summary",
+            "to"
+          ],
+          "required": [
+            "message",
+            "to"
+          ],
+          "hasDescription": true
+        },
+        "ShowOnboardingRolePicker": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Skill": {
+          "params": [
+            "args",
+            "skill"
+          ],
+          "required": [
+            "skill"
+          ],
+          "hasDescription": true
+        },
+        "SuggestConnectors": {
+          "params": [
+            "uuids"
+          ],
+          "required": [
+            "uuids"
+          ],
+          "hasDescription": true
+        },
+        "SuggestPluginInstall": {
+          "params": [
+            "contextLabel",
+            "plugins"
+          ],
+          "required": [
+            "contextLabel",
+            "plugins"
+          ],
+          "hasDescription": true
+        },
+        "SuggestSkills": {
+          "params": [
+            "contextLabel",
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "TaskCreate": {
+          "params": [
+            "activeForm",
+            "description",
+            "metadata",
+            "subject"
+          ],
+          "required": [
+            "description",
+            "subject"
+          ],
+          "hasDescription": true
+        },
+        "TaskGet": {
+          "params": [
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "TaskList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskOutput": {
+          "params": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "required": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "hasDescription": true
+        },
+        "TaskStop": {
+          "params": [
+            "shell_id",
+            "task_id"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskUpdate": {
+          "params": [
+            "activeForm",
+            "addBlockedBy",
+            "addBlocks",
+            "description",
+            "metadata",
+            "owner",
+            "status",
+            "subject",
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "WebFetch": {
+          "params": [
+            "prompt",
+            "url"
+          ],
+          "required": [
+            "prompt",
+            "url"
+          ],
+          "hasDescription": true
+        },
+        "WebSearch": {
+          "params": [
+            "allowed_domains",
+            "blocked_domains",
+            "query"
+          ],
+          "required": [
+            "query"
+          ],
+          "hasDescription": true
+        },
+        "Workflow": {
+          "params": [
+            "args",
+            "description",
+            "name",
+            "resumeFromRunId",
+            "script",
+            "scriptPath",
+            "title"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "Write": {
+          "params": [
+            "content",
+            "file_path"
+          ],
+          "required": [
+            "content",
+            "file_path"
+          ],
+          "hasDescription": true
+        }
+      },
+      "thinking": {
+        "type": "adaptive",
+        "budget_tokens": null
+      },
+      "hasTemperature": false,
+      "stream": true,
+      "topLevelKeys": [
+        "context_management",
+        "max_tokens",
+        "messages",
+        "metadata",
+        "model",
+        "output_config",
+        "stream",
+        "system",
+        "thinking",
+        "tools"
+      ]
+    },
+    "mcp-added": {
+      "present": true,
+      "systemKind": "blocks",
+      "systemBlocks": 2,
+      "systemCacheBreakpoints": 1,
+      "toolNames": [
+        "Agent",
+        "Bash",
+        "CronCreate",
+        "CronDelete",
+        "CronList",
+        "Edit",
+        "EnterWorktree",
+        "ExitWorktree",
+        "ListConnectors",
+        "ListPlugins",
+        "ListSkills",
+        "NotebookEdit",
+        "Read",
+        "ReportFindings",
+        "ScheduleWakeup",
+        "SearchMcpRegistry",
+        "SearchPlugins",
+        "SearchSkills",
+        "SendMessage",
+        "ShowOnboardingRolePicker",
+        "Skill",
+        "SuggestConnectors",
+        "SuggestPluginInstall",
+        "SuggestSkills",
+        "TaskCreate",
+        "TaskGet",
+        "TaskList",
+        "TaskOutput",
+        "TaskStop",
+        "TaskUpdate",
+        "WebFetch",
+        "WebSearch",
+        "Workflow",
+        "Write",
+        "mcp__conf__ping"
+      ],
+      "toolCount": 35,
+      "toolCacheBreakpoints": 0,
+      "toolSchemas": {
+        "Agent": {
+          "params": [
+            "description",
+            "isolation",
+            "model",
+            "prompt",
+            "run_in_background",
+            "subagent_type"
+          ],
+          "required": [
+            "description",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "Bash": {
+          "params": [
+            "command",
+            "dangerouslyDisableSandbox",
+            "description",
+            "run_in_background",
+            "timeout"
+          ],
+          "required": [
+            "command"
+          ],
+          "hasDescription": true
+        },
+        "CronCreate": {
+          "params": [
+            "cron",
+            "durable",
+            "prompt",
+            "recurring"
+          ],
+          "required": [
+            "cron",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "CronDelete": {
+          "params": [
+            "id"
+          ],
+          "required": [
+            "id"
+          ],
+          "hasDescription": true
+        },
+        "CronList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Edit": {
+          "params": [
+            "file_path",
+            "new_string",
+            "old_string",
+            "replace_all"
+          ],
+          "required": [
+            "file_path",
+            "new_string",
+            "old_string"
+          ],
+          "hasDescription": true
+        },
+        "EnterWorktree": {
+          "params": [
+            "name",
+            "path"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ExitWorktree": {
+          "params": [
+            "action",
+            "discard_changes"
+          ],
+          "required": [
+            "action"
+          ],
+          "hasDescription": true
+        },
+        "ListConnectors": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "NotebookEdit": {
+          "params": [
+            "cell_id",
+            "cell_type",
+            "edit_mode",
+            "new_source",
+            "notebook_path"
+          ],
+          "required": [
+            "new_source",
+            "notebook_path"
+          ],
+          "hasDescription": true
+        },
+        "Read": {
+          "params": [
+            "file_path",
+            "limit",
+            "offset",
+            "pages"
+          ],
+          "required": [
+            "file_path"
+          ],
+          "hasDescription": true
+        },
+        "ReportFindings": {
+          "params": [
+            "findings",
+            "level"
+          ],
+          "required": [
+            "findings"
+          ],
+          "hasDescription": true
+        },
+        "ScheduleWakeup": {
+          "params": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "required": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "hasDescription": true
+        },
+        "SearchMcpRegistry": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SendMessage": {
+          "params": [
+            "message",
+            "summary",
+            "to"
+          ],
+          "required": [
+            "message",
+            "to"
+          ],
+          "hasDescription": true
+        },
+        "ShowOnboardingRolePicker": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Skill": {
+          "params": [
+            "args",
+            "skill"
+          ],
+          "required": [
+            "skill"
+          ],
+          "hasDescription": true
+        },
+        "SuggestConnectors": {
+          "params": [
+            "uuids"
+          ],
+          "required": [
+            "uuids"
+          ],
+          "hasDescription": true
+        },
+        "SuggestPluginInstall": {
+          "params": [
+            "contextLabel",
+            "plugins"
+          ],
+          "required": [
+            "contextLabel",
+            "plugins"
+          ],
+          "hasDescription": true
+        },
+        "SuggestSkills": {
+          "params": [
+            "contextLabel",
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "TaskCreate": {
+          "params": [
+            "activeForm",
+            "description",
+            "metadata",
+            "subject"
+          ],
+          "required": [
+            "description",
+            "subject"
+          ],
+          "hasDescription": true
+        },
+        "TaskGet": {
+          "params": [
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "TaskList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskOutput": {
+          "params": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "required": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "hasDescription": true
+        },
+        "TaskStop": {
+          "params": [
+            "shell_id",
+            "task_id"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskUpdate": {
+          "params": [
+            "activeForm",
+            "addBlockedBy",
+            "addBlocks",
+            "description",
+            "metadata",
+            "owner",
+            "status",
+            "subject",
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "WebFetch": {
+          "params": [
+            "prompt",
+            "url"
+          ],
+          "required": [
+            "prompt",
+            "url"
+          ],
+          "hasDescription": true
+        },
+        "WebSearch": {
+          "params": [
+            "allowed_domains",
+            "blocked_domains",
+            "query"
+          ],
+          "required": [
+            "query"
+          ],
+          "hasDescription": true
+        },
+        "Workflow": {
+          "params": [
+            "args",
+            "description",
+            "name",
+            "resumeFromRunId",
+            "script",
+            "scriptPath",
+            "title"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "Write": {
+          "params": [
+            "content",
+            "file_path"
+          ],
+          "required": [
+            "content",
+            "file_path"
+          ],
+          "hasDescription": true
+        },
+        "mcp__conf__ping": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        }
+      },
+      "thinking": {
+        "type": "adaptive",
+        "budget_tokens": null
+      },
+      "hasTemperature": false,
+      "stream": true,
+      "topLevelKeys": [
+        "context_management",
+        "max_tokens",
+        "messages",
+        "metadata",
+        "model",
+        "output_config",
+        "stream",
+        "system",
+        "thinking",
+        "tools"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## 概要

守密人裁定「既然解锁了，对着接口全部测试一轮，作为参考目标」。把请求体差分从单探针扩为**逐接口全覆盖**，并把官方线缆结构固化为**参考目标**。

## 改动

- **`scenarios-wire.mjs`**：5 个选项级场景（default / thinking-off / thinking-4096 / cache-off / mcp-added），双臂同参驱动。
- **`wire-fingerprint.mjs`**：新增**逐工具 input_schema 指纹** + `diffToolSchemas()`——「每个接口」的真信号：我方每个工具的参数/必填集是否对齐官方（共有工具集）。
- **`run-wire.mjs`**：迭代场景矩阵、双臂、写报告 +（`--update-reference`）写参考目标。
- **`wire-reference.json`**（committed）：官方 0.3.199/2.1.201 逐场景**结构指纹**（纯结构、无提示词正文，assertContentBlind 通过）——我方引擎瞄准的目标。
- **`conformance-wire.test.ts`**：升级为**参考目标棘轮**——keyless 驱我方臂逐场景，断言「对参考的实际缺口 = 登记缺口」（新漂移即红；缺口修复后仍留条目也红）。

## 全覆盖新发现（引擎对齐候选，交引擎团队）

逐工具 schema 差分暴露**我方工具参数落后官方当前版本**，五场景一致稳定：

- **Agent**：缺 `isolation` / `model`，且必填集不同；
- **Bash**：缺 `dangerouslyDisableSandbox`；
- **Read**：缺 `pages`（PDF 页范围）。

连同已知的 thinking 自适应、工具缓存断点，构成引擎侧「对齐官方线缆」完整清单。cache-off 的系统分段差属 bpt-only 选项非对称（官方忽略 `promptCaching:false`），已标注不追。

## 验证

`tsc --noEmit` + `npx vitest run` **1091 通过 / 2 跳过（+6）**全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_