### PR TITLE
fix(bpt-sdk): re-land the v0.14.0 thinking-signature fix (source lost in #505's empty merge)

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -13,17 +13,27 @@ granularity stops at the commit-title level.
 
 ## 0.14.0 — 2026-07-07
 
-- **fix (cross-model thinking-signature replay)**: strip
-  `thinking`/`redacted_thinking` blocks from CLOSED history turns whose signing
-  model differs from the target model, at the single outgoing choke point —
-  root-causing the invalid-signature 400 when a conversation switches models
-  mid-history. Each assistant turn is stamped with its signing model (a
-  non-enumerable Symbol); same-model replay passes through byte-identical,
-  unstamped (resumed) turns are treated as stale, and a mid-tool-loop fallback
-  switch is withheld with a clean error instead of retrying into a guaranteed
-  400. Mirrors Anthropic's replay contract. No consumer action required.
-  (Shipped in #505; this entry + the package.json bump to 0.14.0 reconcile the
-  version artifacts, which #505 left at 0.13.0.)
+- **fix (cross-model thinking-signature 400, BPT request 2026-07-07)**: root-cause
+  fix for `400 invalid_request_error: Invalid signature in thinking block`, which
+  killed a conversation on every turn once the run switched models (fallback) or
+  resumed under a different model — the historical `thinking` blocks were signed
+  by the original model and fail verification on any other. The engine now tracks
+  each assistant turn's SIGNING model (a non-enumerable Symbol stamp that never
+  reaches the wire) and, at the single outgoing-assembly choke point, strips
+  `thinking`/`redacted_thinking` from every CLOSED history turn whose signer ≠ the
+  target model. This mirrors Anthropic's own replay contract (same model → pass
+  back as-is; different model → drop). `text`/`tool_use`/`tool_result` are never
+  touched; same-model turns pass through byte-identical (cache-safe). Covers both
+  the in-run fallback switch and the resume-to-another-model path (an unstamped
+  resumed turn is treated as stale and stripped).
+  - **hard edge (mid-tool-loop switch)**: the in-flight tool-loop turn's thinking
+    is API-REQUIRED (can't be stripped) yet would fail signature verification on
+    the fallback model. Rather than retry into a guaranteed 400, the engine now
+    WITHHOLDS the fallback switch mid-tool-loop and surfaces the original error as
+    a clean `error_during_execution` result — no 400 loop, no double tool
+    execution. (Auto-recovering read-only rewind-restart is a scoped follow-up.)
+  - No consumer action required — previously-failing cross-model conversations now
+    just work. +13 tests; full suite 1460 green; `tsc`/`build` exit 0.
 
 ## 0.13.0 — 2026-07-07
 

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -58,6 +58,12 @@ import {
   evaluateStructuredOutput,
 } from './structured-output.js';
 import { applyCacheControl } from './cache-control.js';
+import {
+  protectedTurnIndex,
+  signingModelOf,
+  stampSigningModel,
+  stripStaleThinking,
+} from './thinking-provenance.js';
 
 const DEFAULT_THINKING_BUDGET = 10_000;
 
@@ -401,7 +407,7 @@ export async function* runAgentLoop(
    * {role:'assistant',content:[]} turn would make the next request (a
    * follow-up turn or a resume) 400 with "content must not be empty".
    */
-  const pushAssistant = (content: ContentBlock[]): void => {
+  const pushAssistant = (content: ContentBlock[], signingModel: string): void => {
     const filtered = nonEmptyContent(content);
     if (filtered.length === 0) {
       deps.debug(
@@ -411,6 +417,10 @@ export async function* runAgentLoop(
       return;
     }
     const turn: APIMessageParam = { role: 'assistant', content: filtered };
+    // Record which model SIGNED this turn's thinking blocks, so a later
+    // cross-model replay (fallback switch / resume to another model) strips the
+    // now-unverifiable signatures instead of 400-ing forever (BPT 2026-07-07).
+    stampSigningModel(turn, signingModel);
     history.push(turn);
     mirror(turn);
   };
@@ -600,7 +610,11 @@ export async function* runAgentLoop(
       model: useModel,
       max_tokens: config.maxOutputTokens,
       system: systemField,
-      messages: reqMsgs,
+      // Strip cross-model thinking signatures from CLOSED history turns before
+      // they replay (BPT 2026-07-07): same-model turns pass through untouched
+      // (identity return -> cache intact); a fallback switch or a resume to a
+      // different model would otherwise 400 forever on the stale signature.
+      messages: stripStaleThinking(reqMsgs, useModel),
       tools: toolDefs.length > 0 ? toolDefs : undefined,
       thinking: computeThinking(),
       signal,
@@ -1002,6 +1016,23 @@ export async function* runAgentLoop(
           err instanceof APIStatusError &&
           isFallbackStatus(err.status)
         ) {
+          // §4 hard edge: if we are mid-tool-loop, the in-flight assistant turn
+          // (its thinking is API-REQUIRED before its tool_use, so it can't be
+          // stripped) was signed by the now-failing model. Retrying it on the
+          // fallback model would 400 on its stale signature — trading one
+          // failure for a worse, un-strippable one. Withhold the switch and
+          // surface the ORIGINAL error instead: no invalid-signature 400 loop,
+          // no double tool execution. (Auto-recovering read-only rewind-restart
+          // is a scoped follow-up; clean-fail is the stable choice for now.)
+          const protIdx = protectedTurnIndex(reqMsgs);
+          if (protIdx >= 0 && signingModelOf(reqMsgs[protIdx]!) !== config.fallbackModel) {
+            deps.debug(
+              `engine: fallback to ${config.fallbackModel} withheld — the in-flight ` +
+                `tool-loop turn is signed by the failing model ${model} and its thinking ` +
+                `is API-required; surfacing the original error to avoid an invalid-signature 400`,
+            );
+            throw err;
+          }
           deps.debug(
             `engine: model ${model} failed with status ${err.status}; retrying turn with fallback model ${config.fallbackModel}`,
           );
@@ -1109,7 +1140,7 @@ export async function* runAgentLoop(
         // the persisted trailing assistant tool_use is healed on resume by
         // the session store's repairPairing.
         if (config.maxBudgetUsd !== undefined && totalCostUsd > config.maxBudgetUsd) {
-          pushAssistant(assistant.content);
+          pushAssistant(assistant.content, assistant.model);
           deps.debug(
             `engine: budget pre-stop - ${toolUses.length} requested tool call(s) ` +
               `not executed (estimated cost $${totalCostUsd.toFixed(6)} > ` +
@@ -1191,7 +1222,7 @@ export async function* runAgentLoop(
           // the next group runs.
           yield* drainObs();
         }
-        pushAssistant(assistant.content);
+        pushAssistant(assistant.content, assistant.model);
         const userTurn: APIMessageParam = { role: 'user', content: results };
         history.push(userTurn);
         mirror(userTurn);
@@ -1286,7 +1317,7 @@ export async function* runAgentLoop(
       if (config.outputFormat !== undefined) {
         const outcome = evaluateStructuredOutput(text, config.outputFormat.schema);
         if (outcome.status === 'invalid') {
-          pushAssistant(assistant.content); // keep the invalid answer in history
+          pushAssistant(assistant.content, assistant.model); // keep the invalid answer in history
           const maxRetries =
             config.maxStructuredOutputRetries ?? DEFAULT_STRUCTURED_OUTPUT_RETRIES;
           if (structuredRetries >= maxRetries) {
@@ -1334,7 +1365,7 @@ export async function* runAgentLoop(
       if (deps.drainSubagentResults !== undefined) {
         const extra = deps.drainSubagentResults();
         if (extra.length > 0) {
-          pushAssistant(assistant.content); // keep this turn's answer in history
+          pushAssistant(assistant.content, assistant.model); // keep this turn's answer in history
           const bgTurn: APIMessageParam = { role: 'user', content: extra };
           history.push(bgTurn);
           mirror(bgTurn);
@@ -1361,7 +1392,7 @@ export async function* runAgentLoop(
 
       // Natural end: keep history complete for follow-up turns in the same
       // session, fire Stop hooks, emit the success result.
-      pushAssistant(assistant.content);
+      pushAssistant(assistant.content, assistant.model);
       if (deps.hooks.hasHooks('Stop')) {
         const stopAgg = await deps.hooks.run(
           'Stop',

--- a/projects/bpt-agent-sdk/src/engine/thinking-provenance.ts
+++ b/projects/bpt-agent-sdk/src/engine/thinking-provenance.ts
@@ -1,0 +1,100 @@
+/**
+ * Cross-model thinking-block hygiene (BPT request 2026-07-07).
+ *
+ * Extended-thinking blocks carry a `signature` the SIGNING model verifies on
+ * replay. Replaying a thinking block to a DIFFERENT model than produced it
+ * fails signature verification → `400 invalid_request_error: Invalid signature
+ * in thinking block`, and since the bad block lives in history, EVERY later turn
+ * re-hits it (the conversation dies). This mirrors Anthropic's own replay
+ * contract: same model → pass thinking back as-is; different model → drop it.
+ *
+ * We track the signing model per assistant turn as a NON-ENUMERABLE Symbol
+ * property (so it never serializes onto the wire `messages`), then strip
+ * `thinking` / `redacted_thinking` from every CLOSED historical assistant turn
+ * whose signer ≠ the target model. Turns with NO stamp (loaded from a resumed
+ * transcript) are treated as stale and stripped too — safe, and it fixes the
+ * resume path without threading provenance through the store. The one turn we
+ * never strip is the in-flight tool-loop turn (the API REQUIRES its thinking
+ * before the tool_use); that cross-model edge is handled upstream at the
+ * fallback-switch site, not here.
+ */
+
+import type { APIMessageParam, ContentBlockParam } from '../types.js';
+
+/** Non-enumerable marker: which model SIGNED this assistant turn's blocks. */
+const SIGNING_MODEL = Symbol('bpt.signingModel');
+
+/** Stamp an assistant turn with the model that produced (signed) it. */
+export function stampSigningModel(turn: APIMessageParam, model: string): void {
+  Object.defineProperty(turn, SIGNING_MODEL, {
+    value: model,
+    enumerable: false, // never reaches JSON.stringify -> never on the wire
+    configurable: true,
+    writable: true,
+  });
+}
+
+/** The signing model of a turn, or undefined when unstamped (e.g. resumed). */
+export function signingModelOf(turn: APIMessageParam): string | undefined {
+  return (turn as { [SIGNING_MODEL]?: string })[SIGNING_MODEL];
+}
+
+function isThinking(b: ContentBlockParam): boolean {
+  return b.type === 'thinking' || b.type === 'redacted_thinking';
+}
+
+function contentHasToolResult(content: APIMessageParam['content']): boolean {
+  return Array.isArray(content) && content.some((b) => b.type === 'tool_result');
+}
+
+function contentHasThinking(content: APIMessageParam['content']): boolean {
+  return Array.isArray(content) && content.some(isThinking);
+}
+
+/**
+ * Index of the in-flight assistant turn whose thinking must NOT be stripped:
+ * only when the request is a tool-loop continuation (its last message is a
+ * user turn carrying tool_result blocks) is the preceding assistant turn
+ * "open" and its thinking API-required. A fresh user prompt closes the prior
+ * assistant turn, so nothing is protected. Returns -1 when none is protected.
+ */
+export function protectedTurnIndex(messages: APIMessageParam[]): number {
+  const last = messages[messages.length - 1];
+  if (last === undefined || last.role !== 'user' || !contentHasToolResult(last.content)) {
+    return -1;
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === 'assistant') return i;
+  }
+  return -1;
+}
+
+/**
+ * Return a copy of `messages` with `thinking`/`redacted_thinking` stripped from
+ * every CLOSED assistant turn whose signing model ≠ `targetModel` (or which
+ * carries no stamp). The in-flight tool-loop turn (protectedTurnIndex) is left
+ * intact. When nothing needs stripping — the common same-model steady state —
+ * the ORIGINAL array reference is returned unchanged, so the request bytes (and
+ * the prompt cache) are untouched. text / tool_use / tool_result are never
+ * altered.
+ */
+export function stripStaleThinking(
+  messages: APIMessageParam[],
+  targetModel: string,
+): APIMessageParam[] {
+  const protectedIdx = protectedTurnIndex(messages);
+  let changed = false;
+  const out = messages.map((m, i) => {
+    if (m.role !== 'assistant' || i === protectedIdx) return m;
+    if (!contentHasThinking(m.content)) return m;
+    const signer = signingModelOf(m);
+    const stale = signer === undefined || signer !== targetModel;
+    if (!stale) return m;
+    changed = true;
+    return {
+      role: m.role,
+      content: (m.content as ContentBlockParam[]).filter((b) => !isThinking(b)),
+    };
+  });
+  return changed ? out : messages;
+}

--- a/projects/bpt-agent-sdk/tests/engine.test.ts
+++ b/projects/bpt-agent-sdk/tests/engine.test.ts
@@ -53,6 +53,7 @@ import {
   textReplyEvents,
   toolUseReplyEvents,
 } from './helpers/mock-transport.js';
+import { stampSigningModel } from '../src/engine/thinking-provenance.js';
 
 // ---------------------------------------------------------------------------
 // Fakes
@@ -1213,6 +1214,92 @@ describe('runAgentLoop', () => {
     // Both models appear in the per-model ledger.
     expect(result.modelUsage['claude-primary']!.inputTokens).toBe(100);
     expect(result.modelUsage['claude-fallback']!.inputTokens).toBe(50);
+  });
+
+  // ----- BPT 2026-07-07: cross-model thinking-signature hygiene -----
+
+  it('strips a cross-model CLOSED thinking block from the outgoing replay', async () => {
+    const transport = new MockTransport([textReplyEvents('ok', { model: 'model-b' })]);
+    const deps = makeDeps(transport);
+    const closed: APIMessageParam = {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'draft', signature: 'sig-a' } as ContentBlockParam,
+        { type: 'text', text: 'answer' } as ContentBlockParam,
+      ],
+    };
+    stampSigningModel(closed, 'model-a');
+    const history: APIMessageParam[] = [
+      { role: 'user', content: 'go' },
+      closed,
+      { role: 'user', content: 'again' },
+    ];
+    await collect(runAgentLoop(history, deps, makeConfig({ model: 'model-b' })));
+    const sent = transport.requests[0]!.messages[1]!;
+    const kinds = (sent.content as ContentBlockParam[]).map((b) => b.type);
+    expect(kinds).toEqual(['text']); // thinking stripped cross-model; text kept
+  });
+
+  it('KEEPS the in-flight tool-loop turn thinking even cross-model (protected)', async () => {
+    const transport = new MockTransport([textReplyEvents('done', { model: 'model-b' })]);
+    const deps = makeDeps(transport);
+    const inflight: APIMessageParam = {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'draft', signature: 'sig-a' } as ContentBlockParam,
+        { type: 'tool_use', id: 't1', name: 'Read', input: {} } as ContentBlockParam,
+      ],
+    };
+    stampSigningModel(inflight, 'model-a');
+    const history: APIMessageParam[] = [
+      { role: 'user', content: 'go' },
+      inflight,
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' } as ContentBlockParam],
+      },
+    ];
+    await collect(runAgentLoop(history, deps, makeConfig({ model: 'model-b' })));
+    const sent = transport.requests[0]!.messages[1]!;
+    const kinds = (sent.content as ContentBlockParam[]).map((b) => b.type);
+    expect(kinds).toEqual(['thinking', 'tool_use']); // protected -> thinking retained
+  });
+
+  it('WITHHOLDS a fallback switch mid-tool-loop to avoid an invalid-signature 400', async () => {
+    const transport = new MockTransport([
+      () => {
+        throw new APIStatusError(529, 'overloaded_error', 'overloaded');
+      },
+    ]);
+    const deps = makeDeps(transport);
+    const inflight: APIMessageParam = {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'draft', signature: 'sig-p' } as ContentBlockParam,
+        { type: 'tool_use', id: 't1', name: 'Read', input: {} } as ContentBlockParam,
+      ],
+    };
+    stampSigningModel(inflight, 'claude-primary');
+    const history: APIMessageParam[] = [
+      { role: 'user', content: 'go' },
+      inflight,
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' } as ContentBlockParam],
+      },
+    ];
+    const messages = await collect(
+      runAgentLoop(
+        history,
+        deps,
+        makeConfig({ model: 'claude-primary', fallbackModel: 'claude-fallback' }),
+      ),
+    );
+    // The guard fired: NO second attempt on the fallback model...
+    expect(transport.requests).toHaveLength(1);
+    // ...and the original overload surfaces as a clean error result (not a 400 loop).
+    const result = lastResult(messages);
+    expect(result.subtype).toBe('error_during_execution');
   });
 
   it('records api_error_status on an unrecovered APIStatusError result', async () => {

--- a/projects/bpt-agent-sdk/tests/thinking-provenance.test.ts
+++ b/projects/bpt-agent-sdk/tests/thinking-provenance.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Cross-model thinking-block hygiene (BPT request 2026-07-07) — unit coverage
+ * of the strip logic. Engine-level end-to-end (fallback switch / resume replay /
+ * the mid-tool-loop edge) lives in engine.test.ts where the loop harness is.
+ *
+ * §6 test plan mapping: (2) same model not over-stripped; (1) cross-model
+ * stripped, text/tool_use intact; resume (no stamp) stripped; (3) in-flight
+ * tool-loop turn protected; redacted_thinking covered.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  protectedTurnIndex,
+  signingModelOf,
+  stampSigningModel,
+  stripStaleThinking,
+} from '../src/engine/thinking-provenance.js';
+import type { APIMessageParam, ContentBlockParam } from '../src/types.js';
+
+function thinking(text = 'draft', signature = 'sig'): ContentBlockParam {
+  return { type: 'thinking', thinking: text, signature } as ContentBlockParam;
+}
+function redacted(data = 'xxx'): ContentBlockParam {
+  return { type: 'redacted_thinking', data } as ContentBlockParam;
+}
+function text(t: string): ContentBlockParam {
+  return { type: 'text', text: t } as ContentBlockParam;
+}
+function toolUse(id: string): ContentBlockParam {
+  return { type: 'tool_use', id, name: 'Read', input: {} } as ContentBlockParam;
+}
+function toolResult(id: string): ContentBlockParam {
+  return { type: 'tool_result', tool_use_id: id, content: 'ok' } as ContentBlockParam;
+}
+function assistant(content: ContentBlockParam[], model?: string): APIMessageParam {
+  const m: APIMessageParam = { role: 'assistant', content };
+  if (model) stampSigningModel(m, model);
+  return m;
+}
+function user(content: string | ContentBlockParam[]): APIMessageParam {
+  return { role: 'user', content };
+}
+function types(m: APIMessageParam): string[] {
+  return Array.isArray(m.content) ? m.content.map((b) => b.type) : ['<string>'];
+}
+
+describe('signing-model stamp', () => {
+  it('round-trips a non-enumerable stamp that never serializes to JSON', () => {
+    const m = assistant([thinking(), text('hi')], 'A');
+    expect(signingModelOf(m)).toBe('A');
+    // the symbol stamp must not leak onto the wire
+    expect(JSON.parse(JSON.stringify(m))).toEqual({
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'draft', signature: 'sig' },
+        { type: 'text', text: 'hi' },
+      ],
+    });
+  });
+  it('is undefined on an unstamped (e.g. resumed) turn', () => {
+    expect(signingModelOf(user('hi'))).toBeUndefined();
+  });
+});
+
+describe('protectedTurnIndex', () => {
+  it('protects the last assistant when the request is a tool-loop continuation', () => {
+    const msgs = [user('go'), assistant([thinking(), toolUse('t1')], 'A'), user([toolResult('t1')])];
+    expect(protectedTurnIndex(msgs)).toBe(1);
+  });
+  it('protects nothing when the last message is a fresh user prompt', () => {
+    const msgs = [user('go'), assistant([thinking(), text('done')], 'A'), user('again')];
+    expect(protectedTurnIndex(msgs)).toBe(-1);
+  });
+});
+
+describe('stripStaleThinking', () => {
+  it('(§6.1) strips thinking from a cross-model CLOSED turn; text/tool_use survive', () => {
+    const msgs = [
+      user('go'),
+      assistant([thinking(), text('answer'), toolUse('t1')], 'A'),
+      user([toolResult('t1')]),
+      assistant([text('more')], 'A'),
+      user('next'),
+    ];
+    const out = stripStaleThinking(msgs, 'B');
+    // the first assistant (closed, model A, target B) loses thinking, keeps rest
+    expect(types(out[1]!)).toEqual(['text', 'tool_use']);
+    expect(out).not.toBe(msgs); // a change happened -> new array
+  });
+
+  it('(§6.2) leaves same-model thinking intact and returns the SAME array (cache-safe)', () => {
+    const msgs = [user('go'), assistant([thinking(), text('answer')], 'B'), user('next')];
+    const out = stripStaleThinking(msgs, 'B');
+    expect(types(out[1]!)).toEqual(['thinking', 'text']);
+    expect(out).toBe(msgs); // identity -> no request-byte churn
+  });
+
+  it('strips an UNSTAMPED closed turn (resume path — provenance unknown = stale)', () => {
+    const stale = assistant([thinking(), text('a')]); // no stamp
+    const msgs = [user('go'), stale, user('next')];
+    const out = stripStaleThinking(msgs, 'B');
+    expect(types(out[1]!)).toEqual(['text']);
+  });
+
+  it('(§6.3) NEVER strips the in-flight tool-loop turn, even cross-model', () => {
+    const msgs = [user('go'), assistant([thinking(), toolUse('t1')], 'A'), user([toolResult('t1')])];
+    const out = stripStaleThinking(msgs, 'B');
+    // protected turn keeps its thinking (API requires it before the tool_use)
+    expect(types(out[1]!)).toEqual(['thinking', 'tool_use']);
+    expect(out).toBe(msgs);
+  });
+
+  it('covers redacted_thinking the same as thinking', () => {
+    const msgs = [user('go'), assistant([redacted(), text('a')], 'A'), user('next')];
+    const out = stripStaleThinking(msgs, 'B');
+    expect(types(out[1]!)).toEqual(['text']);
+  });
+
+  it('strips EARLIER cross-model turns while protecting the in-flight one', () => {
+    const msgs = [
+      user('go'),
+      assistant([thinking(), text('turn1')], 'A'), // closed, cross-model -> strip
+      user('again'),
+      assistant([thinking(), toolUse('t2')], 'A'), // in-flight -> keep
+      user([toolResult('t2')]),
+    ];
+    const out = stripStaleThinking(msgs, 'B');
+    expect(types(out[1]!)).toEqual(['text']); // stripped
+    expect(types(out[3]!)).toEqual(['thinking', 'tool_use']); // protected
+  });
+});


### PR DESCRIPTION
## 概述

**事故修复。** PR #505 声称合并了跨模型 thinking-signature 修复(v0.14.0),但因 pre-push 钩子 rebase 与复用分支的交互,被推送的分支不含实际提交 → **#505 合并了空 diff**,源码从未落 main(`src/engine/thinking-provenance.ts` 缺失、`loop.ts` 未接线)。#506 随后又只把版本号刷成 0.14.0,使 main **标称 0.14.0 却无修复代码**。本 PR 从 reflog 恢复完整提交、重新落地。审计子代理(3 个)独立佐证了「thinking-provenance 只存在于编译出的 .d.ts、src 源缺失、loop 逐字重放」。

## 变更类型

- [x] Bug 修复(事故恢复 + 原 v0.14.0 根治)

## 内容(即原 v0.14.0,完整)

- `src/engine/thinking-provenance.ts`(新):签发印章(非枚举 Symbol)+ `stripStaleThinking` + `protectedTurnIndex`。
- `src/engine/loop.ts`:`pushAssistant` 盖章(`assistant.model`)、choke point `stripStaleThinking(reqMsgs, useModel)`、硬边界扣下工具循环中途 fallback 切换。
- 覆盖路径一(fallback)+ 路径二(resume 换模型);同模型 identity 透传(缓存不动);text/tool_use/tool_result 不动。

## 验证清单

- [x] `npx tsc --noEmit` EXIT 0。
- [x] `tests/thinking-provenance.test.ts`(10)+ `tests/engine.test.ts`(含 3 端到端)= 70 通过。
- [x] 从最新 origin/main 开分支,已确认**远端分支树内含 `thinking-provenance.ts`**(不再空合)。
- [x] 冲突仅 CHANGELOG(#506 的占位条目),已保留完整真实条目。

## 安全声明

- [x] 仅银芯自研 SDK,无黑池/内网/未发布数据;不含 emoji;未改主控台档案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E)_