### PR TITLE
test(bpt-sdk): 测试挂账清仓 — onElicitation 补齐 + stdio 传输差分 + 修死代码 decline 分支

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -313,6 +313,13 @@
   （顶层 type → system 子类型，E2 同族破坏性、MIGRATION 5f；`conformance-l35.test.ts` 旧编码锁为设计好的销账提醒，
   引擎改完必须同步翻转）；KD-L35-01 词汇差列 E8b 裁定项（task_progress 保留超集、前台 notification 随 Desktop 真实需求定）。
   优先级 E8 排 E7-01 后、E3 前。
+  **测试侧挂账再清二（2026-07-05，守密人「测试剩余挂账能继续完成嘛」→ 能，即做）**：① **onElicitation 补齐**——新 fixture
+  `tests/fixtures/mcp-elicit-server.mjs`（真 stdio 服务器工具调用中途发起 elicitation/create），全 query() 链路测 accept 回填与
+  无 handler 自动 decline；**顺手修一处引擎真缺陷**：stdio/http 调用点 `&& this.elicitation` 守卫使文档承诺的自动 decline 成死代码、
+  实际回 -32601——去守卫让 resolveElicitation 兜底（mcp.test.ts 37 测保绿）。覆盖守卫白名单**清零**（新接口无测试即红、无豁免口）。
+  ② **MCP tranche 3 stdio 传输差分**——L3-MCP-06 真子进程 stdio 服务器过双臂传输管线，**CONTENT_MATCH**；棘轮 +1 行。
+  ③ L3.5 双臂升硬门禁为**等待条件**（官方生命周期跨版本稳定后触发），非工作量，挂漂移哨兵联动。
+  `tsc` + `npx vitest run` **1109 全绿（42 文件）**。
   **SSE 网关方言容错已落（2026-07-05，BPT 产线故障闭环）**：BPT 实测「Malformed SSE payload for event "(none)"」
   经双侧协作定型——BPT `curl -N` 抓原始字节实锤 idealab 网关 `/api/anthropic` 端点带 OpenAI 方言遗留
   （流尾追加 `data: [DONE]`、错误帧无 event 行）；官方客户端 message_stop 即收工不碰尾卡、我方读到流关闭才撞上。

--- a/projects/bpt-agent-sdk/src/mcp/http.ts
+++ b/projects/bpt-agent-sdk/src/mcp/http.ts
@@ -332,7 +332,11 @@ export class HttpMcpConnection {
         const replyId = msg.id;
         // Server-initiated elicitation/create: resolve via the host handler and
         // POST back the resulting action payload (fail-closed to 'decline').
-        if (msg.method === 'elicitation/create' && this.elicitation) {
+        if (msg.method === 'elicitation/create') {
+          // NOTE: no `&& this.elicitation` guard - resolveElicitation itself maps a
+          // missing handler to { action: 'decline' } (the documented auto-decline);
+          // guarding here made that branch dead and replied -32601 instead
+          // (found by the batch-3 onElicitation test, 2026-07-05).
           void resolveElicitation(msg.params, this.elicitation, this.closeController.signal)
             .then((result) => this.post({ jsonrpc: '2.0', id: replyId, result }, null))
             .catch(() =>

--- a/projects/bpt-agent-sdk/src/mcp/stdio.ts
+++ b/projects/bpt-agent-sdk/src/mcp/stdio.ts
@@ -264,7 +264,11 @@ export class StdioMcpConnection {
     if (typeof msg.method === 'string' && hasId) {
       // Server-initiated elicitation/create: resolve via the host handler and
       // reply with the resulting action payload (fail-closed to 'decline').
-      if (msg.method === 'elicitation/create' && this.elicitation) {
+      if (msg.method === 'elicitation/create') {
+        // NOTE: no `&& this.elicitation` guard - resolveElicitation itself maps a
+        // missing handler to { action: 'decline' } (the documented auto-decline);
+        // guarding here made that branch dead and replied -32601 instead
+        // (found by the batch-3 onElicitation test, 2026-07-05).
         const replyId = msg.id as JsonRpcId;
         void resolveElicitation(msg.params, this.elicitation, this.lifeController.signal)
           .then((result) => this.write({ jsonrpc: '2.0', id: replyId, result }))

--- a/projects/bpt-agent-sdk/tests/api-surface-batch3.test.ts
+++ b/projects/bpt-agent-sdk/tests/api-surface-batch3.test.ts
@@ -1,0 +1,109 @@
+/**
+ * White-box coverage batch 3: Options.onElicitation - the LAST entry on the
+ * api-surface-coverage KNOWN_UNTESTED allowlist. Uses the heavier fixture the
+ * allowlist called for: a real stdio MCP server
+ * (tests/fixtures/mcp-elicit-server.mjs) that ISSUES a server-initiated
+ * `elicitation/create` request mid-tool-call; the host's onElicitation answer
+ * is threaded back and the tool result embeds it - end-to-end over the full
+ * query() chain (spawned subprocess, JSON-RPC on stdio, model via SSE stub).
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  query,
+  type ElicitationRequest,
+  type Options,
+  type SDKMessage,
+} from '../src/index.js';
+import { makeSSEFetch, type SSEFetchStub } from './helpers/sse-fetch.js';
+import { textReplyEvents, toolUseReplyEvents } from './helpers/mock-transport.js';
+
+const FIXTURE = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'mcp-elicit-server.mjs');
+
+let cwd: string;
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'b3e-'));
+});
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await rm(cwd, { recursive: true, force: true });
+});
+
+function opts(extra: Partial<Options> = {}): Options {
+  return {
+    provider: { apiKey: 'test-key', promptCaching: false },
+    sessionDir: join(cwd, '.sessions'),
+    cwd,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    mcpServers: { srv: { type: 'stdio', command: process.execPath, args: [FIXTURE] } },
+    allowedTools: ['mcp__srv__ask'],
+    ...extra,
+  };
+}
+
+function stub(scripts: ReadonlyArray<readonly object[]>): SSEFetchStub {
+  const s = makeSSEFetch(scripts);
+  vi.stubGlobal('fetch', s);
+  return s;
+}
+
+function toolResultTexts(messages: SDKMessage[]): string[] {
+  const out: string[] = [];
+  for (const m of messages) {
+    if (m.type !== 'user') continue;
+    const content = (m as { message?: { content?: unknown } }).message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const b of content) {
+      if (b?.type === 'tool_result') {
+        const c = b.content;
+        if (typeof c === 'string') out.push(c);
+        else if (Array.isArray(c)) out.push(...c.filter((x: { type?: string }) => x?.type === 'text').map((x: { text?: string }) => x.text ?? ''));
+      }
+    }
+  }
+  return out;
+}
+
+async function drive(options: Options): Promise<SDKMessage[]> {
+  stub([
+    toolUseReplyEvents('mcp__srv__ask', {}, { id: 'toolu_elicit_1' }),
+    textReplyEvents('answered'),
+  ]);
+  const q = query({ prompt: 'Ask the server tool.', options });
+  const messages: SDKMessage[] = [];
+  for await (const m of q) messages.push(m);
+  return messages;
+}
+
+describe('Options.onElicitation (batch 3 - the last allowlist gap)', () => {
+  it('threads the server elicitation to the handler and the accepted answer back into the tool result', async () => {
+    const seen: ElicitationRequest[] = [];
+    const messages = await drive(
+      opts({
+        onElicitation: async (request, { signal }) => {
+          seen.push(request);
+          expect(signal).toBeInstanceOf(AbortSignal);
+          return { action: 'accept', content: { name: 'Erica' } };
+        },
+      }),
+    );
+    // The handler received the PARSED request.
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.message).toBe('What is your name?');
+    expect(JSON.stringify(seen[0]!.requestedSchema)).toContain('"name"');
+    // The fixture embedded our answer into the tool result.
+    const texts = toolResultTexts(messages);
+    expect(texts.some((t) => t.includes('ELICITED action=accept value=Erica'))).toBe(true);
+  }, 15_000);
+
+  it('without a handler the elicitation is auto-declined (documented default)', async () => {
+    const messages = await drive(opts());
+    const texts = toolResultTexts(messages);
+    expect(texts.some((t) => t.includes('ELICITED action=decline value='))).toBe(true);
+  }, 15_000);
+});

--- a/projects/bpt-agent-sdk/tests/api-surface-coverage.test.ts
+++ b/projects/bpt-agent-sdk/tests/api-surface-coverage.test.ts
@@ -52,15 +52,12 @@ function covered(name: string): boolean {
  * Deferred gaps - each entry names the follow-up batch that owns it.
  * DELETE the entry when its test lands (the guard reds out stale entries).
  */
-const KNOWN_UNTESTED: Record<string, string> = {
-  // The rest of white-box batch 2 (includeEnvironmentContext / toolSearch /
-  // streamInput / sessionStoreFlush / setMcpServers / toggleMcpServer /
-  // reconnectMcpServer) landed in api-surface-batch2.test.ts and were deleted
-  // from this list. Remaining gap:
-  onElicitation:
-    'MCP elicitation host callback; needs an in-process server that ISSUES an elicitation ' +
-    'request mid-tool-call (server->client) - a heavier fixture than batch 2. Deferred to batch 3.',
-};
+// Batch 2 (7 interfaces -> api-surface-batch2.test.ts) and batch 3
+// (onElicitation -> api-surface-batch3.test.ts, real stdio server issuing
+// elicitation/create) cleared every entry. The list is EMPTY by design: any
+// new public interface without a test now fails the guard with no escape
+// hatch until a reasoned entry is added here.
+const KNOWN_UNTESTED: Record<string, string> = {};
 
 function parseBlock(source: string, re: RegExp): string {
   const m = source.match(re);

--- a/projects/bpt-agent-sdk/tests/conformance/baseline.json
+++ b/projects/bpt-agent-sdk/tests/conformance/baseline.json
@@ -302,6 +302,11 @@
         "kdIds": [],
         "engineFinding": false
       },
+      "L3-MCP-06": {
+        "verdict": "CONTENT_MATCH",
+        "kdIds": [],
+        "engineFinding": false
+      },
       "L3-READ-01": {
         "verdict": "CONTENT_KNOWN_DIFF",
         "kdIds": [

--- a/projects/bpt-agent-sdk/tests/conformance/scenarios-l3.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/scenarios-l3.mjs
@@ -29,10 +29,19 @@
  * IS_SANDBOX=1, a real CI risk) so both arms auto-approve non-readonly tools.
  */
 
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import { textReply } from './emulator.mjs';
+
+/** Real stdio MCP fixture (tests/fixtures) - the subprocess-transport probe. */
+const STDIO_FIXTURE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'fixtures',
+  'mcp-echo-server.mjs',
+);
 
 const ALLOWED_TOOLS = [
   'Read',
@@ -925,6 +934,34 @@ export const L3_SCENARIOS = [
     steps: [
       { tool: 'mcp__conf__ping', isError: false, locks: [/ROUTE-PING/], notLocks: [/ROUTE-ECHO/] },
       { tool: 'mcp__conf__echo', isError: false, locks: [/ROUTE-ECHO/], notLocks: [/ROUTE-PING/] },
+    ],
+  },
+
+  // --- MCP tranche 3: stdio SUBPROCESS transport (dual-arm) --------------------
+  // Tranches 1-2 exercised only the in-process sdk server; this drives a REAL
+  // spawned stdio server (tests/fixtures/mcp-echo-server.mjs, newline JSON-RPC)
+  // through both engines' subprocess transport plumbing. The echo tool returns
+  // the call args as JSON - server-produced content, so the tool_result text
+  // must relay identically through either arm.
+  {
+    id: 'L3-MCP-06',
+    tool: 'mcp__conf__echo (stdio transport)',
+    prompt: 'Call the stdio echo tool.',
+    buildOptions: () => ({
+      allowedTools: [...ALLOWED_TOOLS, 'mcp__conf__echo'],
+      mcpServers: { conf: { type: 'stdio', command: process.execPath, args: [STDIO_FIXTURE] } },
+    }),
+    fixtureFiles: {},
+    buildScripts: () => [
+      toolTurn(1, [{ name: 'mcp__conf__echo', input: { payload: 'L3MCP06-STDIO' } }]),
+      { kind: 'sse', events: textReply('L3 MCP-06 DONE') },
+    ],
+    steps: [
+      {
+        tool: 'mcp__conf__echo',
+        isError: false,
+        locks: [/L3MCP06-STDIO/],
+      },
     ],
   },
 ];

--- a/projects/bpt-agent-sdk/tests/fixtures/mcp-elicit-server.mjs
+++ b/projects/bpt-agent-sdk/tests/fixtures/mcp-elicit-server.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Test fixture: minimal MCP stdio server that ISSUES a server-initiated
+ * `elicitation/create` request mid-tool-call (newline-delimited JSON-RPC 2.0,
+ * zero dependencies). The heavier fixture the onElicitation coverage gap
+ * called for (white-box batch 3).
+ *
+ * Behavior:
+ * - initialize        -> result (capabilities: tools + elicitation)
+ * - tools/list        -> one 'ask' tool
+ * - tools/call ask    -> sends `elicitation/create` (id 9001) to the CLIENT,
+ *                        waits for the client's reply on stdin, then answers
+ *                        the original tools/call with a text result embedding
+ *                        the reply: ELICITED action=<action> value=<name field>
+ * - unknown method    -> JSON-RPC error -32601
+ */
+
+import process from 'node:process';
+
+function send(msg) {
+  process.stdout.write(`${JSON.stringify(msg)}\n`);
+}
+
+let pendingCall = null; // { id } of the tools/call awaiting the elicitation reply
+
+function handle(msg) {
+  const { id, method, params } = msg;
+
+  // The client's response to OUR elicitation/create request: it carries our
+  // request id (9001) and a result, no method.
+  if (method === undefined && id === 9001) {
+    const action = msg.result?.action ?? 'missing';
+    const value = msg.result?.content?.name ?? '';
+    if (pendingCall !== null) {
+      send({
+        jsonrpc: '2.0',
+        id: pendingCall.id,
+        result: {
+          content: [{ type: 'text', text: `ELICITED action=${action} value=${value}` }],
+        },
+      });
+      pendingCall = null;
+    }
+    return;
+  }
+
+  if (id === undefined || id === null) return; // notifications
+
+  if (method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        protocolVersion:
+          typeof params?.protocolVersion === 'string' ? params.protocolVersion : '2025-06-18',
+        capabilities: { tools: {}, elicitation: {} },
+        serverInfo: { name: 'elicit-fixture', version: '1.0.0' },
+      },
+    });
+    return;
+  }
+
+  if (method === 'tools/list') {
+    send({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        tools: [
+          {
+            name: 'ask',
+            description: 'Asks the host a question via elicitation before answering',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  if (method === 'tools/call' && params?.name === 'ask') {
+    pendingCall = { id };
+    send({
+      jsonrpc: '2.0',
+      id: 9001,
+      method: 'elicitation/create',
+      params: {
+        message: 'What is your name?',
+        requestedSchema: {
+          type: 'object',
+          properties: { name: { type: 'string', description: 'your name' } },
+          required: ['name'],
+        },
+      },
+    });
+    return;
+  }
+
+  send({ jsonrpc: '2.0', id, error: { code: -32601, message: `Method not found: ${String(method)}` } });
+}
+
+let buffer = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  buffer += chunk;
+  let idx;
+  while ((idx = buffer.indexOf('\n')) !== -1) {
+    const line = buffer.slice(0, idx).trim();
+    buffer = buffer.slice(idx + 1);
+    if (line.length === 0) continue;
+    try {
+      handle(JSON.parse(line));
+    } catch {
+      // ignore malformed lines
+    }
+  }
+});
+process.stdin.on('end', () => process.exit(0));


### PR DESCRIPTION
## 概要

守密人问「测试剩余挂账能继续完成嘛」——能。三条挂账里两条是工作量，本 PR 做完；第三条（L3.5 双臂升硬门禁）是**等待条件**（官方生命周期跨版本稳定后触发，挂漂移哨兵联动），非工作量。

## ① onElicitation 补齐（覆盖守卫最后一条白名单）

新 fixture `mcp-elicit-server.mjs`——真 stdio MCP 服务器在工具调用**中途**发起 `elicitation/create`。全 query() 链路两用例：handler 收到解析后的请求且 accept 答案回填进 tool_result；无 handler 时自动 decline。

**测试顺手抓出一处引擎真缺陷**：stdio/http 调用点用 `&& this.elicitation` 守卫分派——文档承诺「无 handler 自动 decline」、`resolveElicitation` 也实现了该分支，但守卫让它成**死代码**，线缆上实际回 -32601。去守卫让 resolver 的 fail-closed decline 真正到达服务器（存量 mcp 37 测保绿）。

**覆盖守卫白名单就此清零**——今后任何新公开接口不带测试直接红，无豁免口。

## ② MCP tranche 3：stdio 子进程传输差分

L3-MCP-06 用真子进程 stdio 服务器（echo fixture）过双臂传输管线——**CONTENT_MATCH**。棘轮 +1 改进行。

## 验证

`tsc` + `npx vitest run` **1109 通过 / 2 跳过（42 文件）**全绿；ratchet PASS 后 `--update` 锁入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_