### PR TITLE
feat(bpt-sdk): 从包入口导出 harness 基座构造 buildSystemPromptParts (v0.30.0)

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,25 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.30.0 — 2026-07-08
+
+- **feat (public harness-base constructor export, black-pool ContextRing request
+  2026-07-08)**: the package entry now re-exports `buildSystemPromptParts` and
+  `buildSystemPrompt` (plus the `SystemPromptParts` / `EnvironmentContext` /
+  `PromptContext` types) from `engine/prompts.js`. A host can now size the
+  built-in harness base — the V5 preset prose (~11.7k chars ≈ ~2.9k tokens)
+  injected on the `claude_code` preset path — via the public API:
+  `buildSystemPromptParts(opt, ctx).base`. `.base` is the vN harness prose ONLY
+  (no caller `append`, project instructions, or `<env>` tail), the exact segment
+  the engine measures as `base` in `query.ts` — so with the same `toolNames` /
+  `variant` it is byte-identical to what preset mode injects. Read-only, zero side
+  effects; same rationale as `enumerateBuiltinToolMetadata` (ADR 0014), retiring
+  the host-side `dist/engine/prompts.js` file-path stopgap.
+- **temp (one-off token-accounting diagnostic)**: `engine/loop.ts` prints each
+  turn's raw `input_tokens` / `cache_read_input_tokens` /
+  `cache_creation_input_tokens` to stderr (`[bpt-usage] …`). Throwaway — to be
+  removed once the cache-behavior numbers are captured.
+
 ## 0.29.0 — 2026-07-08
 
 **Revert the entire i18n-zh prompt campaign back to English** (keeper ruling,

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -385,6 +385,14 @@ export async function* runAgentLoop(
 
   /** Fold one attempt's usage into the running totals + per-model ledger. */
   const recordUsage = (responseModel: string, usage: NonNullableUsage): void => {
+    // TEMP one-off diagnostic (black-pool token-accounting, 2026-07-08): print
+    // each turn's raw input_tokens / cache_read / cache_creation verbatim to
+    // stderr. Remove once the cache-behavior numbers are captured.
+    console.error(
+      `[bpt-usage] input_tokens=${usage.input_tokens} ` +
+        `cache_read_input_tokens=${usage.cache_read_input_tokens} ` +
+        `cache_creation_input_tokens=${usage.cache_creation_input_tokens}`,
+    );
     totalUsage = addUsage(totalUsage, usage);
     const cost = estimateCostUsd(responseModel, usage, config.cacheTtl);
     totalCostUsd += cost;

--- a/projects/bpt-agent-sdk/src/engine/prompts.ts
+++ b/projects/bpt-agent-sdk/src/engine/prompts.ts
@@ -35,7 +35,7 @@ export type EnvironmentContext = {
   gitBranch?: string;
 };
 
-type PromptContext = {
+export type PromptContext = {
   cwd: string;
   toolNames: string[];
   /**

--- a/projects/bpt-agent-sdk/src/index.ts
+++ b/projects/bpt-agent-sdk/src/index.ts
@@ -22,6 +22,16 @@ export { tool, createSdkMcpServer } from './mcp/sdk-server.js';
 // same way it sizes MCP tools.
 export { enumerateBuiltinToolMetadata } from './tools/index.js';
 export type { BuiltinToolMetadata } from './tools/index.js';
+// BPT-EXTENSION (2026-07-08, black-pool ContextRing request): expose the harness
+// system-prompt base constructor so a host can size the built-in harness base —
+// the ~2.9k-token V5 preset prose injected on the `claude_code` preset path — the
+// SAME way the engine does. `buildSystemPromptParts(opt, ctx).base` returns the
+// vN harness prose only (no caller `append` / project instructions / `<env>`
+// tail), which is exactly the segment query.ts measures as `base`. Read-only,
+// zero side effects — same rationale as enumerateBuiltinToolMetadata (ADR 0014),
+// so a host no longer has to reach into dist/engine/prompts.js by file path.
+export { buildSystemPromptParts, buildSystemPrompt } from './engine/prompts.js';
+export type { SystemPromptParts, EnvironmentContext, PromptContext } from './engine/prompts.js';
 export { getSessionInfo, listSessions } from './sessions/store.js';
 export {
   getSessionMessages,

--- a/projects/bpt-agent-sdk/tests/harness-base-export.test.ts
+++ b/projects/bpt-agent-sdk/tests/harness-base-export.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Public harness-base constructor export (black-pool ContextRing request
+ * 2026-07-08). The package entry re-exports buildSystemPromptParts /
+ * buildSystemPrompt so a host can size the built-in harness base — the V5 preset
+ * prose injected on the `claude_code` preset path — via the public API, instead
+ * of reaching into dist/engine/prompts.js by file path.
+ *
+ * These tests pin the acceptance criteria: the export is reachable from the
+ * entry, it IS the same function the engine uses (so `.base` matches what preset
+ * mode injects), `.base` is the vN harness prose only (no append / project /
+ * <env> tail), and toolNames / variant flow through.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildSystemPromptParts,
+  buildSystemPrompt,
+  type SystemPromptParts,
+  type PromptContext,
+} from '../src/index.js';
+import { buildSystemPromptParts as engineBuildParts } from '../src/engine/prompts.js';
+import type { Options } from '../src/types.js';
+
+const PRESET: Options['systemPrompt'] = {
+  type: 'preset',
+  preset: 'claude_code',
+  append: '',
+};
+
+const TOOLS = ['Read', 'Edit', 'Write', 'Grep', 'Glob', 'Bash', 'Agent'];
+
+describe('harness-base constructor export', () => {
+  it('is reachable from the package entry as functions', () => {
+    expect(typeof buildSystemPromptParts).toBe('function');
+    expect(typeof buildSystemPrompt).toBe('function');
+  });
+
+  it('is the SAME function the engine uses (so .base matches what preset mode injects)', () => {
+    // Identity guarantees the host-computed base is produced by the exact
+    // function query.ts measures — not a divergent copy.
+    expect(buildSystemPromptParts).toBe(engineBuildParts);
+  });
+
+  it('.base is the V5 default harness prose for the claude_code preset', () => {
+    const { base } = buildSystemPromptParts(PRESET, { cwd: '', toolNames: TOOLS });
+    expect(base).toContain(
+      'You are an interactive agent that helps users with software engineering tasks.',
+    );
+    // V5 is the comprehensive reproduction — comfortably large (the ~11.7k-char
+    // preset base the request sizes), far bigger than the terse v1.
+    expect(base.length).toBeGreaterThan(5000);
+    const v1 = buildSystemPromptParts(PRESET, {
+      cwd: '',
+      toolNames: TOOLS,
+      variant: 'v1',
+    }).base;
+    expect(v1.length).toBeLessThan(base.length);
+  });
+
+  it('flows toolNames into the base (Available-tools line + tool-gated fragments)', () => {
+    const withAgent = buildSystemPromptParts(PRESET, {
+      cwd: '',
+      toolNames: TOOLS,
+    }).base;
+    expect(withAgent).toContain(`Available tools: ${TOOLS.join(', ')}.`);
+    // the Agent tool clause is gated on the Agent tool being present
+    expect(withAgent).toContain('Use the Agent tool');
+
+    const noAgent = buildSystemPromptParts(PRESET, {
+      cwd: '',
+      toolNames: ['Read', 'Edit'],
+    }).base;
+    expect(noAgent).not.toContain('Use the Agent tool');
+  });
+
+  it('.base excludes caller append / project instructions / <env> tail', () => {
+    const parts = buildSystemPromptParts(
+      { type: 'preset', preset: 'claude_code', append: 'ZZZ_APPEND_MARKER' },
+      {
+        cwd: '/repo',
+        toolNames: TOOLS,
+        projectInstructions: 'ZZZ_PROJECT_MARKER',
+        environment: { platform: 'linux', date: '2026-07-08' },
+      },
+    );
+    // base is the harness prose only — none of append / project / env bleeds in
+    expect(parts.base).not.toContain('ZZZ_APPEND_MARKER');
+    expect(parts.base).not.toContain('ZZZ_PROJECT_MARKER');
+    expect(parts.base).not.toContain('<env>');
+    // and the append/project DO land in the stable tail (invariant base+project===stable)
+    expect(parts.project).toContain('ZZZ_APPEND_MARKER');
+    expect(parts.project).toContain('ZZZ_PROJECT_MARKER');
+    expect(parts.base + parts.project).toBe(parts.stable);
+  });
+
+  it('append does not change .base (append is not part of the harness base)', () => {
+    const a = buildSystemPromptParts(
+      { type: 'preset', preset: 'claude_code', append: '' },
+      { cwd: '', toolNames: TOOLS },
+    ).base;
+    const b = buildSystemPromptParts(
+      { type: 'preset', preset: 'claude_code', append: 'anything at all' },
+      { cwd: '', toolNames: TOOLS },
+    ).base;
+    expect(a).toBe(b);
+  });
+
+  it('buildSystemPrompt joins stable + volatile (flat form still reachable)', () => {
+    const flat = buildSystemPrompt(PRESET, {
+      cwd: '/repo',
+      toolNames: TOOLS,
+      environment: { platform: 'linux' },
+    });
+    expect(flat).toContain(
+      'You are an interactive agent that helps users with software engineering tasks.',
+    );
+    // the volatile tail (cwd) is present in the flat form
+    expect(flat).toContain('/repo');
+  });
+
+  it('exports the SystemPromptParts / PromptContext types (assignable)', () => {
+    const ctx: PromptContext = { cwd: '', toolNames: TOOLS };
+    const parts: SystemPromptParts = buildSystemPromptParts(PRESET, ctx);
+    expect(typeof parts.base).toBe('string');
+    expect(typeof parts.stable).toBe('string');
+    expect(typeof parts.volatile).toBe('string');
+  });
+});


### PR DESCRIPTION
## 概述

黑池 BPT 转派（ContextRing，2026-07-08，P2）：从 `bpt-agent-sdk` 包入口导出 harness 基座构造，让黑池「上下文构成」面板能如实量出 preset 模式注入的 V5 基座 token 占用（约 11.7k 字符 ≈ ~2.9k token），取代其直连 `dist/engine/prompts.js` 文件路径的 stopgap。属银芯→黑池单向输出线（银芯改 SDK 源、黑池只消费）。

---

## 变更类型

- [x] 其他：**SDK 公开 API 补充** —— 从入口导出既有内部构造（只读、零副作用）
- [x] 附带：一次性 token 记账诊断日志（临时）

---

## 变更明细

**主改动（首选方案）**：

- `src/index.ts`：re-export `buildSystemPromptParts` + `buildSystemPrompt`，及 `SystemPromptParts` / `EnvironmentContext` / `PromptContext` 类型。理由同先例 `enumerateBuiltinToolMetadata`（ADR 0014）：只读、零副作用。
- `src/engine/prompts.ts`：把内部 `PromptContext` 提升为 `export type`，使 ctx 形参可被消费方命名。
- 导出的即引擎 `query.ts` 所用的同一函数，故 `buildSystemPromptParts(opt, ctx).base` 与 preset 模式实际注入的基座**逐字一致**（同 `toolNames` / `variant`）。黑池 `loadSdkHarnessBase` 已先探入口 API，落地后**零改动自动命中**、去掉文件路径 stopgap。

**附带（另一条守密人请求）**：`src/engine/loop.ts` 加一次性诊断日志，把每轮 `input_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens` 原样打到 stderr（`[bpt-usage] …`）。**临时，取数后即可移除**。

---

## 安全声明

- [x] 本变更不含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据；仅从入口导出银芯自有 SDK 的既有内部构造。
- [x] 不引入 emoji（CLAUDE.md 硬约束）
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md` 等主控台档案

---

## 验收清单

- [x] 从包入口可 `import { buildSystemPromptParts } from 'bpt-agent-sdk'`（`npm run build` 后 `dist/index.js` 确认导出）
- [x] 返回的 `.base` 与 preset 模式注入基座一致：测试断言导出函数 === 引擎函数；端到端从入口 import 取 `.base` 得 **12,213 字符**、英文 intro、`Available tools:` 行齐全
- [x] `.base` 仅含 vN harness 正文（不含 `append` / 项目指令 / `<env>`）——测试覆盖
- [x] `npm run typecheck` 通过；`npm test`：**66 文件、1500 项通过，2 跳过**（新增 `harness-base-export.test.ts` 8 项）
- [x] 版本前向 `0.29.0 → 0.30.0`，CHANGELOG 双条记录

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcCr7DPBJTRqnM4JGbwP9n

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcCr7DPBJTRqnM4JGbwP9n)_