### PR TITLE
feat(bpt-sdk): Read 输出总字符上限（BPT 变更请求 2026-07-06）v0.10.0

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,32 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.10.0 — 2026-07-06
+
+- **feat (Read total-output cap, BPT request 2026-07-06)**: Read now caps the
+  TOTAL characters it returns (default 50000), closing the tail gap where a
+  2000-line file of medium-length lines could flood the context past the line
+  and per-line limits (observed p99 ~90K chars; ~2% of reads exceed 50K). The
+  cap applies on a LINE BOUNDARY (never mid-line); since every line is already
+  ≤2000 chars, 50000 > 2000 guarantees ≥~25 lines, so output is never empty and
+  offset continuation never dead-loops.
+  - **footer consistency**: when the char cap (or the line limit) truncates, the
+    footer reflects the REAL last line returned and the reason —
+    `(Showing lines 1-N of Z; output truncated at 50000 chars. Use offset=N+1 to
+    continue reading.)` — never claiming more lines than were emitted.
+  - **per-line truncation is now marked**: an over-long line carries
+    `…[line truncated: N chars total]` instead of a silent 2000-char slice, so
+    the model doesn't mistake a half-line for the whole (correctness, not tokens).
+  - **Grep hint**: a large file (>256KB) truncated with long lines nudges toward
+    Grep instead of paging.
+  - **configurable (§E)**: `options.readLimits: { maxOutputChars?, maxLineChars? }`
+    (mechanism in the SDK, numbers are the caller's); also `createReadTool(limits)`
+    / `createBuiltinTools({ readLimits })`. `SDKResultMessage` unaffected.
+  - **Behavior note**: consumers that relied on Read returning >50000 chars in
+    one call now get a truncated window + a continue footer; pass
+    `readLimits: { maxOutputChars: <large> }` to opt out. Image/PDF/binary/empty
+    reads are exempt (they return before the cap logic).
+
 ## 0.9.0 — 2026-07-06
 
 - **feat (BPT-EXTENSION): SessionManager — in-process shared coordination +

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -70,6 +70,7 @@ Per-row detail lives in the sections below; this is the at-a-glance table.
 |---|---|---|---|
 | **Engine model** | — | wraps the Claude Code CLI (black-box subprocess) | drives the Messages API directly (fetch+SSE, no CLI); this is the root of most divergences below |
 | `createBptSession` (SessionManager) | BPT-EXTENSION | no in-process coordinator (coordination lives in the wrapped CLI host) | one manager hosts many `mgr.query()` conversations over a shared transport + shared MCP pool; supervised auto-resume from a store; `error_code` on result (v0.9.0) |
+| Read total-output cap (`readLimits`) | BPT-EXTENSION | line + per-line caps only | additionally caps TOTAL Read output on a line boundary (default 50000), with a footer that reflects the real range, per-line truncation markers, and a Grep hint; `options.readLimits` tunes the numbers (v0.10.0) |
 | `provider.cacheTtl` | BPT-EXTENSION | no cache-TTL knob (CLI decides 5m/1h internally; only reports the split in usage) | caller picks `'5m'`/`'1h'` per query (v0.7.1) |
 | `provider.promptCaching` | BPT-EXTENSION | no toggle (caching is internal) | caller can turn the whole breakpoint layer off |
 | tool-block cache breakpoint | KEPT-DIVERGENCE | 0 breakpoints on tool blocks | 1 (last tool) — measured to only ever gain cache hits on system-prompt divergence, never lose (E7-03) |

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -572,7 +572,10 @@ export function query(args: {
 
   // Built-in tools, optionally filtered by the array form of options.tools
   // (the claude_code preset and undefined both mean "all built-ins").
-  const allBuiltins = createBuiltinTools({ sandbox: sandboxCtx });
+  const allBuiltins = createBuiltinTools({
+    sandbox: sandboxCtx,
+    readLimits: options.readLimits,
+  });
   let builtinTools: Map<string, BuiltinTool>;
   if (Array.isArray(options.tools)) {
     builtinTools = new Map();

--- a/projects/bpt-agent-sdk/src/tools/descriptions.ts
+++ b/projects/bpt-agent-sdk/src/tools/descriptions.ts
@@ -73,6 +73,11 @@
  *    doctrine, caps, quality patterns) is reproduced faithfully — the shipped
  *    engine implements those semantics (official caps verbatim: min(16,
  *    cores-2) concurrent, 1000 lifetime, 4096 items per call).
+ *  - Read (BPT request 2026-07-06): adapted glue, not archive text. One line is
+ *    appended documenting this SDK's TOTAL-output character cap (default ~50000)
+ *    — a shipped mechanism the public archive does not describe. The existing
+ *    "up to 2000 lines" / "lines longer than 2000 characters" clauses are
+ *    archive text, retained verbatim; only the total-cap sentence is added.
  *  - Background shells: launched via Bash `run_in_background: true`; read output
  *    with BashOutput; stop with KillShell.
  *  - Git guidance for Bash is retained (Bash can run git), with CLI-product-specific
@@ -211,6 +216,7 @@ Usage:
 - The file_path parameter must be an absolute path, not a relative path
 - By default, it reads up to 2000 lines starting from the beginning of the file
 - Any lines longer than 2000 characters will be truncated
+- Output is also capped at ~50000 characters total; when truncated, a footer shows the exact line range returned and the offset to continue reading from
 - Results are returned using cat -n format, with line numbers starting at 1
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
 - This tool allows you to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as this is a multimodal model.

--- a/projects/bpt-agent-sdk/src/tools/edit.ts
+++ b/projects/bpt-agent-sdk/src/tools/edit.ts
@@ -45,7 +45,12 @@ function buildSnippet(updated: string, firstEditIndex: number, newString: string
   const editSpan = newString.split('\n').length;
   const from = Math.max(1, editLine - SNIPPET_CONTEXT_LINES);
   const to = Math.min(display.length, editLine + editSpan - 1 + SNIPPET_CONTEXT_LINES);
-  return formatCatN(display.slice(from - 1, to), from);
+  // Edit shows a bounded diff-context snippet, not a paginated read: disable
+  // the total-output cap so a large edit context is never truncated (the small
+  // snippet never approaches it anyway); the per-line marker still applies.
+  return formatCatN(display.slice(from - 1, to), from, {
+    maxOutputChars: Number.MAX_SAFE_INTEGER,
+  }).text;
 }
 
 export const editTool: BuiltinTool = {

--- a/projects/bpt-agent-sdk/src/tools/fsutil.ts
+++ b/projects/bpt-agent-sdk/src/tools/fsutil.ts
@@ -17,11 +17,38 @@ import * as path from 'node:path';
 /** Number of leading bytes sniffed when deciding whether a file is binary. */
 const BINARY_SNIFF_BYTES = 8192;
 
-/** Maximum characters kept per line in cat -n style output. */
-const MAX_LINE_CHARS = 2000;
+/** Default maximum characters kept per line in cat -n style output. */
+export const MAX_LINE_CHARS = 2000;
+
+/**
+ * Default cap on the TOTAL characters one Read returns (BPT request 2026-07-06).
+ * The line limit (2000) and per-line cap (2000) bound rows and row-width but
+ * not the AGGREGATE — a 2000-line file of medium-length lines can still flood
+ * the context. This cap is applied on a LINE BOUNDARY (never mid-line) during
+ * formatting; because every line is already <= MAX_LINE_CHARS, 50000 > 2000
+ * guarantees at least ~25 lines are emitted, so the output is never empty and
+ * an offset continuation never dead-loops. ~50K aligns with the WebFetch cap.
+ */
+export const MAX_READ_OUTPUT_CHARS = 50000;
 
 /** Width of the right-aligned line-number column. */
 const LINE_NUMBER_WIDTH = 6;
+
+/** Structured result of formatCatN: the text plus what bounded it, so the Read
+ *  tool can build a footer that reflects the cap that actually took effect. */
+export type FormatCatNResult = {
+  /** The assembled cat -n output. */
+  text: string;
+  /** How many of the input lines were emitted (< lines.length when the total-
+   *  character cap stopped assembly early on a line boundary). */
+  linesEmitted: number;
+  /** True when the total-character cap stopped assembly before all input lines
+   *  fit (distinct from the caller's line-count limit). */
+  charCapped: boolean;
+  /** Count of emitted lines that exceeded the per-line cap and were truncated
+   *  (each carries a `…[line truncated: N chars total]` marker). */
+  truncatedLines: number;
+};
 
 /**
  * Resolve `p` (absolute or cwd-relative) to an absolute path. No containment
@@ -45,15 +72,44 @@ export function looksBinary(buf: Buffer): boolean {
 }
 
 /**
- * Format lines in `cat -n` style: right-aligned 6-char line number, a tab,
- * then the line text truncated at 2000 characters.
+ * Format lines in `cat -n` style: right-aligned 6-char line number, a tab, then
+ * the line text. Two caps apply: each line is truncated at `maxLineChars` (a
+ * `…[line truncated: N chars total]` marker replaces the silent slice so the
+ * model knows the row is incomplete), and the TOTAL output is capped at
+ * `maxOutputChars` on a line boundary (never mid-line). The first line is
+ * always emitted, so the result is never empty even if that line alone exceeds
+ * the total cap. Returns what bounded the output so the caller can footer it.
  */
-export function formatCatN(lines: string[], startLine: number): string {
+export function formatCatN(
+  lines: string[],
+  startLine: number,
+  opts?: { maxLineChars?: number; maxOutputChars?: number },
+): FormatCatNResult {
+  const maxLineChars = opts?.maxLineChars ?? MAX_LINE_CHARS;
+  const maxOutputChars = opts?.maxOutputChars ?? MAX_READ_OUTPUT_CHARS;
   const out: string[] = [];
+  let running = 0;
+  let truncatedLines = 0;
+  let charCapped = false;
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i] ?? '';
-    const text = raw.length > MAX_LINE_CHARS ? raw.slice(0, MAX_LINE_CHARS) : raw;
-    out.push(`${String(startLine + i).padStart(LINE_NUMBER_WIDTH)}\t${text}`);
+    let text: string;
+    if (raw.length > maxLineChars) {
+      text = `${raw.slice(0, maxLineChars)}…[line truncated: ${raw.length} chars total]`;
+      truncatedLines += 1;
+    } else {
+      text = raw;
+    }
+    const formatted = `${String(startLine + i).padStart(LINE_NUMBER_WIDTH)}\t${text}`;
+    // Cost of appending this line = the '\n' join separator (none before the
+    // first line) + the formatted text. The first line always goes in.
+    const addition = (out.length === 0 ? 0 : 1) + formatted.length;
+    if (out.length > 0 && running + addition > maxOutputChars) {
+      charCapped = true;
+      break;
+    }
+    out.push(formatted);
+    running += addition;
   }
-  return out.join('\n');
+  return { text: out.join('\n'), linesEmitted: out.length, charCapped, truncatedLines };
 }

--- a/projects/bpt-agent-sdk/src/tools/index.ts
+++ b/projects/bpt-agent-sdk/src/tools/index.ts
@@ -24,11 +24,11 @@
  */
 
 import type { BuiltinTool } from '../internal/contracts.js';
-import { readTool } from './read.js';
+import { createReadTool, readTool } from './read.js';
 import { writeTool } from './write.js';
 import { editTool } from './edit.js';
 import { bashTool, createBashTool } from './bash.js';
-import type { SandboxContext } from '../types.js';
+import type { ReadLimits, SandboxContext } from '../types.js';
 import { globTool } from './glob.js';
 import { grepTool } from './grep.js';
 import { webFetchTool } from './webfetch.js';
@@ -53,11 +53,13 @@ import { workflowTool } from './workflow.js';
 export function createBuiltinTools(cfg?: {
   sandbox?: SandboxContext;
   env?: Record<string, string | undefined>;
+  /** Read output limits (spec §E). Undefined -> the default-limits readTool. */
+  readLimits?: ReadLimits;
 }): Map<string, BuiltinTool> {
   const env = cfg?.env ?? process.env;
   const legacyTodo = env['CLAUDE_CODE_ENABLE_TASKS'] === '0';
   const tools: BuiltinTool[] = [
-    readTool,
+    cfg?.readLimits !== undefined ? createReadTool(cfg.readLimits) : readTool,
     writeTool,
     editTool,
     cfg?.sandbox !== undefined ? createBashTool(cfg.sandbox) : bashTool,

--- a/projects/bpt-agent-sdk/src/tools/read.ts
+++ b/projects/bpt-agent-sdk/src/tools/read.ts
@@ -11,8 +11,14 @@ import type {
   ToolContext,
   ToolResultPayload,
 } from '../internal/contracts.js';
+import type { ReadLimits } from '../types.js';
 import { AbortError, isAbortError } from '../errors.js';
-import { formatCatN, looksBinary, resolveAbs } from './fsutil.js';
+import {
+  MAX_READ_OUTPUT_CHARS,
+  formatCatN,
+  looksBinary,
+  resolveAbs,
+} from './fsutil.js';
 import { READ_DESCRIPTION } from './descriptions.js';
 
 const DEFAULT_LINE_LIMIT = 2000;
@@ -76,7 +82,15 @@ function detectImageMediaType(buf: Buffer): string | undefined {
   return undefined;
 }
 
-export const readTool: BuiltinTool = {
+/** File byte size above which a char-capped read with long lines nudges toward
+ *  Grep instead of paging (spec §D): a big file whose rows are also long is
+ *  usually a "search, don't read" signal. */
+const GREP_HINT_FILE_BYTES = 256 * 1024;
+
+/** Build a Read tool bound to the given output limits (spec §E). `readTool`
+ *  below is the default-limits instance for direct imports / no-config use. */
+export function createReadTool(limits?: ReadLimits): BuiltinTool {
+  return {
   name: 'Read',
   description: READ_DESCRIPTION,
   readOnly: true,
@@ -294,9 +308,36 @@ export const readTool: BuiltinTool = {
       // any successful Read of the file) registers the path.
       ctx.readFilePaths?.add(abs);
 
-      let content = formatCatN(selected, startLine);
-      if (lastShown < total) {
-        content += `\n\n(Showing lines ${startLine}-${lastShown} of ${total}. Use offset=${lastShown + 1} to continue reading.)`;
+      const maxOutputChars = limits?.maxOutputChars ?? MAX_READ_OUTPUT_CHARS;
+      const fmt = formatCatN(selected, startLine, {
+        maxOutputChars,
+        maxLineChars: limits?.maxLineChars,
+      });
+      // The char cap may bound the output BEFORE the line window does, so the
+      // real last line shown is what formatCatN actually emitted (spec §B: the
+      // footer must reflect whichever cap took effect — never claim more lines
+      // than were returned).
+      const shownLines = fmt.linesEmitted;
+      const realLastShown = startLine + shownLines - 1;
+      let content = fmt.text;
+      if (fmt.charCapped) {
+        // Total-character cap took effect (may be tighter than the line limit).
+        let footer =
+          `\n\n(Showing lines ${startLine}-${realLastShown} of ${total}; ` +
+          `output truncated at ${maxOutputChars} chars. ` +
+          `Use offset=${realLastShown + 1} to continue reading.)`;
+        // §D: a big file whose rows are also long — Grep is usually the better
+        // tool than paging through it. read.ts holds the byte size + long-line
+        // signal that an app-layer hook could only guess at.
+        if (fmt.truncatedLines > 0 && buf.length > GREP_HINT_FILE_BYTES) {
+          footer +=
+            '\n(This file is large and has very long lines; consider the Grep ' +
+            'tool to search it instead of reading page by page.)';
+        }
+        content += footer;
+      } else if (realLastShown < total) {
+        // Line-count limit (or offset window) bounded the output, chars did not.
+        content += `\n\n(Showing lines ${startLine}-${realLastShown} of ${total}. Use offset=${realLastShown + 1} to continue reading.)`;
       }
       return { content };
     } catch (e) {
@@ -306,4 +347,8 @@ export const readTool: BuiltinTool = {
       return errorResult(`Read failed: ${(e as Error).message}`);
     }
   },
-};
+  };
+}
+
+/** Default-limits Read tool (50000 total / 2000 per line). */
+export const readTool: BuiltinTool = createReadTool();

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -1079,9 +1079,24 @@ export interface SpawnedProcess {
   off(event: 'error', listener: (error: Error) => void): void;
 }
 
+/**
+ * BPT-EXTENSION: tunable Read output limits (spec 2026-07-06). The MECHANISM
+ * (total-char cap on a line boundary, a footer that reflects the cap, per-line
+ * truncation markers, the Grep hint) lives in the SDK; only the NUMBERS are the
+ * caller's. Both default when omitted (50000 total chars / 2000 per line).
+ */
+export type ReadLimits = {
+  /** Total characters one Read returns before truncating on a line boundary. */
+  maxOutputChars?: number;
+  /** Characters kept per line before the per-line truncation marker. */
+  maxLineChars?: number;
+};
+
 export type Options = {
   abortController?: AbortController;
   additionalDirectories?: string[];
+  /** Read output limits (BPT-EXTENSION); omit for the defaults. */
+  readLimits?: ReadLimits;
   /** Programmatic subagent definitions (type-compatible; execution in v0.2). */
   agents?: Record<string, AgentDefinition>;
   allowedTools?: string[];

--- a/projects/bpt-agent-sdk/tests/read-output-cap.test.ts
+++ b/projects/bpt-agent-sdk/tests/read-output-cap.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Read total-output character cap (BPT request 2026-07-06).
+ *
+ * Covers the spec's boundary matrix: line-limit vs char-cap precedence, the
+ * consistent footer (§B — never claims more lines than it returned), the
+ * per-line truncation marker (§C), the Grep hint (§D), configurable limits
+ * (§E), and the never-empty invariant (total cap > per-line cap => >= ~25
+ * lines). formatCatN is also unit-tested directly.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createReadTool, readTool } from '../src/tools/read.js';
+import {
+  MAX_READ_OUTPUT_CHARS,
+  MAX_LINE_CHARS,
+  formatCatN,
+} from '../src/tools/fsutil.js';
+import { createBuiltinTools } from '../src/tools/index.js';
+import { AbortError } from '../src/errors.js';
+import type { ToolContext } from '../src/internal/contracts.js';
+
+let sandboxes: string[] = [];
+async function makeSandbox(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'bpt-readcap-'));
+  sandboxes.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(sandboxes.map((d) => rm(d, { recursive: true, force: true })));
+  sandboxes = [];
+});
+
+function makeCtx(cwd: string): ToolContext {
+  return {
+    cwd,
+    additionalDirectories: [],
+    env: {},
+    signal: new AbortController().signal,
+    debug: () => {},
+  };
+}
+
+async function writeFileLines(dir: string, name: string, lines: string[]): Promise<string> {
+  const p = path.join(dir, name);
+  await writeFile(p, lines.join('\n'), 'utf8');
+  return p;
+}
+
+function contentOf(res: { content: unknown }): string {
+  return typeof res.content === 'string' ? res.content : JSON.stringify(res.content);
+}
+
+describe('formatCatN (unit)', () => {
+  it('reports linesEmitted, charCapped=false when everything fits', () => {
+    const r = formatCatN(['a', 'b', 'c'], 1);
+    expect(r.linesEmitted).toBe(3);
+    expect(r.charCapped).toBe(false);
+    expect(r.truncatedLines).toBe(0);
+    expect(r.text.split('\n')).toHaveLength(3);
+  });
+
+  it('stops on a line boundary at the total-char cap and flags charCapped', () => {
+    // 200 lines of ~100 chars each ~= 20K; cap at 5000 -> ~40-50 lines.
+    const lines = Array.from({ length: 200 }, (_, i) => `line ${i} ` + 'x'.repeat(90));
+    const r = formatCatN(lines, 1, { maxOutputChars: 5000 });
+    expect(r.charCapped).toBe(true);
+    expect(r.linesEmitted).toBeGreaterThan(0);
+    expect(r.linesEmitted).toBeLessThan(200);
+    expect(r.text.length).toBeLessThanOrEqual(5000);
+  });
+
+  it('always emits the first line even if it alone exceeds the total cap (never empty)', () => {
+    const r = formatCatN(['x'.repeat(500)], 1, { maxOutputChars: 10 });
+    expect(r.linesEmitted).toBe(1);
+    expect(r.text.length).toBeGreaterThan(0);
+  });
+
+  it('marks a per-line truncation with the original length (§C), not a silent slice', () => {
+    const long = 'y'.repeat(MAX_LINE_CHARS + 5000);
+    const r = formatCatN([long], 1);
+    expect(r.truncatedLines).toBe(1);
+    expect(r.text).toContain(`…[line truncated: ${MAX_LINE_CHARS + 5000} chars total]`);
+    // the kept portion is exactly maxLineChars of the original
+    expect(r.text).toContain('y'.repeat(MAX_LINE_CHARS));
+  });
+
+  it('honors custom maxLineChars / maxOutputChars', () => {
+    const r = formatCatN(['z'.repeat(100)], 1, { maxLineChars: 10 });
+    expect(r.truncatedLines).toBe(1);
+    expect(r.text).toContain('…[line truncated: 100 chars total]');
+  });
+});
+
+describe('Read total-output cap (boundary matrix)', () => {
+  it('§3 case 1: line limit hits first, char cap not reached -> plain line footer', async () => {
+    const dir = await makeSandbox();
+    // 3000 short lines: the 2000-line limit bounds it well before 50K chars.
+    const file = await writeFileLines(dir, 'many-short.txt', Array.from({ length: 3000 }, (_, i) => `l${i}`));
+    const res = await readTool.execute({ file_path: file }, makeCtx(dir));
+    const c = contentOf(res);
+    expect(c).toContain('Showing lines 1-2000 of 3000. Use offset=2001 to continue reading.');
+    expect(c).not.toContain('truncated at');
+  });
+
+  it('§3 case 2: char cap hits first -> footer reports truncated at cap + offset', async () => {
+    const dir = await makeSandbox();
+    // 2000 lines x 500 chars ~= 1MB: the 50K char cap bounds it near line ~90.
+    const file = await writeFileLines(dir, 'wide.txt', Array.from({ length: 2000 }, () => 'w'.repeat(500)));
+    const res = await readTool.execute({ file_path: file }, makeCtx(dir));
+    const c = contentOf(res);
+    expect(c).toContain(`output truncated at ${MAX_READ_OUTPUT_CHARS} chars`);
+    // footer must name the REAL last line (< 2000), not claim all 2000
+    const m = c.match(/Showing lines 1-(\d+) of 2000/);
+    expect(m).not.toBeNull();
+    const lastShown = Number(m![1]);
+    expect(lastShown).toBeLessThan(2000);
+    expect(lastShown).toBeGreaterThanOrEqual(25); // never-empty invariant
+    expect(c).toContain(`Use offset=${lastShown + 1} to continue reading.`);
+    // §B consistency: the actual body has exactly `lastShown` numbered rows
+    const body = c.split('\n\n(')[0];
+    expect(body.split('\n')).toHaveLength(lastShown);
+  });
+
+  it('§3 case 3: offset continuation reads the window after the cap', async () => {
+    const dir = await makeSandbox();
+    const file = await writeFileLines(dir, 'wide.txt', Array.from({ length: 2000 }, (_, i) => `${i}:` + 'w'.repeat(500)));
+    const first = contentOf(await readTool.execute({ file_path: file }, makeCtx(dir)));
+    const off = Number(first.match(/Use offset=(\d+)/)![1]);
+    const second = contentOf(await readTool.execute({ file_path: file, offset: off }, makeCtx(dir)));
+    // the second read starts exactly where the first stopped
+    expect(second).toContain(`${String(off).padStart(6)}\t${off - 1}:`);
+  });
+
+  it('§3 case 4: a 45K single line is per-line truncated + marked, still bounded', async () => {
+    const dir = await makeSandbox();
+    const file = await writeFileLines(dir, 'onelong.txt', ['head', 'z'.repeat(45000), 'tail']);
+    const res = await readTool.execute({ file_path: file }, makeCtx(dir));
+    const c = contentOf(res);
+    expect(c).toContain('…[line truncated: 45000 chars total]');
+    expect(c).toContain('head');
+    expect(c).toContain('tail'); // 3 short-ish lines, no total cap hit
+  });
+
+  it('a complete small read has no footer at all', async () => {
+    const dir = await makeSandbox();
+    const file = await writeFileLines(dir, 'small.txt', ['one', 'two', 'three']);
+    const c = contentOf(await readTool.execute({ file_path: file }, makeCtx(dir)));
+    expect(c).not.toContain('Showing lines');
+    expect(c).not.toContain('truncated');
+  });
+
+  it('§E: createReadTool with a tight cap truncates sooner; createBuiltinTools threads readLimits', async () => {
+    const dir = await makeSandbox();
+    const file = await writeFileLines(dir, 'medium.txt', Array.from({ length: 500 }, (_, i) => `line ${i} ` + 'q'.repeat(80)));
+    const tight = createReadTool({ maxOutputChars: 3000 });
+    const c = contentOf(await tight.execute({ file_path: file }, makeCtx(dir)));
+    expect(c).toContain('output truncated at 3000 chars');
+
+    const tools = createBuiltinTools({ readLimits: { maxOutputChars: 3000 } });
+    const read = tools.get('Read')!;
+    const c2 = contentOf(await read.execute({ file_path: file }, makeCtx(dir)));
+    expect(c2).toContain('output truncated at 3000 chars');
+  });
+
+  it('§3 exemption: an empty file returns the empty note before any cap logic', async () => {
+    const dir = await makeSandbox();
+    const file = path.join(dir, 'empty.txt');
+    await writeFile(file, '', 'utf8');
+    const c = contentOf(await readTool.execute({ file_path: file }, makeCtx(dir)));
+    expect(c).toContain('exists but is empty');
+    expect(c).not.toContain('truncated');
+  });
+
+  it('aborts cleanly', async () => {
+    const dir = await makeSandbox();
+    const file = await writeFileLines(dir, 'x.txt', ['a']);
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      readTool.execute({ file_path: file }, { ...makeCtx(dir), signal: ac.signal }),
+    ).rejects.toBeInstanceOf(AbortError);
+  });
+});


### PR DESCRIPTION
## 背景

BPT 变更请求:Read 现有四道闸(2000 行 / 每行 2000 字符 / 50MB 文件 / 续读 footer)唯独缺「总量」——一个 2000 行×500 字符 ≈ 25 万 token 的文件能绕过所有现有闸灌爆上下文。生产扫描:p99 ~90K 字符,~2% Read 超 50K。归属论证:机制进 SDK(避免应用层钩子双头维护 footer),数值留应用。锚点已在换底后 0.10.0 源上重跑复核在位。

## 改动(v0.10.0,规格 A–F 全落)

- **A 总字符上限**:`MAX_READ_OUTPUT_CHARS` 默认 50000,行边界累加、达标即停(不切行中);`formatCatN` 改返回结构化结果(text / linesEmitted / charCapped / truncatedLines)。因每行 ≤2000、50000>2000 保证 ≥~25 行:永不空输出、无 offset 死循环。
- **B footer 一致性**:字符上限或行上限触发时,footer 反映**真实**最后一行 + 原因(`Showing lines 1-N of Z; output truncated at 50000 chars. Use offset=N+1...`)——绝不出现「footer 说 2000 行、实际只 812 行」矛盾。
- **C 单行截断残迹标记**:超长行显示 `…[line truncated: N chars total]` 而非静默切(正确性:防模型把半截行当完整拿去 Edit)。
- **D 超大文件 Grep 提示**:大文件(>256KB)+ 命中上限 + 有超长行 → footer 建议 Grep。
- **E 阈值可配**:`options.readLimits: { maxOutputChars?, maxLineChars? }` + `createReadTool(limits)` / `createBuiltinTools({ readLimits })`,默认 50000/2000。
- **F 描述同步**:READ_DESCRIPTION 补总字符上限句(登记 adaptation,守卫绿)。

**行为变更提示**:依赖单次 Read 返回 >50K 字符的调用方现在得到截断窗口 + 续读 footer;`readLimits.maxOutputChars` 可放宽/关闭。image/PDF/binary/空文件豁免。

## 验证

- `tsc --noEmit` 零错;`npx vitest run` **61 档 / 1405 passed / 2 skipped**(+13 新:边界矩阵 §3 全六例 + formatCatN 单测);版本护栏 OK;隔离 worktree 钉 HEAD 验证。

## 前向说明（非本次）

请求提到 PostToolUse `updatedToolOutput` 可把「工具输出流控」抽象成通用设施(供 web_browse 复用)——供架构参考,未在本次交付。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E)_