### PR TITLE
fix(bpt-sdk): 前台 Bash Windows kill 孪生 bug + POSIX 危险静态守卫（诊断问答落地）+ bump 0.6.5

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -344,6 +344,13 @@
   作用（sandbox writablePaths）。**顺带消除一个 KD**：L3-READ-03 现双臂都读到仓外文件 → CONTENT_MATCH、**KD-L3-04 退役**（残余
   只剩既有 Read 尾换行 KD-L3-18）；两条单臂围栏锁 L3-SA-READ-CONTAIN/ADDDIR 退役；5 条 fs 单测改为「无栏、官方对齐」正向断言。
   版本 bump **0.6.4** + CHANGELOG + COMPAT additionalDirectories 行更新。棘轮基线 --update 锁入。`npx vitest run` **1125 全绿**。
+  **Windows 环境保真守卫已立 + 揪出第四潜伏 bug（2026-07-05，守密人「提示词按环境编排?」诊断问答）**：诊断结论——三起 Windows 故障
+  根因是**引擎代码 POSIX-first**（工具接口之下：负 PID 进程组 / 裸 spawn shell 名 / 硬编码 tmp），**非提示词编排**（`<env>` 本就注入
+  `Platform:`、工具指导本就引向平台中立内建工具）；提示词能改的余地为零，模型工具调用本身是对的。预防落为**静态守卫**
+  `tests/posix-hazard-guard.test.ts`：扫 src/ 的 POSIX-only 危险写法（`process.kill(-`/`spawn('bash'|'sh')`/`'/tmp'`），未标 `win-ok:`
+  即红。**守卫未建先还债**：揪出 `bash.ts` 前台 Bash 超时/abort 的 killGroup 是与 KillShell 同款未分支 `process.kill(-pid)`+空 catch
+  （Windows 前台命令杀不掉、错误被吞）——已复用 planProcessKill 修（win32→taskkill）。合法平台分支两处标 win-ok。版本 bump **0.6.5**
+  + CHANGELOG。`npx vitest run` **1128 全绿（45 文件）**。机器守卫累计四件：接口覆盖 / 参考目标棘轮 / 版本 bump / POSIX 危险。
   **版本纪律已立（2026-07-05，黑池「三拨构建同名 0.6.0」诉求）**：版本 bump 至 **0.6.2**（0.6.1/0.6.2 为对已发货
   三拨构建的追溯标号，台账见新增 `CHANGELOG.md`——随 npm pack tarball 发货，黑池箱内可读）；纪律 = 改发货运行时必 bump
   （修复 patch / 新能力 minor）+ CHANGELOG 一行；**CI 守卫** `scripts/check-version-bump.mjs`（bpt-agent-sdk.yml test job，

--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -8,6 +8,19 @@ and adds one line here. A CI guard (`scripts/check-version-bump.mjs`) reds
 any src-changing merge that forgets. 0.6.1 and 0.6.2 below are retroactive
 labels for builds that shipped under a duplicated "0.6.0".
 
+## 0.6.5 — 2026-07-05
+
+- **fix (Windows)**: foreground Bash termination (timeout/abort) used the same
+  POSIX-only `process.kill(-pid)` process-group call as the background
+  KillShell bug — a no-op on Windows with the failure swallowed. Now routes
+  through planProcessKill (win32 -> taskkill /T /F). Found by the new guard,
+  not a fourth pilot report.
+- **test/guard**: posix-hazard static guard (`tests/posix-hazard-guard.test.ts`)
+  scans src/ for engine-code Windows hazards below the tool interface
+  (`process.kill(-pid)`, bare `spawn('bash'/'sh')`, hardcoded `/tmp`); an
+  unmarked hit reds CI. Legit platform-branched sites carry a `win-ok:` marker.
+  Machine prevention for the POSIX-first-Windows-afterthought defect class.
+
 ## 0.6.4 — 2026-07-05
 
 - **behavior/security (keeper ruling, BPT report #2)**: Read/Write/Edit no

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/tools/bash.ts
+++ b/projects/bpt-agent-sdk/src/tools/bash.ts
@@ -9,6 +9,7 @@
 
 import { spawn } from 'node:child_process';
 import { resolvePosixShells, SHELL_NOT_FOUND_GUIDANCE } from './shell-resolve.js';
+import { planProcessKill } from './kill-plan.js';
 import { AbortError } from '../errors.js';
 import { BASH_DESCRIPTION, buildBashSandboxNote } from './descriptions.js';
 import { planShellSpawn } from '../sandbox/backend.js';
@@ -100,19 +101,29 @@ function runShell(
     let killTimer: NodeJS.Timeout | undefined;
     let flushTimer: NodeJS.Timeout | undefined;
 
-    // Signal the shell's entire process group; fall back to the direct child
-    // when the pid is unknown. ESRCH (group already gone) is expected and
-    // swallowed.
+    // Terminate the shell's whole tree, platform-correctly (planProcessKill):
+    // POSIX signals the process group (-pid); Windows uses taskkill /T /F
+    // (process groups/negative-pid do nothing there - the same latent bug the
+    // background KillShell had, surfaced by the posix-hazard guard 2026-07-05).
+    let winKilled = false;
     const killGroup = (sig: NodeJS.Signals): void => {
-      const pid = child.pid;
+      const plan = planProcessKill(child.pid, sig);
       try {
-        if (pid !== undefined) {
-          process.kill(-pid, sig);
+        if (plan.kind === 'group') {
+          process.kill(-plan.pid, plan.signal as NodeJS.Signals); // win-ok: posix branch of planProcessKill
+        } else if (plan.kind === 'child') {
+          child.kill(plan.signal as NodeJS.Signals);
         } else {
-          child.kill(sig);
+          if (winKilled) return;
+          winKilled = true;
+          const tk = spawn('taskkill', ['/PID', String(plan.pid), '/T', '/F'], { stdio: 'ignore' });
+          tk.on('error', (e) => ctx.debug(`Bash: taskkill failed for pid ${plan.pid}: ${e.message}`));
+          tk.unref();
         }
-      } catch {
-        /* group/process already gone or cannot be signalled */
+      } catch (err) {
+        // Benign when the tree already exited; anything else goes to debug
+        // rather than being swallowed (the old empty catch hid Windows misses).
+        ctx.debug(`Bash: kill(${sig}) failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     };
 

--- a/projects/bpt-agent-sdk/src/tools/shells.ts
+++ b/projects/bpt-agent-sdk/src/tools/shells.ts
@@ -91,7 +91,7 @@ export function createShellManager(debug: (msg: string) => void): ShellManager {
         const plan = planProcessKill(child.pid, sig);
         try {
           if (plan.kind === 'group') {
-            process.kill(-plan.pid, plan.signal as NodeJS.Signals);
+            process.kill(-plan.pid, plan.signal as NodeJS.Signals); // win-ok: posix branch of planProcessKill
           } else if (plan.kind === 'child') {
             child.kill(plan.signal as NodeJS.Signals);
           } else {

--- a/projects/bpt-agent-sdk/tests/posix-hazard-guard.test.ts
+++ b/projects/bpt-agent-sdk/tests/posix-hazard-guard.test.ts
@@ -1,0 +1,91 @@
+/**
+ * POSIX-hazard static guard (2026-07-05, BPT Windows pilot: three production
+ * incidents - SSE-gateway aside - were engine-code POSIX assumptions BELOW the
+ * tool interface that no prompt could route around: `process.kill(-pid)`
+ * process groups, bare `spawn('bash'/'sh')`, hardcoded `/tmp`. This machine
+ * guard scans src/ for those exact hazard shapes so the NEXT one reds CI
+ * before it ships, instead of surfacing as a fourth pilot report. (It already
+ * earned its keep: it surfaced the foreground-Bash killGroup twin of the
+ * KillShell bug.)
+ *
+ * A hazard line is allowed iff it carries a `win-ok:` marker comment naming
+ * why it is platform-safe (e.g. the POSIX branch of planProcessKill, whose
+ * win32 path is taskkill). No blanket allowlist - each exception is annotated
+ * at the site. Comment/JSDoc lines are skipped (they discuss the hazards).
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SRC = join(__dirname, '..', 'src');
+
+const HAZARDS: { id: string; re: RegExp; why: string }[] = [
+  {
+    id: 'process-group-kill',
+    re: /process\.kill\(\s*-/,
+    why: 'negative-pid / process-group signal is POSIX-only (no-op on Windows); use planProcessKill (win32 -> taskkill)',
+  },
+  {
+    id: 'bare-shell-spawn',
+    re: /spawn\(\s*['"](bash|sh)['"]/,
+    why: "spawning 'bash'/'sh' by name ENOENTs on stock Windows; resolve via resolvePosixShells",
+  },
+  {
+    id: 'hardcoded-tmp',
+    re: /['"]\/tmp(\/|['"])/,
+    why: 'hardcoded /tmp is POSIX-only; use os.tmpdir()',
+  },
+];
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...tsFiles(p));
+    else if (name.endsWith('.ts') && !name.endsWith('.d.ts')) out.push(p);
+  }
+  return out;
+}
+
+/** A pure comment/JSDoc line (they discuss hazards, never execute them). */
+function isCommentLine(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+}
+
+describe('POSIX-hazard guard (Windows env-fidelity)', () => {
+  const files = tsFiles(SRC);
+
+  it('sanity: the scan covers a real src tree', () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  it('no unmarked POSIX-only hazard in shipped engine code', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const rel = file.slice(SRC.length + 1);
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (isCommentLine(line)) return;
+        for (const h of HAZARDS) {
+          if (h.re.test(line) && !/win-ok:/.test(line)) {
+            violations.push(`${rel}:${i + 1} [${h.id}] ${h.why}\n    ${line.trim()}`);
+          }
+        }
+      });
+    }
+    expect(
+      violations,
+      `unmarked POSIX-only hazard(s) (fix for Windows, or annotate the site with a "win-ok: <reason>" comment):\n${violations.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('the guard actually fires on a hazard sample (negative control)', () => {
+    const sample = 'process.kill(-pid, sig);';
+    expect(HAZARDS.some((h) => h.re.test(sample) && !/win-ok:/.test(sample))).toBe(true);
+    // ...and is silenced by the marker.
+    const marked = 'process.kill(-pid, sig); // win-ok: posix branch';
+    expect(HAZARDS.every((h) => !(h.re.test(marked) && !/win-ok:/.test(marked)))).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

守密人诊断问「是不是提示词没按环境编排导致」——查证后答**否**：三起 Windows 故障根因是**工具接口之下的引擎代码 POSIX-first**（负 PID 进程组 / 裸 spawn shell 名 / 硬编码 /tmp），任何提示词措辞都绕不过；模型的工具调用本身是对的。`<env>` 块本就注入 `Platform:`，工具指导本就引向平台中立内建工具。所以预防落在**机器守卫**，不在提示词。

## 改动

- **`tests/posix-hazard-guard.test.ts`（新守卫）**：扫 src/ 的 POSIX-only 危险写法（`process.kill(-`/`spawn('bash'|'sh')`/`'/tmp'`），未标 `win-ok:` 即红。合法平台分支点（planProcessKill 的 POSIX 分支，win32 走 taskkill）就地标注。含负控测试（守卫真能命中样本、且 marker 能消音）。
- **守卫未建先还债**：揪出 `bash.ts` **前台** Bash 超时/abort 的 `killGroup` 是与后台 KillShell 同款未分支 `process.kill(-pid)` + 空 catch——Windows 上前台命令杀不掉、错误被吞（**潜伏第四 bug**）。已复用 `planProcessKill` 修（win32→`taskkill /T /F`），空 catch 改 debug。

## 验证

`tsc` + `npx vitest run` **1128 通过 / 2 跳过（45 文件）**。版本 **bump 0.6.5** + CHANGELOG（`bpt-agent-sdk-0.6.5.tgz`）。机器守卫累计四件：接口覆盖 / 参考目标棘轮 / 版本 bump / POSIX 危险。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_