### PR TITLE
chore(bpt-sdk): 版本纪律 — bump 0.6.2 + 随箱 CHANGELOG + CI 版本守卫

### DIFF
--- a/.github/workflows/bpt-agent-sdk.yml
+++ b/.github/workflows/bpt-agent-sdk.yml
@@ -106,6 +106,9 @@ jobs:
             !/Public-Info-Pool/Record/
             !/Public-Info-Pool/Reference/
           sparse-checkout-cone-mode: false
+          # fetch-depth 2: the version-bump guard diffs HEAD~1 (squash merge =
+          # one commit; the guard skips gracefully when no parent exists).
+          fetch-depth: 2
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -117,6 +120,8 @@ jobs:
         run: npm run build
       - name: Test (keyless, includes emulator e2e)
         run: npm test
+      - name: Version-bump guard (BPT tarball pinning, 2026-07-05)
+        run: node scripts/check-version-bump.mjs
 
   conformance:
     # Conformance suite M1-M3 (design final 2026-07-05): the full L1-L4

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -331,6 +331,11 @@
   是 WSL、文件系统视图静默漂移，宁可响亮失败）。前台/后台链同修；非 Windows 行为不变（bash→sh 原链）。
   6 条注入式单测（platform/probe 可注入，Linux 上全覆盖 win32 路径）；MIGRATION 5b-2 + COMPAT Bash 行同步。
   `npx vitest run` **1115 全绿（43 文件）**。BPT 侧装新 build 后 Bash 应可用（前提装了 Git for Windows）。
+  **版本纪律已立（2026-07-05，黑池「三拨构建同名 0.6.0」诉求）**：版本 bump 至 **0.6.2**（0.6.1/0.6.2 为对已发货
+  三拨构建的追溯标号，台账见新增 `CHANGELOG.md`——随 npm pack tarball 发货，黑池箱内可读）；纪律 = 改发货运行时必 bump
+  （修复 patch / 新能力 minor）+ CHANGELOG 一行；**CI 守卫** `scripts/check-version-bump.mjs`（bpt-agent-sdk.yml test job，
+  fetch-depth 2 diff HEAD~1）：改 src/依赖不 bump 版本即红——同名不同货从此进不了 main。tarball 名随版本唯一
+  （`bpt-agent-sdk-0.6.2.tgz`），黑池可精确 pin/回退/对账。
   **SSE 网关方言容错已落（2026-07-05，BPT 产线故障闭环）**：BPT 实测「Malformed SSE payload for event "(none)"」
   经双侧协作定型——BPT `curl -N` 抓原始字节实锤 idealab 网关 `/api/anthropic` 端点带 OpenAI 方言遗留
   （流尾追加 `data: [DONE]`、错误帧无 event 行）；官方客户端 message_stop 即收工不碰尾卡、我方读到流关闭才撞上。

--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog — bpt-agent-sdk
+
+Consumer-facing build ledger (BPT pins `npm pack` tarballs by this version:
+`bpt-agent-sdk-<version>.tgz`). Discipline, in force since 0.6.2: **every
+merge that changes shipped runtime code (`src/` or runtime dependencies)
+bumps the version** — bug fixes bump patch, new capability bumps minor —
+and adds one line here. A CI guard (`scripts/check-version-bump.mjs`) reds
+any src-changing merge that forgets. 0.6.1 and 0.6.2 below are retroactive
+labels for builds that shipped under a duplicated "0.6.0".
+
+## 0.6.2 — 2026-07-05
+
+- **fix (Windows)**: Bash tool shell resolution — `CLAUDE_CODE_GIT_BASH_PATH`
+  honored, Git for Windows probed at standard locations, actionable guidance
+  instead of `spawn sh ENOENT`; bare `bash` never tried on Windows (WSL trap).
+  (#479, BPT Windows pilot incident #2)
+- **fix (MCP)**: server-initiated `elicitation/create` with NO `onElicitation`
+  handler now auto-declines on the wire as documented (the guard that made the
+  decline branch dead code removed; previously replied `-32601`). (#477)
+- test-only alongside: official pins chased 0.3.199 -> 0.3.201, zero
+  conformance drift (#478).
+
+## 0.6.1 — 2026-07-05 (retroactive label)
+
+- **fix (transport)**: gateway SSE dialect tolerance — consumption stops at
+  `message_stop` (official-client lifecycle); event-less non-JSON frames
+  before stop are skipped; malformed NAMED frames still throw, now with
+  evidence (event, frame count, data snippet). Closes the BPT production
+  incident `Malformed SSE payload for event "(none)"` behind the idealab
+  gateway. (#461)
+- **feat/behavior (engine alignment batch E1–E5)**: `claude_code` preset
+  defaults extended thinking ON; Write enforces the official
+  read-before-write gate; `maxBudgetUsd` stops BEFORE executing an
+  in-flight tool group; truncated turns degrade gracefully (salvage complete
+  blocks); **breaking**: `result` messages report official per-result
+  semantics (`num_turns`/`usage` per result, cost/apiMs cumulative — see
+  MIGRATION 5e). (#462)
+
+## 0.6.0 — 2026-07-05
+
+- v0.6 feature series: generators/classifiers as shipped product features
+  (`src/generators/`), verifier (`src/verifier/`), context tips (`src/tips/`),
+  memory-file selection, hook condition gating, worker-fork preset, default-on
+  Bash sandbox (pluggable bwrap backend), prompt assembly layer Track B with
+  v5 as the `claude_code` preset default.

--- a/projects/bpt-agent-sdk/CONTEXT.md
+++ b/projects/bpt-agent-sdk/CONTEXT.md
@@ -24,6 +24,9 @@ drop-in 兼容 `@anthropic-ai/claude-agent-sdk`，引擎直连 Anthropic Message
   官方臂协议剖面（首个合规执行范例）：
   `Public-Info-Pool/Resource/repo-engineering/bpt-sdk-official-arm-protocol-profile-20260705.md`；
   一致性套件蓝图（r2）：`.../bpt-sdk-conformance-suite-design-20260705-r2.md`。
+- **版本纪律（2026-07-05，黑池消费方诉求）**：凡改动发货运行时（`src/` 或 runtime 依赖）的 merge **必 bump 版本**
+  （修复 patch / 新能力 minor）并在 `CHANGELOG.md` 记一行（随 tarball 发货）；CI 守卫 `scripts/check-version-bump.mjs`
+  改 src 不 bump 即红。背景：三拨不同构建同名 0.6.0 tarball，黑池无法 pin/回退/对账。
 - 兼容矩阵（实现 / 部分 / 仅接受 / 不支持 四档）：`docs/COMPAT.md`
 - 模块施工图与内部契约：`docs/ARCHITECTURE.md` + `src/internal/contracts.ts`
 

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",
@@ -15,6 +15,7 @@
   "files": [
     "dist",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "engines": {

--- a/projects/bpt-agent-sdk/scripts/check-version-bump.mjs
+++ b/projects/bpt-agent-sdk/scripts/check-version-bump.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Version-bump guard (2026-07-05, BPT consumer request: three different
+ * builds shipped as identical "0.6.0" tarballs - same name, different goods;
+ * no pinning, no rollback, no audit trail on the consumer side).
+ *
+ * Rule enforced: a commit that changes SHIPPED RUNTIME content (src/** of
+ * this package, or package.json dependencies) must also change
+ * package.json's version. Docs/tests/CI-only changes need no bump.
+ *
+ * Runs in CI against the merge commit (squash-merge discipline: one merge =
+ * one commit on main): compares HEAD to HEAD~1. Tolerant by design - when
+ * the diff cannot be computed (shallow clone without a parent, repo root
+ * mismatch), it reports and exits 0 rather than red-flagging unrelated CI.
+ *
+ * Usage: node scripts/check-version-bump.mjs  (cwd: projects/bpt-agent-sdk)
+ */
+
+import { execSync } from 'node:child_process';
+
+const PKG_DIR_RE = /^projects\/bpt-agent-sdk\//;
+
+function git(args) {
+  return execSync(`git ${args}`, { encoding: 'utf8' }).trim();
+}
+
+let changed;
+try {
+  changed = git('diff --name-only HEAD~1 HEAD').split('\n').filter(Boolean);
+} catch {
+  console.log('version-bump guard: cannot diff HEAD~1 (shallow/root commit) - skipping.');
+  process.exit(0);
+}
+
+const runtimeChanged = changed.some(
+  (f) => PKG_DIR_RE.test(f) && /^projects\/bpt-agent-sdk\/src\//.test(f),
+);
+
+let depsChanged = false;
+let versionChanged = false;
+if (changed.includes('projects/bpt-agent-sdk/package.json')) {
+  const patch = git('diff HEAD~1 HEAD -- projects/bpt-agent-sdk/package.json');
+  versionChanged = /^[+-]\s*"version":/m.test(patch);
+  depsChanged = /^[+-]\s*"[^"]+":\s*"[^"]+"/m.test(
+    patch
+      .split('\n')
+      .filter((l) => /"(dependencies|devDependencies)"/.test(l) || /^[+-]/.test(l))
+      .join('\n'),
+  ) && /"dependencies"|"devDependencies"/.test(patch);
+}
+
+if (!runtimeChanged && !depsChanged) {
+  console.log('version-bump guard: no shipped-runtime change in this commit - OK.');
+  process.exit(0);
+}
+if (versionChanged) {
+  console.log('version-bump guard: runtime changed AND version bumped - OK.');
+  process.exit(0);
+}
+console.error(
+  'version-bump guard FAILED: this commit changes shipped runtime content ' +
+    '(projects/bpt-agent-sdk/src/ or dependencies) but package.json "version" ' +
+    'is unchanged. Consumers pin npm-pack tarballs BY VERSION - same-version ' +
+    'different-content builds cannot be pinned, rolled back, or audited. ' +
+    'Bump patch for fixes, minor for new capability, and add a CHANGELOG.md line.',
+);
+process.exit(1);


### PR DESCRIPTION
## 概要

黑池消费方回报：三拨内容不同的构建全叫 `bpt-agent-sdk-0.6.0.tgz`——同名不同货，无法 pin、无法回退、无法对账。诉求全部落实：

- **版本 bump 至 0.6.2**（0.6.1/0.6.2 为已发货三拨构建的追溯标号）；tarball 名随版本唯一（`bpt-agent-sdk-0.6.2.tgz`）。
- **新增 `CHANGELOG.md` 且随 tarball 发货**（进 package.json `files`）——黑池开箱即可读「这版含哪些改动」；三拨已发货构建的台账已补记。
- **纪律成文**（CONTEXT.md）：改发货运行时（`src/` 或 runtime 依赖）的 merge 必 bump（修复 patch / 新能力 minor）+ CHANGELOG 一行。
- **CI 守卫** `scripts/check-version-bump.mjs`（test job，fetch-depth 2 diff squash 合并提交）：改 src/依赖不 bump 版本直接红——与接口覆盖守卫同哲学，不靠自觉靠机器。无父提交时优雅跳过。

## 验证

`npm pack --dry-run` 出 `bpt-agent-sdk-0.6.2.tgz` 且含 CHANGELOG.md；守卫本地干跑 OK（本提交无 src 变更 → 放行）；`npx vitest run` **1115 通过 / 2 跳过**全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_