### PR TITLE
test(bpt-sdk): retire the now-inert English-archive corpus-sync guards

### DIFF
--- a/projects/bpt-agent-sdk/tests/generators.test.ts
+++ b/projects/bpt-agent-sdk/tests/generators.test.ts
@@ -1,11 +1,9 @@
 /**
- * v0.6 generators/classifiers — parser robustness, wiring, and a corpus-sync
- * guard holding every reproduced prompt faithful to its archived source.
+ * v0.6 generators/classifiers — parser robustness, wiring, and provenance
+ * (attribution + translation state). The former English-archive corpus-sync
+ * guard is retired now that every generator prompt is translated to Chinese
+ * (i18n-zh Phase 2); reversion is caught by the structural i18n guards.
  */
-
-import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
@@ -25,20 +23,13 @@ import {
   selectMemoryFilesToAttach,
 } from '../src/generators/index.js';
 import {
-  AWAY_SUMMARY_PROVENANCE,
   AWAY_SUMMARY_SYSTEM,
-  MEMORY_FILES_PROVENANCE,
   MEMORY_FILES_SYSTEM,
   BACKGROUND_STATE_SYSTEM,
-  COMMAND_PREFIX_PROVENANCE,
   COMMAND_PREFIX_SYSTEM,
-  BACKGROUND_STATE_PROVENANCE,
   GENERATOR_PROVENANCE,
-  SESSION_NAME_PROVENANCE,
   SESSION_NAME_SYSTEM,
-  SESSION_TITLE_PROVENANCE,
   SESSION_TITLE_SYSTEM,
-  TITLE_AND_BRANCH_PROVENANCE,
   TITLE_AND_BRANCH_SYSTEM,
 } from '../src/generators/prompts.js';
 import { MockTransport, textReplyEvents } from './helpers/mock-transport.js';
@@ -402,59 +393,23 @@ describe('selectMemoryFilesToAttach over a mock transport', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Corpus-sync guard — every reproduced prompt is faithful to the archive
+// Provenance — attribution + translation state
 // ---------------------------------------------------------------------------
+// The former per-face English-archive drift check (Track B corpus-sync guard) is
+// RETIRED here (2026-07-08): every generator prompt is now translated to Chinese
+// (i18n-zh Phase 2 batches C+D), so faithful:false throughout and that check
+// could only ever skip. A revert-to-English is instead caught by the structural
+// i18n guards (tests/gen-tips-i18n-zh.test.ts, tests/classifiers-i18n-zh.test.ts,
+// which assert CJK.test===true). The `slug` provenance is kept below as the
+// open-reproduction attribution: it records the English archive source each
+// Chinese prompt was translated FROM.
 
-describe('generator prompt provenance (corpus-sync guard, Track B parity)', () => {
-  const archive = join(
-    dirname(fileURLToPath(import.meta.url)),
-    '..',
-    '..',
-    '..',
-    'Public-Info-Pool',
-    'Reference',
-    'Claude-Code-System-Prompts',
-    'system-prompts',
-  );
-  const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
-  const stripHeader = (md: string) => md.replace(/^<!--[\s\S]*?-->\n?/, '');
-
-  const faces = [
-    { prompt: COMMAND_PREFIX_SYSTEM, prov: COMMAND_PREFIX_PROVENANCE },
-    { prompt: BACKGROUND_STATE_SYSTEM, prov: BACKGROUND_STATE_PROVENANCE },
-    { prompt: SESSION_TITLE_SYSTEM, prov: SESSION_TITLE_PROVENANCE },
-    { prompt: TITLE_AND_BRANCH_SYSTEM, prov: TITLE_AND_BRANCH_PROVENANCE },
-    { prompt: SESSION_NAME_SYSTEM, prov: SESSION_NAME_PROVENANCE },
-    { prompt: AWAY_SUMMARY_SYSTEM, prov: AWAY_SUMMARY_PROVENANCE },
-    { prompt: MEMORY_FILES_SYSTEM, prov: MEMORY_FILES_PROVENANCE },
-  ];
-
-  it('the provenance table has one entry per reproduced face; all generators translated', () => {
+describe('generator prompt provenance (attribution + translation state)', () => {
+  it('every reproduced face keeps its source slug and is translated (faithful:false)', () => {
     expect(Object.keys(GENERATOR_PROVENANCE)).toHaveLength(7);
     for (const p of Object.values(GENERATOR_PROVENANCE)) {
-      expect(p.slug.length).toBeGreaterThan(0);
-    }
-    // i18n-zh Phase 2: batch C translated the 5 small generators; batch D
-    // translated the two big classifiers (command-prefix, background-state) —
-    // prose only, with output enums / JSON / example blocks kept English. All
-    // seven are now faithful:false, so the English corpus-sync guard is inert.
-    for (const p of Object.values(GENERATOR_PROVENANCE)) {
-      expect(p.faithful).toBe(false);
+      expect(p.slug.length).toBeGreaterThan(0); // attribution: the English source
+      expect(p.faithful).toBe(false); // translated in-place (prose Chinese, contracts English)
     }
   });
-
-  for (const { prompt, prov } of faces) {
-    // Translated (faithful:false) prompts can't be anchor-matched against the
-    // English archive; the archive check runs only for still-faithful faces.
-    it.runIf(existsSync(archive) && prov.faithful)(`${prov.slug} is faithful to its archived source`, () => {
-      const body = norm(stripHeader(readFileSync(join(archive, `${prov.slug}.md`), 'utf8')));
-      const drifted = norm(prompt)
-        .split(/(?<=[.:])\s+/)
-        .map(norm)
-        // skip short/boilerplate lines and the interpolation placeholder line
-        .filter((s) => s.length >= 40 && !s.includes('{description}'))
-        .filter((s) => !body.includes(s.slice(0, 60)));
-      expect(drifted, `not found in archive:\n${drifted.join('\n')}`).toEqual([]);
-    });
-  }
 });

--- a/projects/bpt-agent-sdk/tests/hooks-condition.test.ts
+++ b/projects/bpt-agent-sdk/tests/hooks-condition.test.ts
@@ -4,10 +4,6 @@
  * corpus-sync guards holding both reproduced prompts to their archive.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -208,46 +204,19 @@ describe('DefaultHookRunner condition gate', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Corpus-sync guard
+// Provenance — attribution + translation state
 // ---------------------------------------------------------------------------
+// The English-archive drift check is RETIRED (2026-07-08): both prompts are
+// translated to Chinese (i18n-zh batch B), faithful:false, so it could only
+// skip. The CJK structural guard in tests/aux-prompts-i18n-zh.test.ts covers
+// reversion; the slug provenance (attribution) is retained on the table entries.
 
-describe('hook-condition prompt provenance (corpus-sync guard, Track B parity)', () => {
-  const archive = join(
-    dirname(fileURLToPath(import.meta.url)),
-    '..',
-    '..',
-    '..',
-    'Public-Info-Pool',
-    'Reference',
-    'Claude-Code-System-Prompts',
-    'system-prompts',
-  );
-  const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
-  const stripHeader = (md: string) => md.replace(/^<!--[\s\S]*?-->\n?/, '');
-
-  it('the provenance table has 2 entries, now translated (faithful:false)', () => {
+describe('hook-condition prompt provenance (attribution + translation state)', () => {
+  it('the provenance table has 2 entries, translated in-place with source slugs retained', () => {
     expect(Object.keys(HOOK_CONDITION_PROVENANCE_TABLE)).toHaveLength(2);
-    // i18n-zh Phase 2 batch B: both prompts translated to Chinese (JSON contract
-    // — ok/reason/impossible keys + booleans — kept English), so faithful:false.
     for (const p of Object.values(HOOK_CONDITION_PROVENANCE_TABLE)) {
-      expect(p.faithful).toBe(false);
+      expect(p.faithful).toBe(false); // translated (JSON ok/reason/impossible kept English)
+      expect(p.slug.length).toBeGreaterThan(0); // English source (attribution)
     }
   });
-
-  const faces = [
-    { text: HOOK_CONDITION_SYSTEM, prov: HOOK_CONDITION_PROVENANCE },
-    { text: HOOK_STOP_CONDITION_SYSTEM, prov: HOOK_STOP_CONDITION_PROVENANCE },
-  ];
-  for (const { text, prov } of faces) {
-    // Translated (faithful:false): Chinese prose can't anchor-match the English archive.
-    it.runIf(existsSync(archive) && prov.faithful)(`${prov.slug} is faithful to its archived source`, () => {
-      const body = norm(stripHeader(readFileSync(join(archive, `${prov.slug}.md`), 'utf8')));
-      const drifted = norm(text)
-        .split(/(?<=[.:])\s+/)
-        .map(norm)
-        .filter((s) => s.length >= 40)
-        .filter((s) => !body.includes(s.slice(0, 60)));
-      expect(drifted, `not found in archive:\n${drifted.join('\n')}`).toEqual([]);
-    });
-  }
 });

--- a/projects/bpt-agent-sdk/tests/subagents.test.ts
+++ b/projects/bpt-agent-sdk/tests/subagents.test.ts
@@ -9,8 +9,7 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -1240,61 +1239,27 @@ describe('subagent runtime — task control', () => {
   });
 });
 
-describe('general-purpose prompt provenance (corpus-sync guard, Track B)', () => {
-  const archive = join(
-    dirname(fileURLToPath(import.meta.url)),
-    '..',
-    '..',
-    '..',
-    'Public-Info-Pool',
-    'Reference',
-    'Claude-Code-System-Prompts',
-    'system-prompts',
-  );
-  const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
-  const stripHeader = (md: string) => md.replace(/^<!--[\s\S]*?-->\n?/, '');
-
+describe('general-purpose prompt provenance (attribution + translation state)', () => {
+  // The English-archive drift check is RETIRED (2026-07-08): GENERAL_PURPOSE_PROMPT
+  // is translated to Chinese (i18n-zh batch B), faithful:false, so it could only
+  // skip. Reversion-to-English is caught by the CJK structural guard in
+  // tests/aux-prompts-i18n-zh.test.ts; the slug provenance (attribution) is
+  // retained on GENERAL_PURPOSE_PROMPT_PROVENANCE.
   it('reproduces the official Strengths + Guidelines substance (translated)', () => {
-    // i18n-zh Phase 2 batch B: the prompt is Chinese; parent-agent framing +
-    // Strengths/Guidelines substance are asserted against the translated wording.
     expect(GENERAL_PURPOSE_PROMPT).toContain('父代理'); // parent agent
     expect(GENERAL_PURPOSE_PROMPT).not.toContain('official CLI');
     expect(GENERAL_PURPOSE_PROMPT).toContain('你的强项：'); // Your strengths:
     expect(GENERAL_PURPOSE_PROMPT).toContain('绝不主动创建文档文件'); // NEVER proactively create documentation files
     expect(GENERAL_PURPOSE_PROMPT).toContain('用 Read'); // the Read wire token survives
-  });
-
-  // Translated (faithful:false): Chinese prose can't anchor-match the English archive.
-  it.runIf(existsSync(archive) && GENERAL_PURPOSE_PROMPT_PROVENANCE.faithful)('its cited archive source is still represented', () => {
-    const desc = norm(GENERAL_PURPOSE_PROMPT);
-    for (const slug of GENERAL_PURPOSE_PROMPT_PROVENANCE.slugs) {
-      const file = join(archive, `${slug}.md`);
-      expect(existsSync(file), slug).toBe(true);
-      const body = norm(stripHeader(readFileSync(file, 'utf8')));
-      const anchors = body
-        .split(/(?<=[.:])\s+/)
-        .map(norm)
-        .filter((s) => s.length >= 40 && !s.includes('${'))
-        .map((s) => s.slice(0, 45));
-      expect(anchors.some((a) => desc.includes(a)), `${slug} not represented`).toBe(true);
-    }
+    expect(GENERAL_PURPOSE_PROMPT_PROVENANCE.faithful).toBe(false); // translated
+    expect(GENERAL_PURPOSE_PROMPT_PROVENANCE.slugs.length).toBeGreaterThan(0); // attribution
   });
 });
 
 describe('worker-fork preset (O-B0)', () => {
-  const archive = join(
-    dirname(fileURLToPath(import.meta.url)),
-    '..',
-    '..',
-    '..',
-    'Public-Info-Pool',
-    'Reference',
-    'Claude-Code-System-Prompts',
-    'system-prompts',
-  );
-  const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
-  const stripHeader = (md: string) => md.replace(/^<!--[\s\S]*?-->\n?/, '');
-
+  // English-archive drift check retired (2026-07-08): WORKER_FORK_FRAMING is
+  // translated (i18n-zh batch B), faithful:false; the CJK structural guard in
+  // tests/aux-prompts-i18n-zh.test.ts covers reversion, slug is retained.
   it('the preset rides fork mode with the official worker profile', () => {
     expect(WORKER_FORK_AGENT.fork).toBe(true);
     expect(WORKER_FORK_AGENT.maxTurns).toBe(200);
@@ -1307,19 +1272,8 @@ describe('worker-fork preset (O-B0)', () => {
     expect(p).toContain('</system>\n\nAudit src/tips for dead code.');
     expect(p.endsWith('Extra: only report.')).toBe(true);
   });
-  // Translated (faithful:false): skip the English-archive anchor match.
-  it.runIf(existsSync(archive) && WORKER_FORK_PROVENANCE.faithful)('the framing is faithful to its archived source', () => {
-    const body = norm(
-      stripHeader(readFileSync(join(archive, `${WORKER_FORK_PROVENANCE.slug}.md`), 'utf8')),
-    )
-      // normalize the archive's template variables to our adapted values
-      .replace(/\$\{AGENT_TOOL_NAME\}/g, 'Agent')
-      .replace(/\$\{""\}/g, '');
-    const drifted = norm(WORKER_FORK_FRAMING)
-      .split(/(?<=[.:])\s+/)
-      .map(norm)
-      .filter((s) => s.length >= 40)
-      .filter((s) => !body.includes(s.slice(0, 60)));
-    expect(drifted, `not found in archive:\n${drifted.join('\n')}`).toEqual([]);
+  it('is translated in-place, with its source slug retained (attribution)', () => {
+    expect(WORKER_FORK_PROVENANCE.faithful).toBe(false); // translated (i18n-zh)
+    expect(WORKER_FORK_PROVENANCE.slug.length).toBeGreaterThan(0); // English source
   });
 });

--- a/projects/bpt-agent-sdk/tests/tips.test.ts
+++ b/projects/bpt-agent-sdk/tests/tips.test.ts
@@ -17,13 +17,7 @@ import {
   parseTipReception,
   selectContextTip,
 } from '../src/tips/index.js';
-import {
-  CONTEXT_TIP_SELECTOR_PROVENANCE,
-  CONTEXT_TIP_SELECTOR_SYSTEM,
-  TIP_PROVENANCE,
-  TIP_RECEPTION_PROVENANCE,
-  TIP_RECEPTION_SYSTEM,
-} from '../src/tips/prompts.js';
+import { TIP_PROVENANCE } from '../src/tips/prompts.js';
 import {
   SITUATION_MANUAL_POLLING,
   SITUATION_PERSISTENT_MEMORY,
@@ -195,19 +189,20 @@ describe('context-tip prompt provenance (corpus-sync guard, Track B parity)', ()
       .filter((s) => !body.includes(s.slice(0, 60)));
   };
 
-  it('the provenance table has 2 entries, now translated (faithful:false)', () => {
+  it('the provenance table has 2 entries, translated in-place with source slugs retained', () => {
     expect(Object.keys(TIP_PROVENANCE)).toHaveLength(2);
     // i18n-zh Phase 2 batch C: both tip prompts translated (examples/tokens/JSON
     // enum kept English), so faithful:false; catalog situations stay faithful.
-    for (const p of Object.values(TIP_PROVENANCE)) expect(p.faithful).toBe(false);
+    // The per-prompt English-archive drift check is RETIRED (it could only skip);
+    // the CJK guard in tests/gen-tips-i18n-zh.test.ts covers reversion, and the
+    // slug provenance (attribution) is asserted here.
+    for (const p of Object.values(TIP_PROVENANCE)) {
+      expect(p.faithful).toBe(false);
+      expect(p.slug.length).toBeGreaterThan(0);
+    }
   });
-  // Translated (faithful:false): Chinese prose can't anchor-match the English archive.
-  it.runIf(existsSync(archive) && CONTEXT_TIP_SELECTOR_PROVENANCE.faithful)('selector is faithful to its archive', () => {
-    expect(faithful(CONTEXT_TIP_SELECTOR_SYSTEM, CONTEXT_TIP_SELECTOR_PROVENANCE.slug)).toEqual([]);
-  });
-  it.runIf(existsSync(archive) && TIP_RECEPTION_PROVENANCE.faithful)('reception evaluator is faithful to its archive', () => {
-    expect(faithful(TIP_RECEPTION_SYSTEM, TIP_RECEPTION_PROVENANCE.slug)).toEqual([]);
-  });
+  // The catalog SITUATION data is NOT translated (still English), so its
+  // corpus-sync archive check stays active.
   it.runIf(existsSync(archive))('catalog situations are faithful to their archive', () => {
     expect(faithful(SITUATION_MANUAL_POLLING, 'data-context-tip-situation-manual-polling')).toEqual([]);
     expect(faithful(SITUATION_PERSISTENT_MEMORY, 'data-context-tip-situation-persistent-memory')).toEqual([]);

--- a/projects/bpt-agent-sdk/tests/verifier.test.ts
+++ b/projects/bpt-agent-sdk/tests/verifier.test.ts
@@ -17,9 +17,7 @@ import {
   parseVerdict,
 } from '../src/verifier/index.js';
 import {
-  RECALL_BIAS_GUIDANCE,
   RECALL_BIAS_PROVENANCE,
-  THREE_STATE_VERDICT_DEFINITIONS,
   VERDICT_DEFINITIONS_PROVENANCE,
   VERIFIER_PROVENANCE,
   VERIFY_KEEP_RULE,
@@ -191,7 +189,12 @@ describe('adversarialVerify over a mock transport', () => {
 // Corpus-sync guard — reproduced fragments faithful to the archive
 // ---------------------------------------------------------------------------
 
-describe('verifier prompt provenance (corpus-sync guard, Track B parity)', () => {
+describe('verifier prompt provenance (attribution + translation state)', () => {
+  // The per-fragment English-archive drift check is RETIRED for the two ON-THE-WIRE
+  // fragments (2026-07-08): they are translated to Chinese (i18n-zh batch B),
+  // faithful:false, so it could only skip; the CJK guard in
+  // tests/aux-prompts-i18n-zh.test.ts covers reversion. VERIFY_KEEP_RULE stays
+  // English (a doc anchor, never sent to the model) and is still archive-checked.
   const archive = join(
     dirname(fileURLToPath(import.meta.url)),
     '..',
@@ -202,8 +205,6 @@ describe('verifier prompt provenance (corpus-sync guard, Track B parity)', () =>
     'Claude-Code-System-Prompts',
     'system-prompts',
   );
-  const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
-  const stripHeader = (md: string) => md.replace(/^<!--[\s\S]*?-->\n?/, '');
 
   it('the provenance table has 3 entries with non-empty slugs; translated wire fragments are faithful:false', () => {
     expect(Object.keys(VERIFIER_PROVENANCE)).toHaveLength(3);
@@ -217,24 +218,6 @@ describe('verifier prompt provenance (corpus-sync guard, Track B parity)', () =>
     expect(RECALL_BIAS_PROVENANCE.faithful).toBe(false);
     expect(VERIFY_PHASE_PROVENANCE.faithful).toBe(true);
   });
-
-  const fragments = [
-    { text: THREE_STATE_VERDICT_DEFINITIONS, prov: VERDICT_DEFINITIONS_PROVENANCE },
-    { text: RECALL_BIAS_GUIDANCE, prov: RECALL_BIAS_PROVENANCE },
-  ];
-  for (const { text, prov } of fragments) {
-    // Translated (faithful:false) fragments can't be anchor-matched against the
-    // English archive; the archive check runs only for still-faithful fragments.
-    it.runIf(existsSync(archive) && prov.faithful)(`${prov.slug} is faithful to its archived source`, () => {
-      const body = norm(stripHeader(readFileSync(join(archive, `${prov.slug}.md`), 'utf8')));
-      const drifted = norm(text)
-        .split(/(?<=[.:])\s+/)
-        .map(norm)
-        .filter((s) => s.length >= 40)
-        .filter((s) => !body.includes(s.slice(0, 60)));
-      expect(drifted, `not found in archive:\n${drifted.join('\n')}`).toEqual([]);
-    });
-  }
 
   it.runIf(existsSync(archive))('VERIFY_KEEP_RULE appears verbatim in the skill file', () => {
     const body = readFileSync(join(archive, `${VERIFY_PHASE_PROVENANCE.slug}.md`), 'utf8');


### PR DESCRIPTION
## What

Follow-up cleanup to the i18n-zh campaign. Retire the **15 permanently-inert English-archive corpus-sync checks** that the translation left behind, so the test suite stops reporting misleading "will-never-run" skips.

## Why

After every tool description and prompt was translated to Chinese (all `faithful:false`), the per-face English-archive drift checks — written as `it.runIf(existsSync(archive) && prov.faithful)(...)` — can only ever **skip** (`faithful` is now permanently false on a deliberately-Chinese surface). A test that reports as a skip but will never run again is noise: it reads as "conditionally not run" when it's actually dead.

The full-suite skip count had grown to **17** (15 of these + 2 legitimate environment-gated `sandbox` bwrap tests).

## What changed

Across `generators` / `verifier` / `hooks-condition` / `subagents` / `tips` test files:

- **Removed** the dead per-face archive-check tests and the imports/helpers they orphaned (`archive` / `norm` / `stripHeader`, the node `fs`/`url`/`path` imports where fully unused, and the now-unused provenance/system constant imports).
- **Kept** everything that still has value:
  - the `slug` provenance data — the open-reproduction **attribution** (the English archive source each Chinese prompt was translated FROM) — now asserted as `faithful:false` + non-empty slug;
  - the checks that still guard **English** text: `VERIFY_KEEP_RULE` (a doc anchor never sent to the model) and the tip catalog `SITUATION` data (untranslated) — both remain actively archive-checked;
  - reversion-to-English is already caught by the structural i18n guards (`*-i18n-zh.test.ts`, which assert `CJK.test===true`).

## Result

- Skipped tests: **17 → 2** (only the environment-gated `sandbox` bwrap tests remain, which skip because bubblewrap isn't on this platform — unrelated to i18n).
- `npx tsc -p tsconfig.json --noEmit` → exit 0
- `npx vitest run` → 70 files, **1558 passed / 2 skipped, 0 failed**

## Notes

Test-only change — no `src/` runtime touched, so no version bump / CHANGELOG entry (per the CHANGELOG discipline, which bumps only on shipped-runtime changes). The `check-version-bump` guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBmZntTqCiHg3rPf1CgqAK)_