### PR TITLE
feat(bpt-sdk): SessionManager — 进程内共享协调 + 监督恢复 + FileSessionStore + Bash DX (v0.9.0)

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -8,6 +8,49 @@ and adds one line here. A CI guard (`scripts/check-version-bump.mjs`) reds
 any src-changing merge that forgets. 0.6.1 and 0.6.2 below are retroactive
 labels for builds that shipped under a duplicated "0.6.0".
 
+## 0.9.0 — 2026-07-06
+
+- **feat (BPT-EXTENSION): SessionManager — in-process shared coordination +
+  supervised recovery** (proposal `Public-Info-Pool/Resource/proposal/
+  bpt-sdk-session-manager-20260706.md`). `createBptSession(options)` returns a
+  manager that hosts multiple `mgr.query()` conversations over ONE shared
+  transport + ONE shared MCP registry (connect once, multiplex — no more N×
+  connections for N conversations); `mgr.usage()` aggregates cost/tokens
+  read-only; `mgr.close()` is the single reaper. Ownership contract: queries
+  BORROW shared connections and never tear them down; a borrowed registry
+  no-ops closeAll and rejects setServers. Standalone `query()` is unchanged
+  (sugar over a private manager). Per-query `provider`/`mcpServers` on a
+  managed query are rejected (D1: shared-only in v1). The official Agent SDK
+  has no in-process coordinator (its coordination lives in the wrapped CLI).
+- **feat: supervised auto-resume**. When a managed query has a `sessionStore`
+  and `recovery.autoResume !== false`, a RECOVERABLE failure (APIConnectionError,
+  MCP connection-class McpError, or APIStatusError 429/5xx — classified by the
+  stable E6c error `code`, never message text) is transparently re-driven from
+  the store via resume, up to `recovery.maxResumes` (default 2). Terminal
+  failures (abort/config/4xx/unknown — fail-closed) are forwarded/rethrown
+  untouched; on exhaustion the last error carries `resumeAttempts`. A
+  `system/status` observability message is emitted before each re-drive. The
+  engine surfaces API failures as an `error_during_execution` RESULT (not a
+  throw), so the supervisor watches error results; `SDKResultMessage` gains an
+  additive `error_code` field carrying the underlying stable code.
+- **feat: write-ahead turn checkpoints**. A persisting query brackets each
+  engine turn with `pending_turn` / `turn_complete` store records; a resume
+  whose transcript ends with a dangling `pending_turn` re-drives that request
+  segment before consuming new input — never replaying already-executed tools
+  (their tool_results are already paired in the replayed history).
+- **feat: built-in `fileSessionStore(dir)` / `FileSessionStore`** — durable
+  JSONL session store (one file per session, reversible path-safe encoding,
+  torn-tail tolerant) satisfying the public `SessionStore` contract, so
+  durable persistence + crash recovery is a one-line opt-in.
+- **feat (DX): Bash cmd-habit correction**. On Windows the Bash description
+  gains a registered note (POSIX bash, not cmd — ls/cp/mv, forward slashes);
+  on any platform an exit-127 failure whose first command word is cmd-only
+  (copy/move/del/erase/xcopy/robocopy/findstr/cls/md/rd/ren) gets a corrective
+  hint appended (dir/type excluded — real coreutils/builtin, zero false
+  positives).
+- Migration: none required — all additions are additive. Consumers switching
+  on `SDKResultMessage` may read the new optional `error_code`.
+
 ## 0.8.1 — 2026-07-05
 
 - **fix (CRITICAL — thinking model-gate)**: the `claude_code` preset default no

--- a/projects/bpt-agent-sdk/docs/ARCHITECTURE.md
+++ b/projects/bpt-agent-sdk/docs/ARCHITECTURE.md
@@ -392,6 +392,7 @@ build red.
 | `src/mcp/` | `McpError`, `NotImplementedError`, `ConfigurationError` |
 | `src/sessions/` | `ConfigurationError` |
 | `src/query.ts` | `ConfigurationError` |
+| `src/session-manager.ts` | `ConfigurationError` |
 | `src/tools/bash.ts` | `Error` |
 
 (`src/tools/bash.ts` keeps one bare `Error` for spawn impossibility - the

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -69,6 +69,7 @@ Per-row detail lives in the sections below; this is the at-a-glance table.
 | Area | Kind | Official | Ours |
 |---|---|---|---|
 | **Engine model** | — | wraps the Claude Code CLI (black-box subprocess) | drives the Messages API directly (fetch+SSE, no CLI); this is the root of most divergences below |
+| `createBptSession` (SessionManager) | BPT-EXTENSION | no in-process coordinator (coordination lives in the wrapped CLI host) | one manager hosts many `mgr.query()` conversations over a shared transport + shared MCP pool; supervised auto-resume from a store; `error_code` on result (v0.9.0) |
 | `provider.cacheTtl` | BPT-EXTENSION | no cache-TTL knob (CLI decides 5m/1h internally; only reports the split in usage) | caller picks `'5m'`/`'1h'` per query (v0.7.1) |
 | `provider.promptCaching` | BPT-EXTENSION | no toggle (caching is internal) | caller can turn the whole breakpoint layer off |
 | tool-block cache breakpoint | KEPT-DIVERGENCE | 0 breakpoints on tool blocks | 1 (last tool) — measured to only ever gain cache hits on system-prompt divergence, never lose (E7-03) |

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -6,7 +6,13 @@
 
 import { randomUUID } from 'node:crypto';
 
-import { AbortError, APIConnectionError, APIStatusError, isAbortError } from '../errors.js';
+import {
+  AbortError,
+  APIConnectionError,
+  APIStatusError,
+  errorCodeOf,
+  isAbortError,
+} from '../errors.js';
 import type {
   APIAssistantMessage,
   APIMessageParam,
@@ -344,6 +350,11 @@ export async function* runAgentLoop(
       | 'error_max_structured_output_retries',
     errorMessage: string,
     apiErrorStatus?: number,
+    // SM-乙b: stable machine code of the underlying SDK error (E6c), carried so
+    // a SessionManager can classify a recoverable-vs-terminal API failure by
+    // CODE rather than by parsing errorMessage. Absent for non-SDK / codeless
+    // failures. Additive; does not touch the request wire.
+    errorCode?: string,
   ): SDKResultMessage => ({
     type: 'result',
     subtype,
@@ -353,6 +364,7 @@ export async function* runAgentLoop(
     // the last API stop_reason observed, or null when no turn completed.
     stop_reason: lastStopReason,
     ...(apiErrorStatus !== undefined ? { api_error_status: apiErrorStatus } : {}),
+    ...(errorCode !== undefined ? { error_code: errorCode } : {}),
     ...resultBase(),
     // Official-surface parallel: the reference SDK reports error text as a
     // string[]. Placed AFTER the resultBase spread so the fatal message wins
@@ -1357,7 +1369,7 @@ export async function* runAgentLoop(
     const message = err instanceof Error ? err.message : String(err);
     deps.debug(`engine: error during execution: ${message}`);
     const apiStatus = err instanceof APIStatusError ? err.status : undefined;
-    yield errorResult('error_during_execution', message, apiStatus);
+    yield errorResult('error_during_execution', message, apiStatus, errorCodeOf(err));
     return;
   }
 }

--- a/projects/bpt-agent-sdk/src/index.ts
+++ b/projects/bpt-agent-sdk/src/index.ts
@@ -7,6 +7,9 @@
  */
 
 export { query } from './query.js';
+// BPT-EXTENSION: in-process multi-conversation coordinator (SessionManager /
+// SessionManagerOptions / SessionManagerUsage types ride the types.js export).
+export { createBptSession } from './session-manager.js';
 export { tool, createSdkMcpServer } from './mcp/sdk-server.js';
 export { getSessionInfo, listSessions } from './sessions/store.js';
 export {

--- a/projects/bpt-agent-sdk/src/index.ts
+++ b/projects/bpt-agent-sdk/src/index.ts
@@ -10,6 +10,9 @@ export { query } from './query.js';
 // BPT-EXTENSION: in-process multi-conversation coordinator (SessionManager /
 // SessionManagerOptions / SessionManagerUsage types ride the types.js export).
 export { createBptSession } from './session-manager.js';
+// Built-in durable session store (SM-乙a): fileSessionStore(dir) for the
+// SessionManager's `store` option and options.sessionStore recovery.
+export { FileSessionStore, fileSessionStore } from './sessions/file-store.js';
 export { tool, createSdkMcpServer } from './mcp/sdk-server.js';
 export { getSessionInfo, listSessions } from './sessions/store.js';
 export {

--- a/projects/bpt-agent-sdk/src/internal/contracts.ts
+++ b/projects/bpt-agent-sdk/src/internal/contracts.ts
@@ -497,6 +497,18 @@ export type StoredSession = {
   lastModified: number;
   firstPrompt?: string;
   cwd?: string;
+  /**
+   * SM-乙b §5.2 write-ahead checkpoint: true when the transcript carries a
+   * `pending_turn` record with no matching `turn_complete` — evidence the
+   * prior run crashed inside a turn's API request segment. Resume re-drives
+   * that request segment (never its tools: their execution state is whatever
+   * tool_result records made it to disk).
+   */
+  pendingTurnInterrupted?: boolean;
+  /** uuid of the dangling pending_turn (the recovery re-drive settles it). */
+  pendingTurnUuid?: string;
+  /** turn_ref of the dangling pending_turn (the interrupted user turn's uuid). */
+  pendingTurnRef?: string;
 };
 
 export interface SessionStore {

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -319,6 +319,18 @@ type ResolvedSession = {
   resumed: boolean;
   /** True when the meta line still needs to be written on first persist. */
   needMeta: boolean;
+  /**
+   * SM-乙b §5.2: the resumed transcript carries a dangling pending_turn
+   * (crash inside the request segment). When the replayed history also ends
+   * with a user turn, run() re-drives exactly that API request segment before
+   * consuming new input — tools are NEVER replayed (their execution state is
+   * whatever tool_result records reached disk).
+   */
+  redrivePending?: boolean;
+  /** uuid of the dangling pending_turn record (settled after the re-drive). */
+  pendingTurnUuid?: string;
+  /** turn_ref of the dangling pending_turn (the interrupted user turn uuid). */
+  pendingTurnRef?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -905,6 +917,40 @@ export function query(args: {
   }
 
   /**
+   * §5.2 write-ahead checkpoint: mark that a turn is entering its API request
+   * segment. A crash before the matching turn_complete leaves this record
+   * dangling, which a later resume reads as "the interruption happened in the
+   * request segment — re-drive it". turn_ref references the already-persisted
+   * user turn's uuid (no content copied). Always on when the query persists:
+   * the record is tiny and it is what makes the crash point diagnosable.
+   */
+  function persistPendingTurn(
+    sessionId: string,
+    pendingUuid: string,
+    turnRef: string,
+  ): void {
+    if (!persist) return;
+    store.append(sessionId, {
+      type: 'pending_turn',
+      uuid: pendingUuid,
+      timestamp: new Date().toISOString(),
+      turn_ref: turnRef,
+    });
+  }
+
+  /** §5.2: settle a pending_turn (append-only — the pending line stays, the
+   *  pairing makes it logically closed). */
+  function persistTurnComplete(sessionId: string, pendingUuid: string): void {
+    if (!persist) return;
+    store.append(sessionId, {
+      type: 'turn_complete',
+      uuid: randomUUID(),
+      timestamp: new Date().toISOString(),
+      pending_uuid: pendingUuid,
+    });
+  }
+
+  /**
    * Session resolution:
    *   - resume / continue-latest -> load and replay the prior transcript (the
    *     explicit resume path). forkSession copies it under a fresh id.
@@ -923,6 +969,17 @@ export function query(args: {
     if (resumeSource !== undefined) {
       const stored = await store.load(resumeSource);
       if (stored !== null) {
+        // §5.2: carry the dangling-checkpoint evidence into the run so the
+        // interrupted request segment is re-driven before new input.
+        const pendingFields = {
+          ...(stored.pendingTurnInterrupted === true ? { redrivePending: true } : {}),
+          ...(stored.pendingTurnUuid !== undefined
+            ? { pendingTurnUuid: stored.pendingTurnUuid }
+            : {}),
+          ...(stored.pendingTurnRef !== undefined
+            ? { pendingTurnRef: stored.pendingTurnRef }
+            : {}),
+        };
         if (options.forkSession === true) {
           // Copy the transcript under a new id; the original stays untouched.
           // The fork's future turns run under the CURRENT query's cwd, so the
@@ -953,6 +1010,10 @@ export function query(args: {
           history: [...stored.messages],
           resumed: true,
           needMeta: false,
+          // §5.2: a dangling pending_turn on the resumed transcript arms the
+          // redrive-on-resume in run() (fork deliberately omits this — a fork
+          // is a clean copy under a fresh id, not a crash recovery).
+          ...pendingFields,
         };
       }
       // Resume target has no stored transcript.
@@ -1159,6 +1220,183 @@ export function query(args: {
       // by the engine for its own turns, and compacted in place by the engine.
       const requestView = { messages: [...history] };
 
+      /**
+       * Drive ONE user turn's engine loop: build the per-turn deps, bracket
+       * the API request segment with the §5.2 write-ahead checkpoint, run the
+       * engine, and yield/persist its output exactly as the input loop did
+       * before SM-乙b (byte-identical message stream — the full suite is the
+       * regression guard). Shared by the input loop (fresh pending_turn) AND
+       * the redrive-on-resume path (settles an EXISTING dangling pending_turn
+       * without writing a new one). Returns 'stop' to end run() (string-mode
+       * interrupt) or 'continue' to proceed to the next input.
+       */
+      async function* driveTurn(
+        userUuid: string,
+        existingPendingUuid?: string,
+      ): AsyncGenerator<SDKMessage, 'stop' | 'continue'> {
+        checkpointStore?.beginTurn(userUuid);
+        turnController = new AbortController();
+        // A cancel requested while no turn was active (interrupt() between turns
+        // or right after init) aborts THIS turn immediately (finding #36).
+        if (interruptRequested) {
+          interruptRequested = false;
+          turnController.abort(new AbortError('The turn was interrupted'));
+        }
+        const turnSignal = AbortSignal.any([outer.signal, turnController.signal]);
+        const toolContext: ToolContext = {
+          // EnterWorktree survives turn-boundary context rebuilds: the session
+          // state is keyed on the shared readFilePaths Set, so the per-turn
+          // context picks the active worktree up again (Bash follows via its
+          // persistent state; this covers the fs tools and subagent spawns).
+          cwd:
+            peekWorktreeSession({ readFilePaths } as ToolContext)?.dir ?? cwd,
+          // Recomputed per turn so session addDirectories / removeDirectories
+          // permission updates take real effect on the fs tools (T2-7:
+          // removeDirectories revokes; addDirectories grants).
+          additionalDirectories: gate.effectiveAdditionalDirectories(
+            options.additionalDirectories ?? [],
+          ),
+          env,
+          signal: turnSignal,
+          debug,
+          spawnSubagent: subagentRuntime.makeSpawnFn(0),
+          webSearch: options.webSearch,
+          askUser: options.onUserQuestion,
+          mcpResources: {
+            list: (server, signal) => mcpEff.listResources(server, signal),
+            read: (server, uri, signal) => mcpEff.readResource(server, uri, signal),
+          },
+          allowPrivateWebFetch: options.allowPrivateWebFetch === true,
+          recordFileChange: checkpointStore
+            ? (abs, pre): void => checkpointStore!.record(abs, pre)
+            : undefined,
+          shells,
+          sandbox: sandboxCtx,
+          readFilePaths,
+        };
+        // ExitPlanMode bridge: the tool flips this query's own gate. Attached
+        // via the tool's context extension (deliberately not part of the core
+        // ToolContext contract).
+        (toolContext as ToolContextWithPermissionGate).permissionGate = gate;
+        const deps: EngineDeps = {
+          transport,
+          builtinTools,
+          mcp: mcpEff,
+          permissions: gate,
+          hooks,
+          toolContext,
+          debug,
+          requestView,
+          drainSubagentResults: () => subagentRuntime.drainCompletedResults(),
+          drainObservability,
+        };
+
+        // The engine appends assistant + tool_result-user messages to `history`
+        // in place. It YIELDS assistant messages (persisted here at yield time,
+        // finding #34) but NOT the tool_result user turns, so we surface each
+        // appended user turn as an SDKUserMessage (finding #27) and persist it,
+        // in order, before the engine message that follows it.
+        let historyTail = history.length;
+        const flushToolResultUsers = function* (): Generator<SDKUserMessage> {
+          while (historyTail < history.length) {
+            const entry = history[historyTail];
+            historyTail += 1;
+            // Assistant entries are persisted at their own yield time; only the
+            // engine-appended tool_result user turns need surfacing here.
+            if (entry !== undefined && entry.role === 'user') {
+              persistParam(sess.sessionId, entry);
+              yield {
+                type: 'user',
+                uuid: randomUUID(),
+                session_id: sess.sessionId,
+                message: { role: 'user', content: entry.content },
+                parent_tool_use_id: null,
+              };
+            }
+          }
+        };
+
+        // §5.2 write-ahead checkpoint: open a pending_turn just before the
+        // request segment (fresh id for a normal turn; the redrive path passes
+        // the EXISTING dangling id so it does not double-write the record).
+        const pendingUuid = existingPendingUuid ?? randomUUID();
+        if (existingPendingUuid === undefined) {
+          persistPendingTurn(sess.sessionId, pendingUuid, userUuid);
+        }
+        // Track whether the turn ended in an ERROR result. The engine converts
+        // API/connection failures into an is_error `error_during_execution`
+        // result (only AbortError is thrown), so a "successful iteration" can
+        // still be a failed turn — in which case the pending_turn is left
+        // dangling so a resume re-drives the interrupted request segment.
+        let turnErrored = false;
+
+        try {
+          for await (const msg of runAgentLoop(history, deps, engineConfig)) {
+            yield* flushToolResultUsers();
+            yield* drainMirror();
+            yield* drainObs();
+            if (msg.type === 'assistant') {
+              persistAssistant(sess.sessionId, msg.message.content);
+              yield msg;
+            } else if (msg.type === 'result') {
+              if (msg.is_error === true) turnErrored = true;
+              // Fold any completed subagent usage into the session totals before
+              // the result is rewritten so subagent tokens/cost are reported.
+              foldSubagentUsage(subagentRuntime.drainUsageLedger());
+              accumulateResult(msg);
+              yield rewriteResult(msg);
+            } else {
+              yield msg;
+            }
+          }
+          yield* flushToolResultUsers();
+          yield* drainMirror();
+          // Trailing lifecycle events (a background subagent that finished as
+          // the turn ended, Stop-hook responses) surface before the next turn.
+          yield* drainObs();
+          // §5.2: settle the pending_turn ONLY when the request segment
+          // actually completed. An errored turn leaves it dangling so a later
+          // resume re-drives it.
+          if (!turnErrored) {
+            persistTurnComplete(sess.sessionId, pendingUuid);
+          }
+        } catch (err) {
+          // Persist (but do not re-yield on error) any trailing tool_result
+          // user turn so the transcript stays durable across the failure. The
+          // pending_turn is deliberately LEFT dangling: a resume re-drives it.
+          while (historyTail < history.length) {
+            const entry = history[historyTail];
+            historyTail += 1;
+            if (entry !== undefined && entry.role === 'user') {
+              persistParam(sess.sessionId, entry);
+            }
+          }
+          if (isAbortError(err)) {
+            if (outer.signal.aborted) {
+              throw err instanceof AbortError ? err : new AbortError();
+            }
+            // Turn-level interrupt(): streaming mode keeps accepting input;
+            // string mode ends the run WITH a terminal result so an awaiting
+            // consumer is not left hanging with no explanation (finding #36).
+            debug('query: turn interrupted');
+            if (!streamingMode) {
+              endReason = 'interrupt';
+              yield terminalResult(
+                'error_during_execution',
+                sess.sessionId,
+                'The turn was interrupted',
+              );
+              return 'stop';
+            }
+            return 'continue';
+          }
+          throw err;
+        } finally {
+          turnController = null;
+        }
+        return 'continue';
+      }
+
       // 1. SessionStart hooks (matchValue is the start source).
       const source: 'startup' | 'resume' = sess.resumed ? 'resume' : 'startup';
       let sessionStartContext: string[] = [];
@@ -1237,6 +1475,32 @@ export function query(args: {
       if (sessionStartBlocked !== undefined) {
         yield blockedResult(sess.sessionId, sessionStartBlocked);
         return;
+      }
+
+      // 2b. Redrive-on-resume (SM-乙b §5.2/§6): a resumed transcript whose
+      // last replayed message is a user turn AND that carries a dangling
+      // pending_turn means the prior run crashed inside that turn's API
+      // request segment. Re-drive exactly that segment ONCE against the
+      // existing history before consuming new input. Correctness: the engine
+      // never re-runs a tool that already has a tool_result on disk — history
+      // only carries settled tool calls, and repairPairing already healed any
+      // trailing unpaired tool_use — so this re-issues only the interrupted
+      // API request, never a side-effecting tool. driveTurn settles the
+      // existing pending_turn on completion; a 'stop' outcome ends the run.
+      if (
+        sess.redrivePending === true &&
+        sess.pendingTurnUuid !== undefined &&
+        history.length > 0 &&
+        history[history.length - 1]?.role === 'user'
+      ) {
+        debug(
+          `query: redriving interrupted request segment (pending ${sess.pendingTurnUuid})`,
+        );
+        const outcome = yield* driveTurn(
+          sess.pendingTurnRef ?? randomUUID(),
+          sess.pendingTurnUuid,
+        );
+        if (outcome === 'stop') return;
       }
 
       // 3. Consume user turns until the input queue closes.
@@ -1353,145 +1617,12 @@ export function query(args: {
           engineConfig.maxTurns = options.maxTurns - sessionTurns;
         }
 
-        // Delegate to the engine loop for this turn.
-        checkpointStore?.beginTurn(userUuid);
-        turnController = new AbortController();
-        // A cancel requested while no turn was active (interrupt() between turns
-        // or right after init) aborts THIS turn immediately (finding #36).
-        if (interruptRequested) {
-          interruptRequested = false;
-          turnController.abort(new AbortError('The turn was interrupted'));
-        }
-        const turnSignal = AbortSignal.any([outer.signal, turnController.signal]);
-        const toolContext: ToolContext = {
-          // EnterWorktree survives turn-boundary context rebuilds: the session
-          // state is keyed on the shared readFilePaths Set, so the per-turn
-          // context picks the active worktree up again (Bash follows via its
-          // persistent state; this covers the fs tools and subagent spawns).
-          cwd:
-            peekWorktreeSession({ readFilePaths } as ToolContext)?.dir ?? cwd,
-          // Recomputed per turn so session addDirectories / removeDirectories
-          // permission updates take real effect on the fs tools (T2-7:
-          // removeDirectories revokes; addDirectories grants).
-          additionalDirectories: gate.effectiveAdditionalDirectories(
-            options.additionalDirectories ?? [],
-          ),
-          env,
-          signal: turnSignal,
-          debug,
-          spawnSubagent: subagentRuntime.makeSpawnFn(0),
-          webSearch: options.webSearch,
-          askUser: options.onUserQuestion,
-          mcpResources: {
-            list: (server, signal) => mcpEff.listResources(server, signal),
-            read: (server, uri, signal) => mcpEff.readResource(server, uri, signal),
-          },
-          allowPrivateWebFetch: options.allowPrivateWebFetch === true,
-          recordFileChange: checkpointStore
-            ? (abs, pre): void => checkpointStore!.record(abs, pre)
-            : undefined,
-          shells,
-          sandbox: sandboxCtx,
-          readFilePaths,
-        };
-        // ExitPlanMode bridge: the tool flips this query's own gate. Attached
-        // via the tool's context extension (deliberately not part of the core
-        // ToolContext contract).
-        (toolContext as ToolContextWithPermissionGate).permissionGate = gate;
-        const deps: EngineDeps = {
-          transport,
-          builtinTools,
-          mcp: mcpEff,
-          permissions: gate,
-          hooks,
-          toolContext,
-          debug,
-          requestView,
-          drainSubagentResults: () => subagentRuntime.drainCompletedResults(),
-          drainObservability,
-        };
-
-        // The engine appends assistant + tool_result-user messages to `history`
-        // in place. It YIELDS assistant messages (persisted here at yield time,
-        // finding #34) but NOT the tool_result user turns, so we surface each
-        // appended user turn as an SDKUserMessage (finding #27) and persist it,
-        // in order, before the engine message that follows it.
-        let historyTail = history.length;
-        const flushToolResultUsers = function* (): Generator<SDKUserMessage> {
-          while (historyTail < history.length) {
-            const entry = history[historyTail];
-            historyTail += 1;
-            // Assistant entries are persisted at their own yield time; only the
-            // engine-appended tool_result user turns need surfacing here.
-            if (entry !== undefined && entry.role === 'user') {
-              persistParam(sess.sessionId, entry);
-              yield {
-                type: 'user',
-                uuid: randomUUID(),
-                session_id: sess.sessionId,
-                message: { role: 'user', content: entry.content },
-                parent_tool_use_id: null,
-              };
-            }
-          }
-        };
-
-        try {
-          for await (const msg of runAgentLoop(history, deps, engineConfig)) {
-            yield* flushToolResultUsers();
-            yield* drainMirror();
-            yield* drainObs();
-            if (msg.type === 'assistant') {
-              persistAssistant(sess.sessionId, msg.message.content);
-              yield msg;
-            } else if (msg.type === 'result') {
-              // Fold any completed subagent usage into the session totals before
-              // the result is rewritten so subagent tokens/cost are reported.
-              foldSubagentUsage(subagentRuntime.drainUsageLedger());
-              accumulateResult(msg);
-              yield rewriteResult(msg);
-            } else {
-              yield msg;
-            }
-          }
-          yield* flushToolResultUsers();
-          yield* drainMirror();
-          // Trailing lifecycle events (a background subagent that finished as
-          // the turn ended, Stop-hook responses) surface before the next turn.
-          yield* drainObs();
-        } catch (err) {
-          // Persist (but do not re-yield on error) any trailing tool_result
-          // user turn so the transcript stays durable across the failure.
-          while (historyTail < history.length) {
-            const entry = history[historyTail];
-            historyTail += 1;
-            if (entry !== undefined && entry.role === 'user') {
-              persistParam(sess.sessionId, entry);
-            }
-          }
-          if (isAbortError(err)) {
-            if (outer.signal.aborted) {
-              throw err instanceof AbortError ? err : new AbortError();
-            }
-            // Turn-level interrupt(): streaming mode keeps accepting input;
-            // string mode ends the run WITH a terminal result so an awaiting
-            // consumer is not left hanging with no explanation (finding #36).
-            debug('query: turn interrupted');
-            if (!streamingMode) {
-              endReason = 'interrupt';
-              yield terminalResult(
-                'error_during_execution',
-                sess.sessionId,
-                'The turn was interrupted',
-              );
-              return;
-            }
-            continue;
-          }
-          throw err;
-        } finally {
-          turnController = null;
-        }
+        // Delegate this turn to the shared engine driver (SM-乙b §5.2 wires
+        // the write-ahead checkpoint inside it). A 'stop' outcome (string-mode
+        // interrupt) ends the run; anything else falls through to the next
+        // input (streaming-mode interrupt or normal completion).
+        const outcome = yield* driveTurn(userUuid);
+        if (outcome === 'stop') return;
       }
     } catch (err) {
       if (isAbortError(err)) {

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -42,6 +42,7 @@ import type {
   McpRegistry,
   McpToolEntry,
   ToolContext,
+  Transport,
 } from './internal/contracts.js';
 import { AnthropicTransport } from './transport/anthropic.js';
 import { DefaultPermissionGate } from './permissions/gate.js';
@@ -324,9 +325,34 @@ type ResolvedSession = {
 // query()
 // ---------------------------------------------------------------------------
 
+/**
+ * @internal Shared-collaborator injection seam for the SessionManager
+ * (src/session-manager.ts). NOT public API — the public Options surface is
+ * unchanged and standalone query() behavior is byte-identical when this is
+ * absent.
+ *
+ * Ownership contract (谁拥有谁拆 / "whoever constructs it closes it"):
+ * a field left undefined means query() constructs its OWN collaborator and
+ * tears it down exactly as before; a field provided means the collaborator is
+ * BORROWED — the injector (the SessionManager) owns its lifecycle and this
+ * query must never close it. Query-scoped resources (shells, sandbox tmp dir,
+ * checkpoint store) are always owned and reclaimed by the query itself.
+ */
+export type QueryInternalInjection = {
+  /** Shared Messages-API transport. Stateless per-request (each stream() is an
+   *  independent fetch+SSE) so borrowing needs no teardown at all. */
+  transport?: Transport;
+  /** Shared MCP registry (manager-owned, already connect-coalesced). The query
+   *  must NOT closeAll() it — sibling conversations are multiplexing the same
+   *  server connections. */
+  mcpRegistry?: McpRegistry;
+};
+
 export function query(args: {
   prompt: string | AsyncIterable<SDKUserMessage>;
   options?: Options;
+  /** @internal See QueryInternalInjection. Absent for all public callers. */
+  _internal?: QueryInternalInjection;
 }): Query {
   const { prompt } = args;
   const options: Options = args.options ?? {};
@@ -381,12 +407,18 @@ export function query(args: {
           debug,
         })
       : localStore;
-  const transport = new AnthropicTransport({
-    provider: options.provider,
-    env,
-    debug,
-    betas: options.betas,
-  });
+  // Shared-coordination seam (SessionManager 甲): an injected transport is
+  // borrowed (manager-owned, stateless requester — nothing to tear down);
+  // otherwise construct our own exactly as before.
+  const injected = args._internal;
+  const transport: Transport =
+    injected?.transport ??
+    new AnthropicTransport({
+      provider: options.provider,
+      env,
+      debug,
+      betas: options.betas,
+    });
   // Safety interlock: bypassPermissions must be explicitly unlocked with
   // allowDangerouslySkipPermissions (matches @anthropic-ai/claude-agent-sdk).
   // Enforced for the initial mode here and for setPermissionMode() below.
@@ -484,17 +516,35 @@ export function query(args: {
 
   // Merge project .mcp.json servers (when settingSources includes 'project')
   // under the explicit options.mcpServers (which win on key collision).
-  const projectServers = loadProjectMcpServers(cwd, options.settingSources, debug);
+  //
+  // Shared-coordination seam (SessionManager 甲): an injected registry replaces
+  // local construction entirely — the server set comes from the shared layer
+  // (D1: no per-query private MCP overlay in v1), so no local merge happens
+  // and `ownsMcp` gates every teardown site below (谁拥有谁拆: the query only
+  // closes a registry it constructed itself; a borrowed one stays connected
+  // for sibling conversations and is closed by SessionManager.close() alone).
+  const ownsMcp = injected?.mcpRegistry === undefined;
+  const projectServers = ownsMcp
+    ? loadProjectMcpServers(cwd, options.settingSources, debug)
+    : {};
   const mergedServers: Record<string, McpServerConfig> = {
     ...projectServers,
-    ...(options.mcpServers ?? {}),
+    ...(ownsMcp ? (options.mcpServers ?? {}) : {}),
   };
-  const realMcp = new DefaultMcpRegistry({
-    servers: mergedServers,
-    env,
-    debug,
-    elicitation: options.onElicitation,
-  });
+  const realMcp: McpRegistry =
+    injected?.mcpRegistry ??
+    new DefaultMcpRegistry({
+      servers: mergedServers,
+      env,
+      debug,
+      elicitation: options.onElicitation,
+    });
+  // Configured MCP server count: drives ToolSearch deferral and MCP resource
+  // tool visibility. On the borrowed path the shared registry is the source of
+  // truth (statuses() lists every registered server, connected or not).
+  const mcpServerCount = ownsMcp
+    ? Object.keys(mergedServers).length
+    : realMcp.statuses().length;
   const mcp: McpRegistry =
     bareDisallowed.length > 0
       ? new ToolFilterMcpRegistry(realMcp, isBareDisallowed)
@@ -503,7 +553,7 @@ export function query(args: {
   // servers are configured (auto-activates past the threshold, or forced by
   // options.toolSearch). When null, mcpEff === mcp (exact v0.1 behavior).
   const deferred =
-    options.toolSearch !== false && Object.keys(mergedServers).length > 0
+    options.toolSearch !== false && mcpServerCount > 0
       ? new DeferredMcpRegistry(mcp, { debug })
       : null;
   const mcpEff: McpRegistry = deferred ?? mcp;
@@ -525,7 +575,7 @@ export function query(args: {
   // The MCP resource tools are only advertised by default when MCP servers
   // exist (they are no-ops otherwise). An explicit options.tools selection is
   // honored verbatim.
-  if (!Array.isArray(options.tools) && Object.keys(mergedServers).length === 0) {
+  if (!Array.isArray(options.tools) && mcpServerCount === 0) {
     builtinTools.delete('ListMcpResourcesTool');
     builtinTools.delete('ReadMcpResourceTool');
   }
@@ -1491,12 +1541,20 @@ export function query(args: {
           );
         }
       }
-      try {
-        await mcpEff.closeAll();
-      } catch (err) {
-        debug(
-          `mcp closeAll failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+      // Lifecycle contract (SessionManager 甲, proposal §4.2): whoever
+      // constructed the MCP registry closes it. A standalone query owns its
+      // registry and tears it down here exactly as before; a managed query
+      // only BORROWS the shared registry — sibling conversations are still
+      // multiplexing those connections, so closing them here is the design's
+      // #1 regression red line. mgr.close() is the single teardown point.
+      if (ownsMcp) {
+        try {
+          await mcpEff.closeAll();
+        } catch (err) {
+          debug(
+            `mcp closeAll failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
     }
   }
@@ -1680,11 +1738,15 @@ export function query(args: {
       if (!outer.signal.aborted) outer.abort(reason);
       subagentRuntime.abortAll();
       void inner.return(undefined).catch(() => undefined);
-      void mcpEff.closeAll().catch((err) => {
-        debug(
-          `mcp closeAll failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+      // Ownership contract: only close a registry this query constructed. A
+      // borrowed (SessionManager-shared) registry outlives any single query.
+      if (ownsMcp) {
+        void mcpEff.closeAll().catch((err) => {
+          debug(
+            `mcp closeAll failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
+      }
     },
   };
 

--- a/projects/bpt-agent-sdk/src/session-manager.ts
+++ b/projects/bpt-agent-sdk/src/session-manager.ts
@@ -21,8 +21,9 @@
  */
 
 import process from 'node:process';
+import { randomUUID } from 'node:crypto';
 
-import { ConfigurationError } from './errors.js';
+import { APIStatusError, ConfigurationError, errorCodeOf, isAbortError } from './errors.js';
 import { AnthropicTransport } from './transport/anthropic.js';
 import { DefaultMcpRegistry } from './mcp/registry.js';
 import { loadProjectMcpServers } from './mcp/project-config.js';
@@ -40,6 +41,7 @@ import type {
   Query,
   SDKMessage,
   SDKResultMessage,
+  SDKStatusMessage,
   SDKUserMessage,
   SessionManager,
   SessionManagerOptions,
@@ -49,6 +51,14 @@ import type {
 // ---------------------------------------------------------------------------
 // Usage accounting
 // ---------------------------------------------------------------------------
+
+/** An input stream that closes immediately: a resume re-drive replays nothing
+ *  from the caller — the resumed query's §5.2 redrive continues the
+ *  interrupted turn from the persisted transcript, then the empty stream ends
+ *  the run. */
+async function* emptyInputStream(): AsyncGenerator<SDKUserMessage, void> {
+  // Intentionally yields nothing.
+}
 
 const zeroUsage = (): NonNullableUsage => ({
   input_tokens: 0,
@@ -104,6 +114,10 @@ type QueryLedger = {
   costUsd: number;
   modelUsage: Record<string, ModelUsage>;
 };
+
+/** The error arm of the SDKResultMessage union (carries error_code /
+ *  api_error_status / errorMessage — the fields supervision classifies on). */
+type SDKResultErrorMessage = Exclude<SDKResultMessage, { subtype: 'success' }>;
 
 // ---------------------------------------------------------------------------
 // Shared registry facade
@@ -212,13 +226,6 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
     else process.stderr.write(line);
   };
 
-  if (recovery !== undefined) {
-    debug(
-      'options.recovery is accepted but has no effect yet: supervision lands ' +
-        'in the next batch (SM-乙b)',
-    );
-  }
-
   // --- Shared collaborators (§4.1) -----------------------------------------
   // One transport per manager: a stateless requester (each stream() call is an
   // independent fetch+SSE holding only config), safe to share across
@@ -314,17 +321,221 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
   }
 
   /**
-   * Single wrap point for every managed query run (the SM-乙b seam).
-   *
-   * SM-乙b (supervision/auto-resume, proposal §6) lands HERE in the next
-   * batch: it will wrap `start` in a bounded supervision loop — classify the
-   * failure via the stable error codes, re-invoke `start` with resume
-   * arguments up to recovery.maxResumes, and emit observability messages.
-   * SM-甲 only instruments usage accounting around the single run.
+   * §6.1 recovery decision — classification is by the stable machine `code`
+   * (E6c) / HTTP status, never by message text.
+   *   - recoverable: APIConnectionError (network / malformed SSE / idle
+   *     watchdog), MCP connection-class McpError, APIStatusError 429 or >=500
+   *     (transport already exhausted its own retries before surfacing);
+   *   - terminal: AbortError (user), ConfigurationError, NotImplementedError,
+   *     APIStatusError 4xx (non-429), and — fail-closed — any UNKNOWN /
+   *     codeless failure (never auto-resumed).
    */
-  function runManaged(start: () => Query, ledger: QueryLedger): Query {
-    const q = start();
-    return instrumentUsage(q, ledger);
+  function isRecoverableCode(code: string | undefined): boolean {
+    switch (code) {
+      case 'api_connection_failed':
+      case 'sse_malformed_frame':
+      case 'stream_idle_timeout':
+      case 'mcp_connect_timeout':
+      case 'mcp_connection_closed':
+      case 'mcp_server_exited':
+      case 'mcp_process_error':
+        return true;
+      default:
+        // Fail-closed: an unknown / codeless failure is never auto-resumed.
+        return false;
+    }
+  }
+
+  /** Classify a THROWN error. AbortError is the only failure this engine throws
+   *  to the query layer; API/connection failures surface as error RESULTS
+   *  (classified by isRecoverableResult). */
+  function isRecoverableError(err: unknown): boolean {
+    if (isAbortError(err)) return false;
+    if (err instanceof APIStatusError) return err.status === 429 || err.status >= 500;
+    return isRecoverableCode(errorCodeOf(err));
+  }
+
+  /** Classify an is_error RESULT (the engine's actual API-failure surface):
+   *  by HTTP status when present (429|>=500 recoverable, other 4xx terminal),
+   *  else by the stable error_code the engine stamps on the result. */
+  function isRecoverableResult(r: SDKResultErrorMessage): boolean {
+    if (r.api_error_status !== undefined) {
+      return r.api_error_status === 429 || r.api_error_status >= 500;
+    }
+    return isRecoverableCode(r.error_code);
+  }
+
+  /** §6.2 observability: one status message per auto-resume, carrying the
+   *  attempt count and the classified failure so the resume leaves a trace in
+   *  the consumer's own message stream (SDKStatusMessage — an existing
+   *  observability variant, no new type). */
+  function resumeObservation(
+    sessionId: string,
+    attempt: number,
+    maxResumes: number,
+    code: string,
+    reason: string,
+  ): SDKStatusMessage {
+    return {
+      type: 'system',
+      subtype: 'status',
+      uuid: randomUUID(),
+      session_id: sessionId,
+      status: 'auto-resume',
+      details: { attempt, maxResumes, code, reason },
+    };
+  }
+
+  /**
+   * Single wrap point for every managed query run. When `supervise` is off
+   * (no store, streaming input, or autoResume:false) this only instruments
+   * usage — behaviourally identical to SM-甲.
+   *
+   * When on, it merges usage instrumentation with the §6 supervision loop into
+   * ONE wrapped generator. DESIGN RECORD: the engine surfaces API / connection
+   * failures as an is_error RESULT message (only AbortError is thrown), so
+   * supervision keys off recoverable error RESULTS, not only throws:
+   *   - a recoverable error result is SWALLOWED (not forwarded); a status
+   *     observation is emitted and `start` is re-invoked with a resume arg so
+   *     the §5.2 redrive continues the interrupted turn — up to `maxResumes`;
+   *   - a terminal error result is FORWARDED unchanged (the honest terminal
+   *     outcome), never resumed;
+   *   - on exhaustion the last recoverable error result is forwarded with a
+   *     `resumeAttempts` field attached (the result-surface analog of the
+   *     spec's "rethrow with resumeAttempts" — preserving the engine's
+   *     result-not-throw surface keeps managed and standalone consumers
+   *     interoperable);
+   *   - a genuine THROW (AbortError) is rethrown, with `resumeAttempts`
+   *     attached iff at least one resume was tried.
+   * Standalone query() is untouched (no manager, no supervision).
+   */
+  function runManaged(
+    start: (resume?: { sessionId: string }) => Query,
+    ledger: QueryLedger,
+    supervise: boolean,
+  ): Query {
+    let q = start();
+    if (!supervise) {
+      return instrumentUsage(q, ledger);
+    }
+
+    const maxResumes = recovery?.maxResumes ?? 2;
+    let sessionId: string | undefined;
+    let attempts = 0;
+    // Status observations queued to surface (in the consumer's stream) just
+    // before the retried query's first message.
+    const observations: SDKMessage[] = [];
+
+    /** Arm a transparent resume: emit the observation, re-drive, bump count. */
+    const scheduleResume = (code: string, reason: string): void => {
+      attempts += 1;
+      debug(
+        `[session-manager] auto-resume ${attempts}/${maxResumes} ` +
+          `(session ${sessionId}, code ${code})`,
+      );
+      observations.push(
+        resumeObservation(sessionId!, attempts, maxResumes, code, reason),
+      );
+      // No prompt is re-sent (the resumed query's §5.2 redrive continues the
+      // interrupted turn against the persisted history).
+      q = start({ sessionId: sessionId! });
+    };
+
+    const wrapped: Query = {
+      async next(
+        ...nextArgs: [] | [unknown]
+      ): Promise<IteratorResult<SDKMessage, void>> {
+        for (;;) {
+          const obs = observations.shift();
+          if (obs !== undefined) return { done: false, value: obs };
+
+          let r: IteratorResult<SDKMessage, void>;
+          try {
+            r = await q.next(...nextArgs);
+          } catch (err) {
+            // The engine throws only AbortError (terminal); classify anyway.
+            if (
+              isRecoverableError(err) &&
+              sessionId !== undefined &&
+              attempts < maxResumes
+            ) {
+              scheduleResume(
+                errorCodeOf(err) ?? 'unknown',
+                err instanceof Error ? err.message : String(err),
+              );
+              continue;
+            }
+            if (attempts > 0 && err !== null && typeof err === 'object') {
+              throw Object.assign(err, { resumeAttempts: attempts });
+            }
+            throw err;
+          }
+
+          if (r.done === true) return r;
+
+          const v = r.value;
+          if (v.type === 'system' && v.subtype === 'init') {
+            sessionId = v.session_id;
+          }
+
+          // The `subtype` discriminant (not is_error) narrows to the error arm.
+          if (v.type === 'result' && v.subtype !== 'success') {
+            record(ledger, v);
+            if (
+              isRecoverableResult(v) &&
+              sessionId !== undefined &&
+              attempts < maxResumes
+            ) {
+              // Swallow this error result and re-drive transparently.
+              scheduleResume(
+                v.error_code ?? `http_${v.api_error_status ?? 'error'}`,
+                v.errorMessage ?? 'recoverable error',
+              );
+              continue;
+            }
+            // Terminal or exhausted: forward the result, annotated with the
+            // resume scene when at least one resume was tried.
+            if (attempts > 0) {
+              return {
+                done: false,
+                value: Object.assign({ ...v }, { resumeAttempts: attempts }) as SDKMessage,
+              };
+            }
+            return r;
+          }
+
+          if (v.type === 'result') record(ledger, v);
+          return r;
+        }
+      },
+      // Iterator + control plane all delegate to the CURRENT q (it is
+      // reassigned on each transparent resume), so a consumer that calls
+      // return()/throw()/interrupt()/... after a resume reaches the live query,
+      // not the abandoned one.
+      return: (value) => q.return(value),
+      throw: (err?: unknown) => q.throw(err),
+      [Symbol.asyncIterator](): Query {
+        return wrapped;
+      },
+      interrupt: () => q.interrupt(),
+      setPermissionMode: (mode) => q.setPermissionMode(mode),
+      setModel: (model) => q.setModel(model),
+      setMaxThinkingTokens: (n) => q.setMaxThinkingTokens(n),
+      initializationResult: () => q.initializationResult(),
+      supportedCommands: () => q.supportedCommands(),
+      supportedModels: () => q.supportedModels(),
+      supportedAgents: () => q.supportedAgents(),
+      mcpServerStatus: () => q.mcpServerStatus(),
+      accountInfo: () => q.accountInfo(),
+      reconnectMcpServer: (name) => q.reconnectMcpServer(name),
+      toggleMcpServer: (name, enabled) => q.toggleMcpServer(name, enabled),
+      setMcpServers: (servers) => q.setMcpServers(servers),
+      rewindFiles: (id, opts) => q.rewindFiles(id, opts),
+      stopTask: (taskId) => q.stopTask(taskId),
+      streamInput: (stream) => q.streamInput(stream),
+      close: () => q.close(),
+    };
+    return wrapped;
   }
 
   const mgr: SessionManager = {
@@ -345,14 +556,29 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
         modelUsage: {},
       };
       ledgers.push(ledger);
+      // §6.2 activation gate: supervise only when a store is attached (nowhere
+      // to resume from otherwise, R2), autoResume is not disabled, and the
+      // prompt is a string (v1 scope — a streaming-input conversation owns its
+      // own input channel and is not supervised).
+      const supervise =
+        effective.sessionStore !== undefined &&
+        recovery?.autoResume !== false &&
+        typeof queryArgs.prompt === 'string';
       return runManaged(
-        () =>
+        (resume) =>
           query({
-            prompt: queryArgs.prompt,
-            options: effective,
+            // On a resume re-drive no prompt is re-sent: an immediately-closing
+            // input stream lets the resumed query's §5.2 redrive continue the
+            // interrupted turn, then end.
+            prompt: resume !== undefined ? emptyInputStream() : queryArgs.prompt,
+            options:
+              resume !== undefined
+                ? { ...effective, resume: resume.sessionId }
+                : effective,
             _internal: { transport, mcpRegistry: shared },
           }),
         ledger,
+        supervise,
       );
     },
 

--- a/projects/bpt-agent-sdk/src/session-manager.ts
+++ b/projects/bpt-agent-sdk/src/session-manager.ts
@@ -1,0 +1,383 @@
+/**
+ * SessionManager (SM-甲): in-process shared coordination across conversations.
+ *
+ * Implements 职责一 of the approved proposal
+ * (Public-Info-Pool/Resource/proposal/bpt-sdk-session-manager-20260706.md):
+ * one shared AnthropicTransport + one shared MCP registry per manager, with
+ * every mgr.query() borrowing both instead of constructing its own
+ * (the src/query.ts:384/:492 lift). BPT-EXTENSION — the official SDK has no
+ * in-process multi-conversation coordinator.
+ *
+ * Lifecycle contract (§4.2, the design's #1 correctness constraint):
+ *   - the MANAGER owns the shared connections (connectAll once, coalesced);
+ *   - queries BORROW and never close them (query.ts guards every closeAll
+ *     site with `ownsMcp`);
+ *   - mgr.close() is the single teardown point; after close(), mgr.query()
+ *     throws ConfigurationError.
+ *
+ * 职责二 (persistence + supervision, §5/§6) belongs to SM-乙: this file only
+ * leaves the seams — `options.recovery` is typed-but-inert and runManaged()
+ * is the single wrap point where the supervision loop will land.
+ */
+
+import process from 'node:process';
+
+import { ConfigurationError } from './errors.js';
+import { AnthropicTransport } from './transport/anthropic.js';
+import { DefaultMcpRegistry } from './mcp/registry.js';
+import { loadProjectMcpServers } from './mcp/project-config.js';
+import { query } from './query.js';
+import type { McpRegistry, McpToolEntry } from './internal/contracts.js';
+import type {
+  CallToolResult,
+  McpResource,
+  McpResourceContent,
+  McpServerConfig,
+  McpServerStatus,
+  ModelUsage,
+  NonNullableUsage,
+  Options,
+  Query,
+  SDKMessage,
+  SDKResultMessage,
+  SDKUserMessage,
+  SessionManager,
+  SessionManagerOptions,
+  SessionManagerUsage,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Usage accounting
+// ---------------------------------------------------------------------------
+
+const zeroUsage = (): NonNullableUsage => ({
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_creation_input_tokens: 0,
+  cache_read_input_tokens: 0,
+});
+
+function addUsage(a: NonNullableUsage, b: NonNullableUsage): NonNullableUsage {
+  return {
+    input_tokens: a.input_tokens + b.input_tokens,
+    output_tokens: a.output_tokens + b.output_tokens,
+    cache_creation_input_tokens:
+      a.cache_creation_input_tokens + b.cache_creation_input_tokens,
+    cache_read_input_tokens: a.cache_read_input_tokens + b.cache_read_input_tokens,
+  };
+}
+
+/** Additive merge of one per-model usage map into an accumulator (same
+ *  semantics as query.ts's session accumulator: counters add, static
+ *  per-model figures latest-wins with fallback). */
+function mergeModelUsage(
+  into: Record<string, ModelUsage>,
+  from: Record<string, ModelUsage>,
+): void {
+  for (const [modelId, mu] of Object.entries(from)) {
+    const prev = into[modelId];
+    into[modelId] =
+      prev === undefined
+        ? { ...mu }
+        : {
+            inputTokens: prev.inputTokens + mu.inputTokens,
+            outputTokens: prev.outputTokens + mu.outputTokens,
+            cacheReadInputTokens: prev.cacheReadInputTokens + mu.cacheReadInputTokens,
+            cacheCreationInputTokens:
+              prev.cacheCreationInputTokens + mu.cacheCreationInputTokens,
+            webSearchRequests: prev.webSearchRequests + mu.webSearchRequests,
+            costUSD: prev.costUSD + mu.costUSD,
+            contextWindow: mu.contextWindow ?? prev.contextWindow,
+            maxOutputTokens: mu.maxOutputTokens ?? prev.maxOutputTokens,
+          };
+  }
+}
+
+/**
+ * Per-conversation ledger. Result messages carry two reporting semantics
+ * (E2/KD-L5-04): `usage` is THAT turn's own figures (summed here), while
+ * `total_cost_usd` / `modelUsage` are conversation-cumulative (latest snapshot
+ * wins here). usage() folds the ledgers at read time.
+ */
+type QueryLedger = {
+  usage: NonNullableUsage;
+  costUsd: number;
+  modelUsage: Record<string, ModelUsage>;
+};
+
+// ---------------------------------------------------------------------------
+// Shared registry facade
+// ---------------------------------------------------------------------------
+
+/**
+ * Manager-owned view of the shared DefaultMcpRegistry handed to every managed
+ * query. Two jobs:
+ *
+ * 1. connect-once latch: connectAll() coalesces every caller (the manager's
+ *    constructor kick-off AND each query's own connect barrier) onto ONE
+ *    in-flight connect, so a query starting while the manager is still
+ *    connecting can never double-spawn a stdio server or double-open an HTTP
+ *    session.
+ * 2. defense-in-depth on the lifecycle contract: borrowers cannot tear the
+ *    shared pool down. query.ts's `ownsMcp` guard is the primary protection
+ *    (a managed query never calls closeAll); this facade additionally makes
+ *    closeAll() a no-op and setServers() an explicit ConfigurationError, so
+ *    even a Query.setMcpServers() control call cannot dismantle connections
+ *    that sibling conversations are multiplexing. Teardown authority lives in
+ *    SessionManager.close() alone, which closes the INNER registry directly.
+ */
+class SharedMcpRegistry implements McpRegistry {
+  private connectOnce: Promise<void> | null = null;
+
+  constructor(
+    private readonly inner: DefaultMcpRegistry,
+    private readonly debug: (msg: string) => void,
+  ) {}
+
+  connectAll(): Promise<void> {
+    this.connectOnce ??= this.inner.connectAll();
+    return this.connectOnce;
+  }
+  statuses(): McpServerStatus[] {
+    return this.inner.statuses();
+  }
+  allTools(): McpToolEntry[] {
+    return this.inner.allTools();
+  }
+  has(qualifiedName: string): boolean {
+    return this.inner.has(qualifiedName);
+  }
+  call(
+    qualifiedName: string,
+    args: Record<string, unknown>,
+    signal: AbortSignal,
+  ): Promise<CallToolResult> {
+    return this.inner.call(qualifiedName, args, signal);
+  }
+  listResources(server: string | undefined, signal: AbortSignal): Promise<McpResource[]> {
+    return this.inner.listResources(server, signal);
+  }
+  readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]> {
+    return this.inner.readResource(server, uri, signal);
+  }
+  reconnect(serverName: string): Promise<void> {
+    return this.inner.reconnect(serverName);
+  }
+  setEnabled(serverName: string, enabled: boolean): void {
+    this.inner.setEnabled(serverName, enabled);
+  }
+  setServers(): Promise<void> {
+    // setServers() internally closes every connection before swapping the set
+    // — from a borrower that is exactly the #1 red line, so it is refused
+    // loudly rather than ignored quietly.
+    return Promise.reject(
+      new ConfigurationError(
+        'setMcpServers is not available on a SessionManager-managed query: ' +
+          'the MCP server set is owned by the shared layer (configure it on ' +
+          'createBptSession).',
+      ),
+    );
+  }
+  closeAll(): Promise<void> {
+    // Borrowers never tear down the shared pool (lifecycle contract §4.2).
+    this.debug(
+      '[session-manager] closeAll() ignored on the shared MCP registry ' +
+        '(manager-owned; use SessionManager.close())',
+    );
+    return Promise.resolve();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// createBptSession()
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a SessionManager: the in-process coordinator sharing one transport +
+ * one MCP connection pool across many query() conversations (BPT-EXTENSION,
+ * proposal 层一 职责一). See the SessionManager interface JSDoc in types.ts
+ * for the API contract.
+ */
+export function createBptSession(options: SessionManagerOptions = {}): SessionManager {
+  const { recovery, ...base } = options;
+
+  const cwd = base.cwd ?? process.cwd();
+  const env: Record<string, string | undefined> = base.env ?? process.env;
+  const debugEnabled = base.debug === true;
+  const stderrCb = base.stderr;
+  const debug = (msg: string): void => {
+    if (!debugEnabled) return;
+    const line = `[bpt-agent-sdk] ${msg}\n`;
+    if (stderrCb !== undefined) stderrCb(line);
+    else process.stderr.write(line);
+  };
+
+  if (recovery !== undefined) {
+    debug(
+      'options.recovery is accepted but has no effect yet: supervision lands ' +
+        'in the next batch (SM-乙b)',
+    );
+  }
+
+  // --- Shared collaborators (§4.1) -----------------------------------------
+  // One transport per manager: a stateless requester (each stream() call is an
+  // independent fetch+SSE holding only config), safe to share across
+  // concurrent conversations.
+  const transport = new AnthropicTransport({
+    provider: base.provider,
+    env,
+    debug,
+    betas: base.betas,
+  });
+  // One MCP registry per manager: same merge the standalone query() performs
+  // (project .mcp.json under explicit mcpServers), built once, connected once.
+  // Responses are request-id correlated, so cross-conversation concurrency
+  // multiplexes without cross-talk (§4.1).
+  const projectServers = loadProjectMcpServers(cwd, base.settingSources, debug);
+  const mergedServers: Record<string, McpServerConfig> = {
+    ...projectServers,
+    ...(base.mcpServers ?? {}),
+  };
+  const registry = new DefaultMcpRegistry({
+    servers: mergedServers,
+    env,
+    debug,
+    elicitation: base.onElicitation,
+  });
+  const shared = new SharedMcpRegistry(registry, debug);
+  // Kick the shared connect off at construction; connectAll never throws
+  // (per-server failures land in statuses). Queries' own connect barriers
+  // coalesce onto this same promise via the facade latch.
+  void shared.connectAll();
+
+  // --- Manager state ---------------------------------------------------------
+  let closed = false;
+  const ledgers: QueryLedger[] = [];
+
+  /** Validate + assemble the effective options for one managed query.
+   *  Per-query options override per-conversation knobs; provider/mcpServers
+   *  come from the shared layer only (D1). */
+  function managedOptions(perQuery: Options | undefined): Options {
+    if (perQuery?.provider !== undefined) {
+      throw new ConfigurationError(
+        "SessionManager.query: per-query 'provider' is not supported — the " +
+          'transport is shared and configured once on createBptSession().',
+      );
+    }
+    if (perQuery?.mcpServers !== undefined) {
+      throw new ConfigurationError(
+        "SessionManager.query: per-query 'mcpServers' is not supported (D1) — " +
+          'MCP servers come from the shared pool configured on ' +
+          'createBptSession(); a private per-query MCP overlay is deferred to v2.',
+      );
+    }
+    const merged: Options = { ...base, ...perQuery };
+    // The registry is injected; the query must not re-merge a server set of
+    // its own (query.ts also short-circuits this on the borrowed path).
+    delete merged.mcpServers;
+    return merged;
+  }
+
+  /** Fold one result message into this conversation's ledger. The update is
+   *  a synchronous single-tick read-modify-write — JS's run-to-completion
+   *  semantics make it atomic (the serialization §4.1 asks of the aggregate
+   *  ledger). Do not introduce an await between the reads and writes. */
+  function record(ledger: QueryLedger, r: SDKResultMessage): void {
+    ledger.usage = addUsage(ledger.usage, r.usage); // per-turn figures: sum
+    ledger.costUsd = r.total_cost_usd; // conversation-cumulative: latest wins
+    const snapshot: Record<string, ModelUsage> = {};
+    mergeModelUsage(snapshot, r.modelUsage); // deep copy
+    ledger.modelUsage = snapshot; // conversation-cumulative: latest wins
+  }
+
+  /** Wrap a managed query so its result stream feeds the usage ledger while
+   *  every control method delegates to the underlying Query untouched. */
+  function instrumentUsage(q: Query, ledger: QueryLedger): Query {
+    const wrapped: Query = {
+      ...q,
+      next: async (
+        ...nextArgs: [] | [unknown]
+      ): Promise<IteratorResult<SDKMessage, void>> => {
+        const r = await q.next(...nextArgs);
+        if (r.done !== true && r.value.type === 'result') {
+          record(ledger, r.value);
+        }
+        return r;
+      },
+      return: (value) => q.return(value),
+      throw: (err?: unknown) => q.throw(err),
+      [Symbol.asyncIterator](): Query {
+        return wrapped;
+      },
+    };
+    return wrapped;
+  }
+
+  /**
+   * Single wrap point for every managed query run (the SM-乙b seam).
+   *
+   * SM-乙b (supervision/auto-resume, proposal §6) lands HERE in the next
+   * batch: it will wrap `start` in a bounded supervision loop — classify the
+   * failure via the stable error codes, re-invoke `start` with resume
+   * arguments up to recovery.maxResumes, and emit observability messages.
+   * SM-甲 only instruments usage accounting around the single run.
+   */
+  function runManaged(start: () => Query, ledger: QueryLedger): Query {
+    const q = start();
+    return instrumentUsage(q, ledger);
+  }
+
+  const mgr: SessionManager = {
+    query(queryArgs: {
+      prompt: string | AsyncIterable<SDKUserMessage>;
+      options?: Options;
+    }): Query {
+      if (closed) {
+        throw new ConfigurationError(
+          'SessionManager is closed: its shared connections were torn down. ' +
+            'Create a new manager with createBptSession().',
+        );
+      }
+      const effective = managedOptions(queryArgs.options);
+      const ledger: QueryLedger = {
+        usage: zeroUsage(),
+        costUsd: 0,
+        modelUsage: {},
+      };
+      ledgers.push(ledger);
+      return runManaged(
+        () =>
+          query({
+            prompt: queryArgs.prompt,
+            options: effective,
+            _internal: { transport, mcpRegistry: shared },
+          }),
+        ledger,
+      );
+    },
+
+    usage(): SessionManagerUsage {
+      let totalCostUsd = 0;
+      let usage = zeroUsage();
+      const modelUsage: Record<string, ModelUsage> = {};
+      for (const ledger of ledgers) {
+        totalCostUsd += ledger.costUsd;
+        usage = addUsage(usage, ledger.usage);
+        mergeModelUsage(modelUsage, ledger.modelUsage);
+      }
+      return { totalCostUsd, usage, modelUsage, queries: ledgers.length };
+    },
+
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      // Unified teardown (§4.2): the manager closes the INNER registry
+      // directly — the facade's closeAll is a borrower-facing no-op. The
+      // shared transport holds no open resources between calls (stateless
+      // requester), so there is nothing further to release.
+      await registry.closeAll();
+    },
+  };
+
+  return mgr;
+}

--- a/projects/bpt-agent-sdk/src/sessions/file-store.ts
+++ b/projects/bpt-agent-sdk/src/sessions/file-store.ts
@@ -1,0 +1,313 @@
+/**
+ * Built-in file-backed external SessionStore (SM-B.a, SessionManager
+ * proposal §5.1: "堵 G1" — persistence lands with ONE line of wiring).
+ *
+ * `fileSessionStore(dir)` returns an implementation of the PUBLIC
+ * `SessionStore` contract from ../types.js (the same surface
+ * `InMemorySessionStore` references) that persists each session key to its
+ * own JSONL file:
+ *
+ *   {dir}/
+ *     {enc(projectKey)}/
+ *       {enc(sessionId)}/
+ *         main.jsonl                 <- subpath === undefined | ''
+ *         sub/
+ *           {enc(subpath)}.jsonl     <- one file per subkey
+ *
+ * Every key component is percent-encoded byte-wise (only [A-Za-z0-9._-]
+ * pass through) before it touches the filesystem, so an attacker-controlled
+ * sessionId such as `../../etc/cron.d` can never traverse out of `dir`:
+ * `/`, `\` and `%` are all escaped, and the exact names `.` / `..` / `` are
+ * mapped to reserved escapes. The encoding is reversible, which is what lets
+ * listSessions()/listSubkeys() recover the ORIGINAL ids from directory
+ * names (a lossy sanitizer like store.ts's isSafeSessionId gate could not).
+ * This mirrors the attack-surface stance documented on SAFE_SESSION_ID in
+ * ./store.js: ids arrive straight from an embedder's request and this
+ * encoder is the single choke point that keeps reads and writes inside the
+ * store root.
+ *
+ * Durability / concurrency semantics (LOCK-FREE — the honest boundary):
+ *  - append() serializes the whole batch to one string and issues ONE
+ *    `fs.appendFile` (open with O_APPEND). Within a single process, Node
+ *    serializes each appendFile through the thread pool as one open/write/
+ *    close sequence, and for batch payloads up to typical entry sizes the
+ *    data lands in a single write(2), so concurrent queries mirroring into
+ *    the SAME session file do not interleave bytes mid-line; ordering
+ *    ACROSS concurrently flushed batches is unspecified.
+ *  - Cross-process: no lock file is taken and none is promised. O_APPEND
+ *    keeps each write positioned at EOF atomically on local POSIX
+ *    filesystems, so whole-line integrity holds in practice, but two
+ *    processes appending the same session get an unspecified interleaving
+ *    order, and NFS-style filesystems void even the positioning guarantee.
+ *  - Crash tolerance: a process dying mid-write leaves a torn final line.
+ *    load() tolerates that: any line that fails JSON.parse (torn tail or
+ *    corrupt middle) is silently dropped, every intact line survives.
+ *    append() also self-heals the torn tail: the FIRST append to each file
+ *    per store instance checks the file's last byte and, when it is not a
+ *    newline, prefixes the batch with '\n' — otherwise the fresh line would
+ *    glue onto the torn tail and BOTH lines would be lost. A racing double
+ *    check at worst writes an extra blank line, which load() skips.
+ *  - Dedup: load() drops repeated `entry.uuid`s (first occurrence wins),
+ *    matching InMemorySessionStore's append-side dedup. Doing it at read
+ *    time keeps append() a single blind O_APPEND write and stays correct
+ *    even when a retried batch was appended twice.
+ */
+
+import { Buffer } from 'node:buffer';
+import { appendFile, mkdir, open, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+import type {
+  SessionKey,
+  SessionStore,
+  SessionStoreEntry,
+  SessionStoreListEntry,
+} from '../types.js';
+
+const MAIN_FILE = 'main.jsonl';
+const SUB_DIR = 'sub';
+const JSONL_EXT = '.jsonl';
+
+/** Filename-safe bytes that pass through the encoder unescaped. */
+const SAFE_BYTES: ReadonlySet<number> = (() => {
+  const s = new Set<number>();
+  const add = (from: string, to: string) => {
+    for (let c = from.charCodeAt(0); c <= to.charCodeAt(0); c += 1) s.add(c);
+  };
+  add('A', 'Z');
+  add('a', 'z');
+  add('0', '9');
+  for (const ch of '._-') s.add(ch.charCodeAt(0));
+  return s;
+})();
+
+/**
+ * Encode one key component (projectKey / sessionId / subpath) into a single
+ * safe filename. Byte-wise percent-encoding: bytes outside [A-Za-z0-9._-]
+ * become `%XX`. Reversible via decodeKeyComponent. The only names the safe
+ * charset could still produce that are dangerous as filenames — `.`, `..`
+ * and the empty string — are mapped to reserved escape forms (`%2E`,
+ * `%2E%2E`, `%`; a literal `%` in input always encodes to `%25`, so the
+ * bare-`%` empty marker cannot collide).
+ */
+export function encodeKeyComponent(raw: string): string {
+  if (raw === '') return '%';
+  let out = '';
+  for (const b of Buffer.from(raw, 'utf8')) {
+    out += SAFE_BYTES.has(b)
+      ? String.fromCharCode(b)
+      : `%${b.toString(16).toUpperCase().padStart(2, '0')}`;
+  }
+  if (out === '.') return '%2E';
+  if (out === '..') return '%2E%2E';
+  return out;
+}
+
+/** Reverse encodeKeyComponent (used to list original ids from filenames). */
+export function decodeKeyComponent(name: string): string {
+  if (name === '%') return '';
+  const bytes: number[] = [];
+  for (let i = 0; i < name.length; i += 1) {
+    const hex = name[i] === '%' ? name.slice(i + 1, i + 3) : '';
+    if (/^[0-9A-Fa-f]{2}$/.test(hex)) {
+      bytes.push(Number.parseInt(hex, 16));
+      i += 2;
+      continue;
+    }
+    bytes.push(name.charCodeAt(i));
+  }
+  return Buffer.from(bytes).toString('utf8');
+}
+
+/** Expand a leading `~`/`~/` to the home directory (proposal usage shows
+ *  `fileSessionStore('~/.bpt/sessions')`). */
+function expandTilde(dir: string): string {
+  if (dir === '~') return homedir();
+  if (dir.startsWith('~/')) return join(homedir(), dir.slice(2));
+  return dir;
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+/**
+ * File-backed implementation of the public SessionStore contract. See the
+ * module doc for layout, path-safety and lock-free durability semantics.
+ */
+export class FileSessionStore implements SessionStore {
+  private readonly root: string;
+
+  /** Files whose tail byte was already verified by this instance. */
+  private readonly tailChecked = new Set<string>();
+
+  constructor(dir: string) {
+    this.root = resolve(expandTilde(dir));
+  }
+
+  /** Directory holding everything for one (projectKey, sessionId). */
+  private sessionDir(key: { projectKey: string; sessionId: string }): string {
+    return join(
+      this.root,
+      encodeKeyComponent(key.projectKey),
+      encodeKeyComponent(key.sessionId),
+    );
+  }
+
+  /** JSONL file for one full key (main transcript or subkey). */
+  private filePath(key: SessionKey): string {
+    const base = this.sessionDir(key);
+    const subpath = key.subpath ?? '';
+    if (subpath === '') return join(base, MAIN_FILE);
+    return join(base, SUB_DIR, `${encodeKeyComponent(subpath)}${JSONL_EXT}`);
+  }
+
+  /**
+   * True when the file exists, is non-empty and does NOT end in a newline —
+   * i.e. a previous process crashed mid-append and left a torn tail.
+   */
+  private async endsWithoutNewline(file: string): Promise<boolean> {
+    let fh;
+    try {
+      fh = await open(file, 'r');
+    } catch (err) {
+      if (isEnoent(err)) return false;
+      throw err;
+    }
+    try {
+      const st = await fh.stat();
+      if (st.size === 0) return false;
+      const buf = Buffer.alloc(1);
+      await fh.read(buf, 0, 1, st.size - 1);
+      return buf[0] !== 0x0a;
+    } finally {
+      await fh.close();
+    }
+  }
+
+  /**
+   * Append a batch: one JSON object per line, whole batch in ONE
+   * O_APPEND write call. Missing directories are created (mkdir -p).
+   * The first append per file heals a crash-torn tail (see module doc).
+   */
+  async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    const file = this.filePath(key);
+    await mkdir(dirname(file), { recursive: true });
+    let prefix = '';
+    if (!this.tailChecked.has(file)) {
+      this.tailChecked.add(file);
+      if (await this.endsWithoutNewline(file)) prefix = '\n';
+    }
+    let payload = prefix;
+    for (const e of entries) payload += `${JSON.stringify(e)}\n`;
+    await appendFile(file, payload, { encoding: 'utf8', flag: 'a' });
+  }
+
+  /**
+   * Load the full entry list for a key, or null when the key was never
+   * appended to. Torn/corrupt lines (crash mid-append is a NORMAL event)
+   * are silently dropped; duplicate `uuid`s keep the first occurrence.
+   */
+  async load(key: SessionKey): Promise<SessionStoreEntry[] | null> {
+    let raw: string;
+    try {
+      raw = await readFile(this.filePath(key), 'utf8');
+    } catch (err) {
+      if (isEnoent(err)) return null;
+      throw err;
+    }
+    const out: SessionStoreEntry[] = [];
+    const seen = new Set<string>();
+    for (const line of raw.split('\n')) {
+      if (line.trim() === '') continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue; // torn tail from a crash, or a corrupt middle line
+      }
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        continue; // JSONL entries are objects; scalars are line debris
+      }
+      const entry = parsed as SessionStoreEntry;
+      if (typeof entry.uuid === 'string') {
+        if (seen.has(entry.uuid)) continue;
+        seen.add(entry.uuid);
+      }
+      out.push(entry);
+    }
+    return out;
+  }
+
+  /**
+   * List sessions that have a MAIN transcript under a project key, newest
+   * first (mtime of main.jsonl). Subkey-only sessions are not listed,
+   * matching InMemorySessionStore.
+   */
+  async listSessions(projectKey: string): Promise<SessionStoreListEntry[]> {
+    const projectDir = join(this.root, encodeKeyComponent(projectKey));
+    let names: string[];
+    try {
+      names = await readdir(projectDir);
+    } catch (err) {
+      if (isEnoent(err)) return [];
+      throw err;
+    }
+    const out: SessionStoreListEntry[] = [];
+    for (const name of names) {
+      try {
+        const st = await stat(join(projectDir, name, MAIN_FILE));
+        out.push({ sessionId: decodeKeyComponent(name), mtime: st.mtimeMs });
+      } catch (err) {
+        if (!isEnoent(err)) throw err; // no main transcript -> not a session
+      }
+    }
+    out.sort((a, b) => b.mtime - a.mtime);
+    return out;
+  }
+
+  /** Delete a subkey file, or (for a main key) the whole session directory
+   *  — cascading to every subkey, matching InMemorySessionStore. */
+  async delete(key: SessionKey): Promise<void> {
+    const isMain = key.subpath === undefined || key.subpath === '';
+    if (isMain) {
+      await rm(this.sessionDir(key), { recursive: true, force: true });
+      return;
+    }
+    await rm(this.filePath(key), { force: true });
+  }
+
+  /** List the ORIGINAL subpath strings that have subkey files. */
+  async listSubkeys(key: { projectKey: string; sessionId: string }): Promise<string[]> {
+    const subDir = join(this.sessionDir(key), SUB_DIR);
+    let names: string[];
+    try {
+      names = await readdir(subDir);
+    } catch (err) {
+      if (isEnoent(err)) return [];
+      throw err;
+    }
+    const out: string[] = [];
+    for (const name of names) {
+      if (!name.endsWith(JSONL_EXT)) continue;
+      out.push(decodeKeyComponent(name.slice(0, -JSONL_EXT.length)));
+    }
+    return out;
+  }
+}
+
+/**
+ * Built-in file store factory (SessionManager proposal §5.1): the one-line
+ * wiring for `options.sessionStore` / the future SessionManager `store`
+ * option. Persistence stays OFF unless the embedder passes this in (R1:
+ * the library never writes to disk on its own initiative).
+ */
+export function fileSessionStore(dir: string): FileSessionStore {
+  return new FileSessionStore(dir);
+}

--- a/projects/bpt-agent-sdk/src/sessions/store.ts
+++ b/projects/bpt-agent-sdk/src/sessions/store.ts
@@ -8,6 +8,10 @@
  *   { type: 'user' | 'assistant', message: { role, content }, ... }
  * renameSession/tagSession append meta_update records (last write wins):
  *   { type: 'meta_update', uuid, customTitle? | tag? | gitBranch? }
+ * SM-乙b §5.2 write-ahead checkpoints bracket each turn's API request segment
+ * (they are control records, never replayed as conversation messages):
+ *   { type: 'pending_turn', uuid, timestamp, turn_ref }
+ *   { type: 'turn_complete', uuid, timestamp, pending_uuid }
  * Corrupt or unrecognized lines are skipped with a debug warning so a
  * damaged transcript never blocks a resume.
  */
@@ -257,6 +261,10 @@ export class JsonlSessionStore implements SessionStore {
     let tag: string | undefined;
     let gitBranch: string | undefined;
     const messages: APIMessageParam[] = [];
+    // SM-乙b §5.2 write-ahead checkpoints: pending_turn opens a request
+    // segment, turn_complete settles it. Insertion order is preserved so the
+    // LAST unsettled entry is the most recent interruption.
+    const openPending = new Map<string, string | undefined>();
 
     const lines = raw.split('\n');
     for (let i = 0; i < lines.length; i += 1) {
@@ -297,6 +305,26 @@ export class JsonlSessionStore implements SessionStore {
         continue;
       }
 
+      // SM-乙b §5.2: write-ahead checkpoint records are transcript-control
+      // lines, NOT conversation messages — recognized here so they are (a)
+      // filtered out of the replayed message list (like meta/meta_update) and
+      // (b) folded into the dangling-interruption evidence resume consumes.
+      if (entry.type === 'pending_turn') {
+        if (typeof entry.uuid === 'string') {
+          openPending.set(
+            entry.uuid,
+            typeof entry.turn_ref === 'string' ? entry.turn_ref : undefined,
+          );
+        }
+        continue;
+      }
+      if (entry.type === 'turn_complete') {
+        if (typeof entry.pending_uuid === 'string') {
+          openPending.delete(entry.pending_uuid);
+        }
+        continue;
+      }
+
       if (entry.type === 'user' || entry.type === 'assistant') {
         const message = entry.message as { content?: unknown } | undefined;
         const content = message?.content;
@@ -325,6 +353,14 @@ export class JsonlSessionStore implements SessionStore {
       // File raced away between read and stat; keep what we parsed.
     }
 
+    // Most recent dangling pending_turn (insertion order; last wins).
+    let pendingTurnUuid: string | undefined;
+    let pendingTurnRef: string | undefined;
+    for (const [uuid, ref] of openPending) {
+      pendingTurnUuid = uuid;
+      pendingTurnRef = ref;
+    }
+
     return {
       sessionId,
       messages: repairPairing(messages, this.debug, sessionId),
@@ -335,6 +371,13 @@ export class JsonlSessionStore implements SessionStore {
       customTitle,
       tag,
       gitBranch,
+      ...(pendingTurnUuid !== undefined
+        ? {
+            pendingTurnInterrupted: true,
+            pendingTurnUuid,
+            ...(pendingTurnRef !== undefined ? { pendingTurnRef } : {}),
+          }
+        : {}),
     };
   }
 

--- a/projects/bpt-agent-sdk/src/tools/bash.ts
+++ b/projects/bpt-agent-sdk/src/tools/bash.ts
@@ -11,7 +11,7 @@ import { spawn } from 'node:child_process';
 import { resolvePosixShells, SHELL_NOT_FOUND_GUIDANCE } from './shell-resolve.js';
 import { planProcessKill } from './kill-plan.js';
 import { AbortError } from '../errors.js';
-import { BASH_DESCRIPTION, buildBashSandboxNote } from './descriptions.js';
+import { BASH_DESCRIPTION, BASH_WIN32_NOTE, buildBashSandboxNote } from './descriptions.js';
 import { planShellSpawn } from '../sandbox/backend.js';
 import { detectSandboxEvidence, sandboxFailureHint } from '../sandbox/evidence.js';
 import type { SandboxContext } from '../types.js';
@@ -263,6 +263,63 @@ function withPersistentState(command: string, stateDir: string): string {
 }
 
 /**
+ * Windows-cmd habit correction (BPT pilot incident 2026-07-06: on Windows
+ * hosts the model kept writing cmd.exe spellings — copy/move/del/findstr —
+ * into the Bash tool, burning turns on retries). Two layers:
+ *   - description layer: BASH_WIN32_NOTE is appended to the Bash description
+ *     ONLY when the platform is win32 (createBashTool below — same
+ *     conditional-assembly pattern as the sandbox note; non-win32
+ *     descriptions stay byte-identical).
+ *   - error layer (all platforms): when a command exits 127 (command not
+ *     found) and its FIRST command word is a cmd.exe-only word, the error
+ *     text gains a one-line correction (windowsCmdHint below).
+ *
+ * The word list is high-confidence only, to avoid false positives:
+ * `dir` and `type` are deliberately EXCLUDED — `dir` is a real GNU coreutils
+ * command and `type` is a bash builtin, so both succeed in bash and must not
+ * be steered away from.
+ */
+const CMD_ONLY_WORDS = new Set([
+  'copy',
+  'move',
+  'del',
+  'erase',
+  'xcopy',
+  'robocopy',
+  'findstr',
+  'cls',
+  'md',
+  'rd',
+  'ren',
+]);
+
+const CMD_NOT_FOUND_HINT =
+  'Note: this shell is POSIX bash, not Windows cmd — use cp/mv/rm/grep ' +
+  'instead of copy/move/del/findstr.';
+
+/**
+ * Return the cmd-habit correction to append to a failure, or '' when it does
+ * not apply. Fires only on exit code 127 (command not found) with the first
+ * command word in CMD_ONLY_WORDS. First-word extraction is deliberately
+ * simple: trim, skip leading VAR=value env assignments, take the first
+ * whitespace-delimited token (matched case-insensitively — cmd habits often
+ * arrive uppercased). Compound commands (`&&`, `;`, pipes) are only checked
+ * at the very front of the string: a cmd word later in the line does not
+ * trigger the hint (kept simple by design; the 127 still surfaces normally).
+ */
+export function windowsCmdHint(command: string, exitCode: number | null): string {
+  if (exitCode !== 127) return '';
+  let first = '';
+  for (const token of command.trim().split(/\s+/)) {
+    // Skip leading environment assignments (FOO=bar cmd ...).
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) continue;
+    first = token;
+    break;
+  }
+  return CMD_ONLY_WORDS.has(first.toLowerCase()) ? '\n\n' + CMD_NOT_FOUND_HINT : '';
+}
+
+/**
  * Build the Bash tool, gated on the active sandbox (G-SANDBOX):
  *   - description: BASH_DESCRIPTION alone when unsandboxed; + the faithful
  *     sandbox note (default/mandatory mode) when a sandbox is active.
@@ -277,14 +334,22 @@ function withPersistentState(command: string, stateDir: string): string {
  *     The gating red line still applies to the DESCRIPTION: the sandbox note
  *     (and mandatory-mode "disabled by policy" wording) stays state-gated.
  * `createBashTool()` with no argument returns the unsandboxed tool with a
- * byte-identical description (locks tests that import `bashTool` directly).
+ * byte-identical description on non-win32 hosts (locks tests that import
+ * `bashTool` directly). On win32 the platform note (BASH_WIN32_NOTE) is
+ * appended — same gated-assembly pattern as the sandbox note; `platform` is
+ * injectable for tests only.
  */
-export function createBashTool(sandbox?: SandboxContext): BuiltinTool {
+export function createBashTool(
+  sandbox?: SandboxContext,
+  platform: NodeJS.Platform = process.platform,
+): BuiltinTool {
   const active = sandbox !== undefined;
   const mode = sandbox?.allowEscape === false ? 'mandatory' : 'default';
-  const description = active
-    ? BASH_DESCRIPTION + '\n\n' + buildBashSandboxNote(mode, sandbox.allowNetwork)
-    : BASH_DESCRIPTION;
+  let description = BASH_DESCRIPTION;
+  // Gated like the sandbox note: appended ONLY on win32, so the non-win32
+  // description stays byte-identical (conformance wire runs on Linux CI).
+  if (platform === 'win32') description += '\n\n' + BASH_WIN32_NOTE;
+  if (active) description += '\n\n' + buildBashSandboxNote(mode, sandbox.allowNetwork);
   const properties: Record<string, unknown> = {
     command: {
       type: 'string',
@@ -323,7 +388,8 @@ export function createBashTool(sandbox?: SandboxContext): BuiltinTool {
 }
 
 /** The default (unsandboxed) Bash tool — description byte-identical to
- *  pre-sandbox; the schema carries the always-on escape param (no-op here). */
+ *  pre-sandbox on non-win32 hosts (win32 gains the gated platform note);
+ *  the schema carries the always-on escape param (no-op here). */
 export const bashTool: BuiltinTool = createBashTool();
 
 async function execute(
@@ -464,8 +530,12 @@ async function execute(
       const sig = detectSandboxEvidence(outcome.code, outcome.stderr, ctx.sandbox.allowNetwork);
       if (sig !== null) hint = '\n\n' + sandboxFailureHint(sig, ctx.sandbox.allowEscape);
     }
+    // cmd-habit correction (all platforms): 127 + a cmd.exe-only first word
+    // gets a one-line steer to the POSIX spellings. Checked against the
+    // MODEL's command, not the persistent-state wrapper.
+    const cmdHint = windowsCmdHint(command, outcome.code);
     return {
-      content: failure + (streams.length > 0 ? `\n${streams}` : '') + hint,
+      content: failure + (streams.length > 0 ? `\n${streams}` : '') + hint + cmdHint,
       isError: true,
     };
 }

--- a/projects/bpt-agent-sdk/src/tools/descriptions.ts
+++ b/projects/bpt-agent-sdk/src/tools/descriptions.ts
@@ -45,6 +45,15 @@
  *    sandbox backend is active (see createBashTool). When unsandboxed the Bash
  *    description is byte-identical to BASH_DESCRIPTION, with no sandbox content.
  *  - No PowerShell content.
+ *  - Bash win32 platform note (BPT pilot 2026-07-06): BASH_WIN32_NOTE is
+ *    adapted glue (not archive text) appended to the Bash description ONLY
+ *    when the host platform is win32 (createBashTool — same conditional
+ *    assembly pattern as the sandbox note). It states that commands run in
+ *    POSIX bash (Git Bash), not cmd.exe or PowerShell, and steers cmd habits
+ *    (copy/move/del/findstr) to POSIX equivalents. cmd.exe / PowerShell are
+ *    named only as a NEGATIVE disclaimer (what the shell is NOT) — no
+ *    PowerShell capability is described. On non-win32 platforms the Bash
+ *    description stays byte-identical.
  *  - Read: the PDF and Jupyter bullets are ADAPTED to this SDK's actual
  *    behavior (whole-document PDF reads, no pages slicing; notebooks as raw
  *    JSON text) — the official wording describes capabilities not shipped here.
@@ -180,6 +189,20 @@ Important:
 
 # Other common operations
 - View comments on a Github PR: gh api repos/foo/bar/pulls/123/comments`;
+
+/**
+ * Platform note appended to the Bash description ONLY on win32 hosts (see
+ * createBashTool — the same conditional-assembly pattern as the sandbox
+ * note). Adapted glue, not archive text: the archive has no Git-Bash-on-
+ * Windows note. It exists because models habitually reach for cmd.exe
+ * spellings on Windows hosts (BPT pilot incident 2026-07-06) even though this
+ * SDK always runs commands through POSIX bash (Git Bash, via
+ * shell-resolve.ts). cmd.exe / PowerShell are named only as a negative
+ * disclaimer (what the shell is NOT); no unshipped capability is described.
+ * Gated so non-win32 descriptions stay byte-identical (the conformance wire
+ * runs on Linux CI).
+ */
+export const BASH_WIN32_NOTE = `Note: on Windows this tool still runs POSIX bash (Git Bash), not cmd.exe or PowerShell. Use POSIX commands — ls, cp, mv, rm, grep — instead of dir, copy, move, del, findstr, and write paths with forward slashes.`;
 
 export const READ_DESCRIPTION = `Reads a file from the local filesystem. You can access any file directly by using this tool.
 Assume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -1488,6 +1488,14 @@ export type SDKResultMessage =
       errors?: string[];
       /** HTTP status when the run ended on an API error (e.g. 429, 529). */
       api_error_status?: number;
+      /**
+       * BPT-EXTENSION (SM-乙b): stable machine `code` of the underlying SDK
+       * error (E6c ErrorCode string, e.g. 'api_connection_failed') on an
+       * `error_during_execution` result. Lets a SessionManager classify a
+       * recoverable-vs-terminal API failure by code, not by message text.
+       * Absent for codeless failures and on non-error results.
+       */
+      error_code?: string;
       /** Time to first token (ms); only present when a token actually arrived. */
       ttft_ms?: number;
       ttft_stream_ms?: number;
@@ -2284,11 +2292,18 @@ export interface Query extends AsyncGenerator<SDKMessage, void> {
 // ---------------------------------------------------------------------------
 
 /**
- * BPT-EXTENSION: recovery/supervision knobs for a SessionManager.
- *
- * ACCEPTED (typed) but not yet effective in SM-甲 — supervision lands in the
- * next batch (SM-乙b: persistence hardening + crash auto-resume, proposal
- * §5/§6). Passing it today emits one debug notice and changes nothing.
+ * BPT-EXTENSION: recovery/supervision knobs for a SessionManager (SM-乙b,
+ * proposal §6). Effective on mgr.query() when ALL of the following hold:
+ * an external `sessionStore` is attached (shared options or per-query — no
+ * store means nowhere to resume from, R2), the prompt is a string (v1 scope:
+ * streaming-input conversations own their input channel and are not
+ * supervised), and `autoResume` is not false. A supervised query that fails
+ * with a RECOVERABLE error (§6.1: APIConnectionError, MCP connection-class
+ * McpError, or APIStatusError 429/5xx after transport retries) is transparently
+ * re-driven from the store via resume, up to `maxResumes` times; terminal
+ * errors (abort/config/4xx/unknown) always rethrow untouched. When the bound
+ * is exhausted the LAST error is rethrown with a `resumeAttempts` field
+ * attached (same error object, never re-wrapped).
  */
 export type SessionRecoveryOptions = {
   /** Auto-resume recoverable failures (default on once a store is attached). */
@@ -2305,7 +2320,8 @@ export type SessionRecoveryOptions = {
  * pool) is configured once and every mgr.query() borrows it.
  */
 export type SessionManagerOptions = Options & {
-  /** Typed for SM-乙b; supervision lands in the next batch. */
+  /** Supervised auto-resume knobs (SM-乙b, proposal §6). See
+   *  SessionRecoveryOptions for the activation conditions. */
   recovery?: SessionRecoveryOptions;
 };
 

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -2280,6 +2280,75 @@ export interface Query extends AsyncGenerator<SDKMessage, void> {
 }
 
 // ---------------------------------------------------------------------------
+// SessionManager (BPT-EXTENSION: in-process multi-conversation coordinator)
+// ---------------------------------------------------------------------------
+
+/**
+ * BPT-EXTENSION: recovery/supervision knobs for a SessionManager.
+ *
+ * ACCEPTED (typed) but not yet effective in SM-甲 — supervision lands in the
+ * next batch (SM-乙b: persistence hardening + crash auto-resume, proposal
+ * §5/§6). Passing it today emits one debug notice and changes nothing.
+ */
+export type SessionRecoveryOptions = {
+  /** Auto-resume recoverable failures (default on once a store is attached). */
+  autoResume?: boolean;
+  /** Bounded resume attempts per query (supervision default: 2). */
+  maxResumes?: number;
+};
+
+/**
+ * BPT-EXTENSION: options for createBptSession(). The official
+ * @anthropic-ai/claude-agent-sdk has no in-process multi-conversation
+ * coordinator — its coordination lives inside the CLI host process, invisible
+ * to SDK callers. Here the shared layer (one transport + one MCP connection
+ * pool) is configured once and every mgr.query() borrows it.
+ */
+export type SessionManagerOptions = Options & {
+  /** Typed for SM-乙b; supervision lands in the next batch. */
+  recovery?: SessionRecoveryOptions;
+};
+
+/** BPT-EXTENSION: read-only cross-conversation usage aggregate (D2: view
+ *  only — no hard cross-conversation budget cap in v1). */
+export type SessionManagerUsage = {
+  /** Sum of every managed conversation's cumulative estimated cost (USD). */
+  totalCostUsd: number;
+  /** Token totals summed across all managed conversations. */
+  usage: NonNullableUsage;
+  /** Per-model totals merged across all managed conversations. */
+  modelUsage: Record<string, ModelUsage>;
+  /** Number of mgr.query() calls issued so far (open or finished). */
+  queries: number;
+};
+
+/**
+ * BPT-EXTENSION: in-process object-level coordinator (proposal
+ * bpt-sdk-session-manager-20260706, 层一). Owns one shared AnthropicTransport
+ * and one shared MCP registry; queries created through it borrow both.
+ * Lifecycle contract (§4.2): the manager owns the shared connections —
+ * queries never close them; close() is the single teardown point.
+ */
+export interface SessionManager {
+  /**
+   * Start a managed conversation. Same shape as the standalone query();
+   * per-query options may override per-conversation knobs, but `provider` and
+   * `mcpServers` come from the shared layer — passing either throws
+   * ConfigurationError (D1: no private per-query MCP overlay in v1).
+   * Throws ConfigurationError after close().
+   */
+  query(args: {
+    prompt: string | AsyncIterable<SDKUserMessage>;
+    options?: Options;
+  }): Query;
+  /** Read-only aggregated usage/cost across all managed conversations. */
+  usage(): SessionManagerUsage;
+  /** Tear down the shared connections. Idempotent. After it resolves,
+   *  further query() calls throw ConfigurationError. */
+  close(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
 // Session info (listSessions surface)
 // ---------------------------------------------------------------------------
 

--- a/projects/bpt-agent-sdk/tests/bash-dx.test.ts
+++ b/projects/bpt-agent-sdk/tests/bash-dx.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Bash DX — Windows-cmd habit correction (BPT pilot incident 2026-07-06).
+ *
+ * Two layers under test (src/tools/bash.ts + src/tools/descriptions.ts):
+ *   1. Error layer (all platforms): exit 127 + a cmd.exe-only FIRST command
+ *      word appends a one-line POSIX correction to the error text. `dir` and
+ *      `type` are deliberately NOT in the word list (`dir` is GNU coreutils,
+ *      `type` is a bash builtin).
+ *   2. Description layer (win32-gated): BASH_WIN32_NOTE is appended to the
+ *      Bash description ONLY when the platform is win32 — same conditional
+ *      assembly as the sandbox note; non-win32 descriptions are
+ *      byte-identical (the conformance wire runs on Linux CI).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { bashTool, createBashTool, windowsCmdHint } from '../src/tools/bash.js';
+import { BASH_DESCRIPTION, BASH_WIN32_NOTE } from '../src/tools/descriptions.js';
+import type { SandboxContext } from '../src/types.js';
+import type {
+  ToolContext,
+  ToolResultPayload,
+} from '../src/internal/contracts.js';
+
+const HINT_MARKER = 'this shell is POSIX bash, not Windows cmd';
+
+let root: string;
+
+beforeAll(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'bpt-bash-dx-'));
+});
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+function makeCtx(cwd: string): ToolContext {
+  return {
+    cwd,
+    additionalDirectories: [],
+    env: { ...process.env },
+    signal: new AbortController().signal,
+    debug: () => {},
+  };
+}
+
+/** Assert the payload content is a plain string and return it. */
+function text(res: ToolResultPayload): string {
+  expect(typeof res.content).toBe('string');
+  return res.content as string;
+}
+
+async function makeDir(name: string): Promise<string> {
+  const dir = path.join(root, name);
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Error layer: exit-127 cmd-word correction
+// ---------------------------------------------------------------------------
+
+describe('Bash cmd-habit correction on exit 127', () => {
+  it('appends the POSIX correction when a cmd-only word exits 127', async () => {
+    const dir = await makeDir('cmd-copy');
+    const res = await bashTool.execute({ command: 'copy a b' }, makeCtx(dir));
+    expect(res.isError).toBe(true);
+    const out = text(res);
+    expect(out).toContain('exit code 127');
+    expect(out).toContain(HINT_MARKER);
+    expect(out).toContain('use cp/mv/rm/grep instead of copy/move/del/findstr');
+  });
+
+  it('does not append the correction on a non-127 failure', async () => {
+    const dir = await makeDir('cmd-non127');
+    const res = await bashTool.execute({ command: 'false' }, makeCtx(dir));
+    expect(res.isError).toBe(true);
+    expect(text(res)).toContain('exit code 1');
+    expect(text(res)).not.toContain(HINT_MARKER);
+  });
+
+  it('does not append the correction on 127 when the first word is not a cmd word', async () => {
+    const dir = await makeDir('cmd-typo');
+    const res = await bashTool.execute({ command: 'lls -la' }, makeCtx(dir));
+    expect(res.isError).toBe(true);
+    expect(text(res)).toContain('exit code 127');
+    expect(text(res)).not.toContain(HINT_MARKER);
+  });
+
+  it('leaves dir (GNU coreutils) untouched — deliberately NOT in the word list', async () => {
+    const dir = await makeDir('cmd-dir');
+    const res = await bashTool.execute({ command: 'dir .' }, makeCtx(dir));
+    expect(res.isError).toBeFalsy();
+    expect(text(res)).not.toContain(HINT_MARKER);
+  });
+
+  it('leaves type (bash builtin) untouched — deliberately NOT in the word list', async () => {
+    const dir = await makeDir('cmd-type');
+    const res = await bashTool.execute({ command: 'type echo' }, makeCtx(dir));
+    expect(res.isError).toBeFalsy();
+    expect(text(res)).toContain('echo');
+    expect(text(res)).not.toContain(HINT_MARKER);
+  });
+
+  it('fires when the cmd word heads a && chain (127 propagates from the front)', async () => {
+    const dir = await makeDir('cmd-chain');
+    const res = await bashTool.execute(
+      { command: 'copy a b && echo never' },
+      makeCtx(dir),
+    );
+    expect(res.isError).toBe(true);
+    expect(text(res)).toContain('exit code 127');
+    expect(text(res)).toContain(HINT_MARKER);
+  });
+
+  it('skips leading env assignments when extracting the first word', async () => {
+    const dir = await makeDir('cmd-env');
+    const res = await bashTool.execute(
+      { command: 'FOO=1 findstr pattern file.txt' },
+      makeCtx(dir),
+    );
+    expect(res.isError).toBe(true);
+    expect(text(res)).toContain('exit code 127');
+    expect(text(res)).toContain(HINT_MARKER);
+  });
+
+  it('only inspects the very first word — a cmd word later in the line does not trigger it', () => {
+    // Documented limitation (kept simple by design): the extractor looks at
+    // the trimmed string's first segment only.
+    expect(windowsCmdHint('echo hi; copy a b', 127)).toBe('');
+  });
+
+  describe('windowsCmdHint word list (unit)', () => {
+    const cmdWords = [
+      'copy',
+      'move',
+      'del',
+      'erase',
+      'xcopy',
+      'robocopy',
+      'findstr',
+      'cls',
+      'md',
+      'rd',
+      'ren',
+    ];
+    for (const word of cmdWords) {
+      it(`hints on 127 for "${word}"`, () => {
+        expect(windowsCmdHint(`${word} a b`, 127)).toContain(HINT_MARKER);
+      });
+    }
+    it('matches case-insensitively (cmd habits often arrive uppercased)', () => {
+      expect(windowsCmdHint('COPY a b', 127)).toContain(HINT_MARKER);
+    });
+    it('never hints for dir/type, on any exit code', () => {
+      expect(windowsCmdHint('dir /w', 127)).toBe('');
+      expect(windowsCmdHint('type file.txt', 127)).toBe('');
+    });
+    it('never hints on exit codes other than 127', () => {
+      expect(windowsCmdHint('copy a b', 1)).toBe('');
+      expect(windowsCmdHint('copy a b', 0)).toBe('');
+      expect(windowsCmdHint('copy a b', null)).toBe('');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Description layer: win32-gated platform note
+// ---------------------------------------------------------------------------
+
+describe('Bash description win32 platform note (gated assembly)', () => {
+  const fakeSandbox: SandboxContext = {
+    backend: { name: 'fake', wrap: (req) => ({ command: req.shell, args: ['-c', req.command] }) },
+    tmpDir: '/tmp/fake',
+    writablePaths: [],
+    allowNetwork: false,
+    allowEscape: true,
+  };
+
+  it('non-win32 platforms get the byte-identical base description', () => {
+    expect(createBashTool(undefined, 'linux').description).toBe(BASH_DESCRIPTION);
+    expect(createBashTool(undefined, 'darwin').description).toBe(BASH_DESCRIPTION);
+    // The note text never leaks into the base description constant.
+    expect(BASH_DESCRIPTION).not.toContain('Git Bash');
+    expect(BASH_DESCRIPTION).not.toContain(BASH_WIN32_NOTE);
+  });
+
+  it('win32 appends BASH_WIN32_NOTE after the base description', () => {
+    const desc = createBashTool(undefined, 'win32').description;
+    expect(desc).toBe(BASH_DESCRIPTION + '\n\n' + BASH_WIN32_NOTE);
+    expect(desc).toContain('POSIX bash (Git Bash)');
+    expect(desc).toContain('forward slashes');
+  });
+
+  it('win32 + sandbox carries both the platform note and the sandbox note', () => {
+    const desc = createBashTool(fakeSandbox, 'win32').description;
+    expect(desc.startsWith(BASH_DESCRIPTION + '\n\n' + BASH_WIN32_NOTE)).toBe(true);
+    expect(desc).toContain('# Sandbox');
+  });
+
+  it('sandbox without win32 stays exactly as before (no platform note)', () => {
+    const desc = createBashTool(fakeSandbox, 'linux').description;
+    expect(desc).not.toContain(BASH_WIN32_NOTE);
+    expect(desc).toContain('# Sandbox');
+  });
+});

--- a/projects/bpt-agent-sdk/tests/file-store.test.ts
+++ b/projects/bpt-agent-sdk/tests/file-store.test.ts
@@ -1,0 +1,391 @@
+/**
+ * SM-B.a: built-in file-backed external SessionStore (fileSessionStore).
+ *
+ * Covers the public SessionStore contract against real tmp directories:
+ * append/load round-trip, crash-torn-tail tolerance (load AND the append
+ * self-heal), path-traversal containment for attacker-controlled key
+ * components, listSubkeys/listSessions/delete semantics mirrored from
+ * InMemorySessionStore, auto-mkdir, and an end-to-end emulator smoke run
+ * (options.sessionStore wired to a fileSessionStore; transcript lands on
+ * disk and a fresh-host resume replays it).
+ */
+
+import { existsSync } from 'node:fs';
+import { appendFile, mkdtemp, readdir, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  FileSessionStore,
+  decodeKeyComponent,
+  encodeKeyComponent,
+  fileSessionStore,
+} from '../src/sessions/file-store.js';
+import { encodeProjectKey } from '../src/sessions/store-adapter.js';
+import { query, type Options, type Query, type SDKMessage } from '../src/index.js';
+import type { SessionKey, SessionStoreEntry } from '../src/types.js';
+import { makeSSEFetch, type SSEFetchStub } from './helpers/sse-fetch.js';
+import { textReplyEvents } from './helpers/mock-transport.js';
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'bpt-filestore-'));
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await rm(tmp, { recursive: true, force: true });
+});
+
+const PK = 'proj-abc123def456';
+
+const entry = (uuid: string, type = 'user'): SessionStoreEntry => ({
+  type,
+  uuid,
+  message: { role: type, content: `msg-${uuid}` },
+});
+
+/** Recursively list every file under a directory (absolute paths). */
+async function walk(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return out;
+  }
+  for (const name of names) {
+    const p = join(dir, name);
+    const st = await stat(p);
+    if (st.isDirectory()) out.push(...(await walk(p)));
+    else out.push(p);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Key-component encoding
+// ---------------------------------------------------------------------------
+
+describe('encodeKeyComponent / decodeKeyComponent', () => {
+  it('round-trips arbitrary strings including separators and unicode', () => {
+    for (const raw of [
+      'plain-id_1.2',
+      'subagents/x',
+      '../../etc/cron.d',
+      'a b%c\\d',
+      '.',
+      '..',
+      '',
+      '中文/键',
+    ]) {
+      expect(decodeKeyComponent(encodeKeyComponent(raw))).toBe(raw);
+    }
+  });
+
+  it('never emits a path separator or a traversal name', () => {
+    for (const raw of ['../x', '..\\x', '/abs/path', '..', '.', 'a/../b']) {
+      const enc = encodeKeyComponent(raw);
+      expect(enc).not.toMatch(/[/\\]/);
+      expect(enc).not.toBe('.');
+      expect(enc).not.toBe('..');
+      expect(enc.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (1) append -> load round-trip
+// ---------------------------------------------------------------------------
+
+describe('FileSessionStore append/load', () => {
+  it('round-trips multiple records preserving order across appends', async () => {
+    const s = fileSessionStore(tmp);
+    const key: SessionKey = { projectKey: PK, sessionId: 'sess-1' };
+    await s.append(key, [entry('1'), entry('2', 'assistant')]);
+    await s.append(key, [entry('3')]);
+    const loaded = await s.load(key);
+    expect(loaded?.map((e) => e.uuid)).toEqual(['1', '2', '3']);
+    expect(loaded?.[1]?.type).toBe('assistant');
+    // Payload fields survive verbatim.
+    expect(loaded?.[0]?.message).toEqual({ role: 'user', content: 'msg-1' });
+  });
+
+  it('returns null for a never-appended key', async () => {
+    const s = fileSessionStore(tmp);
+    expect(await s.load({ projectKey: PK, sessionId: 'missing' })).toBeNull();
+  });
+
+  it('keeps main transcript and subpath keys in separate files', async () => {
+    const s = fileSessionStore(tmp);
+    const main: SessionKey = { projectKey: PK, sessionId: 'a' };
+    const sub: SessionKey = { projectKey: PK, sessionId: 'a', subpath: 'subagents/x' };
+    await s.append(main, [entry('m1')]);
+    await s.append(sub, [entry('s1')]);
+    expect((await s.load(main))?.map((e) => e.uuid)).toEqual(['m1']);
+    expect((await s.load(sub))?.map((e) => e.uuid)).toEqual(['s1']);
+  });
+
+  it('dedups by entry.uuid across appends (first occurrence wins)', async () => {
+    const s = fileSessionStore(tmp);
+    const key: SessionKey = { projectKey: PK, sessionId: 'dup' };
+    await s.append(key, [entry('1')]);
+    await s.append(key, [entry('1'), entry('2')]);
+    const loaded = await s.load(key);
+    expect(loaded?.map((e) => e.uuid)).toEqual(['1', '2']);
+  });
+
+  it('a second store instance over the same dir sees prior data (durability)', async () => {
+    const key: SessionKey = { projectKey: PK, sessionId: 'persist' };
+    await fileSessionStore(tmp).append(key, [entry('1')]);
+    const reopened = fileSessionStore(tmp);
+    expect((await reopened.load(key))?.map((e) => e.uuid)).toEqual(['1']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (2) crash-torn tail tolerance
+// ---------------------------------------------------------------------------
+
+describe('FileSessionStore crash-tail tolerance', () => {
+  const key: SessionKey = { projectKey: PK, sessionId: 'crashy' };
+  const file = () =>
+    join(tmp, encodeKeyComponent(PK), encodeKeyComponent('crashy'), 'main.jsonl');
+
+  it('load survives a truncated final line and keeps every intact line', async () => {
+    const s = fileSessionStore(tmp);
+    await s.append(key, [entry('1'), entry('2')]);
+    // Simulate a crash mid-append: a torn, unterminated JSON fragment.
+    await appendFile(file(), '{"type":"user","uuid":"torn-3","mess');
+    const loaded = await s.load(key);
+    expect(loaded?.map((e) => e.uuid)).toEqual(['1', '2']);
+  });
+
+  it('load silently drops a corrupt middle line too', async () => {
+    const s = fileSessionStore(tmp);
+    await s.append(key, [entry('1')]);
+    await appendFile(file(), 'not json at all\n');
+    await s.append(key, [entry('2')]);
+    const loaded = await s.load(key);
+    expect(loaded?.map((e) => e.uuid)).toEqual(['1', '2']);
+  });
+
+  it('append after a crash heals the torn tail instead of gluing onto it', async () => {
+    await fileSessionStore(tmp).append(key, [entry('1')]);
+    await appendFile(file(), '{"type":"user","uuid":"torn-2"'); // no newline
+    // Fresh instance = fresh process after the crash.
+    const reopened = fileSessionStore(tmp);
+    await reopened.append(key, [entry('3')]);
+    const loaded = await reopened.load(key);
+    // The torn line is lost (expected); the NEW entry must not be.
+    expect(loaded?.map((e) => e.uuid)).toEqual(['1', '3']);
+  });
+
+  it('an empty (zero-byte) file loads as an empty list, not an error', async () => {
+    const s = fileSessionStore(tmp);
+    await s.append(key, [entry('1')]);
+    await rm(file());
+    await appendFile(file(), '');
+    expect(await s.load(key)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (3) path safety: attacker-controlled key components stay inside the root
+// ---------------------------------------------------------------------------
+
+describe('FileSessionStore path containment', () => {
+  it('a traversal sessionId/projectKey/subpath cannot escape the store root', async () => {
+    const root = join(tmp, 'store-root');
+    const s = fileSessionStore(root);
+    const evil: SessionKey = {
+      projectKey: '../pk-escape',
+      sessionId: '../../session-escape',
+      subpath: '../../../sub-escape',
+    };
+    await s.append(evil, [entry('1')]);
+    // Round-trips through the same key.
+    expect((await s.load(evil))?.map((e) => e.uuid)).toEqual(['1']);
+    // Every file created lives under the store root; nothing leaked into tmp.
+    const files = await walk(tmp);
+    expect(files.length).toBeGreaterThan(0);
+    for (const f of files) {
+      expect(f.startsWith(root + '/')).toBe(true);
+    }
+    expect(existsSync(join(tmp, 'session-escape'))).toBe(false);
+    expect(existsSync(join(tmp, 'sub-escape'))).toBe(false);
+  });
+
+  it('absolute-path and dot sessionIds are neutralized', async () => {
+    const root = join(tmp, 'store-root');
+    const s = fileSessionStore(root);
+    for (const sessionId of ['/etc/passwd', '.', '..']) {
+      const key: SessionKey = { projectKey: PK, sessionId };
+      await s.append(key, [entry(`id-${sessionId}`)]);
+      expect((await s.load(key))?.[0]?.uuid).toBe(`id-${sessionId}`);
+    }
+    const files = await walk(tmp);
+    for (const f of files) expect(f.startsWith(root + '/')).toBe(true);
+    expect(existsSync('/etc/passwd.jsonl')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (4) listSubkeys / listSessions / delete semantics
+// ---------------------------------------------------------------------------
+
+describe('FileSessionStore listSubkeys/listSessions/delete', () => {
+  it('listSubkeys returns the ORIGINAL subpath strings, excluding main', async () => {
+    const s = fileSessionStore(tmp);
+    await s.append({ projectKey: PK, sessionId: 'a' }, [entry('m')]);
+    await s.append({ projectKey: PK, sessionId: 'a', subpath: 'subagents/x' }, [entry('s1')]);
+    await s.append({ projectKey: PK, sessionId: 'a', subpath: 'checkpoints' }, [entry('s2')]);
+    const subs = await s.listSubkeys({ projectKey: PK, sessionId: 'a' });
+    expect(subs.sort()).toEqual(['checkpoints', 'subagents/x']);
+  });
+
+  it('listSubkeys of an unknown session is empty', async () => {
+    const s = fileSessionStore(tmp);
+    expect(await s.listSubkeys({ projectKey: PK, sessionId: 'nope' })).toEqual([]);
+  });
+
+  it('listSessions returns main-transcript sessions newest first', async () => {
+    const s = fileSessionStore(tmp);
+    await s.append({ projectKey: PK, sessionId: 'older' }, [entry('a')]);
+    await new Promise((r) => setTimeout(r, 10));
+    await s.append({ projectKey: PK, sessionId: 'newer' }, [entry('b')]);
+    // A subkey-only session must NOT be listed.
+    await s.append({ projectKey: PK, sessionId: 'subonly', subpath: 'sub/x' }, [entry('c')]);
+    const list = await s.listSessions(PK);
+    expect(list.map((e) => e.sessionId)).toEqual(['newer', 'older']);
+    expect(list[0]?.mtime).toBeGreaterThanOrEqual(list[1]?.mtime ?? Infinity);
+  });
+
+  it('listSessions of an unknown project is empty', async () => {
+    const s = fileSessionStore(tmp);
+    expect(await s.listSessions('never-seen')).toEqual([]);
+  });
+
+  it('delete of the main key cascades to subkeys; subkey delete is scoped', async () => {
+    const s = fileSessionStore(tmp);
+    const main: SessionKey = { projectKey: PK, sessionId: 'a' };
+    const sub: SessionKey = { projectKey: PK, sessionId: 'a', subpath: 'sub/x' };
+    await s.append(main, [entry('1')]);
+    await s.append(sub, [entry('2')]);
+    await s.delete(sub);
+    expect(await s.load(sub)).toBeNull();
+    expect(await s.load(main)).not.toBeNull();
+    await s.append(sub, [entry('3')]);
+    await s.delete(main);
+    expect(await s.load(main)).toBeNull();
+    expect(await s.load(sub)).toBeNull();
+    expect(await s.listSubkeys({ projectKey: PK, sessionId: 'a' })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (5) directory auto-creation
+// ---------------------------------------------------------------------------
+
+describe('FileSessionStore directory bootstrap', () => {
+  it('creates a deeply nested, not-yet-existing store dir on first append', async () => {
+    const deep = join(tmp, 'not', 'yet', 'created');
+    expect(existsSync(deep)).toBe(false);
+    const s = fileSessionStore(deep);
+    await s.append({ projectKey: PK, sessionId: 's' }, [entry('1')]);
+    expect(existsSync(deep)).toBe(true);
+    expect((await s.load({ projectKey: PK, sessionId: 's' }))?.map((e) => e.uuid)).toEqual(['1']);
+  });
+
+  it('exports both the factory and the class, and they are the same store', () => {
+    const viaFactory = fileSessionStore(tmp);
+    expect(viaFactory).toBeInstanceOf(FileSessionStore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (6) integration smoke: options.sessionStore + emulator query + resume
+// ---------------------------------------------------------------------------
+
+describe('fileSessionStore end-to-end (options.sessionStore)', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = join(tmp, 'project');
+  });
+
+  function baseOptions(extra: Partial<Options> = {}): Options {
+    return {
+      provider: { apiKey: 'test-key', promptCaching: false },
+      cwd,
+      env: { PATH: process.env.PATH, HOME: process.env.HOME },
+      model: 'claude-sonnet-4-5',
+      ...extra,
+    };
+  }
+
+  function stub(scripts: ReadonlyArray<readonly object[]>): SSEFetchStub {
+    const s = makeSSEFetch(scripts);
+    vi.stubGlobal('fetch', s);
+    return s;
+  }
+
+  async function drain(q: Query): Promise<SDKMessage[]> {
+    const out: SDKMessage[] = [];
+    for await (const m of q) out.push(m);
+    return out;
+  }
+
+  it('persists the transcript to disk and resumes it on a fresh host', async () => {
+    const storeDir = join(tmp, 'external-store');
+    const projectKey = encodeProjectKey(cwd);
+
+    // -- Turn 1: run a query mirroring into the file store. ------------------
+    stub([textReplyEvents('reply-one')]);
+    const msgs = await drain(
+      query({
+        prompt: 'remember-marker-alpha',
+        options: baseOptions({
+          sessionDir: join(tmp, 'host-a-sessions'),
+          sessionStore: fileSessionStore(storeDir),
+          sessionStoreFlush: 'eager',
+        }),
+      }),
+    );
+    const result = msgs.find((m) => m.type === 'result');
+    expect(result).toBeDefined();
+    const sessionId = (result as { session_id: string }).session_id;
+
+    // Transcript landed on disk and reads back through a fresh store handle.
+    const persisted = await fileSessionStore(storeDir).load({ projectKey, sessionId });
+    expect(persisted).not.toBeNull();
+    const types = (persisted ?? []).map((e) => e.type);
+    expect(types).toContain('user');
+    expect(types).toContain('assistant');
+    expect(JSON.stringify(persisted)).toContain('remember-marker-alpha');
+
+    // -- Turn 2: resume on a DIFFERENT host (fresh local sessionDir). --------
+    const f2 = stub([textReplyEvents('reply-two')]);
+    await drain(
+      query({
+        prompt: 'second-turn',
+        options: baseOptions({
+          sessionDir: join(tmp, 'host-b-sessions'),
+          sessionStore: fileSessionStore(storeDir),
+          resume: sessionId,
+        }),
+      }),
+    );
+    // The resumed request must replay the first conversation from the file
+    // store (host B has no local transcript).
+    const body = f2.requests[0]?.body;
+    expect(body).toBeDefined();
+    const wire = JSON.stringify(body?.messages ?? []);
+    expect(wire).toContain('remember-marker-alpha');
+    expect(wire).toContain('reply-one');
+    expect(wire).toContain('second-turn');
+  });
+});

--- a/projects/bpt-agent-sdk/tests/session-manager.test.ts
+++ b/projects/bpt-agent-sdk/tests/session-manager.test.ts
@@ -1,0 +1,446 @@
+/**
+ * SessionManager (SM-甲) shared-coordination suite — proposal §7 "共享协调" row
+ * (Public-Info-Pool/Resource/proposal/bpt-sdk-session-manager-20260706.md):
+ *
+ *  ① two concurrent mgr.query() runs multiplex ONE shared MCP registry with
+ *    no cross-talk (request-id correlation);
+ *  ② #1 red line: a finished query leaves the shared MCP connection alive —
+ *    the next query reuses the SAME server process (stdio pid proof);
+ *  ③ mgr.close() is the single teardown point (registry closeAll observed);
+ *  ④ mgr.query() after close() throws ConfigurationError;
+ *  ⑤ standalone query() regression: still owns + closes its own registry
+ *    (full-suite vitest is the broader regression guard);
+ *  ⑥ mgr.usage() aggregates cost/tokens across conversations;
+ *  ⑦ D1: per-query mcpServers (and provider) are refused loudly.
+ *
+ * Fixtures follow tests/mcp.test.ts patterns: the in-process sdk server
+ * (createSdkMcpServer) and the stdio echo emulator
+ * (tests/fixtures/mcp-echo-server.mjs), driven end-to-end through query()
+ * against a scripted SSE fetch stub (no network).
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import {
+  ConfigurationError,
+  createBptSession,
+  createSdkMcpServer,
+  query,
+  tool,
+} from '../src/index.js';
+import { DefaultMcpRegistry } from '../src/mcp/registry.js';
+import type {
+  Options,
+  Query,
+  SDKMessage,
+  SDKResultMessage,
+  SDKUserMessage,
+  SessionManagerOptions,
+} from '../src/types.js';
+import {
+  textReplyEvents,
+  toolUseReplyEvents,
+} from './helpers/mock-transport.js';
+import { encodeSSEFrame, makeSSEFetch } from './helpers/sse-fetch.js';
+import type { SSEFetchStub } from './helpers/sse-fetch.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ECHO_FIXTURE = path.join(HERE, 'fixtures', 'mcp-echo-server.mjs');
+
+let sessionDir: string;
+let cwd: string;
+
+beforeEach(async () => {
+  sessionDir = await mkdtemp(join(tmpdir(), 'bpt-mgr-sess-'));
+  cwd = await mkdtemp(join(tmpdir(), 'bpt-mgr-cwd-'));
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await rm(sessionDir, { recursive: true, force: true });
+  await rm(cwd, { recursive: true, force: true });
+});
+
+function baseManagerOptions(extra: Partial<SessionManagerOptions> = {}): SessionManagerOptions {
+  return {
+    provider: { apiKey: 'test-key', promptCaching: false },
+    sessionDir,
+    cwd,
+    // Hermetic env: no ANTHROPIC_* leakage; PATH kept so stdio servers spawn.
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    ...extra,
+  };
+}
+
+function stubFetch(stub: SSEFetchStub): SSEFetchStub {
+  vi.stubGlobal('fetch', stub);
+  return stub;
+}
+
+/**
+ * Body-aware SSE fetch stub for CONCURRENT queries, where call ordering is
+ * nondeterministic and the index-scripted makeSSEFetch cannot be used: the
+ * route callback inspects each request body and returns the raw stream-event
+ * payloads for that reply.
+ */
+function routedSSEFetch(
+  route: (body: Record<string, any>) => object[],
+): (input: unknown, init?: RequestInit) => Promise<Response> {
+  return async (_input, init) => {
+    const body = JSON.parse(String(init?.body)) as Record<string, any>;
+    const events = route(body);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const event of events) controller.enqueue(encodeSSEFrame(event));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  };
+}
+
+async function collect(q: Query): Promise<SDKMessage[]> {
+  const out: SDKMessage[] = [];
+  for await (const m of q) out.push(m);
+  return out;
+}
+
+function lastResult(messages: SDKMessage[]): SDKResultMessage {
+  const last = messages[messages.length - 1];
+  expect(last?.type).toBe('result');
+  return last as SDKResultMessage;
+}
+
+/** All tool_result text payloads surfaced in a query's message stream. */
+function toolResultTexts(messages: SDKMessage[]): string[] {
+  const out: string[] = [];
+  for (const m of messages) {
+    if (m.type !== 'user') continue;
+    const content = (m as SDKUserMessage).message.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if ((block as { type?: string }).type !== 'tool_result') continue;
+      const c = (block as { content?: unknown }).content;
+      if (typeof c === 'string') out.push(c);
+      else if (Array.isArray(c)) {
+        for (const part of c) {
+          if (
+            part !== null &&
+            typeof part === 'object' &&
+            (part as { type?: string }).type === 'text'
+          ) {
+            out.push((part as { text: string }).text);
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** True while the pid exists (signal 0 probe). */
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Poll until the pid no longer exists (process reaped), or time out. */
+async function waitForPidExit(pid: number, timeoutMs = 4000): Promise<boolean> {
+  const start = Date.now();
+  for (;;) {
+    if (!pidAlive(pid)) return true;
+    if (Date.now() - start > timeoutMs) return false;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// ② #1 red line + ③ close tears down + ④ closed manager refuses (stdio pid proof)
+// ---------------------------------------------------------------------------
+
+describe('SessionManager shared MCP lifecycle (stdio emulator)', () => {
+  it('red line: query #1 finishing leaves the shared stdio server alive; query #2 reuses the SAME process; mgr.close() kills it; query after close throws', async () => {
+    const mgr = createBptSession(
+      baseManagerOptions({
+        mcpServers: { echo: { command: 'node', args: [ECHO_FIXTURE] } },
+        allowedTools: ['mcp__echo__pid'],
+      }),
+    );
+    stubFetch(
+      makeSSEFetch([
+        toolUseReplyEvents('mcp__echo__pid', {}, { id: 'toolu_pid_1' }),
+        textReplyEvents('first conversation done'),
+        toolUseReplyEvents('mcp__echo__pid', {}, { id: 'toolu_pid_2' }),
+        textReplyEvents('second conversation done'),
+      ]),
+    );
+
+    // Conversation 1 runs to completion (its generator's finally has run).
+    const msgsA = await collect(mgr.query({ prompt: 'conversation one' }));
+    expect(lastResult(msgsA).subtype).toBe('success');
+    const pid1 = Number.parseInt(toolResultTexts(msgsA)[0] ?? '', 10);
+    expect(Number.isInteger(pid1)).toBe(true);
+    expect(pid1).toBeGreaterThan(0);
+
+    // #1 red line: the shared connection survived conversation 1's end.
+    expect(pidAlive(pid1)).toBe(true);
+
+    // Conversation 2 multiplexes the SAME server process (no respawn).
+    const msgsB = await collect(mgr.query({ prompt: 'conversation two' }));
+    expect(lastResult(msgsB).subtype).toBe('success');
+    const pid2 = Number.parseInt(toolResultTexts(msgsB)[0] ?? '', 10);
+    expect(pid2).toBe(pid1);
+
+    // ③ Unified teardown: mgr.close() is what kills the shared server.
+    await mgr.close();
+    expect(await waitForPidExit(pid1)).toBe(true);
+
+    // ④ close() -> further query() refused loudly.
+    expect(() => mgr.query({ prompt: 'too late' })).toThrow(ConfigurationError);
+    expect(() => mgr.query({ prompt: 'too late' })).toThrow(/closed/);
+  }, 20000);
+});
+
+// ---------------------------------------------------------------------------
+// ① concurrent conversations multiplex one registry without cross-talk
+// ---------------------------------------------------------------------------
+
+describe('SessionManager concurrent conversations (sdk in-process server)', () => {
+  it('two overlapping mgr.query() runs call the same shared registry and each gets ITS OWN tool result back', async () => {
+    const seen: string[] = [];
+    const echo = tool(
+      'echo',
+      'Echo the tag back after an optional delay',
+      { tag: z.string(), delayMs: z.number().optional() },
+      async (args) => {
+        seen.push(args.tag);
+        if (args.delayMs !== undefined) await delay(args.delayMs);
+        return { content: [{ type: 'text', text: args.tag }] };
+      },
+    );
+    const calc = createSdkMcpServer({ name: 'calc', version: '1.0.0', tools: [echo] });
+    const mgr = createBptSession(
+      baseManagerOptions({
+        mcpServers: { calc },
+        allowedTools: ['mcp__calc__echo'],
+      }),
+    );
+
+    // Concurrency makes fetch-call order nondeterministic: route replies by
+    // request body instead of by call index. First round for a conversation
+    // (no tool_result yet) -> tool_use; second round -> final text.
+    vi.stubGlobal(
+      'fetch',
+      routedSSEFetch((body) => {
+        const raw = JSON.stringify(body.messages);
+        const isAlpha = raw.includes('alpha-conversation');
+        const hasToolResult = raw.includes('"tool_result"');
+        if (!hasToolResult) {
+          return toolUseReplyEvents(
+            'mcp__calc__echo',
+            isAlpha
+              ? { tag: 'tag-alpha', delayMs: 60 }
+              : { tag: 'tag-beta', delayMs: 5 },
+            { id: isAlpha ? 'toolu_alpha' : 'toolu_beta' },
+          );
+        }
+        return textReplyEvents(isAlpha ? 'alpha done' : 'beta done');
+      }),
+    );
+
+    const [msgsA, msgsB] = await Promise.all([
+      collect(mgr.query({ prompt: 'alpha-conversation' })),
+      collect(mgr.query({ prompt: 'beta-conversation' })),
+    ]);
+
+    // Both conversations ran the shared server (both tags observed) and each
+    // stream carries exactly its own tool result — no cross-talk.
+    expect(seen.sort()).toEqual(['tag-alpha', 'tag-beta']);
+    expect(toolResultTexts(msgsA)).toEqual(['tag-alpha']);
+    expect(toolResultTexts(msgsB)).toEqual(['tag-beta']);
+    expect(lastResult(msgsA).subtype).toBe('success');
+    expect(lastResult(msgsB).subtype).toBe('success');
+
+    await mgr.close();
+  }, 20000);
+});
+
+// ---------------------------------------------------------------------------
+// ③ ownership: no query-side closeAll; manager close is observed + idempotent
+// ---------------------------------------------------------------------------
+
+describe('SessionManager ownership of the shared registry', () => {
+  it('a finished managed query never calls the shared registry closeAll; mgr.close() calls it exactly once (idempotent)', async () => {
+    const closeSpy = vi.spyOn(DefaultMcpRegistry.prototype, 'closeAll');
+    const ping = tool('ping', 'ping', {}, async () => ({
+      content: [{ type: 'text', text: 'pong' }],
+    }));
+    const srv = createSdkMcpServer({ name: 'probe', tools: [ping] });
+    const mgr = createBptSession(
+      baseManagerOptions({
+        mcpServers: { probe: srv },
+        allowedTools: ['mcp__probe__ping'],
+      }),
+    );
+    stubFetch(
+      makeSSEFetch([
+        toolUseReplyEvents('mcp__probe__ping', {}),
+        textReplyEvents('ok'),
+      ]),
+    );
+
+    const msgs = await collect(mgr.query({ prompt: 'use the probe' }));
+    expect(toolResultTexts(msgs)).toEqual(['pong']);
+    // Borrowed, not owned: the query's teardown left the shared pool intact.
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    await mgr.close();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    await mgr.close(); // idempotent
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Query.setMcpServers on a managed query is refused (it would dismantle the shared pool)', async () => {
+    const srv = createSdkMcpServer({ name: 'probe', tools: [] });
+    const mgr = createBptSession(baseManagerOptions({ mcpServers: { probe: srv } }));
+    stubFetch(makeSSEFetch([textReplyEvents('ok')]));
+
+    const q = mgr.query({ prompt: 'hello' });
+    await expect(q.setMcpServers({})).rejects.toThrow(ConfigurationError);
+    await collect(q);
+    await mgr.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ⑤ standalone query() regression: still owns and closes its own registry
+// ---------------------------------------------------------------------------
+
+describe('standalone query() ownership regression', () => {
+  it('an unmanaged query constructs its own registry and closes it on completion (behavior unchanged)', async () => {
+    const closeSpy = vi.spyOn(DefaultMcpRegistry.prototype, 'closeAll');
+    const ping = tool('ping', 'ping', {}, async () => ({
+      content: [{ type: 'text', text: 'pong' }],
+    }));
+    const srv = createSdkMcpServer({ name: 'solo', tools: [ping] });
+    stubFetch(makeSSEFetch([textReplyEvents('done')]));
+
+    const msgs = await collect(
+      query({
+        prompt: 'no tools needed',
+        options: {
+          ...(baseManagerOptions() as Options),
+          mcpServers: { solo: srv },
+        },
+      }),
+    );
+    expect(lastResult(msgs).subtype).toBe('success');
+    // Owner teardown ran: the standalone query closed the registry it built.
+    expect(closeSpy).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ⑥ usage aggregation across conversations
+// ---------------------------------------------------------------------------
+
+describe('SessionManager.usage()', () => {
+  it('aggregates tokens and cost across two conversations (read-only view, D2)', async () => {
+    const mgr = createBptSession(
+      baseManagerOptions({
+        // R2 seam smoke: recovery is ACCEPTED (typed) and inert in SM-甲.
+        recovery: { autoResume: true, maxResumes: 2 },
+      }),
+    );
+    stubFetch(
+      makeSSEFetch([
+        textReplyEvents('one', { usage: { input_tokens: 25 } }),
+        textReplyEvents('two', { usage: { input_tokens: 25 } }),
+      ]),
+    );
+
+    expect(mgr.usage()).toEqual({
+      totalCostUsd: 0,
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      modelUsage: {},
+      queries: 0,
+    });
+
+    const rA = lastResult(await collect(mgr.query({ prompt: 'conversation a' })));
+    const rB = lastResult(await collect(mgr.query({ prompt: 'conversation b' })));
+
+    const agg = mgr.usage();
+    expect(agg.queries).toBe(2);
+    expect(agg.usage.input_tokens).toBe(rA.usage.input_tokens + rB.usage.input_tokens);
+    expect(agg.usage.output_tokens).toBe(rA.usage.output_tokens + rB.usage.output_tokens);
+    expect(agg.totalCostUsd).toBeCloseTo(rA.total_cost_usd + rB.total_cost_usd, 10);
+    // Per-model rollup merges both conversations' figures for the same model.
+    const perModel = Object.values(agg.modelUsage);
+    expect(perModel.length).toBeGreaterThan(0);
+    const totalInput = perModel.reduce((s, m) => s + m.inputTokens, 0);
+    expect(totalInput).toBe(agg.usage.input_tokens);
+
+    await mgr.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ⑦ D1: shared-layer options cannot be overridden per query
+// ---------------------------------------------------------------------------
+
+describe('SessionManager D1 refusals', () => {
+  it('per-query mcpServers throws ConfigurationError loudly (D1: v1 has no private MCP overlay)', async () => {
+    const mgr = createBptSession(baseManagerOptions());
+    const srv = createSdkMcpServer({ name: 'private', tools: [] });
+    expect(() =>
+      mgr.query({ prompt: 'x', options: { mcpServers: { private: srv } } }),
+    ).toThrow(ConfigurationError);
+    expect(() =>
+      mgr.query({ prompt: 'x', options: { mcpServers: { private: srv } } }),
+    ).toThrow(/D1/);
+    await mgr.close();
+  });
+
+  it('per-query provider throws ConfigurationError (the transport is shared)', async () => {
+    const mgr = createBptSession(baseManagerOptions());
+    expect(() =>
+      mgr.query({ prompt: 'x', options: { provider: { apiKey: 'other' } } }),
+    ).toThrow(ConfigurationError);
+    await mgr.close();
+  });
+
+  it('per-query overrides of NON-shared knobs still work (model override reaches the wire)', async () => {
+    const mgr = createBptSession(baseManagerOptions());
+    const stub = stubFetch(makeSSEFetch([textReplyEvents('ok')]));
+    const msgs = await collect(
+      mgr.query({ prompt: 'hello', options: { model: 'claude-haiku-4-5' } }),
+    );
+    expect(lastResult(msgs).subtype).toBe('success');
+    expect(stub.requests[0]?.body.model).toBe('claude-haiku-4-5');
+    await mgr.close();
+  });
+});

--- a/projects/bpt-agent-sdk/tests/session-recovery.test.ts
+++ b/projects/bpt-agent-sdk/tests/session-recovery.test.ts
@@ -1,0 +1,469 @@
+/**
+ * SM-乙b persistence-hardening + supervised recovery suite (proposal §5.2 +
+ * §6, Public-Info-Pool/Resource/proposal/bpt-sdk-session-manager-20260706.md).
+ *
+ * Covers the three completed pieces:
+ *   A. write-ahead checkpoints (query.ts) — pending_turn is written BEFORE the
+ *      engine loop and settled by turn_complete only when the turn SUCCEEDS
+ *      (test ⑥);
+ *   B. redrive-on-resume (query.ts) — a resumed transcript with a dangling
+ *      pending_turn re-drives ONLY the interrupted API request segment, never
+ *      an already-executed tool (test ⑦);
+ *   C. the manager supervision loop (session-manager.ts) — recoverable
+ *      failures transparently auto-resume up to maxResumes, terminal ones pass
+ *      through, the gate honours store/autoResume/prompt-kind (tests ①-⑤);
+ *      standalone query() is unaffected (test ⑧).
+ *
+ * DESIGN NOTE reflected in the assertions: this engine converts API /
+ * connection failures into an is_error `error_during_execution` RESULT message
+ * (only AbortError is thrown). So supervision keys off recoverable error
+ * RESULTS: a recoverable one is swallowed and re-driven; a terminal one (or the
+ * last one once maxResumes is spent) is forwarded — the latter annotated with
+ * `resumeAttempts`. Genuine throws (AbortError) still rethrow.
+ */
+
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createBptSession, createSdkMcpServer, query, tool } from '../src/index.js';
+import { InMemorySessionStore } from '../src/sessions/store-adapter.js';
+import { textReplyEvents, toolUseReplyEvents } from './helpers/mock-transport.js';
+import { encodeSSEFrame } from './helpers/sse-fetch.js';
+import type {
+  Options,
+  Query,
+  SDKMessage,
+  SDKResultMessage,
+  SDKUserMessage,
+  SessionManagerOptions,
+} from '../src/types.js';
+
+let sessionDir: string;
+let cwd: string;
+
+beforeEach(async () => {
+  sessionDir = await mkdtemp(join(tmpdir(), 'bpt-recov-sess-'));
+  cwd = await mkdtemp(join(tmpdir(), 'bpt-recov-cwd-'));
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await rm(sessionDir, { recursive: true, force: true });
+  await rm(cwd, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** One scripted answer per fetch call: 'crash' rejects (→ APIConnectionError),
+ *  an event array replies 200 SSE, a {status} replies that HTTP error. The
+ *  LAST entry repeats for any further call (so 'crash' alone = crash-forever). */
+type FetchAnswer = 'crash' | readonly object[] | { status: number };
+
+function scriptedFetch(answers: FetchAnswer[]): {
+  fn: (input: unknown, init?: RequestInit) => Promise<Response>;
+  calls: () => number;
+} {
+  let n = 0;
+  const fn = vi.fn(async (_input: unknown, _init?: RequestInit): Promise<Response> => {
+    const answer = answers[n] ?? answers[answers.length - 1];
+    n += 1;
+    if (answer === 'crash') {
+      throw new TypeError('simulated network failure');
+    }
+    if (Array.isArray(answer)) {
+      const events = answer;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const e of events) controller.enqueue(encodeSSEFrame(e));
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    }
+    const { status } = answer as { status: number };
+    return new Response(
+      JSON.stringify({ type: 'error', error: { type: 'terminal', message: 'terminal' } }),
+      { status, headers: { 'content-type': 'application/json' } },
+    );
+  });
+  return { fn, calls: () => n };
+}
+
+function managerOptions(extra: Partial<SessionManagerOptions> = {}): SessionManagerOptions {
+  return {
+    // maxRetries:0 so a rejected/4xx fetch surfaces immediately (no backoff).
+    provider: { apiKey: 'test-key', promptCaching: false, maxRetries: 0 },
+    sessionDir,
+    cwd,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    ...extra,
+  };
+}
+
+function queryOptions(extra: Partial<Options> = {}): Options {
+  return {
+    provider: { apiKey: 'test-key', promptCaching: false, maxRetries: 0 },
+    sessionDir,
+    cwd,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    ...extra,
+  };
+}
+
+/** An input stream that closes at once (a resume re-drive replays no input). */
+async function* emptyStream(): AsyncGenerator<SDKUserMessage, void> {
+  // yields nothing
+}
+
+async function collect(q: Query): Promise<SDKMessage[]> {
+  const out: SDKMessage[] = [];
+  for await (const m of q) out.push(m);
+  return out;
+}
+
+function lastResult(messages: SDKMessage[]): SDKResultMessage {
+  const last = messages[messages.length - 1];
+  expect(last?.type).toBe('result');
+  return last as SDKResultMessage;
+}
+
+function initSessionId(messages: SDKMessage[]): string {
+  const init = messages.find(
+    (m) => m.type === 'system' && m.subtype === 'init',
+  ) as { session_id: string } | undefined;
+  expect(init).toBeDefined();
+  return init!.session_id;
+}
+
+function resumeObservations(messages: SDKMessage[]): Array<Record<string, any>> {
+  return messages.filter(
+    (m) =>
+      m.type === 'system' &&
+      (m as any).subtype === 'status' &&
+      (m as any).status === 'auto-resume',
+  ) as unknown as Array<Record<string, any>>;
+}
+
+async function transcript(sid: string): Promise<Array<Record<string, any>>> {
+  const raw = await readFile(join(sessionDir, `${sid}.jsonl`), 'utf8');
+  return raw
+    .trim()
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l) as Record<string, any>);
+}
+
+// ---------------------------------------------------------------------------
+// ① recoverable failure -> transparent auto-resume -> correct success result
+// ---------------------------------------------------------------------------
+
+describe('supervised auto-resume', () => {
+  it('① recovers a connection failure and completes transparently', async () => {
+    const store = new InMemorySessionStore();
+    const { fn, calls } = scriptedFetch(['crash', textReplyEvents('recovered')]);
+    vi.stubGlobal('fetch', fn);
+
+    const mgr = createBptSession(
+      managerOptions({ sessionStore: store, recovery: { autoResume: true, maxResumes: 2 } }),
+    );
+    const messages = await collect(mgr.query({ prompt: 'hello keeper' }));
+
+    // The consumer's terminal message is a SUCCESS result (from the resume);
+    // the swallowed attempt-1 error result never reaches the consumer.
+    const last = lastResult(messages);
+    expect(last.subtype).toBe('success');
+    expect(last.is_error).not.toBe(true);
+
+    // Exactly one auto-resume observation: attempt #1, coded as a connection
+    // failure — the inline "resume happened" scene the consumer sees.
+    const obs = resumeObservations(messages);
+    expect(obs).toHaveLength(1);
+    expect(obs[0].details.attempt).toBe(1);
+    expect(obs[0].details.code).toBe('api_connection_failed');
+
+    // Two fetch calls: the failure, then the successful redrive.
+    expect(calls()).toBe(2);
+
+    // The write-ahead checkpoint left a trace, and the redrive settled it.
+    const sid = initSessionId(messages);
+    const types = (await transcript(sid)).map((e) => e.type);
+    expect(types).toContain('pending_turn');
+    expect(types).toContain('turn_complete');
+
+    await mgr.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // ③ recoverable but never clears -> exhaust maxResumes -> forward + scene
+  // -------------------------------------------------------------------------
+  it('③ forwards the last error with resumeAttempts once maxResumes is spent', async () => {
+    const store = new InMemorySessionStore();
+    const { fn, calls } = scriptedFetch(['crash']); // crash forever
+    vi.stubGlobal('fetch', fn);
+
+    const mgr = createBptSession(
+      managerOptions({ sessionStore: store, recovery: { maxResumes: 2 } }),
+    );
+    const messages = await collect(mgr.query({ prompt: 'hi' }));
+
+    const last = lastResult(messages);
+    expect(last.is_error).toBe(true);
+    expect(last.error_code).toBe('api_connection_failed');
+    expect((last as any).resumeAttempts).toBe(2);
+    // Two auto-resume observations before the give-up.
+    expect(resumeObservations(messages)).toHaveLength(2);
+    // Initial attempt + 2 resumes = 3 fetch calls.
+    expect(calls()).toBe(3);
+
+    await mgr.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ② terminal failures never resume
+// ---------------------------------------------------------------------------
+
+describe('terminal failures bypass supervision', () => {
+  it('② a 4xx (non-429) API error is forwarded without resuming', async () => {
+    const store = new InMemorySessionStore();
+    const { fn, calls } = scriptedFetch([{ status: 401 }]);
+    vi.stubGlobal('fetch', fn);
+
+    const mgr = createBptSession(managerOptions({ sessionStore: store }));
+    const messages = await collect(mgr.query({ prompt: 'hi' }));
+
+    const last = lastResult(messages);
+    expect(last.is_error).toBe(true);
+    expect(last.api_error_status).toBe(401);
+    // No resume was attempted, so no scene annotation and no observation.
+    expect((last as any).resumeAttempts).toBeUndefined();
+    expect(resumeObservations(messages)).toHaveLength(0);
+    expect(calls()).toBe(1);
+
+    await mgr.close();
+  });
+
+  it('② an AbortError (user interrupt) rethrows without resuming', async () => {
+    const store = new InMemorySessionStore();
+    // A stream that opens 200 but never sends/closes: the turn hangs until the
+    // caller aborts, producing an AbortError (terminal, never resumed).
+    const hangingFn = vi.fn(async (): Promise<Response> => {
+      const stream = new ReadableStream<Uint8Array>({ start() { /* never closes */ } });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    });
+    vi.stubGlobal('fetch', hangingFn);
+
+    const ac = new AbortController();
+    const mgr = createBptSession(managerOptions({ sessionStore: store }));
+    const q = mgr.query({ prompt: 'hi', options: { abortController: ac } });
+
+    const messages: SDKMessage[] = [];
+    let error: unknown;
+    try {
+      for await (const m of q) {
+        messages.push(m);
+        if (m.type === 'system' && m.subtype === 'init') ac.abort();
+      }
+    } catch (e) {
+      error = e;
+    }
+
+    expect((error as Error)?.name).toBe('AbortError');
+    expect((error as any).resumeAttempts).toBeUndefined();
+    expect(resumeObservations(messages)).toHaveLength(0);
+
+    await mgr.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ④/⑤ the activation gate
+// ---------------------------------------------------------------------------
+
+describe('supervision gate', () => {
+  it('④ is OFF when no external store is attached (error forwarded as-is)', async () => {
+    const { fn, calls } = scriptedFetch(['crash']);
+    vi.stubGlobal('fetch', fn);
+
+    // No sessionStore -> supervise=false even though the failure is recoverable.
+    const mgr = createBptSession(managerOptions({ recovery: { autoResume: true } }));
+    const messages = await collect(mgr.query({ prompt: 'hi' }));
+
+    const last = lastResult(messages);
+    expect(last.is_error).toBe(true);
+    expect((last as any).resumeAttempts).toBeUndefined();
+    expect(resumeObservations(messages)).toHaveLength(0);
+    expect(calls()).toBe(1); // no resume attempted
+
+    await mgr.close();
+  });
+
+  it('⑤ is OFF when recovery.autoResume is false', async () => {
+    const store = new InMemorySessionStore();
+    const { fn, calls } = scriptedFetch(['crash']);
+    vi.stubGlobal('fetch', fn);
+
+    const mgr = createBptSession(
+      managerOptions({ sessionStore: store, recovery: { autoResume: false } }),
+    );
+    const messages = await collect(mgr.query({ prompt: 'hi' }));
+
+    const last = lastResult(messages);
+    expect(last.is_error).toBe(true);
+    expect((last as any).resumeAttempts).toBeUndefined();
+    expect(resumeObservations(messages)).toHaveLength(0);
+    expect(calls()).toBe(1);
+
+    await mgr.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ⑥ checkpoint pairing + timing (query-level, no manager)
+// ---------------------------------------------------------------------------
+
+describe('write-ahead checkpoint pairing', () => {
+  it('⑥ writes pending_turn before the engine loop and turn_complete after', async () => {
+    const { fn } = scriptedFetch([textReplyEvents('done')]);
+    vi.stubGlobal('fetch', fn);
+
+    const messages = await collect(query({ prompt: 'hi', options: queryOptions() }));
+    const sid = initSessionId(messages);
+    const lines = await transcript(sid);
+    const types = lines.map((l) => l.type);
+
+    const iUser = types.indexOf('user');
+    const iPending = types.indexOf('pending_turn');
+    const iAssistant = types.indexOf('assistant');
+    const iComplete = types.indexOf('turn_complete');
+
+    // pending_turn brackets the request segment: after the user turn, before
+    // the assistant answer; turn_complete lands after the assistant.
+    expect(iUser).toBeGreaterThanOrEqual(0);
+    expect(iPending).toBeGreaterThan(iUser);
+    expect(iAssistant).toBeGreaterThan(iPending);
+    expect(iComplete).toBeGreaterThan(iAssistant);
+
+    // The pair references match, and turn_ref points at the echoed user uuid.
+    const pending = lines.find((l) => l.type === 'pending_turn')!;
+    const complete = lines.find((l) => l.type === 'turn_complete')!;
+    expect(complete.pending_uuid).toBe(pending.uuid);
+
+    const userEcho = messages.find((m) => m.type === 'user') as { uuid: string };
+    expect(pending.turn_ref).toBe(userEcho.uuid);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ⑦ redrive does NOT replay an already-executed tool
+// ---------------------------------------------------------------------------
+
+describe('redrive-on-resume', () => {
+  it('⑦ re-drives the interrupted request without re-running the executed tool', async () => {
+    const counter = { n: 0 };
+    const ping = tool(
+      'ping',
+      'count invocations',
+      {},
+      async () => {
+        counter.n += 1;
+        return { content: [{ type: 'text', text: 'pong' }] };
+      },
+    );
+    const srv = createSdkMcpServer({ name: 'c', tools: [ping] });
+    const mcpServers = { c: srv } as unknown as Options['mcpServers'];
+
+    // Attempt 1: tool_use -> tool executes (count 1) -> follow-up request fails.
+    const first = scriptedFetch([
+      toolUseReplyEvents('mcp__c__ping', {}, { id: 'toolu_a' }),
+      'crash',
+    ]);
+    vi.stubGlobal('fetch', first.fn);
+
+    const m1 = await collect(
+      query({
+        prompt: 'use the tool',
+        options: queryOptions({ mcpServers, permissionMode: 'bypassPermissions', allowDangerouslySkipPermissions: true }),
+      }),
+    );
+    // The turn ended in an is_error result (the engine converts the failure).
+    expect(lastResult(m1).is_error).toBe(true);
+    expect(counter.n).toBe(1); // tool ran exactly once
+    expect(first.calls()).toBe(2); // tool_use response + the failed follow-up
+
+    const sid = initSessionId(m1);
+    // The interrupted transcript carries the tool_result AND a dangling pending.
+    const t1 = await transcript(sid);
+    expect(t1.map((l) => l.type)).toContain('pending_turn');
+    expect(t1.some((l) => l.type === 'turn_complete')).toBe(false);
+
+    // Attempt 2: resume + redrive. The follow-up request now succeeds; the
+    // historical tool_use is context only, so the tool is NOT re-executed.
+    vi.unstubAllGlobals();
+    const second = scriptedFetch([textReplyEvents('all done')]);
+    vi.stubGlobal('fetch', second.fn);
+
+    const m2 = await collect(
+      query({
+        prompt: emptyStream(),
+        options: queryOptions({ mcpServers, permissionMode: 'default', resume: sid }),
+      }),
+    );
+
+    expect(counter.n).toBe(1); // KEY: no tool replay across the crash
+    expect(second.calls()).toBe(1); // one request: the redrive, no tool round-trip
+    expect(m2.some((m) => m.type === 'assistant')).toBe(true);
+    expect(lastResult(m2).subtype).toBe('success');
+
+    // The redrive settled the previously-dangling pending_turn.
+    const t2 = await transcript(sid);
+    expect(t2.some((l) => l.type === 'turn_complete')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ⑧ standalone query() is unaffected by the supervision machinery
+// ---------------------------------------------------------------------------
+
+describe('standalone query() regression', () => {
+  it('⑧ a failure surfaces as an error result (no auto-resume, no annotation)', async () => {
+    const { fn, calls } = scriptedFetch(['crash']);
+    vi.stubGlobal('fetch', fn);
+
+    const messages = await collect(query({ prompt: 'hi', options: queryOptions() }));
+
+    const last = lastResult(messages);
+    expect(last.is_error).toBe(true);
+    expect((last as any).resumeAttempts).toBeUndefined();
+    expect(resumeObservations(messages)).toHaveLength(0);
+    expect(calls()).toBe(1);
+  });
+
+  it('⑧ persistSession:false writes no transcript at all', async () => {
+    const { fn } = scriptedFetch([textReplyEvents('ok')]);
+    vi.stubGlobal('fetch', fn);
+
+    const messages = await collect(
+      query({ prompt: 'hi', options: queryOptions({ persistSession: false }) }),
+    );
+    expect(lastResult(messages).subtype).toBe('success');
+
+    // Nothing persisted -> no session file (thus no checkpoint records either).
+    const sid = initSessionId(messages);
+    await expect(readFile(join(sessionDir, `${sid}.jsonl`), 'utf8')).rejects.toThrow();
+  });
+});

--- a/projects/bpt-agent-sdk/tests/tool-descriptions.test.ts
+++ b/projects/bpt-agent-sdk/tests/tool-descriptions.test.ts
@@ -84,7 +84,13 @@ describe('faithful tool descriptions', () => {
 
   it('are actually wired onto the built-in tools', () => {
     const tools = createBuiltinTools({ env: {} });
-    expect(tools.get('Bash')?.description).toBe(D.BASH_DESCRIPTION);
+    // Bash is byte-identical to the base description everywhere except win32,
+    // where the gated platform note is appended (see createBashTool).
+    const expectedBash =
+      process.platform === 'win32'
+        ? D.BASH_DESCRIPTION + '\n\n' + D.BASH_WIN32_NOTE
+        : D.BASH_DESCRIPTION;
+    expect(tools.get('Bash')?.description).toBe(expectedBash);
     expect(tools.get('Grep')?.description).toBe(D.GREP_DESCRIPTION);
     // Task quartet is the default task surface (TodoWrite off by default) ...
     expect(tools.get('TaskCreate')?.description).toBe(D.TASKCREATE_DESCRIPTION);


### PR DESCRIPTION
## 背景

守密人裁定链:后台进程讨论 → 层一(进程内协调者)→ A → 稳定性(崩了要能恢复)→ 认可「层一 = 共享协调 + 监督恢复」→ 乙(推完实现)。设计存证见已合并的 #491(proposal §5/§6)。四子代理并行 + 主会话合流。

## 改动(v0.9.0,全 additive)

**SM-甲 共享协调**(`createBptSession`):一个 manager 托管多个 `mgr.query()`,共享**一份** transport + **一份** MCP 池(连一次多路复用,不再 N 对话 N 倍连接);`usage()` 只读聚合;`close()` 单点收尸。所有权契约:query 借用不拆、借用门面 no-op closeAll 且没收 setServers;独立 `query()` 语法糖化零破坏(头号红线用真 stdio pid 实证)。

**SM-乙a FileSessionStore**:落盘 JSONL 会话存储,可逆百分号编码作路径安全唯一收口、崩尾读容忍 + 写自愈,`fileSessionStore(dir)` 一行接。

**SM-乙b 监督恢复 + 预写检查点**:
- 检查点:每引擎轮 `pending_turn`/`turn_complete` 括住;resume 遇 dangling pending 在读输入前重驱该请求段,**绝不重放已执行工具**(tool_result 已在重放 history 配对)。
- 监督:mgr.query 接了 store 且 autoResume≠false 时,可恢复失败(按 E6c 稳定错误码分类,非猜文本)透明重驱 ≤maxResumes(默认 2);终态失败(abort/config/4xx/未知——fail-closed)原样转发/上抛,耗尽带 resumeAttempts。
- **关键适配**:引擎不 throw API 错、而产出 error result → 监督盯 error result;`SDKResultMessage` 加 additive `error_code` 字段(loop.ts 3 行加性)。每次重驱前发一条 `system/status` 观测。

**SM-丙 Bash cmd DX**:win32 门控描述句(Linux 字节不变、棘轮绿)+ exit-127 命中 11 词 cmd 表附纠正提示(`dir`/`type` 不入表,零误伤)。

## 验证

- `tsc --noEmit` 零错;`npx vitest run` **60 档 / 1392 passed / 2 skipped**(+约 46 新用例,含「重驱不翻倍执行工具」红线);
- 一致性 wire 棘轮 **15/15**(共享化/监督/检查点均不改请求体);
- 每子域均经隔离 worktree 钉 HEAD 验证后归档。

## 非目标(钉死)

不做层二守护进程(客户端-服务器 / 断连续跑),范围蔓延另案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E)_