### PR TITLE
fix(bpt-sdk): forward-slash Bash state dir on Windows (v0.18.1)

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,22 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.18.1 — 2026-07-08
+
+Windows bug fix: Bash persistent-state wrapper corrupted by backslash state dir.
+
+- **fix: every foreground Bash call failed on Windows with `cat: '"/cwd"': No
+  such file` + exit 127.** `withPersistentState` embedded the mkdtemp state dir
+  into its bash wrapper verbatim; on Windows mkdtemp returns a backslash path
+  (`C:\Users\…\bpt-shell-X`), and those backslashes corrupt the double-quoted
+  `"$__bpt_state/cwd"` expansion, so the cwd/env replay-capture read/wrote a
+  mangled path and the whole wrapper (and the wrapped command) failed. The state
+  dir is now forward-slashed (`\` → `/`) for the SCRIPT form only — bash/msys
+  accept forward-slash paths on Windows. The Node layer keeps the original OS
+  path (mkdtemp/rmSync/`join` take either separator). No-op on POSIX. Reported
+  by BPT (2026-07-08). Tests in bash-dx.test.ts; existing spawn-level persistence
+  tests (shells.test.ts) cover the POSIX regression.
+
 ## 0.18.0 — 2026-07-07
 
 Official-semantics audit follow-up: structured outputs — COMPAT honesty +

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/tools/bash.ts
+++ b/projects/bpt-agent-sdk/src/tools/bash.ts
@@ -246,11 +246,23 @@ function formatStreams(stdout: string, stderr: string): string {
  * its exported env. After it (EXIT trap, so `exit N` still persists): capture
  * cwd + `export -p`. Functions/aliases/unexported vars do NOT persist — this
  * is a state-file replay, not a long-lived shell process (docs/COMPAT.md).
- * The state dir comes from mkdtemp, so single-quoting it is safe.
+ *
+ * The state dir comes from mkdtemp, so single-quoting it is safe against word
+ * splitting. But on Windows mkdtemp returns a BACKSLASH path
+ * (`C:\Users\…\bpt-shell-X`); embedded verbatim, those backslashes corrupt
+ * `$__bpt_state` when it later expands inside the double-quoted `"$__bpt_state/cwd"`
+ * references, so the replay/capture reads/writes a mangled path and the whole
+ * wrapper fails — the command line degrades to `cat: '"/cwd"': No such file` and
+ * exit 127 (BPT Windows incident 2026-07-08). bash/msys accept forward-slash
+ * paths on Windows, so we normalize `\` -> `/` for the SCRIPT form ONLY. The
+ * Node layer (shells.ts mkdtemp/rm/`join`) keeps the original OS path — those
+ * APIs take either separator, and rewriting them risks an rmSync mismatch.
+ * No-op on POSIX (mkdtemp paths have no backslashes there).
  */
-function withPersistentState(command: string, stateDir: string): string {
+export function withPersistentState(command: string, stateDir: string): string {
+  const bashStateDir = stateDir.replace(/\\/g, '/');
   return [
-    `__bpt_state='${stateDir}'`,
+    `__bpt_state='${bashStateDir}'`,
     'if [ -f "$__bpt_state/cwd" ]; then cd -- "$(cat "$__bpt_state/cwd")" 2>/dev/null || true; fi',
     'if [ -f "$__bpt_state/env" ]; then { . "$__bpt_state/env"; } 2>/dev/null || true; fi',
     '__bpt_persist() {',

--- a/projects/bpt-agent-sdk/tests/bash-dx.test.ts
+++ b/projects/bpt-agent-sdk/tests/bash-dx.test.ts
@@ -17,7 +17,12 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { bashTool, createBashTool, windowsCmdHint } from '../src/tools/bash.js';
+import {
+  bashTool,
+  createBashTool,
+  windowsCmdHint,
+  withPersistentState,
+} from '../src/tools/bash.js';
 import { BASH_DESCRIPTION, BASH_WIN32_NOTE } from '../src/tools/descriptions.js';
 import type { SandboxContext } from '../src/types.js';
 import type {
@@ -205,5 +210,42 @@ describe('Bash description win32 platform note (gated assembly)', () => {
     const desc = createBashTool(fakeSandbox, 'linux').description;
     expect(desc).not.toContain(BASH_WIN32_NOTE);
     expect(desc).toContain('# Sandbox');
+  });
+});
+
+// BPT Windows incident 2026-07-08: mkdtemp returns a backslash path on Windows
+// (C:\Users\…\bpt-shell-X); embedded verbatim into the wrapper, the backslashes
+// corrupt the double-quoted "$__bpt_state/cwd" expansion, and every foreground
+// Bash call fails with `cat: '"/cwd"': No such file` + exit 127. The fix
+// forward-slashes the state dir for the SCRIPT form only.
+describe('withPersistentState state-dir separator normalization (Windows)', () => {
+  it('forward-slashes a Windows backslash state dir in the wrapper assignment', () => {
+    const winDir = 'C:\\Users\\ASTERIA\\AppData\\Local\\Temp\\bpt-shell-PJ7Z1V';
+    const script = withPersistentState('node -e "1"', winDir);
+    // The assignment carries the normalized forward-slash path...
+    expect(script).toContain(
+      "__bpt_state='C:/Users/ASTERIA/AppData/Local/Temp/bpt-shell-PJ7Z1V'",
+    );
+    // ...and no backslash survives anywhere in the generated script (the state
+    // path was the only source of them here).
+    expect(script).not.toContain('\\');
+  });
+
+  it('leaves a POSIX forward-slash state dir untouched (no-op)', () => {
+    const posixDir = '/tmp/bpt-shell-abc123';
+    const script = withPersistentState('echo hi', posixDir);
+    expect(script).toContain(`__bpt_state='${posixDir}'`);
+  });
+
+  it('preserves the replay/capture prologue and appends the command last', () => {
+    const script = withPersistentState('node -e "1"', 'C:\\T\\bpt-shell-1');
+    const lines = script.split('\n');
+    // Assignment first, command last, EXIT trap wiring intact.
+    expect(lines[0]).toBe("__bpt_state='C:/T/bpt-shell-1'");
+    expect(lines[lines.length - 1]).toBe('node -e "1"');
+    expect(script).toContain('trap __bpt_persist EXIT');
+    // The double-quoted state references remain the variable form, not inlined.
+    expect(script).toContain('"$__bpt_state/cwd"');
+    expect(script).toContain('"$__bpt_state/env"');
   });
 });


### PR DESCRIPTION
## 概述

黑池（BPT）报的 Windows 全员可见故障：**每次前台 Bash 命令都失败**，报 `cat: '"/cwd"': No such file or directory` + `exit code 127`。根因在 SDK 的 `withPersistentState()` 持久态包装脚本，黑池应用层拿不到 stateDir 注入点，故机制修复归银芯。

## 变更类型

- Bug 修复（Windows 路径转义）

## 根因

`withPersistentState()` 把 mkdtemp 生成的 stateDir 原样拼进 bash 包装脚本。Windows 上 `mkdtempSync(join(tmpdir(),'bpt-shell-'))` 返回**反斜杠**路径（`C:\Users\ASTERIA\...\bpt-shell-X`）；这段路径在后续 `"$__bpt_state/cwd"` 的**双引号展开**中被反斜杠破坏，cwd/env replay-capture 读写到损坏路径，整个包装脚本连带被包裹的 command 一起失败。

## 修复

| 位置 | 变更 |
|---|---|
| `src/tools/bash.ts` `withPersistentState()` | 入口把 stateDir 的 `\` → `/`（**仅用于 bash 脚本形态**）——bash/msys 在 Windows 下接受正斜杠路径。Node 层（`shells.ts` 的 `mkdtempSync`/`rmSync`/`join`）**保持原始 OS 路径**（两种分隔符都吃；改源头有 rmSync 失配风险）。POSIX 下为 no-op。 |
| 同处文档注释 | 原注释「single-quoting it is safe」在 Windows 下即为错误假设，已改为 Windows-aware 说明 |
| 导出 | `withPersistentState` 导出供单测（与既有 `windowsCmdHint` 同范式）|

边界（遵黑池请求 §4）：只改「塞进 bash 脚本字符串」这一通道，不动 Node 层对 stateDir 的任何使用；不影响非 Windows 平台。

小学生比喻：临时储物柜的地址牌本来用「\」当楼层分隔（Windows 写法），可门卫（bash）把「\」当成暗号符念歪了、找不到柜子；把地址牌统一改成「/」分隔，门卫就认得了。柜子本身的登记册（Node 层）不动，免得清柜时按错地址。

## 验证清单

- [x] `npx tsc -p tsconfig.json --noEmit` — EXIT 0
- [x] `npx vitest run` — 65 test files, **1483 passed / 2 skipped**
- [x] 新增测试 `bash-dx.test.ts`：反斜杠 stateDir → 脚本产出正斜杠且无残留反斜杠；POSIX 路径 no-op；prologue + command 顺序与 `$__bpt_state` 变量引用保持
- [x] POSIX 回归由既有 spawn 级持久态测试 `shells.test.ts`（cd/pwd/env replay）保障
- [x] 不引入 emoji

注：黑池请求 §6 建议的「真实 Windows spawn 复现」在 Linux CI 上无法逐字复现（反斜杠在 Linux 是普通文件名字符、非分隔符），故 Windows 特定修复以确定性脚本生成断言覆盖，POSIX 端到端由现有 spawn 测试覆盖——两者合起来锁住修复边界。

## 安全声明

- [x] 本变更仅涉及银芯自有工程产物（bpt-agent-sdk），不含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据；与 §1.1-HC 防火墙同向（银芯→黑池单向输出）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBmZntTqCiHg3rPf1CgqAK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBmZntTqCiHg3rPf1CgqAK)_