### PR TITLE
docs(bpt-sdk): 子代理接入说明书（CC 风格）

### DIFF
--- a/projects/bpt-agent-sdk/docs/SUBAGENTS.md
+++ b/projects/bpt-agent-sdk/docs/SUBAGENTS.md
@@ -1,0 +1,193 @@
+# Subagents — integration guide (Claude Code style)
+
+Goal: wire a host (BPT) to the SDK's subagent surface the way Claude Code uses
+it — delegate self-contained work to child agents that run in their own context
+and report back a single final message. Read §1–§3 to integrate; keep §6 open
+for the tripwires.
+
+This is the SDK's own guidance for consuming the subagent API. It documents the
+shipped behavior of `src/subagents/*` (`agent-tool.ts` / `agents.ts` /
+`runtime.ts`) and `Options.agents` (`src/types.ts`).
+
+## 1. Mental model (2 min)
+
+- **One tool, one contract.** Subagents are spawned through a single built-in
+  tool, `Agent` (a.k.a. Task). The child gets ONE user turn — the `prompt` you
+  pass — and returns ONE final message to the parent. The child does NOT see the
+  parent conversation; the parent does NOT see the child's intermediate steps.
+- **Isolated by default, fork to continue.** A default spawn is *isolated*: a
+  fresh context, its own system prompt, its own tool set, its own model. Set
+  `fork: true` to instead *continue from the parent* — the child inherits the
+  parent's history, cached prefix, system prompt, tool set, and model, and is as
+  privileged as the parent.
+- **Everything hangs off the loop.** Depth tracking, background delivery,
+  worktree isolation, and model resolution live in the spawn closure the runtime
+  installs on the tool context — not in the tool. The tool is a thin forwarder.
+
+## 2. Wire it in (3 steps)
+
+**Step 1 — register your agents.** Pass `options.agents`, a map of type-name →
+`AgentDefinition`:
+
+```ts
+import { query, type AgentDefinition } from 'bpt-agent-sdk';
+
+const agents: Record<string, AgentDefinition> = {
+  'code-explorer': {
+    description: 'Explore and map a subsystem', // 3-5 words, shown to the model
+    prompt: EXPLORER_SYSTEM_PROMPT,             // the child's behavioral contract
+    model: 'claude-sonnet-5',                   // FULL id — see §3
+    tools: ['Read', 'Grep', 'Glob'],            // allowlist (optional)
+    maxTurns: 20,
+  },
+};
+
+for await (const msg of query({ prompt, options: { agents /* … */ } })) { /* … */ }
+```
+
+**Step 2 — the Agent tool is on by default.** `query()` registers `Agent`
+automatically unless you bare-disallow or tool-filter it. `general-purpose` is a
+valid `subagent_type` even with no `agents` map. Your registered type-names are
+enumerated in the tool's `subagent_type` description, so the model knows exactly
+what it may request.
+
+**Step 3 — inject concrete model ids.** This is the one thing to get right; see
+§3. Everything else has a safe default.
+
+## 3. Model injection (read this or subagents will 400)
+
+The SDK resolves a subagent's model through `resolveModelAlias(model, parent)`
+(`src/subagents/agents.ts`). It is family-agnostic — it does not detect "Claude
+vs not"; it branches on the STRING shape:
+
+| `model` value | resolves to |
+|---|---|
+| unset / `'inherit'` | the parent (main-loop) model — safe; runs what the main loop runs |
+| one of `opus` / `sonnet` / `haiku` / `fable` | a **hardcoded** id in the SDK's built-in table (e.g. `sonnet → claude-sonnet-4-5`) |
+| any other string (a full id) | **passed through verbatim** |
+
+The four short aliases map to Anthropic-official ids that may NOT match your
+gateway (idealab), and one (`sonnet → claude-sonnet-4-5`) is a generation stale.
+
+**Rule for the host: always put a FULL gateway id** in `AgentDefinition.model`
+(or the Agent tool's `model` param) — never a bare alias — until
+`options.modelAliases` ships. A bare `'sonnet'` resolves to the stale
+`claude-sonnet-4-5`; your gateway rejects it and the subagent 400s. A full id is
+passed through untouched and works.
+
+> Note: this same table backs the compaction summarizer and the utility-call /
+> verifier defaults (which hardcode `claude-haiku-4-5`). The proper fix is an
+> `options.modelAliases` injection point so bare aliases and stale defaults map
+> to your ids in one place; until then, pass full ids at every `model` / `opts.model`
+> seam.
+
+## 4. Invocation patterns (Claude Code style)
+
+Pick the mode by the shape of the work — this mirrors how Claude Code delegates.
+
+| Want | Mode | How |
+|---|---|---|
+| Fan out research / broad multi-file exploration without cluttering the main thread | **isolated** (default) | one `Agent` call per independent unit; give each a complete standalone prompt |
+| A child that needs the parent's full context + cached prefix, executes once | **fork** | `fork: true` (or `AgentDefinition.fork`) |
+| Long-running work; don't block the main turn | **background** (depth-0 only) | `run_in_background: true`; the result arrives on a later turn |
+| Several agents that MUTATE files in parallel without clobbering each other | **worktree** | `isolation: 'worktree'` — each gets a temporary git worktree, auto-removed if left unchanged |
+
+Delegation discipline (reproduced from the official main-loop prompt — have your
+host follow it):
+
+- Delegate only when the subtask is **big or independent enough** to be worth
+  it — broad exploration, or a self-contained unit that can run in parallel. For
+  a quick lookup or single search, do it directly.
+- **Don't duplicate a subagent's work.** If you delegated the research, don't
+  also run the same searches in the parent.
+- The `prompt` must be **self-contained.** The child sees only it — include every
+  path, result, and detail it needs, and have it make reasonable assumptions
+  rather than ask follow-up questions.
+
+## 5. Authoring an AgentDefinition
+
+Live knobs (functional in v0.2):
+
+| field | use |
+|---|---|
+| `description` | 3-5 words; shown to the model as what this type is for |
+| `prompt` | the child's system prompt (its behavioral contract). Ignored in fork mode |
+| `tools` | tool **allowlist** (restrict what the child can call) |
+| `disallowedTools` | tool **denylist** (stacks on the parent's bare disallow) |
+| `model` | full gateway id (§3) |
+| `maxTurns` | turn cap (default 20; the worker-fork preset uses 200) |
+| `permissionMode` | the child's permission mode (an isolated child may override the parent's) |
+| `background` | this type backgrounds by default when invoked |
+| `fork` | this type forks by default |
+
+Accepted but inert in v0.2 (safe to set for forward-compat; no effect yet):
+`skills`, `mcpServers` (the child inherits the parent's servers), `memory`,
+`effort`, and `initialPrompt` (main-thread only).
+
+Two ready-made presets ship:
+
+- the synthetic **`general-purpose`** — an isolated research/exploration
+  fallback (used for the reserved type and for any unknown `subagent_type`);
+- **`WORKER_FORK_AGENT`** — a fork preset (execute-once, `maxTurns` 200). Pair it
+  with `buildWorkerForkPrompt(directive)` as the Agent tool's `prompt`.
+
+The coordinator/teams presets are deliberately NOT shipped — they presuppose a
+SendMessage/teams tool this SDK does not have; reproducing them would describe a
+non-existent capability.
+
+## 6. Tripwires
+
+- **Background is depth-0 only.** A nested subagent cannot itself background; the
+  runtime logs a warning and runs it in the foreground.
+- **Nesting caps at depth 5** (`MAX_SUBAGENT_DEPTH`). A depth-5 child has no
+  `Agent` tool in its set — it cannot spawn further.
+- **Fork ignores a batch of fields.** In fork mode `agentDef.model` / `tools` /
+  `disallowedTools` / `permissionMode` / `prompt`-as-system are ALL ignored
+  (honoring them would break the inherited cached prefix). A fork child is as
+  privileged as the parent — do not fork a task you meant to sandbox; use an
+  isolated child with a `tools` allowlist for that.
+- **The child sees only the `prompt`,** not the conversation. An underspecified
+  prompt yields an underspecified result.
+- **Bare model aliases 400 on your gateway** (§3). Pass full ids.
+
+## 7. Worked example
+
+```ts
+import { query, buildWorkerForkPrompt, WORKER_FORK_AGENT } from 'bpt-agent-sdk';
+
+const agents = {
+  explorer: {
+    description: 'Map a subsystem',
+    prompt: EXPLORER_SYSTEM_PROMPT,
+    model: 'claude-sonnet-5',          // full gateway id, not 'sonnet'
+    tools: ['Read', 'Grep', 'Glob'],
+  },
+  worker: WORKER_FORK_AGENT,           // shipped fork preset
+};
+
+// Inside the loop, the model spawns via the Agent tool. Shapes it can request:
+//
+//   isolated fan-out (default):
+//     Agent({ description: 'map auth', prompt: 'Explore src/auth and report …',
+//             subagent_type: 'explorer' })
+//
+//   background isolated (depth 0 only):
+//     Agent({ description: 'audit deps', prompt: '…', subagent_type: 'explorer',
+//             run_in_background: true })
+//
+//   fork (privileged continuation, shared cache):
+//     Agent({ description: 'apply fix', prompt: buildWorkerForkPrompt('Fix the …'),
+//             subagent_type: 'worker', fork: true })
+//
+//   parallel file edits without conflict:
+//     Agent({ description: 'migrate file', prompt: '…', isolation: 'worktree' })
+
+for await (const msg of query({ prompt, options: { agents } })) { /* … */ }
+```
+
+## 8. See also
+
+- `docs/ARCHITECTURE.md` — where the subagent runtime sits in the engine.
+- `docs/CONCURRENCY.md` — background-task lifecycle and draining.
+- `src/subagents/agents.ts` — the presets, `resolveAgentDefinition`, and
+  `resolveModelAlias` (§3).


### PR DESCRIPTION
## 概述

新增 `projects/bpt-agent-sdk/docs/SUBAGENTS.md`——一份面向 host（黑池）的**子代理接入说明书**，教如何按 Claude Code 的风格调用 SDK 的子代理面。纯文档、无 src 改动、不 bump 版本。承接近期「SDK 子代理调用面」系列讨论，把结论沉淀成随 API 同源、版本化、可拉取的 SDK 文档。

---

## 变更类型

- [x] 文档完善（子项目 docs/）

---

## 内容（8 节）

1. **心智模型**——一个 `Agent` 工具、一次性汇报契约、isolated 默认 / fork 继承。
2. **三步接入**——`options.agents` 注册、Agent 工具默认开启、模型注入。
3. **模型注入红线**——`resolveModelAlias` 按字符串形态三路分叉；**host 一律传完整 gateway id**，别传裸别名（裸 `sonnet` → stale `claude-sonnet-4-5` → 非 Anthropic gateway 400）。
4. **CC 风格调用模式**——isolated 扇出 / fork 继承 / background（仅深度 0）/ worktree 并行改文件，附官方委派纪律。
5. **AgentDefinition 旋钮**——已实装（tools/model/maxTurns/permissionMode/background/fork…）vs 接受但空转（skills/mcpServers/memory/effort）。
6. **陷阱**——background 仅深度 0、嵌套 ≤5、fork 忽略 model/tools/权限、子代理只看 prompt、裸别名 400。
7. **完整示例**——注册两个 agent + isolated/background/fork/worktree 四种 spawn 形状。
8. **延伸**——指向 ARCHITECTURE / CONCURRENCY / agents.ts。

内容全部据 `src/subagents/*` + `src/types.ts` 现行代码核实。

---

## 安全声明

- [x] 本变更不含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据；仅记录银芯自有 SDK 的公开 API 用法（银芯→黑池单向指导）。
- [x] 不引入 emoji（CLAUDE.md 硬约束）
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md` 等主控台档案

---

## 验证清单

- [x] 纯文档、无 `src/` 运行时改动 → 按 §7.6「纯文档改动可免跑」不跑测试、不 bump 版本
- [x] 文中所引导出符号（`query` / `AgentDefinition` / `buildWorkerForkPrompt` / `WORKER_FORK_AGENT`）、字段名、行为均据现行源码核对
- [x] 指向的 `docs/ARCHITECTURE.md` / `docs/CONCURRENCY.md` 均存在

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcCr7DPBJTRqnM4JGbwP9n

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcCr7DPBJTRqnM4JGbwP9n)_