### PR TITLE
feat(bpt-sdk)!: settingSources default reversal — omit = load-all (bump-pin ruling, v0.8.0)

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -449,6 +449,17 @@
   `Public-Info-Pool/Resource/repo-engineering/bpt-sdk-engine-alignment-handoff-20260705-r5.md`（退役 r4 待办视图）。
   **代码侧无挂账**；剩余三项纯花预算 / 需裁定的验收（真 L5 验 code-01 残余 / run-l35 双臂封印 KD-L35-02 / 升钉+参考目标刷新+settingSources 反转），
   待守密人「dispatch 真 L5」或「升钉」信号，否则本线判定收官。
+- **升钉裁定落地 —— settingSources 默认反转（守密人「确定升钉了」，2026-07-05，v0.7.1→v0.8.0）**：唯一行为级
+  NEW-IN-DOCS 反转已做。**省略 `settingSources` 现默认加载 user+project+local**（CLAUDE.md / AGENTS.md + 项目
+  `.mcp.json`），对齐官方 Claude Code / live docs；**显式 `[]` = 显式退出（不加载）**、显式子集照旧。单一真相源
+  `src/internal/setting-sources.ts` `resolveSettingSources`（注入式纯函数，仿 shell-resolve/kill-plan）；两消费点
+  （`runtime-context.ts loadProjectInstructions` / `project-config.ts loadProjectMcpServers`）统一经其解析。破坏性——
+  靠「省略=不加载」旧默认的调用方须显式传 `[]`（MIGRATION 5m）。L2 锁 `conformance-l2-locks` 翻转追 live 语义
+  （AHEAD of 钉版臂，属升钉预期）；wire 指纹不受影响（测试目录无 CLAUDE.md）、pin 已 0.3.201 故参考目标无需刷新。
+  自验 tsc 净 / vitest **1321 全绿**。CHANGELOG 0.8.0 + COMPAT settingSources 行转 IMPLEMENTED。
+- **真 L5 已 dispatch（守密人「dispatch 真 L5」，2026-07-05）**：`bpt-agent-sdk.yml` workflow_dispatch
+  `conformance_l5=true` / `l5_repeat=5` / `l5_thinking=空`（各臂自身默认——本轮正为验 E7-01 自适应思考 vs 官方）
+  / haiku，在 main 上跑。目的：验 E7-01 自适应默认是否移动 code-01 残余（现 0/3）。结果待 run 完成回填。
 
 ## BPT-V2T 语音代替输入（`projects/bpt-v2t/`）
 

--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -8,6 +8,21 @@ and adds one line here. A CI guard (`scripts/check-version-bump.mjs`) reds
 any src-changing merge that forgets. 0.6.1 and 0.6.2 below are retroactive
 labels for builds that shipped under a duplicated "0.6.0".
 
+## 0.8.0 — 2026-07-05
+
+- **feat (BEHAVIOR REVERSAL, bump-pin ruling)**: an OMITTED `settingSources`
+  now loads **user+project+local** (CLAUDE.md / AGENTS.md / project `.mcp.json`),
+  matching official Claude Code and the live `@anthropic-ai/claude-agent-sdk`
+  docs. This flips the earlier pinned-0.3.199 default (omitted = load nothing) —
+  the last behavior-level NEW-IN-DOCS hold, gated behind the keeper up-pin
+  decision because a default flip diverges from the pinned conformance arm.
+  An explicit array is honored verbatim: `settingSources: []` is the explicit
+  opt-OUT (load nothing); an explicit subset loads exactly that subset. Single
+  source of truth: `src/internal/setting-sources.ts` (`resolveSettingSources`).
+  Migration: callers who omitted the field to get "no on-disk sources" must now
+  pass `settingSources: []` to keep that behavior. See MIGRATION.md §5g.
+  (skills/plugins loading remains a separate PARTIAL — unchanged here.)
+
 ## 0.7.1 — 2026-07-05
 
 - **feat (BPT-EXTENSION)**: `provider.cacheTtl?: '5m' | '1h'` selects the

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -50,9 +50,9 @@ The keeper ruling 「全面实现」 drove a full-surface alignment pass. What l
   events typed (typed-not-fired — no natural headless hook point), MessageDisplay
   5-field incremental protocol emitted, plus additive optional types
   (SDKMessageOrigin, error/terminal_reason enums, etc.). The **`settingSources`
-  default reversal** (omit = load-all) is deliberately NOT done — it is the one
-  behavior-level reversal, would diverge from the pinned official arm, and awaits
-  a keeper bump-pin decision.
+  default reversal** (omit = load-all) is DONE as of v0.8 (keeper bump-pin ruling
+  2026-07-05): it was the one behavior-level reversal and deliberately tracks the
+  LIVE docs ahead of the pinned arm. Explicit `[]` is the opt-out.
 
 ## Divergences from the official SDK (where we differ on purpose)
 
@@ -84,7 +84,7 @@ Per-row detail lives in the sections below; this is the at-a-glance table.
 | TaskOutput / TaskStop tools | N/A (candidate) | model-facing task tools | capability exists (stopTask/BashOutput) but not exposed as builtins yet |
 | full settings engine / OTel / 3P providers | N/A-BY-DESIGN | present | out of scope for a direct-API engine |
 | `reinitialize()` / `applyFlagSettings()` | N/A-BY-DESIGN | CLI control requests | no CLI to control |
-| `settingSources` default | PENDING | omit = load-all (live docs) | omit = load-nothing (pinned 0.3.199); flip awaits bump-pin |
+| `settingSources` default | IMPLEMENTED | omit = load-all (live docs) | omit = load user+project+local (v0.8 bump-pin flip); explicit `[]` = opt-out |
 | KD-12 rate-limit encoding | KEPT-DIVERGENCE | `system/api_retry` on 429 | `rate_limit_event` on 429 (triaged) |
 
 ## v0.2 status (what graduated from the v0.1 audit)
@@ -224,7 +224,7 @@ SDK implements the agent loop directly against the public Messages API:
 | `allowDangerouslySkipPermissions` | FULL | safety interlock: `bypassPermissions` (initial or via `setPermissionMode`) throws `ConfigurationError` unless this is `true`. BPT-only strictness: official 0.3.199/2.1.201 does NOT enforce the interlock live - it proceeds to the model without the flag (conformance run-l2 s6-bypass-interlock-refusal, 2026-07-05) |
 | `persistSession` / `sessionId` / `resume` | FULL | JSONL store |
 | `provider` | FULL | **BPT extension** — direct-API connection settings |
-| `settingSources` | PARTIAL | loads CLAUDE.md / AGENTS.md ('project'/'local'/'user'); skills/plugins not loaded |
+| `settingSources` | PARTIAL | loads CLAUDE.md / AGENTS.md + project `.mcp.json` ('project'/'local'/'user'); **omit = load-all default (v0.8), explicit `[]` = opt-out**; skills/plugins not loaded |
 | `includeEnvironmentContext` | FULL | **BPT extension** — inject official-style `<env>` block (default true on the preset) |
 | `stderr` | PARTIAL | receives debug log lines (no subprocess stderr exists) |
 | `strictMcpConfig` | ACCEPTED | typed but consulted nowhere in src; the old "only options servers are ever used" rationale is stale since v0.5 `settingSources` can load `.mcp.json` servers, and no strict/lax fork exists to lock (conformance-l2-locks reconciliation, 2026-07-05) |

--- a/projects/bpt-agent-sdk/docs/MIGRATION.md
+++ b/projects/bpt-agent-sdk/docs/MIGRATION.md
@@ -215,6 +215,16 @@ gap is structural, not a backlog):
    whereas the official CLI emits `api_retry` on an actual 429 and reserves
    `rate_limit_event` for quota-status updates it receives from the platform
    (a feed this engine does not have).
+5m. **`settingSources` default reversed to load-all** (bump-pin ruling, v0.8,
+   BREAKING for callers who relied on the silent default): OMITTING
+   `settingSources` now loads **user+project+local** on-disk sources
+   (CLAUDE.md / AGENTS.md, and the project `.mcp.json`), matching official
+   Claude Code and the live `@anthropic-ai/claude-agent-sdk` docs — the flip
+   from the earlier pinned-0.3.199 "omit = load nothing" default, held until
+   the up-pin because it diverges from the pinned conformance arm. To keep the
+   old "no on-disk sources" behavior, pass `settingSources: []` explicitly (the
+   empty array is the opt-out). An explicit subset still loads exactly that
+   subset. skills/plugins loading remains a separate PARTIAL, unchanged.
 6. **Sessions** live in this SDK's own JSONL store (or your `sessionStore`
    backend); official CLI session files are not readable.
 7. **`sse` MCP transport** (legacy) is unsupported; stdio / http / sdk are.

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/engine/runtime-context.ts
+++ b/projects/bpt-agent-sdk/src/engine/runtime-context.ts
@@ -13,6 +13,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { homedir, platform as osPlatform, release } from 'node:os';
 import { dirname, join, parse as parsePath } from 'node:path';
 
+import { resolveSettingSources } from '../internal/setting-sources.js';
 import type { EnvironmentContext } from './prompts.js';
 import type { SettingSource } from '../types.js';
 
@@ -50,23 +51,26 @@ export function gatherEnvironment(
 }
 
 /**
- * Load codebase instructions per `settingSources`. 'project'/'local' walk up
- * from cwd collecting CLAUDE.md/AGENTS.md (root-most first, so the most
+ * Load codebase instructions per the effective `settingSources`. Omitted
+ * settingSources resolves to load-all (bump-pin ruling), so an absent field
+ * loads user+project+local; an explicit `[]` loads nothing. 'project'/'local'
+ * walk up from cwd collecting CLAUDE.md/AGENTS.md (root-most first, so the most
  * specific file lands last); 'user' reads ~/.claude/CLAUDE.md. Returns '' when
- * no sources are requested or nothing is found. Total size is capped.
+ * no sources are effective or nothing is found. Total size is capped.
  */
 export function loadProjectInstructions(
   cwd: string,
   sources: SettingSource[] | undefined,
 ): string {
-  if (!sources || sources.length === 0) return '';
+  const effective = resolveSettingSources(sources);
+  if (effective.length === 0) return '';
   const parts: string[] = [];
-  if (sources.includes('user')) {
+  if (effective.includes('user')) {
     const userFile = join(homedir(), '.claude', 'CLAUDE.md');
     const txt = readIfFile(userFile);
     if (txt) parts.push(`# ${userFile}\n\n${txt}`);
   }
-  if (sources.includes('project') || sources.includes('local')) {
+  if (effective.includes('project') || effective.includes('local')) {
     for (const file of walkUpInstructionFiles(cwd)) {
       const txt = readIfFile(file);
       if (txt) parts.push(`# ${file}\n\n${txt}`);

--- a/projects/bpt-agent-sdk/src/internal/setting-sources.ts
+++ b/projects/bpt-agent-sdk/src/internal/setting-sources.ts
@@ -1,0 +1,31 @@
+/**
+ * settingSources default resolver (single source of truth).
+ *
+ * Bump-pin ruling 2026-07-05 (keeper "确定升钉了"): an OMITTED `settingSources`
+ * now defaults to loading all three on-disk sources — user + project + local —
+ * matching official Claude Code and the live @anthropic-ai/claude-agent-sdk
+ * docs. This reverses the earlier pinned-0.3.199 semantics (omitted = load
+ * NOTHING), which was the last behavior-level NEW-IN-DOCS hold, deliberately
+ * gated behind the up-pin decision because flipping a default diverges from the
+ * pinned conformance arm.
+ *
+ * An EXPLICIT array is honored verbatim — including the empty array: `[]` is
+ * the caller's explicit opt-OUT (load nothing). Only `undefined` (the field is
+ * absent) takes the load-all default. This preserves a real off switch while
+ * making "just use the preset" load the codebase context a user expects.
+ */
+
+import type { SettingSource } from '../types.js';
+
+/** The load-all default applied when `settingSources` is omitted. */
+export const DEFAULT_SETTING_SOURCES: readonly SettingSource[] = ['user', 'project', 'local'];
+
+/**
+ * Resolve `settingSources` to the effective source list. `undefined` (omitted)
+ * → the load-all default; any explicit array (including `[]`) → returned as-is.
+ */
+export function resolveSettingSources(
+  sources: SettingSource[] | undefined,
+): SettingSource[] {
+  return sources === undefined ? [...DEFAULT_SETTING_SOURCES] : sources;
+}

--- a/projects/bpt-agent-sdk/src/mcp/project-config.ts
+++ b/projects/bpt-agent-sdk/src/mcp/project-config.ts
@@ -14,20 +14,24 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { resolveSettingSources } from '../internal/setting-sources.js';
 import type { McpServerConfig, SettingSource } from '../types.js';
 
 /**
- * Load the project .mcp.json when `settingSources` includes 'project'.
- * Returns the top-level `mcpServers` map (shallow-validated: each value must be
- * a non-null object). Returns {} when the source is not enabled, the file is
- * missing, or the file is unreadable/non-JSON. Never throws.
+ * Load the project .mcp.json when the effective `settingSources` includes
+ * 'project'. Omitted settingSources resolves to load-all (bump-pin ruling), so
+ * an absent field now enables the project source; an explicit array without
+ * 'project' (including `[]`) does not. Returns the top-level `mcpServers` map
+ * (shallow-validated: each value must be a non-null object). Returns {} when
+ * the source is not enabled, the file is missing, or the file is unreadable/
+ * non-JSON. Never throws.
  */
 export function loadProjectMcpServers(
   cwd: string,
   settingSources: SettingSource[] | undefined,
   debug: (msg: string) => void,
 ): Record<string, McpServerConfig> {
-  if (!Array.isArray(settingSources) || !settingSources.includes('project')) {
+  if (!resolveSettingSources(settingSources).includes('project')) {
     return {};
   }
 

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -1000,12 +1000,14 @@ export type ThinkingConfigParam =
 // ---------------------------------------------------------------------------
 
 export type SettingSource = 'user' | 'project' | 'local';
-// NEW-IN-DOCS default-semantics note (behavior deliberately NOT changed here):
-// live docs redefine an omitted `settingSources` as "load user+project+local"
-// (matching the CLI). This SDK follows the PINNED semantics — omitted = load
-// NOTHING — unchanged, because flipping the default is a behavior-level reversal
-// that would diverge from the pinned conformance arm. It is a keeper up-pin
-// decision, handled only when the pins move. This SDK touches nothing here.
+// Default semantics (bump-pin ruling 2026-07-05, keeper "确定升钉了"): an OMITTED
+// `settingSources` loads user+project+local — matching official Claude Code /
+// the live @anthropic-ai/claude-agent-sdk docs. This FLIPPED the earlier
+// pinned-0.3.199 default (omitted = load nothing); it was the last behavior-
+// level NEW-IN-DOCS hold, gated behind the up-pin because a default flip
+// diverges from the pinned conformance arm. An explicit array — including `[]`
+// — is honored verbatim: `[]` is the explicit opt-OUT. Resolver:
+// internal/setting-sources.ts (single source of truth).
 
 /**
  * One segment of a caller-composed system prompt (`systemPrompt` segments
@@ -1135,8 +1137,10 @@ export type Options = {
   /**
    * Which on-disk instruction sources to load into the system prompt, matching
    * @anthropic-ai/claude-agent-sdk. 'project'/'local' walk up from cwd for
-   * CLAUDE.md / AGENTS.md; 'user' reads ~/.claude/CLAUDE.md. Empty/undefined
-   * loads nothing (the SDK default — the caller opts in). Only consulted on the
+   * CLAUDE.md / AGENTS.md; 'user' reads ~/.claude/CLAUDE.md. OMITTED (undefined)
+   * loads all three — user+project+local — matching official Claude Code (the
+   * bump-pin default, 2026-07-05). An explicit `[]` loads nothing (opt-out); an
+   * explicit subset loads exactly that subset. Only consulted on the
    * `claude_code` preset / default harness path.
    */
   settingSources?: SettingSource[];

--- a/projects/bpt-agent-sdk/tests/cache-control.test.ts
+++ b/projects/bpt-agent-sdk/tests/cache-control.test.ts
@@ -374,14 +374,17 @@ describe('loadProjectMcpServers', () => {
 
   const noop = (): void => {};
 
-  it('returns {} when settingSources is undefined', () => {
+  it('loads .mcp.json when settingSources is undefined (bump-pin load-all default)', () => {
+    // Reversal 2026-07-05: undefined resolves to user+project+local, so the
+    // project .mcp.json is now loaded by default (matching official CLI).
     writeFileSync(join(dir, '.mcp.json'), JSON.stringify({ mcpServers: { a: { command: 'x' } } }));
-    expect(loadProjectMcpServers(dir, undefined, noop)).toEqual({});
+    expect(loadProjectMcpServers(dir, undefined, noop)).toEqual({ a: { command: 'x' } });
   });
 
-  it('returns {} when settingSources does not include project', () => {
+  it('returns {} when an explicit settingSources omits project (incl. [])', () => {
     writeFileSync(join(dir, '.mcp.json'), JSON.stringify({ mcpServers: { a: { command: 'x' } } }));
     expect(loadProjectMcpServers(dir, ['user', 'local'], noop)).toEqual({});
+    expect(loadProjectMcpServers(dir, [], noop)).toEqual({});
   });
 
   it('parses mcpServers when project is enabled', () => {

--- a/projects/bpt-agent-sdk/tests/conformance-l2-locks.test.ts
+++ b/projects/bpt-agent-sdk/tests/conformance-l2-locks.test.ts
@@ -266,12 +266,21 @@ describe('L2 lock: systemPrompt request mapping', () => {
 });
 
 describe('L2 lock: settingSources CLAUDE.md injection', () => {
-  it("['project'] injects cwd CLAUDE.md into the stable system-reminder; unset does not", async () => {
+  // Bump-pin reversal 2026-07-05 (keeper "确定升钉了"): omitted settingSources now
+  // loads all three sources (user+project+local), matching official Claude Code /
+  // live docs. This lock deliberately tracks the LIVE semantics — AHEAD of the
+  // pinned-0.3.199 arm — per the up-pin ruling. ['project'] AND unset both inject
+  // the cwd CLAUDE.md; an explicit [] is the opt-out that does NOT inject.
+  it('["project"] AND unset both inject cwd CLAUDE.md; explicit [] does not', async () => {
     fs.writeFileSync(
       path.join(sandbox, 'CLAUDE.md'),
       'CONF-L2-CLAUDEMD-MARKER: follow the conformance house rules.\n',
     );
-    const fetchStub = makeSSEFetch([textReplyEvents('ok'), textReplyEvents('ok')]);
+    const fetchStub = makeSSEFetch([
+      textReplyEvents('ok'),
+      textReplyEvents('ok'),
+      textReplyEvents('ok'),
+    ]);
     vi.stubGlobal('fetch', fetchStub);
     const preset = { type: 'preset', preset: 'claude_code' } as const;
 
@@ -294,8 +303,15 @@ describe('L2 lock: settingSources CLAUDE.md injection', () => {
     const volatileBlock = blocks[blocks.length - 1]!;
     expect(volatileBlock.text).not.toContain('CONF-L2-CLAUDEMD-MARKER');
 
+    // Unset now injects too (load-all default).
     await collect(query({ prompt: 'hi', options: opts({ systemPrompt: preset }) }));
-    expect(systemText(fetchStub.requests[1]!.body)).not.toContain('CONF-L2-CLAUDEMD-MARKER');
+    expect(systemText(fetchStub.requests[1]!.body)).toContain('CONF-L2-CLAUDEMD-MARKER');
+
+    // Explicit [] is the opt-out — nothing injected.
+    await collect(
+      query({ prompt: 'hi', options: opts({ systemPrompt: preset, settingSources: [] }) }),
+    );
+    expect(systemText(fetchStub.requests[2]!.body)).not.toContain('CONF-L2-CLAUDEMD-MARKER');
   });
 });
 

--- a/projects/bpt-agent-sdk/tests/runtime-context.test.ts
+++ b/projects/bpt-agent-sdk/tests/runtime-context.test.ts
@@ -52,10 +52,18 @@ describe('gatherEnvironment', () => {
 });
 
 describe('loadProjectInstructions', () => {
-  it('returns empty when no settingSources are requested', () => {
+  it('explicit [] loads nothing (opt-out), even with a CLAUDE.md present', () => {
     writeFileSync(join(dir, 'CLAUDE.md'), 'Do the thing.');
-    expect(loadProjectInstructions(dir, undefined)).toBe('');
     expect(loadProjectInstructions(dir, [])).toBe('');
+  });
+
+  it('omitted settingSources loads the cwd CLAUDE.md (bump-pin load-all default)', () => {
+    // Reversal 2026-07-05: undefined now defaults to user+project+local, so an
+    // absent field picks up the project CLAUDE.md (the deterministic marker),
+    // matching official Claude Code. (The 'user' source reads ~/.claude and is
+    // env-dependent, so this asserts on the project marker only.)
+    writeFileSync(join(dir, 'CLAUDE.md'), 'DEFAULT_LOADALL_MARKER');
+    expect(loadProjectInstructions(dir, undefined)).toContain('DEFAULT_LOADALL_MARKER');
   });
 
   it('loads CLAUDE.md from cwd when project is requested', () => {


### PR DESCRIPTION
## 概述

守密人「确定升钉了」裁定落地：翻转最后一个行为级 NEW-IN-DOCS 挂账。**省略 `settingSources` 现默认加载 user+project+local**（CLAUDE.md / AGENTS.md + 项目 `.mcp.json`），对齐官方 Claude Code / live docs。此前有意 gated 于升钉裁定，因默认翻转会偏离钉版一致性臂——现按裁定让锁追 live 语义（AHEAD of 钉版）。

**破坏性**：靠「省略=不加载」旧默认的调用方须显式传 `settingSources: []` 退出。显式子集照旧。

---

## 变更类型

- [x] Bug 修复 / 行为对齐（settingSources 默认反转，drop-in 语义对齐官方）
- [x] 文档完善（CHANGELOG / MIGRATION / COMPAT / project-status）

---

## 来源声明

- [x] 规格来自官方 Claude Code / live `@anthropic-ai/claude-agent-sdk` 公开文档的默认语义（omit = load user+project+local）。净室 ③ 泄漏禁引 + §1.1-HC 防火墙不变。

---

## 安全声明（强制）

- [x] **不含任何黑池 / 内网 / 未发布数据**，与 §1.1-HC 防火墙同向（银芯→黑池单向输出物）。
- [x] **仅引用公开素材**。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `tsc --noEmit` 净
- [x] `vitest run` 全量 **1321 passed / 2 skipped / 55 files**（含翻转的 runtime-context / cache-control / conformance-l2-locks）
- [x] CLAUDE.md 对账三卫 7 passed（改了 project-status）
- [x] 版本纪律：0.7.1→**0.8.0**（minor，行为反转）+ CHANGELOG 一行；CI version-bump 守卫满足
- [x] 不引入 emoji

---

## 实现要点

- NEW `src/internal/setting-sources.ts`：`resolveSettingSources` 单一真相源（注入式纯函数，仿 shell-resolve/kill-plan）——`undefined`→`['user','project','local']`；显式数组（含 `[]`）逐字返回。
- 两消费点统一经其解析：`runtime-context.ts loadProjectInstructions`（CLAUDE.md/AGENTS.md）+ `project-config.ts loadProjectMcpServers`（.mcp.json）。
- `types.ts` 默认语义注释 + 字段 JSDoc 重写。
- L2 锁 `conformance-l2-locks` 翻转追 live 语义（unset 与 `['project']` 都注入、`[]` 不注入），inline 注记升钉预期。
- wire 指纹不受影响（测试目录无 CLAUDE.md）；pin 已 0.3.201，参考目标无需刷新。

小学生比喻：以前你不填「加载哪些配置」就当你啥都不要；现在不填 = 按官方那样把手边的规则（CLAUDE.md 等）都读上，真想一个都不读就明确写个空清单 `[]`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_