### PR TITLE
docs(bpt-agent-sdk): backfill 0.1–0.5 into CHANGELOG

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -6,7 +6,10 @@ merge that changes shipped runtime code (`src/` or runtime dependencies)
 bumps the version** — bug fixes bump patch, new capability bumps minor —
 and adds one line here. A CI guard (`scripts/check-version-bump.mjs`) reds
 any src-changing merge that forgets. 0.6.1 and 0.6.2 below are retroactive
-labels for builds that shipped under a duplicated "0.6.0".
+labels for builds that shipped under a duplicated "0.6.0". The **0.1–0.5**
+entries at the bottom are likewise retroactive — reconstructed from the commit
+sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
+granularity stops at the commit-title level.
 
 ## 0.9.0 — 2026-07-06
 
@@ -206,3 +209,43 @@ branch merged main's 0.6.3–0.6.5 Windows/path-fence work below).
   memory-file selection, hook condition gating, worker-fork preset, default-on
   Bash sandbox (pluggable bwrap backend), prompt assembly layer Track B with
   v5 as the `claude_code` preset default.
+
+---
+
+_The 0.1–0.5 entries below are retroactive: the foundational series shipped on
+2026-07-04 without a per-merge ledger, so these are reconstructed from the
+commit sequence and their granularity stops at the commit-title level. 0.6+ above
+is the real per-merge record._
+
+## 0.5 — 2026-07-04
+
+- Productization + docs series: generators + classifiers scaffolding
+  (`src/generators/`); verifier + context tips; the prompt-assembly layer with
+  the `v5` `claude_code` preset (open reproduction of the official main-loop
+  prompt); the COMPAT compatibility matrix, the MIGRATION guide, and the
+  positioning docs.
+
+## 0.4 — 2026-07-04
+
+- Interaction + subagents: AskUserQuestion + WebSearch + host callbacks
+  (`onUserQuestion` / `webSearch` / `onElicitation`); tool permission
+  specifiers with `allowedTools` / `disallowedTools` rule-level gating;
+  subagent Task tool + worker fork.
+
+## 0.3 — 2026-07-04
+
+- Persistence + credentials: JSONL session store (`resume` / `continue` /
+  `forkSession`); the `provider` extension + gateway (Bearer-token) auth —
+  connection settings the official SDK does not expose.
+
+## 0.2 — 2026-07-04
+
+- Gating + external tools: permissions + hooks + `canUseTool` gating; MCP
+  client with stdio + streamable-HTTP transports.
+
+## 0.1 — 2026-07-04
+
+- Engine skeleton: clean-room scaffold; the direct Messages-API transport
+  (`fetch` + SSE) + agent engine loop; the six built-in tools
+  (Read/Write/Edit/Bash/Glob/Grep). No filesystem settings are loaded
+  (`settingSources` accepted but inert).


### PR DESCRIPTION
## What

Backfill the foundational **0.1–0.5** versions into `projects/bpt-agent-sdk/CHANGELOG.md`. The ledger previously only recorded 0.6.0+; the 0.1–0.5 series had no per-merge entries at all.

## Why

The five foundational versions all shipped on **2026-07-04** but predate the "bump + one CHANGELOG line per src-changing merge" discipline (in force since 0.6.2), so they were never written up. This closes that gap so the full version history is readable in one place.

## What changed

- Added `## 0.5` → `## 0.1` entries at the bottom of the CHANGELOG (descending order, matching the existing 0.6+ format):
  - **0.5** — generators/classifiers, verifier + context tips, prompt-assembly layer with the `v5` `claude_code` preset, COMPAT/MIGRATION/positioning docs
  - **0.4** — AskUserQuestion + WebSearch + host callbacks, tool permission specifiers + allowedTools/disallowedTools, subagent Task tool + worker fork
  - **0.3** — JSONL session store (resume/continue/fork), `provider` extension + gateway auth
  - **0.2** — permissions + hooks + `canUseTool` gating, MCP client (stdio + streamable-HTTP)
  - **0.1** — clean-room scaffold, direct Messages-API transport (fetch + SSE) + engine loop, six built-in tools
- Marked these entries **retroactive** (reconstructed from the commit sequence, commit-title granularity) and updated the header note to cover the backfill — kept clearly distinct from the real per-merge record for 0.6+.

## Notes

Documentation-only change (`CHANGELOG.md`); no `src/` or test changes, so no version bump and no test run required. Dates and content are sourced from the git commit sequence, not fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfjjAHHQG6nRTSVhFQx1PC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfjjAHHQG6nRTSVhFQx1PC)_