### PR TITLE
fix(bpt-sdk): KillShell Windows 终止 + 诚实终态状态（试点故障 #3）+ bump 0.6.3

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -331,6 +331,15 @@
   是 WSL、文件系统视图静默漂移，宁可响亮失败）。前台/后台链同修；非 Windows 行为不变（bash→sh 原链）。
   6 条注入式单测（platform/probe 可注入，Linux 上全覆盖 win32 路径）；MIGRATION 5b-2 + COMPAT Bash 行同步。
   `npx vitest run` **1115 全绿（43 文件）**。BPT 侧装新 build 后 Bash 应可用（前提装了 Git for Windows）。
+  **KillShell Windows 失效 + 谎报状态已修（2026-07-05，BPT 试点故障 #3，源码行级证据）**：两处真缺陷——① `kill()` 一调用即
+  强置 `status='killed'`、不等信号，exit 处理器因状态已非 running 不再纠正 → 进程跑完退出 0 仍永久标 killed；② 杀进程用
+  POSIX 专属 `process.kill(-pid)`（进程组），Windows 无效且被空 catch 静默吞。修：新 `src/tools/kill-plan.ts` 两纯函数——
+  `planProcessKill`（POSIX 进程组 / **Windows `taskkill /PID <pid> /T /F`** 杀树强制 / 无 pid 回退 child.kill）+ `terminalStatus`
+  （退出处理器据实定状态：kill 请求且非 0 退出→killed、退出 0→completed 即便请求过 kill、崩溃→failed）；`kill()` 只记
+  `killRequested` 意图不再强改状态；空 catch 改 debug 记录（Windows 失败不再隐身）。10 条注入式单测（Linux 上覆盖 win32 分支
+  + 6 条状态诚实矩阵 + 迟到 kill 不改写 completed 的集成回归）。版本 bump **0.6.3** + CHANGELOG。`npx vitest run` **1125 全绿**。
+  **另：BPT 报权限口子不一致（#2，Read/Write/Edit 有 resolveWithin 围栏、Grep/Glob/Bash 无）待守密人裁定设计意图**（关键洞见：
+  Bash 在场时路径围栏本就非硬安全边界）——已提问，未动手。
   **版本纪律已立（2026-07-05，黑池「三拨构建同名 0.6.0」诉求）**：版本 bump 至 **0.6.2**（0.6.1/0.6.2 为对已发货
   三拨构建的追溯标号，台账见新增 `CHANGELOG.md`——随 npm pack tarball 发货，黑池箱内可读）；纪律 = 改发货运行时必 bump
   （修复 patch / 新能力 minor）+ CHANGELOG 一行；**CI 守卫** `scripts/check-version-bump.mjs`（bpt-agent-sdk.yml test job，

--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -8,6 +8,19 @@ and adds one line here. A CI guard (`scripts/check-version-bump.mjs`) reds
 any src-changing merge that forgets. 0.6.1 and 0.6.2 below are retroactive
 labels for builds that shipped under a duplicated "0.6.0".
 
+## 0.6.3 — 2026-07-05
+
+- **fix (Windows)**: KillShell now actually terminates background shells on
+  Windows (`taskkill /PID <pid> /T /F`) instead of the POSIX-only
+  `process.kill(-pid)` that silently no-op'd; the swallowing empty catch is
+  gone (failures go to debug). (BPT Windows pilot incident #3)
+- **fix (honesty)**: background-shell terminal status is decided at exit from
+  what actually happened, never forced to 'killed' when kill() is called — a
+  job that runs to completion reports `completed` even if a kill lost the
+  race (previously marked 'killed' forever). New `kill-plan.ts` pure
+  functions (`planProcessKill`, `terminalStatus`) unit-test both the Windows
+  branch and the status rule on any host.
+
 ## 0.6.2 — 2026-07-05
 
 - **fix (Windows)**: Bash tool shell resolution — `CLAUDE_CODE_GIT_BASH_PATH`

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/internal/contracts.ts
+++ b/projects/bpt-agent-sdk/src/internal/contracts.ts
@@ -215,6 +215,9 @@ export type BackgroundShell = {
   cursorOut: number;
   cursorErr: number;
   status: BackgroundShellStatus;
+  /** True once KillShell/dispose asked to terminate; the exit handler uses it
+   *  to decide the honest terminal status (killed vs completed-before-kill). */
+  killRequested: boolean;
   exitCode: number | null;
   exitSignal: string | null;
   kill: (sig: string) => void;

--- a/projects/bpt-agent-sdk/src/tools/kill-plan.ts
+++ b/projects/bpt-agent-sdk/src/tools/kill-plan.ts
@@ -1,0 +1,50 @@
+/**
+ * Background-shell termination planning (2026-07-05 BPT Windows pilot,
+ * incident #3): the old kill path (a) forced status to 'killed' the instant
+ * kill() was called - before any signal took effect - so a process that ran
+ * to normal completion was reported 'killed' forever; and (b) signalled with
+ * `process.kill(-pid, sig)`, a POSIX process-GROUP call that does nothing on
+ * Windows, with the failure swallowed by an empty catch. Result on Windows:
+ * KillShell was a no-op that lied.
+ *
+ * These two pure functions isolate the platform + honesty decisions so both
+ * are unit-testable on any host (the Windows branch cannot spawn taskkill on
+ * Linux CI, so it is planned here and executed by the caller).
+ */
+
+/** How to terminate a child, chosen by platform + pid availability. */
+export type KillPlan =
+  | { kind: 'group'; pid: number; signal: string } // POSIX: signal the whole process group (-pid)
+  | { kind: 'taskkill'; pid: number } // Windows: taskkill /PID <pid> /T /F (tree, forced)
+  | { kind: 'child'; signal: string }; // no pid: best-effort direct child.kill
+
+export function planProcessKill(
+  pid: number | undefined,
+  signal: string,
+  platform: NodeJS.Platform = process.platform,
+): KillPlan {
+  if (pid === undefined) return { kind: 'child', signal };
+  if (platform === 'win32') return { kind: 'taskkill', pid };
+  return { kind: 'group', pid, signal };
+}
+
+/**
+ * The HONEST terminal status of a background shell, decided from what actually
+ * happened at exit - never eagerly at the kill request. `code` is the exit
+ * code (null when the process died by a signal).
+ *
+ *   - kill was requested AND the process did not exit 0  -> 'killed'
+ *     (POSIX signal death has code null; Windows taskkill /F yields a nonzero
+ *      code - both are "we asked, it was terminated");
+ *   - the process exited 0                               -> 'completed'
+ *     (honest even if a kill was requested but lost the race - it finished
+ *      its work, which is exactly the BPT-reported lie this fixes);
+ *   - any other non-kill nonzero/signal exit             -> 'failed'.
+ */
+export function terminalStatus(
+  killRequested: boolean,
+  code: number | null,
+): 'killed' | 'completed' | 'failed' {
+  if (killRequested && code !== 0) return 'killed';
+  return code === 0 ? 'completed' : 'failed';
+}

--- a/projects/bpt-agent-sdk/src/tools/shells.ts
+++ b/projects/bpt-agent-sdk/src/tools/shells.ts
@@ -19,6 +19,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { planShellSpawn } from '../sandbox/backend.js';
+import { planProcessKill, terminalStatus } from './kill-plan.js';
 import { detectSandboxEvidence, sandboxFailureHint } from '../sandbox/evidence.js';
 import type {
   BackgroundShell,
@@ -82,14 +83,32 @@ export function createShellManager(debug: (msg: string) => void): ShellManager {
         return { error: err instanceof Error ? err.message : String(err) };
       }
 
+      // Windows has no POSIX process groups/signals: taskkill /T /F is one
+      // forcible pass over the whole tree, so the SIGTERM->SIGKILL escalation
+      // collapses to a single call (a second is a harmless no-op once gone).
+      let winKilled = false;
       const killGroup = (sig: string): void => {
-        const pid = child.pid;
-        const signal = sig as NodeJS.Signals;
+        const plan = planProcessKill(child.pid, sig);
         try {
-          if (pid !== undefined) process.kill(-pid, signal);
-          else child.kill(signal);
-        } catch {
-          /* group already gone */
+          if (plan.kind === 'group') {
+            process.kill(-plan.pid, plan.signal as NodeJS.Signals);
+          } else if (plan.kind === 'child') {
+            child.kill(plan.signal as NodeJS.Signals);
+          } else {
+            // taskkill (Windows): fire once, best-effort, never blocks.
+            if (winKilled) return;
+            winKilled = true;
+            const tk = spawn('taskkill', ['/PID', String(plan.pid), '/T', '/F'], {
+              stdio: 'ignore',
+            });
+            tk.on('error', (e) => debug(`Bash: taskkill failed for pid ${plan.pid}: ${e.message}`));
+            tk.unref();
+          }
+        } catch (err) {
+          // Benign when the process/group already exited; surface anything
+          // else to debug instead of swallowing it (the old empty catch hid
+          // the Windows failure that made KillShell a silent no-op).
+          debug(`Bash: kill(${sig}) failed for shell ${id}: ${err instanceof Error ? err.message : String(err)}`);
         }
       };
 
@@ -104,6 +123,7 @@ export function createShellManager(debug: (msg: string) => void): ShellManager {
         cursorOut: 0,
         cursorErr: 0,
         status: 'running',
+        killRequested: false,
         exitCode: null,
         exitSignal: null,
         kill: killGroup,
@@ -123,8 +143,12 @@ export function createShellManager(debug: (msg: string) => void): ShellManager {
       child.on('exit', (code, signal) => {
         rec.exitCode = code;
         rec.exitSignal = signal;
+        // HONEST terminal status, decided from what actually happened - never
+        // eagerly at the kill request. A process that ran to completion is
+        // 'completed' even if a kill was requested but lost the race (the
+        // BPT-reported lie: killed-forever despite exit 0).
         if (rec.status === 'running') {
-          rec.status = code === 0 ? 'completed' : 'failed';
+          rec.status = terminalStatus(rec.killRequested, code);
         }
         // Surface sandbox failure evidence (mirrors foreground): when a
         // sandboxed background shell fails with a matching stderr signature,
@@ -149,7 +173,10 @@ export function createShellManager(debug: (msg: string) => void): ShellManager {
     kill(id) {
       const rec = shells.get(id);
       if (rec === undefined) return false;
-      if (rec.status === 'running') rec.status = 'killed';
+      // Record intent only; the terminal status is set by the exit handler
+      // (terminalStatus) from what actually happens - not forced to 'killed'
+      // here before the signal has even landed.
+      rec.killRequested = true;
       rec.kill('SIGTERM');
       const t = setTimeout(() => rec.kill('SIGKILL'), KILL_GRACE_MS);
       t.unref?.();
@@ -159,6 +186,9 @@ export function createShellManager(debug: (msg: string) => void): ShellManager {
     dispose() {
       for (const rec of shells.values()) {
         if (rec.status === 'running') {
+          // Query teardown: force-kill and mark killed. Records are discarded
+          // immediately below, so this status is not observed post-dispose.
+          rec.killRequested = true;
           rec.status = 'killed';
           rec.kill('SIGKILL');
         }

--- a/projects/bpt-agent-sdk/tests/kill-plan.test.ts
+++ b/projects/bpt-agent-sdk/tests/kill-plan.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Background-shell kill planning + honest terminal status (2026-07-05 BPT
+ * Windows pilot incident #3: KillShell was a silent no-op that reported
+ * 'killed' forever even when the process ran to completion). Both decisions
+ * are pure functions so the Windows branch is testable on Linux CI.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { planProcessKill, terminalStatus } from '../src/tools/kill-plan.js';
+
+describe('planProcessKill', () => {
+  it('POSIX signals the whole process group (-pid)', () => {
+    expect(planProcessKill(1234, 'SIGTERM', 'linux')).toEqual({ kind: 'group', pid: 1234, signal: 'SIGTERM' });
+    expect(planProcessKill(1234, 'SIGKILL', 'darwin')).toEqual({ kind: 'group', pid: 1234, signal: 'SIGKILL' });
+  });
+
+  it('Windows uses taskkill /T /F (no POSIX groups/signals there)', () => {
+    expect(planProcessKill(1234, 'SIGTERM', 'win32')).toEqual({ kind: 'taskkill', pid: 1234 });
+    // The signal is irrelevant on Windows - taskkill /F is one forcible pass.
+    expect(planProcessKill(1234, 'SIGKILL', 'win32')).toEqual({ kind: 'taskkill', pid: 1234 });
+  });
+
+  it('no pid falls back to a direct child.kill on any platform', () => {
+    expect(planProcessKill(undefined, 'SIGTERM', 'linux')).toEqual({ kind: 'child', signal: 'SIGTERM' });
+    expect(planProcessKill(undefined, 'SIGKILL', 'win32')).toEqual({ kind: 'child', signal: 'SIGKILL' });
+  });
+});
+
+describe('terminalStatus (the honesty fix)', () => {
+  it('kill requested + signal death (code null) -> killed', () => {
+    expect(terminalStatus(true, null)).toBe('killed'); // POSIX SIGTERM/SIGKILL
+  });
+  it('kill requested + forced nonzero (Windows taskkill /F) -> killed', () => {
+    expect(terminalStatus(true, 1)).toBe('killed');
+  });
+  it('kill requested BUT process exited 0 first -> completed (NOT a false killed)', () => {
+    // The exact BPT-reported lie: the 20-loop job finished (exit 0) yet was
+    // marked killed. Honesty: it completed its work.
+    expect(terminalStatus(true, 0)).toBe('completed');
+  });
+  it('no kill + exit 0 -> completed', () => {
+    expect(terminalStatus(false, 0)).toBe('completed');
+  });
+  it('no kill + nonzero -> failed', () => {
+    expect(terminalStatus(false, 2)).toBe('failed');
+  });
+  it('no kill + signal crash (code null) -> failed, not killed', () => {
+    // A SIGSEGV crash we did not request is a failure, not a kill.
+    expect(terminalStatus(false, null)).toBe('failed');
+  });
+});

--- a/projects/bpt-agent-sdk/tests/shells.test.ts
+++ b/projects/bpt-agent-sdk/tests/shells.test.ts
@@ -73,6 +73,18 @@ describe('ShellManager', () => {
     expect(manager!.get(id)!.status).toBe('killed');
   });
 
+  it('kill() AFTER the process already completed reports completed, not a false killed (BPT incident #3)', async () => {
+    const ctx = makeCtx(true);
+    const { id } = manager!.spawnBackground('bash', 'echo quick', ctx) as { id: string };
+    // Let it finish on its own first.
+    await until(() => manager!.get(id)!.status === 'completed');
+    expect(manager!.get(id)!.exitCode).toBe(0);
+    // A late kill request must NOT rewrite a completed run to 'killed'.
+    manager!.kill(id);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(manager!.get(id)!.status).toBe('completed');
+  });
+
   it('dispose() removes the state dir', () => {
     makeCtx(true);
     const dir = manager!.stateDir;


### PR DESCRIPTION
## 概要

BPT Windows 试点回报（附源码行级证据）：起 20 秒后台循环 → KillShell 立即返回「已杀死」，但进程照常跑满 20 次、正常退出 0，状态却被永久标成 killed。两处真缺陷已坐实并修复。

## 根因 → 修复

1. **谎报状态**：`kill()` 一调用即强置 `status='killed'`、不等信号；exit 处理器因状态已非 running 不再纠正 → 进程跑完退出 0 仍永久 killed。
2. **Windows 杀不掉**：用 POSIX 专属 `process.kill(-pid)`（进程组信号），Windows 无效，且被空 `catch {}` 静默吞。

新 `src/tools/kill-plan.ts` 两纯函数（可注入 platform，Linux CI 上覆盖 win32 分支）：
- **`planProcessKill`**：POSIX → 进程组 `-pid` 信号；**Windows → `taskkill /PID <pid> /T /F`**（杀树 + 强制）；无 pid → 回退 `child.kill`。
- **`terminalStatus`**：退出时据实定——kill 请求且非 0 退出 → killed；退出 0 → **completed（即便请求过 kill，诚实反映它跑完了）**；非请求崩溃 → failed。

`kill()` 只记 `killRequested` 意图、不再强改状态；空 catch 改 debug（Windows 失败不再隐身）。

## 验证

10 条注入式单测（planProcessKill win32/posix/无 pid + terminalStatus 6 态矩阵）+ 迟到 kill 不改写 completed 的集成回归；既有 POSIX kill 测试保绿。版本 **bump 0.6.3** + CHANGELOG（`bpt-agent-sdk-0.6.3.tgz`）。`tsc` + `npx vitest run` **1125 通过 / 2 跳过**。

## 另（不在本 PR）

BPT 报告 #2（围栏只在 Read/Write/Edit、Grep/Glob/Bash 无）是设计意图问题，已向守密人提问，本 PR 不动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_