### PR TITLE
feat(bpt-sdk)!: 移除 Read/Write/Edit 路径围栏，向官方权限门看齐（BPT #2 裁定）+ bump 0.6.4

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -338,8 +338,12 @@
   （退出处理器据实定状态：kill 请求且非 0 退出→killed、退出 0→completed 即便请求过 kill、崩溃→failed）；`kill()` 只记
   `killRequested` 意图不再强改状态；空 catch 改 debug 记录（Windows 失败不再隐身）。10 条注入式单测（Linux 上覆盖 win32 分支
   + 6 条状态诚实矩阵 + 迟到 kill 不改写 completed 的集成回归）。版本 bump **0.6.3** + CHANGELOG。`npx vitest run` **1125 全绿**。
-  **另：BPT 报权限口子不一致（#2，Read/Write/Edit 有 resolveWithin 围栏、Grep/Glob/Bash 无）待守密人裁定设计意图**（关键洞见：
-  Bash 在场时路径围栏本就非硬安全边界）——已提问，未动手。
+  **BPT #2 权限口子已裁定并落地（2026-07-05，守密人裁定「Read/Write/Edit 过度保守、放宽」）**：移除 Read/Write/Edit 的
+  BPT 自有硬围栏（`fsutil.resolveWithin`→`resolveAbs` 只解析不设栏），向官方权限门模型看齐——路径访问由 permissionMode 门控、
+  非第二道文件系统栅栏（该围栏 Grep/Glob/Bash 本就没有、Bash 在场时更非硬边界，是安全错觉）。`additionalDirectories` 保留真实
+  作用（sandbox writablePaths）。**顺带消除一个 KD**：L3-READ-03 现双臂都读到仓外文件 → CONTENT_MATCH、**KD-L3-04 退役**（残余
+  只剩既有 Read 尾换行 KD-L3-18）；两条单臂围栏锁 L3-SA-READ-CONTAIN/ADDDIR 退役；5 条 fs 单测改为「无栏、官方对齐」正向断言。
+  版本 bump **0.6.4** + CHANGELOG + COMPAT additionalDirectories 行更新。棘轮基线 --update 锁入。`npx vitest run` **1125 全绿**。
   **版本纪律已立（2026-07-05，黑池「三拨构建同名 0.6.0」诉求）**：版本 bump 至 **0.6.2**（0.6.1/0.6.2 为对已发货
   三拨构建的追溯标号，台账见新增 `CHANGELOG.md`——随 npm pack tarball 发货，黑池箱内可读）；纪律 = 改发货运行时必 bump
   （修复 patch / 新能力 minor）+ CHANGELOG 一行；**CI 守卫** `scripts/check-version-bump.mjs`（bpt-agent-sdk.yml test job，

--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -8,6 +8,18 @@ and adds one line here. A CI guard (`scripts/check-version-bump.mjs`) reds
 any src-changing merge that forgets. 0.6.1 and 0.6.2 below are retroactive
 labels for builds that shipped under a duplicated "0.6.0".
 
+## 0.6.4 — 2026-07-05
+
+- **behavior/security (keeper ruling, BPT report #2)**: Read/Write/Edit no
+  longer enforce a hard cwd+additionalDirectories path fence — they resolve
+  paths and reach any location the process can, with the PERMISSION GATE as
+  the sole access control (official Claude Code posture). The v0.1 fence was
+  BPT-specific, inconsistent (Grep/Glob/Bash never had it), and — with Bash
+  present — never a real security boundary, only a false sense of one.
+  `fsutil.resolveWithin` -> `resolveAbs`. `additionalDirectories` keeps its
+  real role (sandbox writablePaths). Consumers relying on the fence as a
+  security control must use `permissionMode` / `canUseTool` instead.
+
 ## 0.6.3 — 2026-07-05
 
 - **fix (Windows)**: KillShell now actually terminates background shells on

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -130,7 +130,7 @@ SDK implements the agent loop directly against the public Messages API:
 | Field | Tier | Notes |
 |---|---|---|
 | `abortController` | FULL | |
-| `additionalDirectories` | FULL | fs tools + additionalDirectories containment |
+| `additionalDirectories` | FULL | sandbox writablePaths (Bash) + subagent inheritance. NOTE: since 0.6.4 (keeper ruling BPT #2) Read/Write/Edit have NO path fence — they reach any path the process can, gated by permission mode (official-aligned); additionalDirectories no longer gates fs-tool access, only sandbox write allowance. |
 | `agents` | PARTIAL | executed since v0.2 (subagent runtime); the delegation tool is named `Agent` here vs official `Task`, and official 2.1.201 delegation made 4 POSTs vs our deterministic parent+child+parent 3 (conformance run-l2 s13-agents-task, KD-11, 2026-07-05) |
 | `allowedTools` / `disallowedTools` | FULL | `Tool(spec)` prefix rules + `mcp__srv__*` (exact server match) + `*` / `mcp__*` globs (v0.4); bare-name `disallowedTools` removes the tool definition from the request; plan mode never auto-approves writes via an allow rule; rewritten inputs re-checked against deny rules |
 | `canUseTool` | FULL | invoked on prompt-fallthrough with `signal`/`suggestions`/`requestId`/`toolUseID`; `updatedInput`/`updatedPermissions` honored (incl. hook-`ask` rewrite); `null` return = skip (app resolves out of band) |

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/tools/edit.ts
+++ b/projects/bpt-agent-sdk/src/tools/edit.ts
@@ -12,7 +12,7 @@ import type {
   ToolResultPayload,
 } from '../internal/contracts.js';
 import { AbortError, isAbortError } from '../errors.js';
-import { formatCatN, looksBinary, resolveWithin } from './fsutil.js';
+import { formatCatN, looksBinary, resolveAbs } from './fsutil.js';
 import { EDIT_DESCRIPTION } from './descriptions.js';
 
 /** Context lines shown around the first edit site in the success snippet. */
@@ -113,11 +113,7 @@ export const editTool: BuiltinTool = {
         );
       }
 
-      const resolved = resolveWithin(ctx.cwd, ctx.additionalDirectories, filePath);
-      if (!resolved.ok) {
-        return errorResult(`Edit failed: ${resolved.reason}`);
-      }
-      const abs = resolved.abs;
+      const abs = resolveAbs(ctx.cwd, filePath);
 
       try {
         const st = await stat(abs);

--- a/projects/bpt-agent-sdk/src/tools/fsutil.ts
+++ b/projects/bpt-agent-sdk/src/tools/fsutil.ts
@@ -1,10 +1,15 @@
 /**
  * Shared filesystem helpers for the built-in FS tools (Read / Write / Edit).
  *
- * Containment model (v0.1): a path is accessible iff, after `path.resolve`,
- * it is lexically inside the session cwd or one of the configured additional
- * directories. The check is a prefix comparison on `path.sep` boundaries.
- * Symlink escapes are NOT resolved/blocked in v0.1 (documented limitation).
+ * Path model (2026-07-05, keeper ruling on BPT report #2): NO hard containment
+ * fence. A path is resolved cwd-relative and used as-is - the same posture as
+ * official Claude Code, where Read/Write/Edit reach any path the process can
+ * and the PERMISSION GATE (permissionMode) is the sole access control, not a
+ * second filesystem fence. The old cwd+additionalDirectories fence (v0.1) was
+ * BPT-specific, inconsistent (Grep/Glob/Bash never had it) and - with Bash in
+ * the tool set - never a real security boundary anyway, only a false sense of
+ * one. additionalDirectories retains its real role: sandbox writablePaths.
+ * (History: resolveWithin removed here; see CHANGELOG 0.6.4.)
  */
 
 import * as path from 'node:path';
@@ -19,32 +24,13 @@ const MAX_LINE_CHARS = 2000;
 const LINE_NUMBER_WIDTH = 6;
 
 /**
- * Resolve `p` (absolute or cwd-relative) and verify it falls inside the cwd
- * or one of the additional directories. Additional directory entries may
- * themselves be relative to cwd.
+ * Resolve `p` (absolute or cwd-relative) to an absolute path. No containment
+ * fence (keeper ruling 2026-07-05, BPT #2): the permission gate is the access
+ * control, aligning with official Claude Code. `additional` is accepted for a
+ * stable signature but does not gate access here.
  */
-export function resolveWithin(
-  cwd: string,
-  additional: string[],
-  p: string,
-): { ok: true; abs: string } | { ok: false; reason: string } {
-  const abs = path.resolve(cwd, p);
-  const roots = [cwd, ...additional].map((r) => path.resolve(cwd, r));
-  for (const root of roots) {
-    if (abs === root) {
-      return { ok: true, abs };
-    }
-    // Boundary-safe prefix check: '/a/bc' must not match root '/a/b'.
-    const prefix = root.endsWith(path.sep) ? root : root + path.sep;
-    if (abs.startsWith(prefix)) {
-      return { ok: true, abs };
-    }
-  }
-  const allowed = roots.map((r) => `"${r}"`).join(', ');
-  return {
-    ok: false,
-    reason: `Path "${abs}" is outside the allowed directories (${allowed}).`,
-  };
+export function resolveAbs(cwd: string, p: string): string {
+  return path.resolve(cwd, p);
 }
 
 /** Heuristic binary sniff: any NUL byte within the first 8KB. */

--- a/projects/bpt-agent-sdk/src/tools/read.ts
+++ b/projects/bpt-agent-sdk/src/tools/read.ts
@@ -12,7 +12,7 @@ import type {
   ToolResultPayload,
 } from '../internal/contracts.js';
 import { AbortError, isAbortError } from '../errors.js';
-import { formatCatN, looksBinary, resolveWithin } from './fsutil.js';
+import { formatCatN, looksBinary, resolveAbs } from './fsutil.js';
 import { READ_DESCRIPTION } from './descriptions.js';
 
 const DEFAULT_LINE_LIMIT = 2000;
@@ -127,11 +127,7 @@ export const readTool: BuiltinTool = {
       // offset is a 1-based line number; 0/negative values clamp to line 1.
       const startLine = Math.max(1, Math.floor((offsetRaw as number | undefined) ?? 1));
 
-      const resolved = resolveWithin(ctx.cwd, ctx.additionalDirectories, filePath);
-      if (!resolved.ok) {
-        return errorResult(`Read failed: ${resolved.reason}`);
-      }
-      const abs = resolved.abs;
+      const abs = resolveAbs(ctx.cwd, filePath);
 
       try {
         const st = await stat(abs);

--- a/projects/bpt-agent-sdk/src/tools/write.ts
+++ b/projects/bpt-agent-sdk/src/tools/write.ts
@@ -15,7 +15,7 @@ import type {
   ToolResultPayload,
 } from '../internal/contracts.js';
 import { AbortError, isAbortError } from '../errors.js';
-import { looksBinary, resolveWithin } from './fsutil.js';
+import { looksBinary, resolveAbs } from './fsutil.js';
 import { WRITE_DESCRIPTION } from './descriptions.js';
 
 function errorResult(message: string): ToolResultPayload {
@@ -59,11 +59,7 @@ export const writeTool: BuiltinTool = {
         return errorResult('Write failed: "content" must be a string.');
       }
 
-      const resolved = resolveWithin(ctx.cwd, ctx.additionalDirectories, filePath);
-      if (!resolved.ok) {
-        return errorResult(`Write failed: ${resolved.reason}`);
-      }
-      const abs = resolved.abs;
+      const abs = resolveAbs(ctx.cwd, filePath);
 
       // Determine created-vs-overwritten before writing; reject directories.
       let existedBefore = false;

--- a/projects/bpt-agent-sdk/tests/conformance/baseline.json
+++ b/projects/bpt-agent-sdk/tests/conformance/baseline.json
@@ -324,7 +324,7 @@
       "L3-READ-03": {
         "verdict": "CONTENT_KNOWN_DIFF",
         "kdIds": [
-          "KD-L3-04"
+          "KD-L3-18"
         ],
         "engineFinding": false
       },
@@ -334,16 +334,6 @@
         "engineFinding": false
       },
       "L3-SA-MCP-ZOD": {
-        "verdict": "LOCKED",
-        "kdIds": [],
-        "engineFinding": false
-      },
-      "L3-SA-READ-ADDDIR": {
-        "verdict": "LOCKED",
-        "kdIds": [],
-        "engineFinding": false
-      },
-      "L3-SA-READ-CONTAIN": {
         "verdict": "LOCKED",
         "kdIds": [],
         "engineFinding": false

--- a/projects/bpt-agent-sdk/tests/conformance/normalize-l3.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/normalize-l3.mjs
@@ -142,11 +142,10 @@ export const KNOWN_TOOL_DIVERGENCES = [
       /(does not exist|no such file|not found)/i.test(o) &&
       /^Read failed: file does not exist:/m.test(u),
   },
-  {
-    id: 'KD-L3-04',
-    tool: 'Read',
-    note: 'containment policy (behavioral): ours refuses paths outside cwd + additionalDirectories (fsutil.resolveWithin), the official arm reads an outside-cwd file under an allowedTools rule. Encoded as per-arm expectations in L3-READ-03.',
-  },
+  // KD-L3-04 RETIRED (2026-07-05, keeper ruling on BPT #2): the BPT-only path
+  // fence was removed (resolveWithin -> resolveAbs), so Read reaches an
+  // outside-cwd file on BOTH arms - L3-READ-03 is now a plain CONTENT_MATCH,
+  // no per-arm split. Id kept out of circulation.
   {
     id: 'KD-L3-05',
     tool: 'Write',

--- a/projects/bpt-agent-sdk/tests/conformance/scenarios-l3.mjs
+++ b/projects/bpt-agent-sdk/tests/conformance/scenarios-l3.mjs
@@ -208,12 +208,17 @@ export const L3_SCENARIOS = [
     ],
     steps: [
       {
+        // Since the keeper's BPT-#2 ruling (2026-07-05) removed the BPT-only
+        // path fence, Read reaches the outside file on BOTH arms - a plain
+        // CONTENT_MATCH. The former per-arm split (ours denied / official
+        // read) and its KD-L3-04 are retired.
         tool: 'Read',
-        crossCompare: false,
-        behavioralKd: 'KD-L3-04',
-        isError: { ours: true, official: false },
-        oursLocks: [/outside the allowed directories/],
-        officialLocks: [/outside-content-token/],
+        isError: false,
+        locks: [/outside-content-token/],
+        // Now that both arms actually READ the file, the normal Read
+        // formatting KD surfaces: official numbers a phantom trailing empty
+        // line for a file ending in '\n', ours drops it (KD-L3-18).
+        kd: ['KD-L3-18'],
       },
     ],
   },
@@ -974,50 +979,11 @@ export const L3_SCENARIOS = [
  * by the dual-arm semantic invariants above.
  */
 export const L3_SINGLE_ARM = [
-  {
-    id: 'L3-SA-READ-CONTAIN',
-    tool: 'Read',
-    reason:
-      'containment reason STRING is BPT policy surface (fsutil.resolveWithin); the official arm has no equivalent knob (its --add-dir feeds a different permission model). The behavioral split itself is dual-arm L3-READ-03.',
-    prompt: 'Read the outside file without a whitelist.',
-    needsOutsideDir: true,
-    outsideFixtureFiles: { 'f.txt': 'secret outside content\n' },
-    fixtureFiles: {},
-    buildScripts: (_cwd, ctx) => [
-      toolTurn(1, [{ name: 'Read', input: { file_path: join(ctx.outsideDir, 'f.txt') } }]),
-      { kind: 'sse', events: textReply('L3 SA CONTAIN DONE') },
-    ],
-    steps: [
-      {
-        tool: 'Read',
-        isError: true,
-        exact:
-          'Read failed: Path "<OUTSIDE>/f.txt" is outside the allowed directories ("<CWD>").',
-      },
-    ],
-  },
-  {
-    id: 'L3-SA-READ-ADDDIR',
-    tool: 'Read',
-    reason:
-      'additionalDirectories whitelist flip - same policy surface as above; locks that the SAME path succeeds once whitelisted.',
-    prompt: 'Read the outside file with the directory whitelisted.',
-    needsOutsideDir: true,
-    outsideFixtureFiles: { 'f.txt': 'secret outside content\n' },
-    fixtureFiles: {},
-    buildOptions: (_cwd, ctx) => ({ additionalDirectories: [ctx.outsideDir] }),
-    buildScripts: (_cwd, ctx) => [
-      toolTurn(1, [{ name: 'Read', input: { file_path: join(ctx.outsideDir, 'f.txt') } }]),
-      { kind: 'sse', events: textReply('L3 SA ADDDIR DONE') },
-    ],
-    steps: [
-      {
-        tool: 'Read',
-        isError: false,
-        exact: '1|secret outside content',
-      },
-    ],
-  },
+  // L3-SA-READ-CONTAIN and L3-SA-READ-ADDDIR RETIRED (2026-07-05, keeper
+  // ruling on BPT #2): the BPT-only path fence they locked was removed
+  // (fsutil resolveWithin -> resolveAbs), aligning Read/Write/Edit with the
+  // official permission-gate model. Read now reaches outside cwd on both arms
+  // (dual-arm L3-READ-03 is a plain CONTENT_MATCH; KD-L3-04 retired).
   {
     id: 'L3-SA-WRITE-REWIND',
     tool: 'Write',

--- a/projects/bpt-agent-sdk/tests/tools-fs.test.ts
+++ b/projects/bpt-agent-sdk/tests/tools-fs.test.ts
@@ -607,63 +607,46 @@ describe('Edit tool', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Containment (resolveWithin behavior through the tools)
+// No path fence (official-aligned; keeper ruling on BPT report #2, 2026-07-05)
+// Read/Write/Edit reach any path the process can; the permission gate - not a
+// filesystem fence - is the access control (the v0.1 cwd fence was removed:
+// BPT-specific, inconsistent with Grep/Glob/Bash, and never a real boundary
+// with Bash present). additionalDirectories keeps its sandbox-writablePaths role.
 // ---------------------------------------------------------------------------
 
-describe('path containment', () => {
-  it('rejects absolute paths outside cwd for Read, Write and Edit, naming allowed roots', async () => {
+describe('no path fence (official-aligned)', () => {
+  it('reads a file OUTSIDE cwd (was denied under the old fence)', async () => {
     const outside = await makeSandbox('bpt-fs-outside-');
     const target = path.join(outside, 'secret.txt');
-    await writeFile(target, 'secret\n', 'utf8');
-    const ctx = makeCtx(sandbox);
+    await writeFile(target, 'outside content\n', 'utf8');
 
-    const readRes = await readTool.execute({ file_path: target }, ctx);
-    const writeRes = await writeTool.execute(
-      { file_path: target, content: 'x' },
-      ctx,
-    );
-    const editRes = await editTool.execute(
-      { file_path: target, old_string: 'secret', new_string: 'public' },
-      ctx,
-    );
-
-    for (const res of [readRes, writeRes, editRes]) {
-      expect(res.isError).toBe(true);
-      const content = String(res.content);
-      expect(content).toMatch(/outside the allowed directories/i);
-      // The deny message names the allowed roots (at least the cwd).
-      expect(content).toContain(sandbox);
-    }
-    // The outside file must be untouched by the denied Write/Edit.
-    expect(await readFile(target, 'utf8')).toBe('secret\n');
+    const readRes = await readTool.execute({ file_path: target }, makeCtx(sandbox));
+    expect(readRes.isError).toBeFalsy();
+    expect(String(readRes.content)).toContain('outside content');
   });
 
-  it('allows access inside an additionalDirectories entry', async () => {
-    const extra = await makeSandbox('bpt-fs-extra-');
-    const ctx = makeCtx(sandbox, { additionalDirectories: [extra] });
-    const target = path.join(extra, 'shared.txt');
+  it('writes and edits OUTSIDE cwd succeed (no "outside the allowed directories" error)', async () => {
+    const outside = await makeSandbox('bpt-fs-outside2-');
+    const target = path.join(outside, 'out.txt');
+    const ctx = makeCtx(sandbox);
 
-    const writeRes = await writeTool.execute(
-      { file_path: target, content: 'shared data' },
-      ctx,
-    );
+    const writeRes = await writeTool.execute({ file_path: target, content: 'hello outside' }, ctx);
     expect(writeRes.isError).toBeFalsy();
-
-    const readRes = await readTool.execute({ file_path: target }, ctx);
-    expect(readRes.isError).toBeFalsy();
-    expect(readRes.content).toBe(catLine(1, 'shared data'));
+    expect(await readFile(target, 'utf8')).toBe('hello outside');
 
     const editRes = await editTool.execute(
-      { file_path: target, old_string: 'shared', new_string: 'common' },
+      { file_path: target, old_string: 'hello', new_string: 'bye' },
       ctx,
     );
     expect(editRes.isError).toBeFalsy();
-    expect(await readFile(target, 'utf8')).toBe('common data');
+    expect(await readFile(target, 'utf8')).toBe('bye outside');
+
+    for (const res of [writeRes, editRes, await readTool.execute({ file_path: target }, ctx)]) {
+      expect(String(res.content)).not.toMatch(/outside the allowed directories/i);
+    }
   });
 
-  it('enforces path.sep boundaries: a sibling dir sharing a name prefix is NOT contained', async () => {
-    // cwd = <root>/proj ; sibling = <root>/projX — plain startsWith on the
-    // root string would wrongly admit the sibling.
+  it('a sibling dir sharing a name prefix is reachable too (no fence to trip on)', async () => {
     const root = await makeSandbox('bpt-fs-prefix-');
     const cwd = path.join(root, 'proj');
     const sibling = path.join(root, 'projX');
@@ -671,51 +654,31 @@ describe('path containment', () => {
     await mkdir(sibling);
     const target = path.join(sibling, 'file.txt');
     await writeFile(target, 'sibling content\n', 'utf8');
-    const ctx = makeCtx(cwd);
 
-    const readRes = await readTool.execute({ file_path: target }, ctx);
-    expect(readRes.isError).toBe(true);
-    expect(String(readRes.content)).toMatch(/outside the allowed directories/i);
-
-    const writeRes = await writeTool.execute(
-      { file_path: target, content: 'clobber' },
-      ctx,
-    );
-    expect(writeRes.isError).toBe(true);
-    expect(await readFile(target, 'utf8')).toBe('sibling content\n');
+    const readRes = await readTool.execute({ file_path: target }, makeCtx(cwd));
+    expect(readRes.isError).toBeFalsy();
+    expect(String(readRes.content)).toContain('sibling content');
   });
 
-  it('boundary check also applies to additionalDirectories entries', async () => {
-    const root = await makeSandbox('bpt-fs-prefix2-');
-    const allowed = path.join(root, 'data');
-    const lookalike = path.join(root, 'database');
-    await mkdir(allowed);
-    await mkdir(lookalike);
-    await writeFile(path.join(lookalike, 'f.txt'), 'x\n', 'utf8');
-    const ctx = makeCtx(sandbox, { additionalDirectories: [allowed] });
-
-    const res = await readTool.execute(
-      { file_path: path.join(lookalike, 'f.txt') },
-      ctx,
-    );
-
-    expect(res.isError).toBe(true);
-    expect(String(res.content)).toMatch(/outside the allowed directories/i);
-  });
-
-  it('relative traversal escaping cwd is rejected', async () => {
+  it('relative traversal escaping cwd resolves and succeeds', async () => {
     const outside = await makeSandbox('bpt-fs-escape-');
     const rel = path.relative(sandbox, path.join(outside, 'esc.txt'));
-    // Sanity: the relative path really escapes the sandbox.
-    expect(rel.startsWith('..')).toBe(true);
+    expect(rel.startsWith('..')).toBe(true); // sanity: really escapes
 
-    const res = await writeTool.execute(
-      { file_path: rel, content: 'escaped' },
-      makeCtx(sandbox),
-    );
+    const res = await writeTool.execute({ file_path: rel, content: 'escaped' }, makeCtx(sandbox));
+    expect(res.isError).toBeFalsy();
+    expect(await readFile(path.join(outside, 'esc.txt'), 'utf8')).toBe('escaped');
+  });
 
-    expect(res.isError).toBe(true);
-    expect(String(res.content)).toMatch(/outside the allowed directories/i);
+  it('additionalDirectories access still works (its surviving role is sandbox writablePaths)', async () => {
+    const extra = await makeSandbox('bpt-fs-extra-');
+    const ctx = makeCtx(sandbox, { additionalDirectories: [extra] });
+    const target = path.join(extra, 'shared.txt');
+
+    const writeRes = await writeTool.execute({ file_path: target, content: 'shared data' }, ctx);
+    expect(writeRes.isError).toBeFalsy();
+    const readRes = await readTool.execute({ file_path: target }, ctx);
+    expect(readRes.content).toBe(catLine(1, 'shared data'));
   });
 });
 


### PR DESCRIPTION
## 概要

BPT 报告 #2：Read 拦截仓库外路径（"outside the allowed directories"），但 Grep/Glob/Bash 读同一路径畅通无阻。守密人裁定：**Read/Write/Edit 过度保守，放宽它们，全工具一致不设硬栅栏，向官方权限门模型看齐。**

## 改动

- **`fsutil`**：`resolveWithin`（解析 + cwd/additionalDirectories 围栏）→ `resolveAbs`（只解析）。Read/Write/Edit 现可及进程能及的任意路径，访问由 **permissionMode / canUseTool 门控**（官方姿态）。理由：该围栏 BPT 自有、与 Grep/Glob/Bash 不一致、且 Bash 在场时本就非硬边界（安全错觉）。`additionalDirectories` 保留真实作用（sandbox writablePaths）、不再门控 fs 工具访问。
- **顺带消除一个 KD**：L3-READ-03 现双臂都读到仓外文件 → **CONTENT_MATCH，KD-L3-04 退役**；两条单臂围栏锁 L3-SA-READ-CONTAIN/ADDDIR 退役（围栏行为已不存在）；L3-READ-03 现合法带既有 Read 尾换行 KD-L3-18。棘轮基线 --update 锁入。
- 5 条 fs 单测改写为「无栏、官方对齐」正向断言；COMPAT `additionalDirectories` 行更新。
- **BREAKING**：把围栏当安全控制的消费方须改用 permissionMode / canUseTool。版本 **bump 0.6.4** + CHANGELOG。

## 验证

`tsc` + `npx vitest run` **1125 通过 / 2 跳过**全绿；L3 差分 + 棘轮 PASS；`bpt-agent-sdk-0.6.4.tgz`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_