### PR TITLE
fix(bpt-sdk): 审计修复批1 — 停止原因语义 + fable 别名（v0.15.0）

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,30 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.15.0 — 2026-07-07
+
+Official-semantics audit fixes, batch 1 (stop-reason + model alias). See
+`Public-Info-Pool/Resource/repo-engineering/bpt-sdk-official-semantics-audit-20260707.md`.
+
+- **fix (C3): `fable` model alias resolved to `claude-sonnet-5`** — a silent
+  wrong-model substitution (wrong price tier + capabilities). Now resolves to
+  `claude-fable-5`.
+- **fix (C4): `pause_turn` was dropped as a completed success** — a long
+  agentic / server-tool turn paused by the API was reported as done, silently
+  truncating the answer. The engine now persists the partial turn and RE-STREAMS
+  to continue it (bounded by `maxTurns` so a runaway pause can't loop forever).
+- **fix (C5): `refusal` was surfaced as a normal `success`** — a safety decline
+  (Fable 5 / newer, HTTP 200 + `stop_reason: refusal`) was handed back as a
+  valid answer and, in structured-output mode, retried against the still-refusing
+  model until the retry cap. It now yields a dedicated ERROR result
+  (`error_code: 'refusal'`), never a success. **Behavioral change** — a refusal
+  is now an error result, not a success with empty text.
+- **fix (C6): a `max_tokens` cut mid-tool-use persisted an unpaired `tool_use`** —
+  poisoning the next same-session request with a 400 ("tool_use ids without
+  tool_result"). The orphan `tool_use` is now dropped from the persisted
+  natural-end turn (the yielded message is unchanged).
+- +4 engine tests. `tsc`/`build` exit 0.
+
 ## 0.14.0 — 2026-07-07
 
 - **fix (cross-model thinking-signature 400, BPT request 2026-07-07)**: root-cause

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -1128,6 +1128,40 @@ export async function* runAgentLoop(
           toolCalls: toolUses.length,
         });
       }
+      // C5 (refusal, BPT audit 2026-07-07): a safety decline (Fable 5 / newer
+      // models) returns stop_reason 'refusal' on a 200 with possibly-empty /
+      // partial content. It is NOT a valid answer — surface a dedicated ERROR
+      // result (never a success, so it can't be mistaken for a real reply nor
+      // fed into the structured-output retry loop below). error_code 'refusal'
+      // lets a host classify + opt into a fallback. Partial content is dropped.
+      if (assistant.stop_reason === 'refusal') {
+        pushAssistant(assistant.content, assistant.model);
+        deps.debug('engine: model declined (stop_reason: refusal)');
+        yield errorResult(
+          'error_during_execution',
+          'The model declined to respond (stop_reason: refusal).',
+          undefined,
+          'refusal',
+        );
+        return;
+      }
+
+      // C4 (pause_turn, BPT audit 2026-07-07): the API paused a long agentic /
+      // server-tool turn. It is NOT complete — persist the partial assistant
+      // content and RE-STREAM so the model continues it (no user turn appended,
+      // no success emitted). The maxTurns guard bounds the continuation (this
+      // for(;;) has no top-of-loop turn check, so a runaway pause loop would
+      // otherwise never terminate).
+      if (assistant.stop_reason === 'pause_turn') {
+        pushAssistant(assistant.content, assistant.model);
+        if (config.maxTurns !== undefined && numTurns >= config.maxTurns) {
+          yield errorResult('error_max_turns', `Reached maxTurns limit (${config.maxTurns})`);
+          return;
+        }
+        deps.debug('engine: turn paused (stop_reason: pause_turn); continuing the turn');
+        continue;
+      }
+
       // stop_reason tool_use but ZERO tool_use blocks (malformed / gateway-
       // rewritten response): treat as a natural end rather than pushing an
       // empty {role:'user',content:[]} turn that would poison the history.
@@ -1392,7 +1426,16 @@ export async function* runAgentLoop(
 
       // Natural end: keep history complete for follow-up turns in the same
       // session, fire Stop hooks, emit the success result.
-      pushAssistant(assistant.content, assistant.model);
+      // C6 (max_tokens mid-tool-use, BPT audit 2026-07-07): a natural-end turn
+      // (end_turn / stop_sequence / max_tokens) should carry no actionable
+      // tool_use — an actionable one would have set stop_reason 'tool_use' and
+      // been dispatched above. A tool_use present here is an ORPHAN (typically a
+      // max_tokens cut mid-tool-use) that was never executed; persisting it
+      // unpaired 400s the next same-session request ("tool_use ids without
+      // tool_result"). Drop such orphans from the PERSISTED turn (the yielded
+      // assistant message already carried the raw content).
+      const naturalEndContent = assistant.content.filter((b) => b.type !== 'tool_use');
+      pushAssistant(naturalEndContent, assistant.model);
       if (deps.hooks.hasHooks('Stop')) {
         const stopAgg = await deps.hooks.run(
           'Stop',

--- a/projects/bpt-agent-sdk/src/subagents/agents.ts
+++ b/projects/bpt-agent-sdk/src/subagents/agents.ts
@@ -190,7 +190,7 @@ const MODEL_ALIASES: Readonly<Record<string, string>> = {
   opus: 'claude-opus-4-8',
   sonnet: 'claude-sonnet-4-5',
   haiku: 'claude-haiku-4-5',
-  fable: 'claude-sonnet-5',
+  fable: 'claude-fable-5',
 };
 
 /**

--- a/projects/bpt-agent-sdk/tests/engine.test.ts
+++ b/projects/bpt-agent-sdk/tests/engine.test.ts
@@ -1302,6 +1302,64 @@ describe('runAgentLoop', () => {
     expect(result.subtype).toBe('error_during_execution');
   });
 
+  // ----- BPT audit 2026-07-07: stop-reason semantics (C4/C5/C6) -----
+
+  it('C4: pause_turn continues the turn instead of ending as a success', async () => {
+    const transport = new MockTransport([
+      textReplyEvents('partial…', { stopReason: 'pause_turn' }),
+      textReplyEvents('final answer', { stopReason: 'end_turn' }),
+    ]);
+    const deps = makeDeps(transport);
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+    const messages = await collect(runAgentLoop(history, deps, makeConfig()));
+    expect(transport.requests).toHaveLength(2); // re-streamed to continue the paused turn
+    const result = lastResult(messages);
+    expect(result.subtype).toBe('success');
+    expect(result.subtype === 'success' && result.result).toBe('final answer');
+  });
+
+  it('C4: a runaway pause_turn is bounded by maxTurns', async () => {
+    const transport = new MockTransport([
+      textReplyEvents('p1', { stopReason: 'pause_turn' }),
+      textReplyEvents('p2', { stopReason: 'pause_turn' }),
+      textReplyEvents('p3', { stopReason: 'pause_turn' }),
+    ]);
+    const deps = makeDeps(transport);
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+    const messages = await collect(runAgentLoop(history, deps, makeConfig({ maxTurns: 2 })));
+    expect(lastResult(messages).subtype).toBe('error_max_turns');
+  });
+
+  it('C5: refusal surfaces as an ERROR result (not success) with error_code refusal', async () => {
+    const transport = new MockTransport([textReplyEvents('', { stopReason: 'refusal' })]);
+    const deps = makeDeps(transport);
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+    const messages = await collect(runAgentLoop(history, deps, makeConfig()));
+    expect(transport.requests).toHaveLength(1);
+    const result = lastResult(messages);
+    expect(result.subtype).toBe('error_during_execution');
+    expect(result.is_error).toBe(true);
+    expect((result as { error_code?: string }).error_code).toBe('refusal');
+  });
+
+  it('C6: a max_tokens orphan tool_use is dropped from the persisted turn', async () => {
+    const events = toolUseReplyEvents('Read', { file_path: '/a' }, { leadingText: 'hmm' });
+    const md = events.find((e) => e.type === 'message_delta') as {
+      delta: { stop_reason: string };
+    };
+    md.delta.stop_reason = 'max_tokens'; // tool_use block present, but cut by max_tokens
+    const transport = new MockTransport([events]);
+    const deps = makeDeps(transport);
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+    const messages = await collect(runAgentLoop(history, deps, makeConfig()));
+    expect(lastResult(messages).subtype).toBe('success'); // natural end, no dispatch
+    // the PERSISTED assistant turn must not carry the unpaired tool_use
+    const persisted = history.find((m) => m.role === 'assistant')!;
+    const kinds = (persisted.content as ContentBlockParam[]).map((b) => b.type);
+    expect(kinds).not.toContain('tool_use');
+    expect(kinds).toContain('text');
+  });
+
   it('records api_error_status on an unrecovered APIStatusError result', async () => {
     const transport = new MockTransport([
       () => {

--- a/projects/bpt-agent-sdk/tests/subagents.test.ts
+++ b/projects/bpt-agent-sdk/tests/subagents.test.ts
@@ -248,7 +248,7 @@ describe('resolveModelAlias', () => {
     expect(resolveModelAlias('opus', 'parent')).toBe('claude-opus-4-8');
     expect(resolveModelAlias('sonnet', 'parent')).toBe('claude-sonnet-4-5');
     expect(resolveModelAlias('haiku', 'parent')).toBe('claude-haiku-4-5');
-    expect(resolveModelAlias('fable', 'parent')).toBe('claude-sonnet-5');
+    expect(resolveModelAlias('fable', 'parent')).toBe('claude-fable-5');
     expect(resolveModelAlias('inherit', 'parent-model')).toBe('parent-model');
     expect(resolveModelAlias(undefined, 'parent-model')).toBe('parent-model');
     expect(resolveModelAlias('claude-custom-9', 'parent')).toBe('claude-custom-9');


### PR DESCRIPTION
## 概述

官方语义审计「全部修复」第一批(停止原因 + 模型别名)。审计报告见 `Public-Info-Pool/Resource/repo-engineering/bpt-sdk-official-semantics-audit-20260707.md`。

## 修复

- **C3** `fable` 别名 → `claude-fable-5`(原错误解析成 `claude-sonnet-5`,静默换错模型)。
- **C4** `pause_turn` 被当完成 success → 持久化部分回合并**续跑**(maxTurns 兜底防跑飞)。
- **C5** `refusal` 被当正常 success → 专门 **error result**(`error_code:'refusal'`),不再喂进结构化重试。**行为变更**:拒答现为错误 result 而非空 success。
- **C6** `max_tokens` 中途 tool_use 落库不配对 → 自然结束回合持久化时**剥掉孤儿 tool_use**(避免下轮 400)。

## 验证清单

- [x] `npx tsc --noEmit` EXIT 0;`npm run build` 通过。
- [x] +4 引擎测试(pause_turn 续跑 / maxTurns 兜底 / refusal 错误 result / max_tokens 剥孤儿);同步修正 subagents.test 里把 bug 当期望的 fable 断言。
- [x] **全量 vitest:1464 passed / 2 skipped**,零回归。
- [x] 从最新 main 开分支,已验证**远端分支含 agents.ts + test 两处修复**。

## 安全声明

- [x] 仅银芯自研 SDK,无黑池/内网/未发布数据;不含 emoji;未改主控台档案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQiqixw7TuZi6iriSq494E)_