### PR TITLE
fix(okf): 治理测试容忍档案派生漂移 + 每日重建兜底（守密人乙+丙）

### DIFF
--- a/.github/workflows/build-okf-bundle.yml
+++ b/.github/workflows/build-okf-bundle.yml
@@ -7,6 +7,11 @@ on:
       - 'scripts/build_okf_bundle.py'
       - 'projects/wiki/data/processed/characters.json'
       - 'projects/news/output/source-health.json'
+  # 丙（守密人 2026-07-06）：sources 层派生自每小时更新的社区档案，push-path 触发盖不住
+  # 数据演进带来的层漂移（新平台/新档案指针）。每日重建一次把 committed bundle 同步上来，
+  # 兜住 test_kb_governance（该测试在 sparse-checkout CI 下跳过、只本地全量现形，见其注释）。
+  schedule:
+    - cron: '17 6 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/scripts/build_okf_bundle.py
+++ b/scripts/build_okf_bundle.py
@@ -666,31 +666,46 @@ def _node_url(rel: str) -> str | None:
     return None
 
 
-def structural_fingerprint(bundle: Path) -> str:
-    """规范化结构哈希：只覆盖**结构**（concept id→type/resource/排序 tags + 排序边），
-    **排除易变量**（timestamp、描述里的活计数）。
+def structural_parts(bundle: Path) -> "tuple[dict, set]":
+    """返回 bundle 的**结构组件**（未哈希）：concept 映射 `rel → (type, resource, tags元组)`
+    + 边集合 `{(source, target, rel_type)}`。只覆盖结构、排除易变量（timestamp/活计数）。
 
-    北极星命令二（`memory/knowledge-layer-design.md`）的落地：让「结构漂移」可被断言，
-    又不被每日时间戳/活数据漂移误报——committed bundle 的结构指纹应恒等于源重建的结构指纹，
-    否则=有人改了源结构却忘了重建（stale commit）或生成器非幂等。
+    暴露未哈希组件是为让治理测试做**子集**比对（守密人 2026-07-06 乙裁定：sources 层派生自
+    每小时更新的社区档案，fresh 重建可合法地比 committed 多出概念，定时重建（丙）随后同步——
+    治理测试改为「committed ⊆ fresh + 公共概念结构相等」，仍抓丢失/改名/结构变/非幂等，
+    但容忍源集增长）。`structural_fingerprint` 仍在其上取整包哈希，供需精确相等的场景。
     """
-    import hashlib
-
-    concepts = []
+    concepts: dict = {}
     for f in sorted(bundle.rglob("*.md")):
         if f.name in RESERVED:
             continue
         rel = "/" + str(f.relative_to(bundle))
         fm = _read_frontmatter(f.read_text(encoding="utf-8"))
-        tags = sorted(fm.get("tags", [])) if isinstance(fm.get("tags"), list) else []
-        concepts.append([rel, fm.get("type", ""), fm.get("resource", ""), tags])
-    concepts.sort()
-    edges = []
+        tags = tuple(sorted(fm.get("tags", []))) if isinstance(fm.get("tags"), list) else ()
+        concepts[rel] = (fm.get("type", ""), fm.get("resource", ""), tags)
+    edges: set = set()
     gp = bundle / "graph.json"
     if gp.exists():
         g = json.loads(gp.read_text(encoding="utf-8"))
-        edges = sorted([e["source"], e["target"], e.get("rel_type", e.get("rel", ""))]
-                       for e in g.get("edges", []))
+        edges = {
+            (e["source"], e["target"], e.get("rel_type", e.get("rel", "")))
+            for e in g.get("edges", [])
+        }
+    return concepts, edges
+
+
+def structural_fingerprint(bundle: Path) -> str:
+    """规范化结构哈希：只覆盖**结构**（concept id→type/resource/排序 tags + 排序边），
+    **排除易变量**（timestamp、描述里的活计数）。整包精确相等场景用；容忍增长的分层比对见
+    `structural_parts` + 治理测试。哈希格式与历史一致（未哈希组件由 structural_parts 提供）。
+    """
+    import hashlib
+
+    concepts_map, edges_set = structural_parts(bundle)
+    concepts = sorted(
+        [rel, t, r, list(tags)] for rel, (t, r, tags) in concepts_map.items()
+    )
+    edges = sorted([s, t, rt] for (s, t, rt) in edges_set)
     blob = json.dumps({"concepts": concepts, "edges": edges}, ensure_ascii=False, sort_keys=True)
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()
 

--- a/tests/test_kb_governance.py
+++ b/tests/test_kb_governance.py
@@ -162,10 +162,35 @@ def test_committed_bundle_structure_matches_sources(tmp_path, monkeypatch):
     bok.build_visualizer(graph)
     bki.build_kb_index()
 
-    fresh = bok.structural_fingerprint(tmp_bundle)
-    committed = bok.structural_fingerprint(REPO / "okf")
-    assert fresh == committed, (
-        "committed okf/ 的结构与源重建不一致——请 `python3 scripts/build_okf_bundle.py` 重建并提交"
+    # 守密人 2026-07-06「乙+丙」裁定：sources 层派生自每小时更新的社区档案，fresh 重建可
+    # 合法地比 committed 多出概念/边（新平台/新档案），定时重建（丙，build-okf-bundle.yml
+    # 的每日 cron）随后把 committed 同步上来。故本测试从「整包精确相等」放宽为**子集**比对：
+    # 容忍源集增长（committed ⊆ fresh），但仍抓真回归——committed 概念从 fresh 缺失
+    # （丢失/改名）、公共概念结构不一致（type/resource/tags 变、生成器非幂等）、committed
+    # 边从 fresh 缺失。锁「已有不丢/不变」，不锁「不许新增」。
+    fresh_c, fresh_e = bok.structural_parts(tmp_bundle)
+    committed_c, committed_e = bok.structural_parts(REPO / "okf")
+
+    dropped = sorted(k for k in committed_c if k not in fresh_c)
+    assert not dropped, (
+        "committed 概念在源重建中消失（丢失/改名）——需 `python3 scripts/build_okf_bundle.py` "
+        f"重建并提交：{dropped[:10]}"
+    )
+    changed = sorted(
+        k for k in committed_c if k in fresh_c and committed_c[k] != fresh_c[k]
+    )
+    assert not changed, (
+        "committed 概念结构与源重建不一致（type/resource/tags 变或生成器非幂等）——需重建："
+        f"{changed[:10]}"
+    )
+    # `mention` 边（community/sources → 角色）是内容派生的：哪个角色被社区文本提及随每小时
+    # 档案更新而双向 churn（掉几条、长几条），不是结构。故边子集检查排除 mention，只锁
+    # **结构边**（层骨架 / 角色关系 / 抽样自 / 聚合自 等）不丢。
+    committed_stable_e = {e for e in committed_e if e[2] != "mention"}
+    fresh_stable_e = {e for e in fresh_e if e[2] != "mention"}
+    dropped_edges = sorted(committed_stable_e - fresh_stable_e)
+    assert not dropped_edges, (
+        f"committed 结构边在源重建中消失——需 `python3 scripts/build_okf_bundle.py` 重建：{dropped_edges[:10]}"
     )
 
 


### PR DESCRIPTION
## 背景

`test_kb_governance::test_committed_bundle_structure_matches_sources` 反复漂红(#494 手修后几小时又红):sources 层派生自每小时更新的社区档案,社区数据一演进(新源概念 / community/sources→角色的 `mention` 边 churn)而 OKF 未重建,整包精确哈希就对不上;该测试在 sparse-checkout CI 下跳过,只本地全量 pytest 现形,故手修是打地鼠。守密人裁定**乙+丙**。

## 乙:治理测试放宽为子集比对

- `scripts/build_okf_bundle.py` 新增 `structural_parts()`——暴露未哈希的概念映射 + 边集合(`structural_fingerprint` 重构为在其上取哈希,**哈希格式不变**,精确相等场景仍可用);
- 测试从「整包哈希精确相等」改为**子集**:committed 概念/边须是 fresh 的子集——仍抓概念**丢失/改名**、公共概念**结构变**(type/resource/tags)、生成器**非幂等**、**结构边**丢失;但容忍源集**增长**(新平台/新档案);
- `mention` 边(内容派生、随档案双向 churn)整体排除出边检查。

## 丙:每日重建兜底

`build-okf-bundle.yml` 加每日 cron(6:17 UTC)——工作流已有全量检出 + 重建 + `[skip ci]` 提交 + 重试,只差定时触发,让 committed bundle 随档案演进定期同步,盖住 push-path 触发盖不到的数据漂移。

## 验证

- `pytest tests/test_kb_governance.py`:14 passed;OKF 三套守护:**720 passed**;
- `structural_fingerprint` 哈希重构前后一致(消费方无感)。

**committed bundle 本 PR 刻意不重建**——那是丙每日 cron 的活,避免大 diff + 重蹈手修覆辙。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E)_