### PR TITLE
test(bpt-sdk): 全面推进 batch 4（收官）— L3.5 子代理/hook 生命周期差分

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -298,6 +298,17 @@
   （Read `pages` / Bash `dangerouslyDisableSandbox` / Agent `isolation`+`model`+必填集，drop-in 硬伤、建议优先）/ E7-03 工具缓存断点策略
   （需实测收益、优先级最低）。每条附代码锚点 + 参考目标棘轮联动（修好须删 `WIRE_ALIGNMENT_GAPS` 条目否则报红）。优先级行更新为
   E1 > E7-02 ≈ E4 ≈ E5 > E7-01 > E3 > E2 > E7-03 > E6a/c/d。
+  **测试侧「全面实现」五缺口清零（2026-07-05，守密人「全面实现以上所有」裁定，四批合并）**：
+  **A1 系统分段**——指纹加 `systemSegments`（逐块 cache_control 位置），抓到断点位置差（我方 block0 稳定前缀 vs 官方 last，归 E7-03）；
+  **A2 多轮轨迹**——新 `tool-loop` 场景抓整条逐 POST 轨迹，检缓存前缀跨轮字节稳定（我方稳定、不变式成立，keyless 锁）；
+  **B1 MCP 差分二批**——L3-MCP-05 多工具路由双臂 CONTENT_MATCH + L3-SA-MCP-ZOD 单臂 zod 校验锁（跨包 zod 不兼容故不做差分，诚实单臂）；
+  stdio/http 传输 + readOnly annotation 自动放行记 tranche 3（需子进程 harness）；
+  **B2 白盒 batch 2**——7 接口真驱动补齐（includeEnvironmentContext/toolSearch/streamInput/sessionStoreFlush/setMcpServers/toggleMcpServer/reconnectMcpServer），
+  从覆盖守卫白名单删除，仅剩 onElicitation（需服务器发起 elicitation 的更重 fixture）；
+  **B3 L3.5 子代理/hook 差分**——我方生命周期本已 e2e 覆盖（observability-v04），真缺口是双臂差分；因两臂 POST 数不等（我方 3、官方 4+）
+  做成**报告制** `run-l35.mjs`（比生命周期事件词汇集非计数，规避脆弱）+ 我方 keyless 锁；**两真发现**：KD-L35-01 前台词汇差
+  （我方发 task_progress、官方发 task_notification）、KD-L35-02 编码差（task_started/updated：我方顶层 type、官方 system 子类型，类同 KD-05 粒度，drop-in 引擎对齐候选）。
+  棘轮 +2 L3 行；`tsc` + `npx vitest run` **1107 全绿（41 文件）**。测试侧挂账仅余：onElicitation、L3.5 双臂升门禁（版本稳定后）、MCP tranche 3 传输层。
   **SSE 网关方言容错已落（2026-07-05，BPT 产线故障闭环）**：BPT 实测「Malformed SSE payload for event "(none)"」
   经双侧协作定型——BPT `curl -N` 抓原始字节实锤 idealab 网关 `/api/anthropic` 端点带 OpenAI 方言遗留
   （流尾追加 `data: [DONE]`、错误帧无 event 行）；官方客户端 message_stop 即收工不碰尾卡、我方读到流关闭才撞上。

--- a/projects/bpt-agent-sdk/.gitignore
+++ b/projects/bpt-agent-sdk/.gitignore
@@ -8,6 +8,7 @@ conformance-l3.json
 conformance-l4.json
 conformance-l5.json
 conformance-wire.json
+conformance-l35.json
 l5-traces/
 drift-report.md
 ab-report-*.json

--- a/projects/bpt-agent-sdk/tests/conformance-l35.test.ts
+++ b/projects/bpt-agent-sdk/tests/conformance-l35.test.ts
@@ -1,0 +1,103 @@
+/**
+ * L3.5 subagent lifecycle - our-arm keyless lock + documented dual-arm KDs
+ * (testing-side sweep, B3).
+ *
+ * Our-arm subagent/hook lifecycle already has end-to-end coverage in
+ * observability-v04.test.ts; this file adds the CONFORMANCE-framed lock that
+ * pins the exact lifecycle VOCABULARY + WIRE ENCODING our engine emits on a
+ * foreground Agent spawn, so the L3.5 differential findings below are guarded
+ * on our side. The dual-arm differential itself lives in run-l35.mjs and is
+ * REPORT-ONLY (arms make different POST counts on a spawn - a count-based hard
+ * gate would be flaky/version-sensitive).
+ *
+ * KD-L35-01 (vocabulary): on a FOREGROUND subagent spawn, ours emits
+ *   task_progress (official does not) and official emits task_notification
+ *   (ours reserves that for BACKGROUND agents). Observed stable 2026-07-05
+ *   (agent-sdk 0.3.199 / claude-code 2.1.201).
+ * KD-L35-02 (encoding): the shared names (task_started / task_updated) are
+ *   TOP-LEVEL message types on our arm ({type:'task_started'}) but system
+ *   SUBTYPES on the official arm ({type:'system', subtype:'task_started'}) -
+ *   the same type-vs-subtype granularity family as KD-05. An engine-alignment
+ *   candidate for Desktop consumers that switch on message.type.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { query, type Options, type Query, type SDKMessage } from '../src/index.js';
+import { makeSSEFetch, type SSEFetchStub } from './helpers/sse-fetch.js';
+import { textReplyEvents, toolUseReplyEvents } from './helpers/mock-transport.js';
+
+let cwd: string;
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'l35-'));
+});
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await rm(cwd, { recursive: true, force: true });
+});
+
+function opts(extra: Partial<Options> = {}): Options {
+  return {
+    provider: { apiKey: 'test-key', promptCaching: false },
+    sessionDir: join(cwd, '.sessions'),
+    cwd,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    agents: { 'general-purpose': { description: 'worker', prompt: 'You are a worker.' } },
+    ...extra,
+  };
+}
+function stub(scripts: ReadonlyArray<readonly object[]>): SSEFetchStub {
+  const s = makeSSEFetch(scripts);
+  vi.stubGlobal('fetch', s);
+  return s;
+}
+
+async function lifecycleOf(): Promise<{ types: string[]; vocab: string[]; encoding: Record<string, string> }> {
+  const scripts = [
+    toolUseReplyEvents('Agent', { subagent_type: 'general-purpose', description: 'demo', prompt: 'do work' }, { id: 'toolu_agent_1' }),
+    textReplyEvents('SUBAGENT DONE'),
+    textReplyEvents('MAIN DONE'),
+  ];
+  stub(scripts);
+  const q: Query = query({ prompt: 'Delegate to a subagent.', options: opts({ allowedTools: ['Agent'] }) });
+  const messages: SDKMessage[] = [];
+  for await (const m of q) messages.push(m);
+  const types = messages.map((m) => m.type);
+  const vocab = new Set<string>();
+  const encoding: Record<string, string> = {};
+  for (const m of messages) {
+    for (const c of [m.type, (m as { subtype?: string }).subtype]) {
+      if (typeof c === 'string' && /^(task_|hook_)/.test(c)) {
+        vocab.add(c);
+        encoding[c] = m.type === 'system' ? 'system-subtype' : 'top-level-type';
+      }
+    }
+  }
+  return { types, vocab: [...vocab].sort(), encoding };
+}
+
+describe('L3.5 subagent lifecycle (our-arm lock)', () => {
+  it('foreground spawn emits task_started -> task_progress -> task_updated before the result', async () => {
+    const { types } = await lifecycleOf();
+    expect(types.indexOf('task_started')).toBeGreaterThanOrEqual(0);
+    expect(types.indexOf('task_started')).toBeLessThan(types.indexOf('task_progress'));
+    expect(types.indexOf('task_progress')).toBeLessThan(types.indexOf('task_updated'));
+    expect(types.indexOf('task_updated')).toBeLessThan(types.indexOf('result'));
+  });
+
+  it('KD-L35-01: our foreground vocabulary is exactly {started, progress, updated} (no task_notification foreground)', async () => {
+    const { vocab } = await lifecycleOf();
+    expect(vocab).toEqual(['task_progress', 'task_started', 'task_updated']);
+    expect(vocab).not.toContain('task_notification'); // reserved for background agents on our arm
+  });
+
+  it('KD-L35-02: our task_* events are TOP-LEVEL message types (not system subtypes)', async () => {
+    const { encoding } = await lifecycleOf();
+    expect(encoding.task_started).toBe('top-level-type');
+    expect(encoding.task_updated).toBe('top-level-type');
+    expect(encoding.task_progress).toBe('top-level-type');
+  });
+});

--- a/projects/bpt-agent-sdk/tests/conformance/run-l35.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/run-l35.mjs
@@ -1,0 +1,160 @@
+/**
+ * L3.5 subagent / hook lifecycle differential (conformance, B3).
+ *
+ * Drives BOTH arms through a foreground subagent spawn against the
+ * content-blind emulator and compares the OBSERVABLE lifecycle event
+ * VOCABULARY (the set of system/task_* and hook_* subtypes each engine emits
+ * on the public SDKMessage stream) - NOT exact POST counts. The probe
+ * (2026-07-05) showed the arms make a DIFFERENT number of POSTs on a subagent
+ * spawn (ours 3, official 4+ then a script-exhaustion throw) and emit a
+ * DIFFERENT lifecycle vocabulary, so a count-based hard gate would be flaky
+ * and version-sensitive. This runner is therefore REPORT-ONLY (like the
+ * pre-ratchet M2/M3 runners): the vocabulary differential is the finding,
+ * triaged as KD-L35-*, never a red gate.
+ *
+ * A generous benign-text script queue keeps EITHER arm from exhausting the
+ * queue (the official arm's extra POSTs would otherwise 400 and truncate its
+ * observed vocabulary). Our-arm lifecycle vocabulary is separately locked
+ * keyless in tests/conformance-l35.test.ts.
+ *
+ * Usage: node tests/conformance/run-l35.mjs [--arm=both|bpt] [--out=path.json]
+ * Prereqs: dist/ built; official pkg installed transiently per pins.json.
+ * Exit: 0 always (report-only).
+ */
+
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startEmulator, textReply, toolUseReply, assertContentBlind } from './emulator.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DUMMY_KEY = 'sk-ant-api03-' + 'A'.repeat(95);
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const m = a.match(/^--([^=]+)(?:=(.*))?$/);
+    return m ? [m[1], m[2] ?? true] : [a, true];
+  }),
+);
+const armMode = args.arm ?? 'both';
+const outPath = typeof args.out === 'string' ? args.out : join(HERE, '..', '..', 'conformance-l35.json');
+
+async function loadQuery(armKind) {
+  const mod = armKind === 'bpt' ? await import('../../dist/index.js') : await import('@anthropic-ai/claude-agent-sdk');
+  return mod.query;
+}
+function baseEnv(url) {
+  const env = {
+    ...process.env,
+    ANTHROPIC_BASE_URL: url,
+    ANTHROPIC_API_KEY: DUMMY_KEY,
+    ANTHROPIC_AUTH_TOKEN: '',
+    ANTHROPIC_MODEL: '',
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+    DISABLE_TELEMETRY: '1',
+    DISABLE_ERROR_REPORTING: '1',
+  };
+  delete env.CLAUDE_CODE_SESSION_ID;
+  delete env.CLAUDE_CODE_SSE_PORT;
+  delete env.CLAUDECODE;
+  return env;
+}
+
+/** Drive one arm through a foreground Agent spawn; return the lifecycle vocabulary. */
+async function captureArm(armKind) {
+  const query = await loadQuery(armKind);
+  const cwd = mkdtempSync(join(tmpdir(), `conf-l35-${armKind}-`));
+  // Turn 1 spawns a subagent; the rest are benign text so NEITHER arm
+  // exhausts the queue regardless of how many nested POSTs it makes.
+  const scripts = [
+    { kind: 'sse', events: toolUseReply([{ name: 'Agent', input: { subagent_type: 'general-purpose', description: 'demo', prompt: 'do work' } }], { id: 'm1' }) },
+    ...Array.from({ length: 10 }, (_, i) => ({ kind: 'sse', events: textReply(`turn ${i + 2} done`, { id: `t${i + 2}` }) })),
+  ];
+  const emulator = await startEmulator(scripts, { captureBodies: false });
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), 60_000);
+  const vocab = new Set();
+  const encoding = {};
+  const allTypes = [];
+  try {
+    const q = query({
+      prompt: 'Delegate this to a subagent.',
+      options: {
+        abortController: ac,
+        cwd,
+        maxTurns: 8,
+        allowedTools: ['Agent'],
+        env: baseEnv(emulator.url),
+        agents: { 'general-purpose': { description: 'general purpose worker', prompt: 'You are a worker.' } },
+        ...(armKind === 'bpt' ? { sessionDir: join(cwd, '.sessions') } : {}),
+      },
+    });
+    for await (const m of q) {
+      const tag = m.type === 'system' && m.subtype ? `system/${m.subtype}` : m.type;
+      allTypes.push(tag);
+      // Lifecycle events may arrive as a TOP-LEVEL type (ours:
+      // {type:'task_started'}) OR a system-message SUBTYPE (official:
+      // {type:'system', subtype:'task_started'}) - collect the NAME from
+      // wherever it lands, and separately record the ENCODING per name so the
+      // type-vs-subtype divergence itself is a reported facet.
+      for (const candidate of [m.type, m.subtype]) {
+        if (typeof candidate === 'string' && /^(task_|hook_)/.test(candidate)) {
+          vocab.add(candidate);
+          encoding[candidate] = m.type === 'system' ? 'system-subtype' : 'top-level-type';
+        }
+      }
+    }
+  } catch {
+    // official may throw on its own iterator quirk after the result; the
+    // vocabulary observed up to that point is still the finding.
+  } finally {
+    clearTimeout(timer);
+    await emulator.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }
+  return { arm: armKind, lifecycleVocab: [...vocab].sort(), encoding, sawResult: allTypes.includes('result') };
+}
+
+const pins = JSON.parse(readFileSync(join(HERE, 'pins.json'), 'utf8'));
+const report = {
+  generated_for: 'bpt-agent-sdk conformance L3.5 (subagent/hook lifecycle vocabulary differential)',
+  pins: { agentSdk: pins.agentSdk, claudeCode: pins.claudeCode },
+  policy: 'REPORT-ONLY: arms make different POST counts on a spawn; vocabulary (not counts) is compared, triaged as KD-L35-*, never a hard gate.',
+  armMode,
+};
+
+const bpt = await captureArm('bpt');
+report.bpt = bpt;
+console.log(`[bpt] lifecycle vocab: ${bpt.lifecycleVocab.join(', ') || '(none)'} | sawResult=${bpt.sawResult}`);
+
+if (armMode !== 'bpt') {
+  try {
+    const official = await captureArm('official');
+    report.official = official;
+    console.log(`[official] lifecycle vocab: ${official.lifecycleVocab.join(', ') || '(none)'} | sawResult=${official.sawResult}`);
+    const onlyBpt = bpt.lifecycleVocab.filter((v) => !official.lifecycleVocab.includes(v));
+    const onlyOfficial = official.lifecycleVocab.filter((v) => !bpt.lifecycleVocab.includes(v));
+    // Encoding divergence: for names BOTH emit, does the wire encoding match?
+    const shared = bpt.lifecycleVocab.filter((v) => official.lifecycleVocab.includes(v));
+    const encodingDiff = shared.filter((v) => bpt.encoding[v] !== official.encoding[v]);
+    report.vocabDiff = { onlyBpt, onlyOfficial };
+    report.encodingDiff = encodingDiff.map((v) => ({ name: v, bpt: bpt.encoding[v], official: official.encoding[v] }));
+    report.verdict =
+      onlyBpt.length === 0 && onlyOfficial.length === 0 && encodingDiff.length === 0 ? 'L35_VOCAB_MATCH' : 'L35_VOCAB_DIFF';
+    console.log(`\nlifecycle vocab diff: onlyBpt=${JSON.stringify(onlyBpt)} onlyOfficial=${JSON.stringify(onlyOfficial)} => ${report.verdict}`);
+    if (encodingDiff.length) console.log(`encoding diff (shared names): ${JSON.stringify(report.encodingDiff)}`);
+  } catch (err) {
+    report.official = { unavailable: String(err?.message ?? err).slice(0, 200) };
+    report.verdict = 'OFFICIAL-ARM-UNAVAILABLE';
+    console.log(`[official] unavailable: ${report.official.unavailable}`);
+  }
+} else {
+  report.verdict = 'single-arm';
+}
+
+const serialized = JSON.stringify(report, null, 2);
+assertContentBlind(serialized);
+writeFileSync(outPath, serialized);
+console.log(`\nreport: ${outPath}`);
+console.log('content-blind self-audit: PASS');
+process.exit(0);


### PR DESCRIPTION
## 概要

测试侧「全面实现」收官批（B3）。我方子代理/hook 生命周期本已有 e2e 覆盖（observability-v04），真缺口是**双臂差分**。探测显示两臂子代理 spawn 的 POST 数不等（我方 3、官方 4+ 后脚本耗尽抛错），故计数式硬门禁会 flaky/版本敏感——采**报告制 + 词汇集比对**。

- **`run-l35.mjs`**（报告制双臂）：宽脚本队列避免任一臂耗尽，比**生命周期事件词汇集**（非计数）。两条稳定真发现：
  - **KD-L35-01（词汇差）**：前台 spawn 我方发 `task_progress`（官方无）、官方发 `task_notification`（我方留给后台代理）。
  - **KD-L35-02（编码差）**：共有的 `task_started`/`task_updated`——我方是**顶层 message type**、官方是 **system 子类型**（KD-05 粒度家族；Desktop 按 type 分派的消费方对齐候选）。
- **`conformance-l35.test.ts`**（keyless 我方锁）：钉死我方生命周期词汇 + 线缆编码，两条发现在我方侧受守护。

## 收官声明（全面实现 A1/A2/B1/B2/B3）

本 PR 完成测试侧五缺口全部：A1 系统分段 / A2 多轮轨迹 / B1 MCP 二批 / B2 白盒 batch 2 / B3 L3.5。

## 延后（已文档化，非本次）

L3.5 双臂升硬门禁（待官方生命周期跨版本稳定）；MCP tranche 3 stdio/http 传输；onElicitation。

## 验证

`tsc` + `npx vitest run` **1107 通过 / 2 跳过（41 文件）**全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_