### PR TITLE
test(bpt-sdk): 测试侧全面推进 batch 1 — A1 系统分段 + A2 多轮前缀稳定

### DIFF
--- a/projects/bpt-agent-sdk/tests/conformance-wire.test.ts
+++ b/projects/bpt-agent-sdk/tests/conformance-wire.test.ts
@@ -9,7 +9,7 @@
  * in the normal keyless `npm test`.
  */
 
-import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -153,33 +153,45 @@ const EXPECTED_SURFACE = new Set(['toolNames', 'toolCount']);
  *                         system-segmentation delta there is an artifact of the
  *                         asymmetric option, documented not chased.
  */
+const TOOL_GAPS = ['Agent:params+required', 'Bash:params', 'Read:params'];
+// systemSegments (A1): our cache breakpoint sits on the stable FIRST system
+// block; official's sits on the LAST - a cache-boundary PLACEMENT gap (E7-03
+// territory). Present on every scenario alongside thinking + toolCacheBreakpoints.
 const WIRE_ALIGNMENT_GAPS: Record<string, { facets: string[]; tools: string[] }> = {
-  default: { facets: ['thinking', 'toolCacheBreakpoints'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
-  'thinking-off': { facets: ['thinking', 'toolCacheBreakpoints'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
-  'thinking-4096': { facets: ['thinking', 'toolCacheBreakpoints'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
-  'cache-off': { facets: ['systemBlocks', 'systemCacheBreakpoints', 'systemKind', 'thinking'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
-  'mcp-added': { facets: ['thinking', 'toolCacheBreakpoints'], tools: ['Agent:params+required', 'Bash:params', 'Read:params'] },
+  default: { facets: ['systemSegments', 'thinking', 'toolCacheBreakpoints'], tools: TOOL_GAPS },
+  'thinking-off': { facets: ['systemSegments', 'thinking', 'toolCacheBreakpoints'], tools: TOOL_GAPS },
+  'thinking-4096': { facets: ['systemSegments', 'thinking', 'toolCacheBreakpoints'], tools: TOOL_GAPS },
+  'cache-off': { facets: ['systemBlocks', 'systemCacheBreakpoints', 'systemKind', 'systemSegments', 'thinking'], tools: TOOL_GAPS },
+  'tool-loop': { facets: ['systemSegments', 'thinking', 'toolCacheBreakpoints'], tools: TOOL_GAPS },
+  'mcp-added': { facets: ['systemSegments', 'thinking', 'toolCacheBreakpoints'], tools: TOOL_GAPS },
 };
 
 interface WireScenario {
   id: string;
   options?: Record<string, unknown>;
   buildOptions?: (ctx: { sdk: unknown }) => Record<string, unknown>;
+  multiTurn?: boolean;
+  fixtureFiles?: Record<string, string>;
+  buildScripts?: (cwd: string) => unknown[];
 }
 
-async function ourFingerprint(scenario: WireScenario) {
+async function ourCapture(scenario: WireScenario) {
   await mkdir(join(cwd, '.sessions'), { recursive: true });
-  const emulator = await startEmulator([{ kind: 'sse', events: textReply('WIRE OK') }], {
-    captureBodies: true,
-  });
+  for (const [name, content] of Object.entries(scenario.fixtureFiles ?? {})) {
+    await writeFile(join(cwd, name), content);
+  }
+  const scripts = scenario.buildScripts
+    ? scenario.buildScripts(cwd)
+    : [{ kind: 'sse', events: textReply('WIRE OK') }];
+  const emulator = await startEmulator(scripts, { captureBodies: true });
   const sdk = await import('../src/index.js');
   const extra = scenario.buildOptions ? scenario.buildOptions({ sdk }) : (scenario.options ?? {});
   try {
     const q: Query = query({
-      prompt: 'Say OK.',
+      prompt: scenario.multiTurn ? 'Read wire.txt then say done.' : 'Say OK.',
       options: {
         cwd,
-        maxTurns: 2,
+        maxTurns: 3,
         sessionDir: join(cwd, '.sessions'),
         sandbox: false,
         systemPrompt: { type: 'preset', preset: 'claude_code' },
@@ -197,7 +209,12 @@ async function ourFingerprint(scenario: WireScenario) {
   } finally {
     await emulator.close();
   }
-  return fingerprintRequestBody(emulator.profile.requestBodies[0]);
+  const bodies = emulator.profile.requestBodies as unknown[];
+  return { fingerprint: fingerprintRequestBody(bodies[0]), trajectory: bodies.map((b) => fingerprintRequestBody(b)) };
+}
+
+async function ourFingerprint(scenario: WireScenario) {
+  return (await ourCapture(scenario)).fingerprint;
 }
 
 describe('wire reference-target ratchet (our arm vs official reference)', () => {
@@ -226,4 +243,30 @@ describe('wire reference-target ratchet (our arm vs official reference)', () => 
       expect(toolGaps, `tool-schema gaps drifted for ${scenario.id}`).toEqual([...expected.tools].sort());
     });
   }
+});
+
+// A2: cache-prefix stability across a multi-turn trajectory. Our system + tool
+// surface must stay byte-stable turn-over-turn or cross-turn prompt-cache reuse
+// breaks (the economics win). Regression lock on OUR arm (keyless).
+describe('wire trajectory: cache-prefix stability (A2)', () => {
+  const loop = (WIRE_SCENARIOS as WireScenario[]).find((s) => s.id === 'tool-loop');
+
+  it('the tool-loop scenario exists and is multi-turn', () => {
+    expect(loop?.multiTurn).toBe(true);
+  });
+
+  it('system + tool prefix is byte-stable across every turn (cache reuse holds)', async () => {
+    const { trajectory } = await ourCapture(loop as WireScenario);
+    expect(trajectory.length, 'expected >= 2 POSTs from the tool loop').toBeGreaterThanOrEqual(2);
+    const first = trajectory[0];
+    const facets = ['systemKind', 'systemBlocks', 'systemSegments', 'toolCount', 'toolCacheBreakpoints', 'thinking'] as const;
+    for (let i = 1; i < trajectory.length; i++) {
+      for (const f of facets) {
+        expect(
+          JSON.stringify(trajectory[i][f]),
+          `prefix facet ${f} drifted at turn ${i + 1} - cross-turn cache reuse would break`,
+        ).toBe(JSON.stringify(first[f]));
+      }
+    }
+  });
 });

--- a/projects/bpt-agent-sdk/tests/conformance/run-wire.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/run-wire.mjs
@@ -69,24 +69,28 @@ function baseEnv(url) {
   return env;
 }
 
-/** Drive one arm through one scenario; fingerprint the first captured POST body. */
+/** Drive one arm through one scenario; return { fingerprint (first POST), trajectory }. */
 async function captureArm(armKind, scenario) {
   const query = await loadQuery(armKind);
   const sdk = await loadSdk(armKind);
   const cwd = mkdtempSync(join(tmpdir(), `conf-wire-${armKind}-`));
-  const emulator = await startEmulator([{ kind: 'sse', events: textReply('WIRE OK') }], {
-    captureBodies: true,
-  });
+  for (const [name, content] of Object.entries(scenario.fixtureFiles ?? {})) {
+    writeFileSync(join(cwd, name), content);
+  }
+  const scripts = scenario.buildScripts
+    ? scenario.buildScripts(cwd)
+    : [{ kind: 'sse', events: textReply('WIRE OK') }];
+  const emulator = await startEmulator(scripts, { captureBodies: true });
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), 60_000);
   const extra = scenario.buildOptions ? scenario.buildOptions({ sdk }) : (scenario.options ?? {});
   try {
     const q = query({
-      prompt: 'Say OK.',
+      prompt: scenario.multiTurn ? 'Read wire.txt then say done.' : 'Say OK.',
       options: {
         abortController: ac,
         cwd,
-        maxTurns: 2,
+        maxTurns: 3,
         env: baseEnv(emulator.url),
         ...(armKind === 'bpt'
           ? { sessionDir: join(cwd, '.sessions'), systemPrompt: { type: 'preset', preset: 'claude_code' } }
@@ -102,7 +106,31 @@ async function captureArm(armKind, scenario) {
     await emulator.close();
     rmSync(cwd, { recursive: true, force: true });
   }
-  return fingerprintRequestBody(emulator.profile.requestBodies[0]);
+  const bodies = emulator.profile.requestBodies;
+  return {
+    fingerprint: fingerprintRequestBody(bodies[0]),
+    // A2: per-POST fingerprints for the trajectory (cache-prefix stability).
+    trajectory: bodies.map((b) => fingerprintRequestBody(b)),
+    posts: bodies.length,
+  };
+}
+
+/**
+ * A2 cache-prefix stability: across a multi-turn trajectory the system + tool
+ * surface must stay byte-stable (only messages grow) or cross-turn cache reuse
+ * breaks. Returns the list of unstable facets (empty = stable).
+ */
+function prefixStability(trajectory) {
+  if (trajectory.length < 2) return [];
+  const first = trajectory[0];
+  const facets = ['systemKind', 'systemBlocks', 'systemSegments', 'toolCount', 'toolCacheBreakpoints', 'thinking'];
+  const unstable = [];
+  for (const fp of trajectory.slice(1)) {
+    for (const f of facets) {
+      if (JSON.stringify(fp?.[f]) !== JSON.stringify(first?.[f]) && !unstable.includes(f)) unstable.push(f);
+    }
+  }
+  return unstable;
 }
 
 const pins = JSON.parse(readFileSync(join(HERE, 'pins.json'), 'utf8'));
@@ -117,12 +145,20 @@ const report = {
 const referenceOut = {};
 
 for (const scenario of WIRE_SCENARIOS) {
-  const bpt = await captureArm('bpt', scenario);
-  const row = { id: scenario.id, notes: scenario.notes, bpt };
+  const bptCap = await captureArm('bpt', scenario);
+  const bpt = bptCap.fingerprint;
+  const bptStability = prefixStability(bptCap.trajectory);
+  const row = { id: scenario.id, notes: scenario.notes, bpt, bptPosts: bptCap.posts, bptPrefixUnstable: bptStability };
+  if (scenario.multiTurn) {
+    console.log(`[${scenario.id}] bpt trajectory posts=${bptCap.posts} prefixUnstable=${JSON.stringify(bptStability)}`);
+  }
   if (armMode !== 'bpt') {
     try {
-      const official = await captureArm('official', scenario);
+      const officialCap = await captureArm('official', scenario);
+      const official = officialCap.fingerprint;
       row.official = official;
+      row.officialPosts = officialCap.posts;
+      row.officialPrefixUnstable = prefixStability(officialCap.trajectory);
       referenceOut[scenario.id] = official;
       const facetDiff = diffFingerprints(official, bpt).map((d) => ({
         ...d,

--- a/projects/bpt-agent-sdk/tests/conformance/scenarios-wire.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/scenarios-wire.mjs
@@ -16,7 +16,11 @@
  *   buildOptions(sdk)          - per-arm option builder (MCP needs each arm's
  *                                own tool()/createSdkMcpServer); takes { sdk }
  *   notes                      - what this scenario probes
+ *   multiTurn / fixtureFiles / buildScripts(cwd) - A2 trajectory scenarios
+ *     that need >1 POST (a tool loop); buildScripts returns emulator scripts.
  */
+
+import { textReply, toolUseReply } from './emulator.mjs';
 
 export const WIRE_SCENARIOS = [
   {
@@ -38,6 +42,20 @@ export const WIRE_SCENARIOS = [
     id: 'cache-off',
     options: { provider: { promptCaching: false } },
     notes: 'prompt caching disabled - cache_control breakpoints should vanish from both arms',
+  },
+  {
+    id: 'tool-loop',
+    // A2 multi-turn trajectory: a Read tool turn then a text turn => 2 POSTs,
+    // so the runner can compare how system/tools prefix + cache breakpoints
+    // EVOLVE across turns (prefix must stay byte-stable for cache reuse).
+    options: { allowedTools: ['Read'] },
+    multiTurn: true,
+    fixtureFiles: { 'wire.txt': 'wire trajectory fixture\n' },
+    buildScripts: (cwd) => [
+      { kind: 'sse', events: toolUseReply([{ name: 'Read', input: { file_path: `${cwd}/wire.txt` } }]) },
+      { kind: 'sse', events: textReply('WIRE LOOP DONE') },
+    ],
+    notes: '2-turn tool loop: probes cache-prefix stability across turns (A2 trajectory)',
   },
   {
     id: 'mcp-added',

--- a/projects/bpt-agent-sdk/tests/conformance/wire-fingerprint.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/wire-fingerprint.mjs
@@ -79,6 +79,10 @@ export function fingerprintRequestBody(body) {
     systemKind,
     systemBlocks: systemKind === 'blocks' ? sys.length : systemKind === 'string' ? 1 : 0,
     systemCacheBreakpoints: systemKind === 'blocks' ? cacheBreakpoints(sys) : 0,
+    // A1: per-block cache_control PRESENCE (position-aware) - captures the
+    // cache-breakpoint PLACEMENT (which block carries it), a cache-economics
+    // signal size/count alone misses. Text prose is deliberately excluded.
+    systemSegments: systemKind === 'blocks' ? sys.map((b) => ({ cc: !!(b && b.cache_control) })) : [],
     toolNames: tools
       .map((t) => t && t.name)
       .filter((n) => typeof n === 'string')
@@ -107,6 +111,7 @@ export function diffFingerprints(a, b) {
     'systemKind',
     'systemBlocks',
     'systemCacheBreakpoints',
+    'systemSegments',
     'toolCount',
     'toolCacheBreakpoints',
     'thinking',

--- a/projects/bpt-agent-sdk/tests/conformance/wire-reference.json
+++ b/projects/bpt-agent-sdk/tests/conformance/wire-reference.json
@@ -11,6 +11,14 @@
       "systemKind": "blocks",
       "systemBlocks": 2,
       "systemCacheBreakpoints": 1,
+      "systemSegments": [
+        {
+          "cc": false
+        },
+        {
+          "cc": true
+        }
+      ],
       "toolNames": [
         "Agent",
         "Bash",
@@ -427,6 +435,14 @@
       "systemKind": "blocks",
       "systemBlocks": 2,
       "systemCacheBreakpoints": 1,
+      "systemSegments": [
+        {
+          "cc": false
+        },
+        {
+          "cc": true
+        }
+      ],
       "toolNames": [
         "Agent",
         "Bash",
@@ -842,6 +858,14 @@
       "systemKind": "blocks",
       "systemBlocks": 2,
       "systemCacheBreakpoints": 1,
+      "systemSegments": [
+        {
+          "cc": false
+        },
+        {
+          "cc": true
+        }
+      ],
       "toolNames": [
         "Agent",
         "Bash",
@@ -1258,6 +1282,438 @@
       "systemKind": "blocks",
       "systemBlocks": 2,
       "systemCacheBreakpoints": 1,
+      "systemSegments": [
+        {
+          "cc": false
+        },
+        {
+          "cc": true
+        }
+      ],
+      "toolNames": [
+        "Agent",
+        "Bash",
+        "CronCreate",
+        "CronDelete",
+        "CronList",
+        "Edit",
+        "EnterWorktree",
+        "ExitWorktree",
+        "ListConnectors",
+        "ListPlugins",
+        "ListSkills",
+        "NotebookEdit",
+        "Read",
+        "ReportFindings",
+        "ScheduleWakeup",
+        "SearchMcpRegistry",
+        "SearchPlugins",
+        "SearchSkills",
+        "SendMessage",
+        "ShowOnboardingRolePicker",
+        "Skill",
+        "SuggestConnectors",
+        "SuggestPluginInstall",
+        "SuggestSkills",
+        "TaskCreate",
+        "TaskGet",
+        "TaskList",
+        "TaskOutput",
+        "TaskStop",
+        "TaskUpdate",
+        "WebFetch",
+        "WebSearch",
+        "Workflow",
+        "Write"
+      ],
+      "toolCount": 34,
+      "toolCacheBreakpoints": 0,
+      "toolSchemas": {
+        "Agent": {
+          "params": [
+            "description",
+            "isolation",
+            "model",
+            "prompt",
+            "run_in_background",
+            "subagent_type"
+          ],
+          "required": [
+            "description",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "Bash": {
+          "params": [
+            "command",
+            "dangerouslyDisableSandbox",
+            "description",
+            "run_in_background",
+            "timeout"
+          ],
+          "required": [
+            "command"
+          ],
+          "hasDescription": true
+        },
+        "CronCreate": {
+          "params": [
+            "cron",
+            "durable",
+            "prompt",
+            "recurring"
+          ],
+          "required": [
+            "cron",
+            "prompt"
+          ],
+          "hasDescription": true
+        },
+        "CronDelete": {
+          "params": [
+            "id"
+          ],
+          "required": [
+            "id"
+          ],
+          "hasDescription": true
+        },
+        "CronList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Edit": {
+          "params": [
+            "file_path",
+            "new_string",
+            "old_string",
+            "replace_all"
+          ],
+          "required": [
+            "file_path",
+            "new_string",
+            "old_string"
+          ],
+          "hasDescription": true
+        },
+        "EnterWorktree": {
+          "params": [
+            "name",
+            "path"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ExitWorktree": {
+          "params": [
+            "action",
+            "discard_changes"
+          ],
+          "required": [
+            "action"
+          ],
+          "hasDescription": true
+        },
+        "ListConnectors": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "ListSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "NotebookEdit": {
+          "params": [
+            "cell_id",
+            "cell_type",
+            "edit_mode",
+            "new_source",
+            "notebook_path"
+          ],
+          "required": [
+            "new_source",
+            "notebook_path"
+          ],
+          "hasDescription": true
+        },
+        "Read": {
+          "params": [
+            "file_path",
+            "limit",
+            "offset",
+            "pages"
+          ],
+          "required": [
+            "file_path"
+          ],
+          "hasDescription": true
+        },
+        "ReportFindings": {
+          "params": [
+            "findings",
+            "level"
+          ],
+          "required": [
+            "findings"
+          ],
+          "hasDescription": true
+        },
+        "ScheduleWakeup": {
+          "params": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "required": [
+            "delaySeconds",
+            "prompt",
+            "reason"
+          ],
+          "hasDescription": true
+        },
+        "SearchMcpRegistry": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchPlugins": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SearchSkills": {
+          "params": [
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "SendMessage": {
+          "params": [
+            "message",
+            "summary",
+            "to"
+          ],
+          "required": [
+            "message",
+            "to"
+          ],
+          "hasDescription": true
+        },
+        "ShowOnboardingRolePicker": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "Skill": {
+          "params": [
+            "args",
+            "skill"
+          ],
+          "required": [
+            "skill"
+          ],
+          "hasDescription": true
+        },
+        "SuggestConnectors": {
+          "params": [
+            "uuids"
+          ],
+          "required": [
+            "uuids"
+          ],
+          "hasDescription": true
+        },
+        "SuggestPluginInstall": {
+          "params": [
+            "contextLabel",
+            "plugins"
+          ],
+          "required": [
+            "contextLabel",
+            "plugins"
+          ],
+          "hasDescription": true
+        },
+        "SuggestSkills": {
+          "params": [
+            "contextLabel",
+            "keywords"
+          ],
+          "required": [
+            "keywords"
+          ],
+          "hasDescription": true
+        },
+        "TaskCreate": {
+          "params": [
+            "activeForm",
+            "description",
+            "metadata",
+            "subject"
+          ],
+          "required": [
+            "description",
+            "subject"
+          ],
+          "hasDescription": true
+        },
+        "TaskGet": {
+          "params": [
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "TaskList": {
+          "params": [],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskOutput": {
+          "params": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "required": [
+            "block",
+            "task_id",
+            "timeout"
+          ],
+          "hasDescription": true
+        },
+        "TaskStop": {
+          "params": [
+            "shell_id",
+            "task_id"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "TaskUpdate": {
+          "params": [
+            "activeForm",
+            "addBlockedBy",
+            "addBlocks",
+            "description",
+            "metadata",
+            "owner",
+            "status",
+            "subject",
+            "taskId"
+          ],
+          "required": [
+            "taskId"
+          ],
+          "hasDescription": true
+        },
+        "WebFetch": {
+          "params": [
+            "prompt",
+            "url"
+          ],
+          "required": [
+            "prompt",
+            "url"
+          ],
+          "hasDescription": true
+        },
+        "WebSearch": {
+          "params": [
+            "allowed_domains",
+            "blocked_domains",
+            "query"
+          ],
+          "required": [
+            "query"
+          ],
+          "hasDescription": true
+        },
+        "Workflow": {
+          "params": [
+            "args",
+            "description",
+            "name",
+            "resumeFromRunId",
+            "script",
+            "scriptPath",
+            "title"
+          ],
+          "required": [],
+          "hasDescription": true
+        },
+        "Write": {
+          "params": [
+            "content",
+            "file_path"
+          ],
+          "required": [
+            "content",
+            "file_path"
+          ],
+          "hasDescription": true
+        }
+      },
+      "thinking": {
+        "type": "adaptive",
+        "budget_tokens": null
+      },
+      "hasTemperature": false,
+      "stream": true,
+      "topLevelKeys": [
+        "context_management",
+        "max_tokens",
+        "messages",
+        "metadata",
+        "model",
+        "output_config",
+        "stream",
+        "system",
+        "thinking",
+        "tools"
+      ]
+    },
+    "tool-loop": {
+      "present": true,
+      "systemKind": "blocks",
+      "systemBlocks": 2,
+      "systemCacheBreakpoints": 1,
+      "systemSegments": [
+        {
+          "cc": false
+        },
+        {
+          "cc": true
+        }
+      ],
       "toolNames": [
         "Agent",
         "Bash",
@@ -1674,6 +2130,14 @@
       "systemKind": "blocks",
       "systemBlocks": 2,
       "systemCacheBreakpoints": 1,
+      "systemSegments": [
+        {
+          "cc": false
+        },
+        {
+          "cc": true
+        }
+      ],
       "toolNames": [
         "Agent",
         "Bash",


### PR DESCRIPTION
## 概要

「全面实现」测试侧计划第 1 批（请求体差分深挖）。

## A1 系统提示词分段差分

指纹新增 `systemSegments`（逐块 `cache_control` 位置，position-aware）。抓到「块数/断点计数」看不出的**缓存断点位置差**：我方断点在稳定的第一块（13.6KB 前缀）、官方在最后一块——归 E7-03 缓存边界家族，现为每场景的跟踪对齐缺口。不捕获提示词正文。

## A2 多轮线缆轨迹

新增 `tool-loop` 场景（Read 轮 → 文本轮 = 2 POST）。run-wire 捕获整条逐 POST 轨迹并检**缓存前缀稳定性**（系统+工具面须跨轮字节稳定，否则跨轮缓存复用失效）。我方臂：前缀跨轮稳定（不变式成立），vitest keyless 回归锁钉死。

## 验证

参考目标已刷新（+systemSegments + tool-loop 场景），`WIRE_ALIGNMENT_GAPS` 棘轮同步。`tsc` + `npx vitest run` **1094 通过 / 2 跳过**（+3，wire 用例增至 15）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_