### PR TITLE
chore(bpt-sdk): reconcile version artifacts to 0.14.0 (#505 left them at 0.13.0)

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,20 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.14.0 — 2026-07-07
+
+- **fix (cross-model thinking-signature replay)**: strip
+  `thinking`/`redacted_thinking` blocks from CLOSED history turns whose signing
+  model differs from the target model, at the single outgoing choke point —
+  root-causing the invalid-signature 400 when a conversation switches models
+  mid-history. Each assistant turn is stamped with its signing model (a
+  non-enumerable Symbol); same-model replay passes through byte-identical,
+  unstamped (resumed) turns are treated as stale, and a mid-tool-loop fallback
+  switch is withheld with a clean error instead of retrying into a guaranteed
+  400. Mirrors Anthropic's replay contract. No consumer action required.
+  (Shipped in #505; this entry + the package.json bump to 0.14.0 reconcile the
+  version artifacts, which #505 left at 0.13.0.)
+
 ## 0.13.0 — 2026-07-07
 
 Five keeper-directed optimizations (correctness + concurrency + DX), each with

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## 概述

#505(跨模型 thinking-signature 剥离)是发货 src 修复,PR 标题标 v0.14.0,但**既没 bump package.json 也没加 CHANGELOG**——version-bump 守卫漏了,导致消费方 pin 的版本字段停在 0.13.0,而代码 / PR 声称 0.14.0。本 PR 把 package.json 升到 0.14.0 + 补对应 CHANGELOG 条,使 BPT 的 `bpt-agent-sdk-<version>.tgz` pin 与实况一致。无代码改动。

> 小学生比喻:书封面印「第 14 版」但版权页还写「第 13 版」——把版权页也改成 14,买书人才不会拿错版本。

---

## 变更类型
- [x] 其他(版本工件对齐:package.json 0.13.0→0.14.0 + CHANGELOG 0.14.0 条)

## 安全声明（强制）
- [x] 不含黑池 / 内网 / 未发布数据
- [x] 仅引用公开素材
- [x] 同意按 MIT License 提交贡献

## 验证清单
- [x] 无代码改动(仅 package.json 版本字段 + CHANGELOG);version-bump 守卫针对「src 改动却没 bump」,本 PR 是反向对齐、不触发
- [x] 不引入 emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp

---
_Generated by [Claude Code](https://claude.ai/code/session_015NFpCjzcKdwgzeAhLaAFZp)_