### PR TITLE
test(bpt-sdk): 全面推进 batch 2 — MCP 差分第二批（多工具路由 + zod 校验锁）

### DIFF
--- a/projects/bpt-agent-sdk/tests/conformance/baseline.json
+++ b/projects/bpt-agent-sdk/tests/conformance/baseline.json
@@ -297,6 +297,11 @@
         ],
         "engineFinding": false
       },
+      "L3-MCP-05": {
+        "verdict": "CONTENT_MATCH",
+        "kdIds": [],
+        "engineFinding": false
+      },
       "L3-READ-01": {
         "verdict": "CONTENT_KNOWN_DIFF",
         "kdIds": [
@@ -319,6 +324,11 @@
         "engineFinding": false
       },
       "L3-SA-BASH-HOUSE": {
+        "verdict": "LOCKED",
+        "kdIds": [],
+        "engineFinding": false
+      },
+      "L3-SA-MCP-ZOD": {
         "verdict": "LOCKED",
         "kdIds": [],
         "engineFinding": false

--- a/projects/bpt-agent-sdk/tests/conformance/scenarios-l3.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/scenarios-l3.mjs
@@ -31,6 +31,7 @@
 
 import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { z } from 'zod';
 import { textReply } from './emulator.mjs';
 
 const ALLOWED_TOOLS = [
@@ -888,6 +889,44 @@ export const L3_SCENARIOS = [
       },
     ],
   },
+
+  // --- MCP tranche 2: multi-tool server routing (dual-arm) --------------------
+  // A server registering >1 tool must route each mcp__server__name to the RIGHT
+  // handler. Empty schemas keep this a clean differential (the zod-coercion
+  // path is a cross-package-zod artifact between arms, so it is a single-arm
+  // lock below, not a differential).
+  {
+    id: 'L3-MCP-05',
+    tool: 'mcp__conf__two (routing)',
+    prompt: 'Call ping then echo.',
+    buildOptions: (_cwd, _ctx, { sdk }) => ({
+      allowedTools: [...ALLOWED_TOOLS, 'mcp__conf__ping', 'mcp__conf__echo'],
+      mcpServers: {
+        conf: sdk.createSdkMcpServer({
+          name: 'conf',
+          version: '1.0.0',
+          tools: [
+            sdk.tool('ping', 'Return the ping marker.', {}, async () => ({
+              content: [{ type: 'text', text: 'ROUTE-PING' }],
+            })),
+            sdk.tool('echo', 'Return the echo marker.', {}, async () => ({
+              content: [{ type: 'text', text: 'ROUTE-ECHO' }],
+            })),
+          ],
+        }),
+      },
+    }),
+    fixtureFiles: {},
+    buildScripts: () => [
+      toolTurn(1, [{ name: 'mcp__conf__ping', input: {} }]),
+      toolTurn(2, [{ name: 'mcp__conf__echo', input: {} }]),
+      { kind: 'sse', events: textReply('L3 MCP-05 DONE') },
+    ],
+    steps: [
+      { tool: 'mcp__conf__ping', isError: false, locks: [/ROUTE-PING/], notLocks: [/ROUTE-ECHO/] },
+      { tool: 'mcp__conf__echo', isError: false, locks: [/ROUTE-ECHO/], notLocks: [/ROUTE-PING/] },
+    ],
+  },
 ];
 
 /**
@@ -1023,6 +1062,49 @@ export const L3_SINGLE_ARM = [
         tool: 'Bash (timeout)',
         isError: true,
         locks: [/^Command timed out after 500ms/],
+      },
+    ],
+  },
+
+  // --- MCP tranche 2: zod input validation (single-arm) -----------------------
+  // Our tool() validates args via zod safeParse and returns an is_error
+  // tool_result on mismatch. This is a SINGLE-ARM lock, not a differential:
+  // passing OUR zod-v4 shape to the official arm's tool() hits its own bundled
+  // zod's converter, which does not recognize the instance and emits a
+  // malformed inputSchema - a cross-package artifact, not a real behavior
+  // split. So the official side is deliberately not compared; our validation
+  // contract is pinned here.
+  {
+    id: 'L3-SA-MCP-ZOD',
+    tool: 'mcp__conf__needs_number',
+    reason:
+      'zod arg validation is BPT tool() internal contract; a cross-arm differential is polluted by the official arm using its own bundled zod on our shape (malformed schema, not a behavior diff).',
+    prompt: 'Call the tool with a wrong-typed argument.',
+    buildOptions: (_cwd, _ctx, { sdk }) => ({
+      allowedTools: [...ALLOWED_TOOLS, 'mcp__conf__needs_number'],
+      mcpServers: {
+        conf: sdk.createSdkMcpServer({
+          name: 'conf',
+          version: '1.0.0',
+          tools: [
+            sdk.tool('needs_number', 'Requires a numeric n.', { n: z.number() }, async (args) => ({
+              content: [{ type: 'text', text: `n=${args.n}` }],
+            })),
+          ],
+        }),
+      },
+    }),
+    fixtureFiles: {},
+    buildScripts: () => [
+      // Scripted tool_use sends a STRING where a number is required.
+      toolTurn(1, [{ name: 'mcp__conf__needs_number', input: { n: 'not-a-number' } }]),
+      { kind: 'sse', events: textReply('L3 SA ZOD DONE') },
+    ],
+    steps: [
+      {
+        tool: 'mcp__conf__needs_number',
+        isError: true,
+        locks: [/Invalid arguments for tool 'needs_number'/, /n:/],
       },
     ],
   },


### PR DESCRIPTION
## 概要

测试侧「全面实现」第 2 批：MCP 差分第二批（B1）。

- **L3-MCP-05（双臂差分）**：一个服务器注册多工具须把每个 `mcp__server__name` 路由到正确 handler。ping+echo 顺序调用——**双臂 CONTENT_MATCH**（路由/命名空间一致）。空 schema 保证差分干净。
- **L3-SA-MCP-ZOD（单臂锁）**：我方 `tool()` 经 zod safeParse 校验参数、mismatch 时回 `is_error`「Invalid arguments for tool ...」。**刻意不做差分**：把我方 zod-v4 shape 传给官方 `tool()` 会命中它自带 zod 的转换器、不认实例而产畸形 inputSchema——跨包假差分，非行为差。故官方侧不比，我方契约单臂锁死，跨臂限制在场景注释写明。

## 诚实边界（记为 tranche 3，需子进程 harness，本批不做）

stdio + http MCP 传输（当前 L3 只测进程内 sdk server）；readOnly annotation 自动放行差分（需受限 permission-mode fixture）。

## 验证

棘轮基线 +2 行 L3（improvement 类）；`npx vitest run` **1094 通过 / 2 跳过**全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_