### PR TITLE
feat(bpt-sdk): 五项优化（正确性 + 并发 + DX）— v0.13.0

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,39 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.13.0 — 2026-07-07
+
+Five keeper-directed optimizations (correctness + concurrency + DX), each with
+tests. Full suite 1447 green; `tsc`/`build` exit 0.
+
+- **fix (Grep — no more silent truncation)**: `count` and `files_with_matches`
+  now default to COMPLETE results (they emit one small entry per file, so the
+  old flat 250-cap silently reported a WRONG count / partial file list on repos
+  with >250 matching files). `content` keeps the 250 flood guard. ALL modes now
+  ANNOUNCE cap-induced truncation with a footer (`results truncated at
+  head_limit=N; … set head_limit=0 for the complete result`) instead of quietly
+  returning a prefix. Explicit `head_limit` still bounds every mode.
+- **feat (Grep full-scan telemetry)**: each Grep emits a `grep.scan mode=…
+  files_total=… files_scanned=… full_scan=… early_stop=…` line on the debug
+  channel, so a host can measure the full-scan share of its Grep traffic (the
+  driver of the pure-JS-vs-ripgrep cost).
+- **feat (BPT-EXTENSION): `runConcurrent(mgr, tasks, opts)`** — drives many
+  `mgr.query()` conversations in parallel (bounded by `concurrency`, default 8)
+  with per-task failure isolation and index-aligned outcomes. Closes the
+  pull-driven footgun where `for (…) { for await (…mgr.query()) }` runs
+  sequentially. Exports `ManagedTask` / `RunConcurrentOutcome`; see
+  `docs/CONCURRENCY.md`.
+- **feat (BPT-EXTENSION): `provider.maxConcurrentRequests`** (env
+  `BPT_MAX_CONCURRENT_REQUESTS`, default 0 = unlimited) — a FIFO counting
+  semaphore in the transport caps concurrent in-flight Messages API requests, so
+  a large multi-conversation fan-out over one shared transport does not thrash
+  the rate limit. A request holds its slot for the whole streaming lifetime.
+- **test (MCP concurrency hardening)**: a stress test proves 50 concurrent
+  `callTool` over ONE stdio connection each route to their own response by
+  JSON-RPC id (no cross-talk), and that one rejected id never corrupts sibling
+  responses — confirming the shared-MCP-pool multiplexing that SessionManager
+  relies on. (Mechanism was already correct; this locks it.)
+
 ## 0.12.0 — 2026-07-06
 
 - **P2 PARTIAL-closure pass**: a row-by-row re-audit of every `docs/COMPAT.md`

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -112,7 +112,9 @@ Per-row detail lives in the sections below; this is the at-a-glance table.
 | Workflow | HONEST-SUBSET | async background launch | synchronous execution, result returned inline |
 | MessageDisplay | HONEST-SUBSET | per-delta incremental | per-completed-message (final always true) |
 | Read PDF `pages` | HONEST-SUBSET | slices PDF pages | validates the param; page-slicing itself unsupported (no PDF dep), errors honestly |
-| Grep | HONEST-SUBSET | ripgrep binary | pure-JS regex (large-repo perf caveat) |
+| Grep | HONEST-SUBSET | ripgrep binary | pure-JS regex (large-repo perf caveat; see the crossover diagnostic 2026-07-07). v0.13.0: `count`/`files_with_matches` default to COMPLETE (no silent 250-cap truncation), all modes announce cap-induced truncation, and a `grep.scan` debug line reports full-scan coverage |
+| `runConcurrent` (SessionManager) | BPT-EXTENSION | no in-process fan-out driver | drives many `mgr.query()` conversations in parallel with a concurrency bound + per-task failure isolation, closing the pull-driven "sequential-await" footgun (v0.13.0) |
+| `provider.maxConcurrentRequests` | BPT-EXTENSION | CLI owns request concurrency | caps concurrent in-flight Messages API requests through a shared transport (FIFO queue), so a large multi-conversation fan-out does not thrash the rate limit (v0.13.0) |
 | six new hooks (Setup/TeammateIdle/…) | HONEST-SUBSET | fire | typed-not-fired (no natural headless hook point) |
 | MCP subscription tools (4) | N/A-BY-DESIGN | subscribe + server push | absent (no push-to-conversation channel) |
 | NotebookEdit | N/A-BY-DESIGN | edits Jupyter cells | absent (no notebook surface) |
@@ -291,7 +293,7 @@ SDK implements the agent loop directly against the public Messages API:
 | BashOutput | FULL | v0.5: incremental reads (new output since last call) + status/exit code; optional per-line regex `filter`; read-only (auto-approved, parallel-group eligible). FULL is vs the DOCUMENTED SDK lifecycle: live official 2.1.201 moved backgrounding to a task-file model and its own BashOutput answers "No task found" for the id its Bash advertised, so no official-arm parity evidence exists (conformance run-l3 L3-BG-01, KD-L3-19, 2026-07-05) |
 | KillShell | FULL | v0.5: SIGTERM then SIGKILL escalation on the background shell's process group. Same official-arm caveat as BashOutput (run-l3 L3-BG-01, KD-L3-19) |
 | Glob | PARTIAL | fast-glob, mtime-sorted newest-first; official 2.1.201 emitted ASCENDING order under ascending-utimes pins, so ordering parity with the live engine is not established - path sets agree (conformance run-l3 L3-GLOB-01, KD-L3-20, 2026-07-05) |
-| Grep | PARTIAL | pure-JS regex engine (no ripgrep binary); large-repo perf caveat |
+| Grep | PARTIAL | pure-JS regex engine (no ripgrep binary); large-repo perf caveat (crossover diagnostic 2026-07-07). v0.13.0 fixed the silent 250-cap truncation: `count`/`files_with_matches` default COMPLETE, all modes announce truncation, `grep.scan` debug telemetry added. The ripgrep-vs-pure-JS decision itself is pending (keeper) |
 | WebFetch / WebSearch | FULL | registered in v0.2 |
 | TodoWrite | PARTIAL | v0.7: OFF by default (Task quadruplet is the default surface); `CLAUDE_CODE_ENABLE_TASKS=0` reverts to TodoWrite-only, per official 0.3.142 |
 | Agent | PARTIAL | the subagent spawn tool; v0.7 gains `model`/`isolation:'worktree'` and the official required set [description, prompt] (subagent_type defaults to general-purpose). Residual param delta = our BPT-only `fork` extension |

--- a/projects/bpt-agent-sdk/docs/CONCURRENCY.md
+++ b/projects/bpt-agent-sdk/docs/CONCURRENCY.md
@@ -1,0 +1,74 @@
+# Running conversations concurrently
+
+The SDK supports true parallelism at three levels: **many conversations** over
+one `SessionManager`, **read-only tools within a turn** (grouped `Promise.all`,
+writes stay serial), and **background subagents**. This doc is about the first
+level and the two knobs that make a large fan-out safe.
+
+## The footgun: pull-driven iteration
+
+`SessionManager.query()` returns a `Query` that only advances when its iterator
+is **pulled**. So this runs SEQUENTIALLY even though the manager supports
+parallelism — you serialized it yourself by awaiting each drive to completion:
+
+```ts
+// WRONG — sequential despite the shared manager
+for (const task of tasks) {
+  for await (const _ of mgr.query(task)) { /* ... */ }
+}
+```
+
+## `runConcurrent` — drive N conversations in parallel
+
+```ts
+import { createBptSession, runConcurrent } from 'bpt-agent-sdk';
+
+const mgr = createBptSession({ /* provider, mcpServers, ... */ });
+const outcomes = await runConcurrent(
+  mgr,
+  tasks.map((prompt) => ({ prompt })),      // ManagedTask[] — same args as mgr.query()
+  { concurrency: 8 },                        // at most 8 conversations in flight
+);
+// outcomes are index-aligned with tasks (NOT completion-ordered):
+for (const { index, result, error } of outcomes) {
+  if (error) console.error(`task ${index} failed`, error);
+  else console.log(`task ${index} ->`, result?.subtype);
+}
+await mgr.close();
+```
+
+- **Failure isolation**: a task whose drive throws gets `{ error, result: null }`;
+  the batch never rejects — one bad task cannot sink its siblings.
+- **`concurrency`** defaults to `min(tasks.length, 8)`.
+- **`collectMessages: true`** attaches the full message list per outcome (off by
+  default to keep memory flat for large fan-outs).
+- **`onMessage(index, message)`** streams every message as it arrives, tagged by
+  task index.
+
+## Two bounds, two layers
+
+`runConcurrent`'s `concurrency` bounds **conversations**. Each conversation can
+issue many API requests over its life, so under a large fan-out you also want to
+bound **requests** to stay under the API rate limit:
+
+```ts
+const mgr = createBptSession({
+  provider: { maxConcurrentRequests: 12 },   // shared transport gate; env: BPT_MAX_CONCURRENT_REQUESTS
+});
+```
+
+`maxConcurrentRequests` (default `0` = unlimited) caps concurrent in-flight
+Messages API requests through the shared transport. A request holds its slot for
+the whole streaming lifetime; excess requests queue FIFO until a slot frees.
+Pair the two: `concurrency` keeps you from opening 500 conversations at once;
+`maxConcurrentRequests` keeps those conversations from opening 500 API streams at
+once.
+
+## What the SDK does NOT coordinate for you
+
+- **Rate-limit sizing** — the transport retries 429 with backoff, but picking the
+  concurrency numbers for your account tier is yours.
+- **Shared files / external state across conversations** — write-tool
+  serialization only holds *within a single conversation-turn*; the
+  read-before-write gate is *per-query*. Two parallel conversations editing the
+  same file is your lock to hold, not the SDK's.

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/index.ts
+++ b/projects/bpt-agent-sdk/src/index.ts
@@ -9,7 +9,8 @@
 export { query } from './query.js';
 // BPT-EXTENSION: in-process multi-conversation coordinator (SessionManager /
 // SessionManagerOptions / SessionManagerUsage types ride the types.js export).
-export { createBptSession } from './session-manager.js';
+export { createBptSession, runConcurrent } from './session-manager.js';
+export type { ManagedTask, RunConcurrentOutcome } from './session-manager.js';
 // Built-in durable session store (SM-乙a): fileSessionStore(dir) for the
 // SessionManager's `store` option and options.sessionStore recovery.
 export { FileSessionStore, fileSessionStore } from './sessions/file-store.js';

--- a/projects/bpt-agent-sdk/src/session-manager.ts
+++ b/projects/bpt-agent-sdk/src/session-manager.ts
@@ -607,3 +607,92 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
 
   return mgr;
 }
+
+// ---------------------------------------------------------------------------
+// runConcurrent — the missing "drive N conversations in parallel" helper
+// ---------------------------------------------------------------------------
+
+/** One conversation to run: the same args shape as SessionManager.query(). */
+export type ManagedTask = {
+  prompt: string | AsyncIterable<SDKUserMessage>;
+  options?: Options;
+};
+
+/** Outcome of one task in runConcurrent, tagged by its input index. */
+export type RunConcurrentOutcome = {
+  /** Index into the input `tasks` array (results are index-tagged, not
+   *  completion-ordered). */
+  index: number;
+  /** The conversation's terminal result message, or null if it produced none
+   *  (e.g. the drive threw before any result). */
+  result: SDKResultMessage | null;
+  /** All messages, in order — only when `collectMessages` is set (off by
+   *  default to keep memory flat for large fan-outs). */
+  messages?: SDKMessage[];
+  /** Set when driving this conversation threw (the batch never rejects — one
+   *  bad task does not sink its siblings). */
+  error?: unknown;
+};
+
+/**
+ * Drive many managed conversations CONCURRENTLY over one SessionManager, at most
+ * `concurrency` in flight at a time. This is the helper that closes the
+ * pull-driven footgun: `SessionManager.query()` only advances when its iterator
+ * is pulled, so `for (const t of tasks) { for await (…mgr.query(t)) {} }` runs
+ * them SEQUENTIALLY even though the manager supports true parallelism. This
+ * function pulls up to `concurrency` iterators at once, so the conversations
+ * actually overlap on the shared transport + MCP pool.
+ *
+ * Failure isolation: a task whose drive throws resolves to an outcome with
+ * `error` set (and `result: null`); the batch as a whole never rejects. Results
+ * are returned index-aligned with `tasks`, regardless of completion order.
+ *
+ * `concurrency` defaults to min(tasks.length, 8). Pair it with the transport's
+ * `maxConcurrentRequests` (provider-level) so a large fan-out does not thrash
+ * the API rate limit — this bounds *conversations*, that bounds *requests*.
+ */
+export async function runConcurrent(
+  mgr: SessionManager,
+  tasks: ManagedTask[],
+  opts?: {
+    concurrency?: number;
+    collectMessages?: boolean;
+    /** Observe every message as it arrives, tagged by task index. */
+    onMessage?: (index: number, message: SDKMessage) => void;
+  },
+): Promise<RunConcurrentOutcome[]> {
+  const outcomes = new Array<RunConcurrentOutcome>(tasks.length);
+  const collect = opts?.collectMessages === true;
+  const onMessage = opts?.onMessage;
+  const concurrency = Math.max(
+    1,
+    Math.min(opts?.concurrency ?? 8, tasks.length || 1),
+  );
+
+  let next = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = next;
+      next += 1;
+      if (index >= tasks.length) return;
+      const task = tasks[index]!;
+      const messages: SDKMessage[] = [];
+      let result: SDKResultMessage | null = null;
+      try {
+        for await (const message of mgr.query(task)) {
+          if (onMessage) onMessage(index, message);
+          if (collect) messages.push(message);
+          if (message.type === 'result') result = message;
+        }
+        outcomes[index] = collect ? { index, result, messages } : { index, result };
+      } catch (error) {
+        outcomes[index] = collect
+          ? { index, result, messages, error }
+          : { index, result, error };
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  return outcomes;
+}

--- a/projects/bpt-agent-sdk/src/tools/grep.ts
+++ b/projects/bpt-agent-sdk/src/tools/grep.ts
@@ -315,11 +315,18 @@ export const grepTool: BuiltinTool = {
     const before = asOptionalCount(input['-B']) ?? bothContext ?? 0;
     const after = asOptionalCount(input['-A']) ?? bothContext ?? 0;
     const rawLimit = input['head_limit'];
-    // 0 (or negative) = unlimited; undefined -> default 250.
+    // 0 (or negative) = unlimited; undefined -> a MODE-DEPENDENT default.
+    // `content` can flood (many lines per file) so it keeps the 250 guard.
+    // `count` and `files_with_matches` emit ONE small entry per file, and a
+    // truncated result there is a WRONG count / an incomplete file list — a
+    // correctness bug, not a flood — so they default to COMPLETE (unlimited).
+    // An explicit head_limit still bounds every mode. (OPT-1, 2026-07-07:
+    // decoupled from the flat 250 that silently truncated counts.)
+    const defaultLimit = outputMode === 'content' ? DEFAULT_HEAD_LIMIT : 0;
     const headLimit =
       typeof rawLimit === 'number' && Number.isFinite(rawLimit)
         ? Math.max(0, Math.floor(rawLimit))
-        : DEFAULT_HEAD_LIMIT;
+        : defaultLimit;
     const limited = headLimit > 0;
     // Skip the first `offset` entries before head_limit (pagination). When
     // limited we must collect offset+headLimit rows before we can stop.
@@ -400,10 +407,19 @@ export const grepTool: BuiltinTool = {
     const useContext = before > 0 || after > 0;
     let anyMatch = false;
     let firstContentFile = true;
+    // OPT-5 telemetry: how much of the corpus this call actually scanned, so a
+    // host can measure the "full-scan share" of its Grep traffic (the driver of
+    // the pure-JS vs ripgrep cost — see the crossover diagnostic 2026-07-07).
+    let scannedFiles = 0;
+    let scanStoppedEarly = false;
 
     for (const file of files) {
       if (ctx.signal.aborted) throw new AbortError();
-      if (out.length >= collectCap) break;
+      if (out.length >= collectCap) {
+        scanStoppedEarly = true;
+        break;
+      }
+      scannedFiles += 1;
 
       const scan = await scanFile(file, pattern, flags, multiline);
       if (scan === null || scan.matches.length === 0) continue;
@@ -460,6 +476,16 @@ export const grepTool: BuiltinTool = {
       }
     }
 
+    // OPT-5: emit the scan-coverage signal on the debug channel (the host taps
+    // options.stderr). full_scan=true means no early stop -> this call paid the
+    // full corpus cost; a host can aggregate the ratio to decide the ripgrep
+    // question empirically instead of guessing.
+    ctx.debug(
+      `grep.scan mode=${outputMode} files_total=${files.length} ` +
+        `files_scanned=${scannedFiles} full_scan=${!scanStoppedEarly} ` +
+        `early_stop=${scanStoppedEarly}`,
+    );
+
     if (!anyMatch) {
       return { content: 'No matches found' };
     }
@@ -469,6 +495,16 @@ export const grepTool: BuiltinTool = {
     if (capped.length === 0) {
       return { content: 'No matches found' };
     }
-    return { content: capped.join('\n') };
+    // OPT-1: never truncate silently. When the head_limit cap cut the scan or
+    // the display short, say so, so a caller does not mistake a partial listing
+    // (or a partial per-file count) for the complete result.
+    const displayTruncated = limited && out.length > offset + headLimit;
+    let content = capped.join('\n');
+    if (scanStoppedEarly || displayTruncated) {
+      content +=
+        `\n(results truncated at head_limit=${headLimit}; more matches may exist` +
+        ` — raise head_limit or set head_limit=0 for the complete result)`;
+    }
+    return { content };
   },
 };

--- a/projects/bpt-agent-sdk/src/transport/anthropic.ts
+++ b/projects/bpt-agent-sdk/src/transport/anthropic.ts
@@ -78,6 +78,10 @@ export class AnthropicTransport implements Transport {
   private readonly betas: string[] | undefined;
   private readonly credential: ResolvedCredential | null;
   private readonly endpoint: string;
+  /** Concurrency gate; null when maxConcurrentRequests resolves to 0
+   *  (unlimited — the default, so existing single-conversation callers see
+   *  zero behavior change). */
+  private readonly slots: RequestSemaphore | null;
 
   constructor(cfg: TransportConfig) {
     this.provider = cfg.provider ?? {};
@@ -85,6 +89,8 @@ export class AnthropicTransport implements Transport {
     this.debug = cfg.debug;
     this.betas = cfg.betas;
     this.credential = resolveCredential(this.provider, cfg.env);
+    const maxConcurrent = resolveMaxConcurrent(this.provider, cfg.env);
+    this.slots = maxConcurrent > 0 ? new RequestSemaphore(maxConcurrent) : null;
     const base = (
       this.provider.baseUrl ??
       nonEmpty(cfg.env.ANTHROPIC_BASE_URL) ??
@@ -97,7 +103,30 @@ export class AnthropicTransport implements Transport {
     return this.credential?.source ?? 'none';
   }
 
+  /**
+   * Stream one Messages API call, gated by the optional concurrency semaphore.
+   * When a cap is set, the permit is held for the WHOLE streaming lifetime
+   * (acquire before the request, release when the generator finishes, returns,
+   * throws, or is closed early by the consumer) — so a slow consumer keeps its
+   * slot exactly as long as its HTTP stream stays open. No cap -> straight
+   * passthrough, zero overhead.
+   */
   async *stream(req: StreamRequest): AsyncGenerator<RawMessageStreamEvent, void> {
+    if (!this.slots) {
+      yield* this.streamRequest(req);
+      return;
+    }
+    const release = await this.slots.acquire();
+    try {
+      yield* this.streamRequest(req);
+    } finally {
+      release();
+    }
+  }
+
+  private async *streamRequest(
+    req: StreamRequest,
+  ): AsyncGenerator<RawMessageStreamEvent, void> {
     if (!this.credential) {
       throw new ConfigurationError(
         'No Anthropic credential found. Set options.provider.apiKey / ' +
@@ -367,6 +396,57 @@ export function resolveMaxRetries(
   const fromEnv = envInt(env.CLAUDE_CODE_MAX_RETRIES);
   if (fromEnv !== undefined) return Math.min(fromEnv, ENV_MAX_RETRIES_CAP);
   return DEFAULT_MAX_RETRIES;
+}
+
+/**
+ * Concurrency-cap resolution: provider.maxConcurrentRequests (explicit
+ * override) > BPT_MAX_CONCURRENT_REQUESTS env > 0 (unlimited).
+ */
+export function resolveMaxConcurrent(
+  provider: ProviderConfig,
+  env: Record<string, string | undefined>,
+): number {
+  if (provider.maxConcurrentRequests !== undefined) {
+    return Math.max(0, Math.floor(provider.maxConcurrentRequests));
+  }
+  return envInt(env.BPT_MAX_CONCURRENT_REQUESTS) ?? 0;
+}
+
+/**
+ * Minimal FIFO counting semaphore. `acquire()` resolves once a permit is free
+ * and returns the matching `release`; excess acquirers queue in order. Used to
+ * bound concurrent in-flight streams through one transport. A permit handed
+ * directly to the next waiter never round-trips through the counter, so no
+ * permit is lost under contention.
+ */
+export class RequestSemaphore {
+  private permits: number;
+  private readonly waiters: Array<() => void> = [];
+  constructor(permits: number) {
+    this.permits = permits;
+  }
+  acquire(): Promise<() => void> {
+    return new Promise<() => void>((resolve) => {
+      let released = false;
+      const releaseOnce = (): void => {
+        if (released) return;
+        released = true;
+        this.release();
+      };
+      const grant = (): void => resolve(releaseOnce);
+      if (this.permits > 0) {
+        this.permits -= 1;
+        grant();
+      } else {
+        this.waiters.push(grant);
+      }
+    });
+  }
+  private release(): void {
+    const next = this.waiters.shift();
+    if (next) next();
+    else this.permits += 1;
+  }
 }
 
 /**

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -916,6 +916,17 @@ export type ProviderConfig = {
    * means the connection is stuck, not merely slow.
    */
   streamIdleTimeoutMs?: number;
+  /**
+   * Cap on concurrently in-flight Messages API requests through THIS transport
+   * (default 0 = unlimited). When many conversations share one transport (a
+   * SessionManager), N concurrent `mgr.query()` drives open N streams at once
+   * and can thrash the API rate limit; set this to bound the API concurrency
+   * while `runConcurrent`'s `concurrency` bounds the conversations. Excess
+   * requests queue (FIFO) until a slot frees; a request holds its slot for the
+   * whole streaming lifetime. Env fallback: `BPT_MAX_CONCURRENT_REQUESTS`.
+   * BPT-EXTENSION: the official SDK has no such knob (its CLI owns concurrency).
+   */
+  maxConcurrentRequests?: number;
   maxOutputTokens?: number;
   /** Automatic prompt caching via cache_control breakpoints; default true. */
   promptCaching?: boolean;

--- a/projects/bpt-agent-sdk/tests/grep-opt.test.ts
+++ b/projects/bpt-agent-sdk/tests/grep-opt.test.ts
@@ -1,0 +1,134 @@
+/**
+ * OPT-1 (count/files_with_matches complete by default + honest truncation) and
+ * OPT-5 (full-scan telemetry signal) for the Grep tool. 2026-07-07.
+ *
+ * Before: every mode shared a flat DEFAULT_HEAD_LIMIT=250, so a `count` over a
+ * repo with >250 matching files silently reported the first 250 — a WRONG
+ * number with no indication. After: count/files_with_matches default to
+ * complete (one small entry per file); content keeps the 250 flood guard; any
+ * cap-induced truncation is announced; and a debug line reports scan coverage.
+ */
+
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { grepTool } from '../src/tools/grep.js';
+import { AbortError } from '../src/errors.js';
+import type { ToolContext } from '../src/internal/contracts.js';
+
+let sandboxes: string[] = [];
+async function makeCorpus(nFiles: number, needleEvery = 1): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'grep-opt-'));
+  sandboxes.push(dir);
+  for (let i = 0; i < nFiles; i++) {
+    if (i % 100 === 0) await mkdir(path.join(dir, `d${Math.floor(i / 100)}`), { recursive: true });
+    const body = i % needleEvery === 0 ? 'alpha\nNEEDLE here\nbeta\n' : 'alpha\nbeta\ngamma\n';
+    await writeFile(path.join(dir, `d${Math.floor(i / 100)}`, `f${i}.txt`), body);
+  }
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(sandboxes.map((d) => rm(d, { recursive: true, force: true })));
+  sandboxes = [];
+});
+
+function makeCtx(cwd: string, onDebug?: (m: string) => void): ToolContext {
+  return {
+    cwd,
+    additionalDirectories: [],
+    env: {},
+    signal: new AbortController().signal,
+    debug: onDebug ?? (() => {}),
+  };
+}
+function contentOf(res: { content: unknown }): string {
+  return typeof res.content === 'string' ? res.content : JSON.stringify(res.content);
+}
+
+describe('OPT-1: count / files_with_matches are complete by default', () => {
+  it('count over >250 matching files reports ALL of them, not the first 250', async () => {
+    const dir = await makeCorpus(300);
+    const c = contentOf(await grepTool.execute({ pattern: 'NEEDLE', path: dir, output_mode: 'count' }, makeCtx(dir)));
+    const lines = c.split('\n').filter((l) => /:\d+$/.test(l));
+    expect(lines).toHaveLength(300); // complete, not capped at 250
+    expect(c).not.toContain('truncated'); // complete -> no footer
+  });
+
+  it('files_with_matches over >250 files lists all of them', async () => {
+    const dir = await makeCorpus(300);
+    const c = contentOf(
+      await grepTool.execute({ pattern: 'NEEDLE', path: dir, output_mode: 'files_with_matches' }, makeCtx(dir)),
+    );
+    expect(c.split('\n').filter((l) => l.endsWith('.txt'))).toHaveLength(300);
+    expect(c).not.toContain('truncated');
+  });
+
+  it('an explicit head_limit still bounds count, and announces the truncation', async () => {
+    const dir = await makeCorpus(300);
+    const c = contentOf(
+      await grepTool.execute({ pattern: 'NEEDLE', path: dir, output_mode: 'count', head_limit: 10 }, makeCtx(dir)),
+    );
+    expect(c.split('\n').filter((l) => /:\d+$/.test(l))).toHaveLength(10);
+    expect(c).toContain('truncated at head_limit=10');
+    expect(c).toContain('head_limit=0 for the complete result');
+  });
+});
+
+describe('OPT-1: content mode keeps the 250 flood guard + honest footer', () => {
+  it('content over a large match set caps at 250 lines and announces it', async () => {
+    const dir = await makeCorpus(300);
+    const c = contentOf(await grepTool.execute({ pattern: 'NEEDLE', path: dir, output_mode: 'content' }, makeCtx(dir)));
+    const bodyLines = c.split('\n').filter((l) => l.includes('NEEDLE'));
+    expect(bodyLines.length).toBeLessThanOrEqual(250);
+    expect(c).toContain('truncated at head_limit=250');
+  });
+
+  it('a small complete content result has no footer', async () => {
+    const dir = await makeCorpus(5);
+    const c = contentOf(await grepTool.execute({ pattern: 'NEEDLE', path: dir, output_mode: 'content' }, makeCtx(dir)));
+    expect(c).not.toContain('truncated');
+  });
+});
+
+describe('OPT-5: full-scan telemetry on the debug channel', () => {
+  it('a complete count reports full_scan=true and files_scanned == files_total', async () => {
+    const dir = await makeCorpus(300);
+    const logs: string[] = [];
+    await grepTool.execute({ pattern: 'NEEDLE', path: dir, output_mode: 'count' }, makeCtx(dir, (m) => logs.push(m)));
+    const scan = logs.find((l) => l.startsWith('grep.scan'));
+    expect(scan).toBeDefined();
+    expect(scan).toContain('full_scan=true');
+    expect(scan).toContain('early_stop=false');
+    expect(scan).toMatch(/files_total=300 files_scanned=300/);
+  });
+
+  it('a capped content search reports full_scan=false / early_stop=true (did not scan the whole corpus)', async () => {
+    const dir = await makeCorpus(300);
+    const logs: string[] = [];
+    await grepTool.execute(
+      { pattern: 'NEEDLE', path: dir, output_mode: 'content', head_limit: 50 },
+      makeCtx(dir, (m) => logs.push(m)),
+    );
+    const scan = logs.find((l) => l.startsWith('grep.scan'));
+    expect(scan).toContain('full_scan=false');
+    expect(scan).toContain('early_stop=true');
+  });
+});
+
+describe('OPT: unchanged basics still hold', () => {
+  it('no matches -> No matches found, no footer', async () => {
+    const dir = await makeCorpus(10);
+    const c = contentOf(await grepTool.execute({ pattern: 'ZZ_ABSENT', path: dir, output_mode: 'count' }, makeCtx(dir)));
+    expect(c).toBe('No matches found');
+  });
+  it('aborts cleanly', async () => {
+    const dir = await makeCorpus(3);
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      grepTool.execute({ pattern: 'NEEDLE', path: dir }, { ...makeCtx(dir), signal: ac.signal }),
+    ).rejects.toBeInstanceOf(AbortError);
+  });
+});

--- a/projects/bpt-agent-sdk/tests/opt-concurrency.test.ts
+++ b/projects/bpt-agent-sdk/tests/opt-concurrency.test.ts
@@ -1,0 +1,287 @@
+/**
+ * OPT-2 (runConcurrent), OPT-3 (MCP shared-pool concurrent-call hardening),
+ * OPT-4 (transport maxConcurrentRequests semaphore). 2026-07-07.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runConcurrent } from '../src/session-manager.js';
+import { RequestSemaphore, AnthropicTransport } from '../src/transport/anthropic.js';
+import { StdioMcpConnection } from '../src/mcp/stdio.js';
+import { encodeSSEFrame } from './helpers/sse-fetch.js';
+import type {
+  Query,
+  SDKMessage,
+  SessionManager,
+} from '../src/types.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ECHO_FIXTURE = path.join(HERE, 'fixtures', 'mcp-echo-server.mjs');
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// OPT-4: RequestSemaphore (the concurrency mechanism)
+// ---------------------------------------------------------------------------
+
+describe('OPT-4: RequestSemaphore', () => {
+  it('never lets more than `permits` holders run at once', async () => {
+    const sem = new RequestSemaphore(3);
+    let active = 0;
+    let maxActive = 0;
+    await Promise.all(
+      Array.from({ length: 20 }, () =>
+        (async () => {
+          const release = await sem.acquire();
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await delay(5);
+          active -= 1;
+          release();
+        })(),
+      ),
+    );
+    expect(maxActive).toBe(3);
+  });
+
+  it('hands permits to waiters in FIFO order', async () => {
+    const sem = new RequestSemaphore(1);
+    const order: number[] = [];
+    const first = await sem.acquire(); // hold the only permit
+    const waiters = [1, 2, 3].map((n) =>
+      sem.acquire().then((rel) => {
+        order.push(n);
+        rel();
+      }),
+    );
+    await delay(5);
+    first(); // release -> waiter 1, which releases -> 2, -> 3
+    await Promise.all(waiters);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('release is idempotent (double-release does not leak a permit)', async () => {
+    const sem = new RequestSemaphore(1);
+    const rel = await sem.acquire();
+    rel();
+    rel(); // must be a no-op, not a second permit
+    let active = 0;
+    let maxActive = 0;
+    await Promise.all(
+      Array.from({ length: 5 }, () =>
+        (async () => {
+          const r = await sem.acquire();
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await delay(3);
+          active -= 1;
+          r();
+        })(),
+      ),
+    );
+    expect(maxActive).toBe(1); // still a 1-permit semaphore
+  });
+});
+
+describe('OPT-4: transport honors maxConcurrentRequests', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubFetch(): { calls: () => number; maxActive: () => number } {
+    let active = 0;
+    let maxActive = 0;
+    let calls = 0;
+    vi.stubGlobal('fetch', async () => {
+      calls += 1;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await delay(25);
+      active -= 1;
+      const body = new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(encodeSSEFrame({ type: 'message_start' }));
+          c.enqueue(encodeSSEFrame({ type: 'message_stop' }));
+          c.close();
+        },
+      });
+      return new Response(body, { status: 200, headers: { 'request-id': 'r' } });
+    });
+    return { calls: () => calls, maxActive: () => maxActive };
+  }
+
+  const req = { model: 'm', max_tokens: 1, messages: [] };
+  async function drain(t: AnthropicTransport): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of t.stream(req)) {
+      // consume
+    }
+  }
+
+  it('caps concurrent in-flight streams at the configured limit', async () => {
+    const probe = stubFetch();
+    const t = new AnthropicTransport({
+      provider: { apiKey: 'sk-test', maxConcurrentRequests: 2 },
+      env: {},
+      debug: () => {},
+      betas: undefined,
+    });
+    await Promise.all(Array.from({ length: 6 }, () => drain(t)));
+    expect(probe.maxActive()).toBeLessThanOrEqual(2);
+    expect(probe.calls()).toBe(6); // all still run, just not all at once
+  });
+
+  it('is unbounded by default (no cap -> all overlap)', async () => {
+    const probe = stubFetch();
+    const t = new AnthropicTransport({
+      provider: { apiKey: 'sk-test' },
+      env: {},
+      debug: () => {},
+      betas: undefined,
+    });
+    await Promise.all(Array.from({ length: 6 }, () => drain(t)));
+    expect(probe.maxActive()).toBeGreaterThan(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPT-2: runConcurrent
+// ---------------------------------------------------------------------------
+
+/** A fake SessionManager whose query() yields an echo message then a result,
+ *  tracking concurrent in-flight drives. A prompt of 'boom' throws mid-drive. */
+function fakeManager(track: { active: number; maxActive: number }): SessionManager {
+  return {
+    query({ prompt }): Query {
+      const label = String(prompt);
+      async function* gen(): AsyncGenerator<SDKMessage, void> {
+        track.active += 1;
+        track.maxActive = Math.max(track.maxActive, track.active);
+        try {
+          await delay(10);
+          yield { type: 'system', subtype: 'echo', label } as unknown as SDKMessage;
+          if (label === 'boom') throw new Error('boom failed');
+          yield {
+            type: 'result',
+            subtype: 'success',
+            label,
+          } as unknown as SDKMessage;
+        } finally {
+          track.active -= 1;
+        }
+      }
+      return gen() as unknown as Query;
+    },
+    usage: () => ({ totalCostUsd: 0, usage: {} as never, modelUsage: {}, queries: 0 }),
+    close: async () => {},
+  } as unknown as SessionManager;
+}
+
+describe('OPT-2: runConcurrent', () => {
+  it('runs all tasks and returns outcomes index-aligned with input', async () => {
+    const track = { active: 0, maxActive: 0 };
+    const mgr = fakeManager(track);
+    const tasks = [0, 1, 2, 3].map((i) => ({ prompt: `t${i}` }));
+    const out = await runConcurrent(mgr, tasks, { concurrency: 2 });
+    expect(out).toHaveLength(4);
+    out.forEach((o, i) => {
+      expect(o.index).toBe(i);
+      expect((o.result as unknown as { label: string })?.label).toBe(`t${i}`);
+      expect(o.error).toBeUndefined();
+    });
+  });
+
+  it('bounds concurrency to the configured limit', async () => {
+    const track = { active: 0, maxActive: 0 };
+    const mgr = fakeManager(track);
+    const tasks = Array.from({ length: 8 }, (_, i) => ({ prompt: `t${i}` }));
+    await runConcurrent(mgr, tasks, { concurrency: 3 });
+    expect(track.maxActive).toBe(3);
+  });
+
+  it('isolates a failing task — its outcome carries error, siblings still succeed', async () => {
+    const track = { active: 0, maxActive: 0 };
+    const mgr = fakeManager(track);
+    const tasks = [{ prompt: 'ok0' }, { prompt: 'boom' }, { prompt: 'ok2' }];
+    const out = await runConcurrent(mgr, tasks, { concurrency: 3 });
+    expect(out[0]!.error).toBeUndefined();
+    expect(out[1]!.error).toBeInstanceOf(Error);
+    expect(out[1]!.result).toBeNull();
+    expect(out[2]!.error).toBeUndefined();
+    expect((out[2]!.result as unknown as { label: string })?.label).toBe('ok2');
+  });
+
+  it('onMessage sees every message tagged by task index; collectMessages captures them', async () => {
+    const track = { active: 0, maxActive: 0 };
+    const mgr = fakeManager(track);
+    const seen: Array<[number, string]> = [];
+    const out = await runConcurrent(mgr, [{ prompt: 'a' }, { prompt: 'b' }], {
+      concurrency: 2,
+      collectMessages: true,
+      onMessage: (i, m) => seen.push([i, (m as unknown as { type: string }).type]),
+    });
+    expect(seen.length).toBe(4); // 2 messages x 2 tasks
+    expect(out[0]!.messages).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPT-3: MCP shared-pool concurrent-call hardening (stdio id multiplexing)
+// ---------------------------------------------------------------------------
+
+describe('OPT-3: concurrent callTool over one stdio connection never cross-talks', () => {
+  it('routes 50 concurrent echo calls each to its OWN response by request id', async () => {
+    const conn = new StdioMcpConnection(
+      { type: 'stdio', command: process.execPath, args: [ECHO_FIXTURE] },
+      { name: 'echo' },
+    );
+    await conn.connect();
+    try {
+      const results = await Promise.all(
+        Array.from({ length: 50 }, (_, i) =>
+          conn.callTool('echo', { payload: `payload-${i}` }),
+        ),
+      );
+      results.forEach((res, i) => {
+        const text = (res.content?.[0] as { text?: string } | undefined)?.text ?? '';
+        // echo returns the args JSON; each must carry ITS OWN payload, proving
+        // the response was routed to the right pending request (no cross-talk).
+        expect(text).toContain(`payload-${i}`);
+      });
+    } finally {
+      await conn.close();
+    }
+  });
+
+  it('an interleaved failing call rejects on its OWN id without disturbing sibling responses', async () => {
+    // At the raw connection layer a JSON-RPC error rejects (isError conversion
+    // is the registry's job); the point here is that one rejected id does not
+    // corrupt the pending map — sibling echoes still resolve to their own text.
+    const conn = new StdioMcpConnection(
+      { type: 'stdio', command: process.execPath, args: [ECHO_FIXTURE] },
+      { name: 'echo' },
+    );
+    await conn.connect();
+    try {
+      const settled = await Promise.allSettled(
+        Array.from({ length: 20 }, (_, i) =>
+          i % 4 === 0 ? conn.callTool('boom', {}) : conn.callTool('echo', { payload: `ok-${i}` }),
+        ),
+      );
+      settled.forEach((s, i) => {
+        if (i % 4 === 0) {
+          expect(s.status).toBe('rejected');
+        } else {
+          expect(s.status).toBe('fulfilled');
+          const text =
+            s.status === 'fulfilled'
+              ? ((s.value.content?.[0] as { text?: string } | undefined)?.text ?? '')
+              : '';
+          expect(text).toContain(`ok-${i}`);
+        }
+      });
+    } finally {
+      await conn.close();
+    }
+  });
+});


### PR DESCRIPTION
## 概述

守密人裁定「按建议全部修复」，落地上一轮盘出的五项优化——都是本会话过程中实打实浮现、非空想，每项带测试。银芯自研 SDK 改动，与 §1.1-HC 同向。

## 变更类型

- [x] Bug 修复（Grep 静默截断）
- [x] 其他：并发能力 + DX（新增公开 API，additive）

## 五项

1. **fix(Grep 静默截断)**：`count`/`files_with_matches` 默认改为**完整**（每文件一条小条目，旧的平坦 250 上限在 >250 命中文件仓上静默报了**错误计数/残缺文件列表**）；`content` 保留 250 防刷屏；**所有模式**遇上限截断都**明示脚注**，不再静默返回前缀。
2. **feat(Grep 全扫描遥测)**：每次 Grep 在 debug 通道输出 `grep.scan mode=… files_total=… files_scanned=… full_scan=…`，宿主可据此量化全扫描占比（纯 JS vs ripgrep 成本的驱动量）。
3. **feat(BPT-EXTENSION) `runConcurrent(mgr, tasks, opts)`**：并发驱动多对话（`concurrency` 封顶、默认 8）+ 逐任务错误隔离 + 结果按输入下标对齐，焊死「串行 await」脚枪。导出 `ManagedTask`/`RunConcurrentOutcome`，见 `docs/CONCURRENCY.md`。
4. **feat(BPT-EXTENSION) `provider.maxConcurrentRequests`**（env `BPT_MAX_CONCURRENT_REQUESTS`，默认 0=无限）：传输层 FIFO 信号量封顶并发在飞 API 请求，大 fan-out 不打爆 429。
5. **test(MCP 硬化)**：50 并发 `callTool` 压测坐实 stdio JSON-RPC id 多路复用**无串线**、单 id 失败不污染兄弟响应——SessionManager 共享池卖点的地基锁定。

## 安全声明

- [x] 仅改银芯自研 SDK，无黑池/内网/未发布数据；与 §1.1-HC 防火墙同向。
- [x] 不含 emoji。未改 `memory/decisions.md` 等主控台档案。

## 验证清单

- [x] `npx tsc --noEmit` EXIT 0；`npm run build` 通过，新导出已入 `dist/*.d.ts`。
- [x] 新增 20 个单测（grep-opt 9 + opt-concurrency 11）。
- [x] **全量 vitest：64 文件全通过，1447 passed / 2 skipped**。
- [x] 无破坏性变更：新默认只扩大完整性；并发旋钮默认关闭（0=无限，byte 行为不变）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E)_