### PR TITLE
feat(bpt-sdk): provider.cacheTtl — caller-selectable prompt-cache lifetime (v0.7.1)

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -8,6 +8,17 @@ and adds one line here. A CI guard (`scripts/check-version-bump.mjs`) reds
 any src-changing merge that forgets. 0.6.1 and 0.6.2 below are retroactive
 labels for builds that shipped under a duplicated "0.6.0".
 
+## 0.7.1 — 2026-07-05
+
+- **feat (BPT-EXTENSION)**: `provider.cacheTtl?: '5m' | '1h'` selects the
+  prompt-cache lifetime for the breakpoints this engine places. Omitted / '5m'
+  keeps the bare `{ type: 'ephemeral' }` marker (5-minute default, byte-
+  identical to before — wire ratchet unaffected); '1h' stamps `ttl: '1h'` on
+  every breakpoint (2x write price, GA — no beta header). The official Agent
+  SDK exposes NO cache-TTL knob (its wrapped CLI decides internally and only
+  reports the 5m/1h split in usage); this direct-API engine lets the caller
+  choose. No effect when `promptCaching` is false.
+
 ## 0.7.0 — 2026-07-05
 
 Completion-inventory full-implementation batch (keeper ruling 全面实现);

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -54,6 +54,39 @@ The keeper ruling 「全面实现」 drove a full-surface alignment pass. What l
   behavior-level reversal, would diverge from the pinned official arm, and awaits
   a keeper bump-pin decision.
 
+## Divergences from the official SDK (where we differ on purpose)
+
+A focused ledger of the INTENTIONAL differences between this SDK and
+`@anthropic-ai/claude-agent-sdk`. Four kinds: **BPT-EXTENSION** (we expose
+something official does not), **HONEST-SUBSET** (official has it; we do a
+scoped, truthfully-labeled version), **KEPT-DIVERGENCE** (measured, kept on
+purpose), **N/A-BY-DESIGN** (out of scope for a direct-API headless engine).
+Per-row detail lives in the sections below; this is the at-a-glance table.
+
+| Area | Kind | Official | Ours |
+|---|---|---|---|
+| **Engine model** | — | wraps the Claude Code CLI (black-box subprocess) | drives the Messages API directly (fetch+SSE, no CLI); this is the root of most divergences below |
+| `provider.cacheTtl` | BPT-EXTENSION | no cache-TTL knob (CLI decides 5m/1h internally; only reports the split in usage) | caller picks `'5m'`/`'1h'` per query (v0.7.1) |
+| `provider.promptCaching` | BPT-EXTENSION | no toggle (caching is internal) | caller can turn the whole breakpoint layer off |
+| tool-block cache breakpoint | KEPT-DIVERGENCE | 0 breakpoints on tool blocks | 1 (last tool) — measured to only ever gain cache hits on system-prompt divergence, never lose (E7-03) |
+| `compaction.model` / `preTier` | BPT-EXTENSION | fixed compaction | route summarization to a cheap model + deterministic pre-tier |
+| `sandbox` object form + bwrap backend | BPT-EXTENSION | CLI-managed sandbox | pluggable object-form config, default-on bwrap, network-off default |
+| worker-fork preset / Agent `fork` param | BPT-EXTENSION | no fork | prefix-sharing subagent fork (residual `Agent:params` wire delta) |
+| result `metrics` / `task_progress` superset | BPT-EXTENSION | — | extra observability fields (additive) |
+| Monitor | HONEST-SUBSET | pushes events into the conversation | background watch, read via BashOutput (no push channel) |
+| Workflow | HONEST-SUBSET | async background launch | synchronous execution, result returned inline |
+| MessageDisplay | HONEST-SUBSET | per-delta incremental | per-completed-message (final always true) |
+| Read PDF `pages` | HONEST-SUBSET | slices PDF pages | validates the param; page-slicing itself unsupported (no PDF dep), errors honestly |
+| Grep | HONEST-SUBSET | ripgrep binary | pure-JS regex (large-repo perf caveat) |
+| six new hooks (Setup/TeammateIdle/…) | HONEST-SUBSET | fire | typed-not-fired (no natural headless hook point) |
+| MCP subscription tools (4) | N/A-BY-DESIGN | subscribe + server push | absent (no push-to-conversation channel) |
+| NotebookEdit | N/A-BY-DESIGN | edits Jupyter cells | absent (no notebook surface) |
+| TaskOutput / TaskStop tools | N/A (candidate) | model-facing task tools | capability exists (stopTask/BashOutput) but not exposed as builtins yet |
+| full settings engine / OTel / 3P providers | N/A-BY-DESIGN | present | out of scope for a direct-API engine |
+| `reinitialize()` / `applyFlagSettings()` | N/A-BY-DESIGN | CLI control requests | no CLI to control |
+| `settingSources` default | PENDING | omit = load-all (live docs) | omit = load-nothing (pinned 0.3.199); flip awaits bump-pin |
+| KD-12 rate-limit encoding | KEPT-DIVERGENCE | `system/api_retry` on 429 | `rate_limit_event` on 429 (triaged) |
+
 ## v0.2 status (what graduated from the v0.1 audit)
 
 v0.2 implemented most of the P0/P1 gaps the audit flagged. Now **FULL / PARTIAL**
@@ -82,7 +115,8 @@ v0.2 implemented most of the P0/P1 gaps the audit flagged. Now **FULL / PARTIAL*
   `canUseTool` full context + `null`=skip, `defer` end-to-end.
 - **Prompt caching** — `cache_control` breakpoints **on by default** (matches
   the official SDK; disable via `provider.promptCaching: false`; capped at the
-  API's 4-breakpoint max), `ttft_ms`/`deferred_tool_use` result extras, init
+  API's 4-breakpoint max; **BPT-EXTENSION v0.7.1** `provider.cacheTtl: '1h'`
+  switches the breakpoints to the 1-hour cache, default `'5m'`), `ttft_ms`/`deferred_tool_use` result extras, init
   fields, hook input `tool_use_id`/`duration_ms`, MCP audio/resource_link,
   `.mcp.json` loading, `thinking.budgetTokens` alias.
   **Stable-prefix caching (v0.5+):** the system prompt is split into a stable

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/engine/cache-control.ts
+++ b/projects/bpt-agent-sdk/src/engine/cache-control.ts
@@ -43,11 +43,19 @@
 import type { StreamRequest } from '../internal/contracts.js';
 import type {
   APIToolDefinition,
+  CacheControlEphemeral,
   ContentBlockParam,
   TextBlockParam,
 } from '../types.js';
 
-const EPHEMERAL = { type: 'ephemeral' } as const;
+/**
+ * The cache_control marker for a breakpoint. `ttl` undefined / '5m' yields the
+ * bare `{ type: 'ephemeral' }` (byte-identical to the pre-cacheTtl default, so
+ * the wire ratchet is unaffected); '1h' adds `ttl: '1h'`.
+ */
+function ephemeral(cacheTtl?: '5m' | '1h'): CacheControlEphemeral {
+  return cacheTtl === '1h' ? { type: 'ephemeral', ttl: '1h' } : { type: 'ephemeral' };
+}
 
 /** Content-block param types that legally carry a cache_control breakpoint. */
 type CacheableLastBlock = 'text' | 'tool_result' | 'image';
@@ -87,10 +95,17 @@ export function applyCacheControl(
      *   breakpoints; the engine must not add or move any.
      */
     cacheSystemBoundary?: 'first' | 'last' | 'dual' | 'preserve';
+    /**
+     * Cache lifetime for every breakpoint placed here. Omitted / '5m' keeps the
+     * bare `{ type: 'ephemeral' }` marker (5-minute default); '1h' stamps
+     * `ttl: '1h'` on all of them. BPT-EXTENSION (Provider.cacheTtl).
+     */
+    cacheTtl?: '5m' | '1h';
   },
 ): StreamRequest {
   if (!opts.enabled) return req;
 
+  const marker = ephemeral(opts.cacheTtl);
   const next: StreamRequest = { ...req };
 
   // (a) TOOLS breakpoint - last tool.
@@ -98,20 +113,21 @@ export function applyCacheControl(
     const tools = req.tools.slice();
     const lastIdx = tools.length - 1;
     const lastTool = tools[lastIdx] as APIToolDefinition;
-    tools[lastIdx] = { ...lastTool, cache_control: EPHEMERAL };
+    tools[lastIdx] = { ...lastTool, cache_control: marker };
     next.tools = tools;
   }
 
   // (b) SYSTEM breakpoint - last text block (or first, for the engine split;
   // or preserve, when the caller authored the blocks + their own breakpoints).
   const boundary = opts.cacheSystemBoundary ?? 'last';
-  next.system = boundary === 'preserve' ? req.system : cacheSystem(req.system, boundary);
+  next.system =
+    boundary === 'preserve' ? req.system : cacheSystem(req.system, boundary, marker);
 
   // (c) MESSAGES breakpoint - last content block of the last message.
   const last =
     opts.cacheMessages !== false ? req.messages[req.messages.length - 1] : undefined;
   if (last !== undefined) {
-    const cachedContent = cacheMessageContent(last.content);
+    const cachedContent = cacheMessageContent(last.content, marker);
     if (cachedContent !== undefined) {
       const messages = req.messages.slice();
       messages[messages.length - 1] = { ...last, content: cachedContent };
@@ -130,10 +146,11 @@ export function applyCacheControl(
 function cacheSystem(
   system: string | TextBlockParam[] | undefined,
   boundary: 'first' | 'last' | 'dual',
+  marker: CacheControlEphemeral,
 ): string | TextBlockParam[] | undefined {
   if (typeof system === 'string') {
     if (system.length === 0) return system;
-    return [{ type: 'text', text: system, cache_control: EPHEMERAL }];
+    return [{ type: 'text', text: system, cache_control: marker }];
   }
   if (Array.isArray(system) && system.length > 0) {
     const blocks = system.slice();
@@ -143,10 +160,10 @@ function cacheSystem(
       // leaving block 2 (per-run cwd) uncached. Guard by existence so a
       // degenerate array only touches indices that exist.
       const base = blocks[0] as TextBlockParam;
-      blocks[0] = { ...base, cache_control: EPHEMERAL };
+      blocks[0] = { ...base, cache_control: marker };
       if (blocks.length > 1) {
         const project = blocks[1] as TextBlockParam;
-        blocks[1] = { ...project, cache_control: EPHEMERAL };
+        blocks[1] = { ...project, cache_control: marker };
       }
       return blocks;
     }
@@ -154,7 +171,7 @@ function cacheSystem(
     // 'last' caches the final block (default for caller-supplied systems).
     const idx = boundary === 'first' ? 0 : blocks.length - 1;
     const target = blocks[idx] as TextBlockParam;
-    blocks[idx] = { ...target, cache_control: EPHEMERAL };
+    blocks[idx] = { ...target, cache_control: marker };
     return blocks;
   }
   return system;
@@ -168,17 +185,18 @@ function cacheSystem(
  */
 function cacheMessageContent(
   content: string | ContentBlockParam[],
+  marker: CacheControlEphemeral,
 ): string | ContentBlockParam[] | undefined {
   if (typeof content === 'string') {
     if (content.length === 0) return undefined;
-    return [{ type: 'text', text: content, cache_control: EPHEMERAL }];
+    return [{ type: 'text', text: content, cache_control: marker }];
   }
   if (content.length === 0) return undefined;
   const lastIdx = content.length - 1;
   const lastBlock = content[lastIdx] as ContentBlockParam;
   if (!isCacheableLastBlock(lastBlock.type)) return undefined;
   const blocks = content.slice();
-  blocks[lastIdx] = { ...lastBlock, cache_control: EPHEMERAL } as ContentBlockParam;
+  blocks[lastIdx] = { ...lastBlock, cache_control: marker } as ContentBlockParam;
   return blocks;
 }
 

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -582,6 +582,7 @@ export async function* runAgentLoop(
     // cache-control is the outermost request shaper; it never mutates `request`.
     const outgoing = applyCacheControl(request, {
       enabled: cachingOn,
+      cacheTtl: config.cacheTtl,
       // Caller-authored segments already carry their own breakpoints; don't add
       // a message breakpoint too or the request could exceed the 4-cap.
       cacheMessages: callerBlocks === undefined,

--- a/projects/bpt-agent-sdk/src/internal/contracts.ts
+++ b/projects/bpt-agent-sdk/src/internal/contracts.ts
@@ -451,6 +451,9 @@ export type EngineConfig = {
   maxStructuredOutputRetries?: number;
   /** Automatic prompt caching (cache_control breakpoints). */
   promptCaching?: boolean;
+  /** Cache lifetime for the breakpoints this engine places ('5m' default, '1h'
+   *  for the 1-hour cache). BPT-EXTENSION; no effect when promptCaching false. */
+  cacheTtl?: '5m' | '1h';
   /** tool_use id of the spawning Agent call; stamped on this loop's messages
    *  so subagent messages thread. Root loop leaves it undefined -> null. */
   parentToolUseId?: string | null;

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -693,6 +693,9 @@ export function query(args: {
     // provider.promptCaching = false to disable (e.g. for very short sessions
     // where the cache-write premium is not amortized).
     promptCaching: options.provider?.promptCaching !== false,
+    // Cache TTL: undefined/'5m' -> 5-minute default; '1h' -> 1-hour cache
+    // (BPT-EXTENSION; the official SDK has no such knob).
+    cacheTtl: options.provider?.cacheTtl,
     includePartialMessages: options.includePartialMessages === true,
     sessionId: '', // resolved when the run starts
     cwd,

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -100,10 +100,18 @@ export type ContentBlock =
   | RedactedThinkingBlock
   | ToolUseBlock;
 
+/**
+ * A prompt-cache breakpoint. `ttl` selects the cache lifetime: omitted / '5m'
+ * is the default 5-minute ephemeral cache (1.25x write price); '1h' is the
+ * 1-hour cache (2x write price, GA — no beta header needed). Read price is
+ * 0.1x either way.
+ */
+export type CacheControlEphemeral = { type: 'ephemeral'; ttl?: '5m' | '1h' };
+
 export type TextBlockParam = {
   type: 'text';
   text: string;
-  cache_control?: { type: 'ephemeral' } | null;
+  cache_control?: CacheControlEphemeral | null;
 };
 
 export type ImageBlockParam = {
@@ -111,7 +119,7 @@ export type ImageBlockParam = {
   source:
     | { type: 'base64'; media_type: string; data: string }
     | { type: 'url'; url: string };
-  cache_control?: { type: 'ephemeral' } | null;
+  cache_control?: CacheControlEphemeral | null;
 };
 
 /**
@@ -130,7 +138,7 @@ export type DocumentBlockParam = {
     | { type: 'url'; url: string };
   title?: string;
   context?: string;
-  cache_control?: { type: 'ephemeral' } | null;
+  cache_control?: CacheControlEphemeral | null;
 };
 
 export type ToolUseBlockParam = {
@@ -145,7 +153,7 @@ export type ToolResultBlockParam = {
   tool_use_id: string;
   content?: string | Array<TextBlockParam | ImageBlockParam | DocumentBlockParam>;
   is_error?: boolean;
-  cache_control?: { type: 'ephemeral' } | null;
+  cache_control?: CacheControlEphemeral | null;
 };
 
 export type ThinkingBlockParam = {
@@ -212,7 +220,7 @@ export type APIToolDefinition = {
   description?: string;
   input_schema: JSONSchema;
   /** Prompt-cache breakpoint marker (set by the cache-control layer). */
-  cache_control?: { type: 'ephemeral' } | null;
+  cache_control?: CacheControlEphemeral | null;
 };
 
 // --- Streaming events (SSE) -------------------------------------------------
@@ -893,6 +901,15 @@ export type ProviderConfig = {
   maxOutputTokens?: number;
   /** Automatic prompt caching via cache_control breakpoints; default true. */
   promptCaching?: boolean;
+  /**
+   * Cache lifetime for the prompt-cache breakpoints this engine places.
+   * '5m' (default when omitted) is the 5-minute ephemeral cache; '1h' is the
+   * 1-hour cache (2x write price, GA). BPT-EXTENSION: the official Agent SDK
+   * exposes NO cache-TTL knob (its wrapped CLI decides internally); this
+   * direct-API engine lets the caller choose. No effect when promptCaching is
+   * false.
+   */
+  cacheTtl?: '5m' | '1h';
 };
 
 /**

--- a/projects/bpt-agent-sdk/tests/cache-control.test.ts
+++ b/projects/bpt-agent-sdk/tests/cache-control.test.ts
@@ -282,6 +282,83 @@ describe('applyCacheControl', () => {
     expect(out.model).toBe('claude-test-1');
     expect(out.max_tokens).toBe(1024);
   });
+
+  // cacheTtl (BPT-EXTENSION): the marker on every breakpoint carries the chosen
+  // lifetime. Omitted / '5m' must stay byte-identical to the pre-cacheTtl
+  // default so the wire ratchet is unaffected; '1h' stamps ttl on all of them.
+  const tools: APIToolDefinition[] = [
+    { name: 't1', input_schema: { type: 'object' } },
+    { name: 't2', input_schema: { type: 'object' } },
+  ];
+  const dualSystem: TextBlockParam[] = [
+    { type: 'text', text: 'base harness prefix' },
+    { type: 'text', text: '\n\nproject tail' },
+    { type: 'text', text: 'Working directory: /tmp/run-xyz' },
+  ];
+
+  /** Collect every cache_control marker placed anywhere in the request. */
+  function allMarkers(req: StreamRequest): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = [];
+    if (Array.isArray(req.tools)) {
+      for (const t of req.tools) if (t.cache_control) out.push(t.cache_control as Record<string, unknown>);
+    }
+    if (Array.isArray(req.system)) {
+      for (const b of req.system) if (b.cache_control) out.push(b.cache_control as Record<string, unknown>);
+    }
+    for (const m of req.messages) {
+      if (Array.isArray(m.content)) {
+        for (const b of m.content) {
+          const cc = (b as { cache_control?: unknown }).cache_control;
+          if (cc) out.push(cc as Record<string, unknown>);
+        }
+      }
+    }
+    return out;
+  }
+
+  it('omitted cacheTtl yields the bare {type:ephemeral} marker (byte-identical default)', () => {
+    const out = applyCacheControl(baseReq({ tools, system: dualSystem }), {
+      enabled: true,
+      cacheSystemBoundary: 'dual',
+    });
+    const markers = allMarkers(out);
+    expect(markers.length).toBe(4);
+    for (const m of markers) expect(m).toEqual({ type: 'ephemeral' });
+  });
+
+  it("cacheTtl '5m' is treated as the default (no ttl field)", () => {
+    const out = applyCacheControl(baseReq({ tools, system: dualSystem }), {
+      enabled: true,
+      cacheSystemBoundary: 'dual',
+      cacheTtl: '5m',
+    });
+    for (const m of allMarkers(out)) expect(m).toEqual({ type: 'ephemeral' });
+  });
+
+  it("cacheTtl '1h' stamps ttl:'1h' on EVERY breakpoint (tools + dual system + message)", () => {
+    const out = applyCacheControl(baseReq({ tools, system: dualSystem }), {
+      enabled: true,
+      cacheSystemBoundary: 'dual',
+      cacheTtl: '1h',
+    });
+    const markers = allMarkers(out);
+    expect(markers.length).toBe(4);
+    for (const m of markers) expect(m).toEqual({ type: 'ephemeral', ttl: '1h' });
+  });
+
+  it('cacheTtl has no effect when caching is disabled (identity)', () => {
+    const req = baseReq({ tools, system: dualSystem });
+    const out = applyCacheControl(req, { enabled: false, cacheTtl: '1h' });
+    expect(out).toBe(req);
+  });
+
+  it("cacheTtl '1h' also stamps a string system and a string last message", () => {
+    const out = applyCacheControl(
+      baseReq({ system: 'You are helpful.', messages: [{ role: 'user', content: 'hi' }] }),
+      { enabled: true, cacheTtl: '1h' },
+    );
+    for (const m of allMarkers(out)) expect(m).toEqual({ type: 'ephemeral', ttl: '1h' });
+  });
 });
 
 describe('loadProjectMcpServers', () => {


### PR DESCRIPTION
## 背景

BPT 侧希望能自己切缓存时长（5 分钟 vs 1 小时），对黑池「隔几分钟聊一句、动辄聊一小时」的节奏，1 小时缓存更划算。

查证官方后确认：**官方 Claude Agent SDK 根本不暴露缓存 TTL 选项**——它包着的 Claude Code CLI 内部决定 5m/1h，调用方只能从 usage 看到 `ephemeral_1h_input_tokens` / `ephemeral_5m_input_tokens` 的分账、改不了。银芯是自研引擎、直驱 Messages API，所以能提供官方给不了的旋钮。

## 改动

- `provider.cacheTtl?: '5m' | '1h'` 沿 `promptCaching` 同一条接线链（types.ts → query.ts → EngineConfig → loop.ts → applyCacheControl）接入。
- `applyCacheControl` 给它打的每个断点（tools / system / message）盖上所选 ttl。
- **默认（省略 / `'5m'`）产出裸 `{ type: 'ephemeral' }` 标记——与改动前逐字节一致，一致性 wire 棘轮不受影响**；`'1h'` 加 `ttl: '1h'`（写入 2x 价，已 GA、无需 beta 头）。`promptCaching:false` 时无效。
- `cache_control` 类型收口到共享 `CacheControlEphemeral`。
- COMPAT.md 加「Divergences from the official SDK」差异总表（BPT-EXTENSION / HONEST-SUBSET / KEPT-DIVERGENCE / N-A-BY-DESIGN 四类），本项标 **BPT-EXTENSION**（官方无此口，非「对齐官方」）。
- 版本 0.7.0 → **0.7.1**，CHANGELOG 同步。

## 验证

- `tsc --noEmit` 零错；`npx vitest run` **1320 passed / 2 skipped**（+5 cacheTtl 用例）。
- **一致性 wire 棘轮全绿**——证明默认路径逐字节不变（5m 无 ttl 字段）。
- cacheTtl `'1h'` 用例断言四个断点全部盖 `ttl:'1h'`；`'5m'` 与省略等价；`promptCaching:false` 时恒等返回。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E)_