### PR TITLE
refactor(bpt-sdk)!: 主循环提示词收敛为单一默认 v5，移除变体 (v0.33.0)

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,32 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.33.0 — 2026-07-09
+
+**Collapse the harness-prompt variant ladder to a single default** (keeper ruling
+2026-07-08). The v1-v4 opt-in variants (a BPT A/B experiment) and the minimal
+`undefined`-systemPrompt fallback are removed; there is now ONE harness prompt —
+the comprehensive faithful reproduction of the official Claude Code main loop
+(the former v5). A measured A/B had already shown it is ~3x cheaper in multi-turn
+than the terse variants (its large stable prefix caches; the tiny ones fell below
+the cache threshold), so it is the sole default.
+
+- **removed (breaking): `Options.harnessPromptVariant`.** The variant-selection
+  knob is gone; callers that passed `'v1'..'v4'` now get the single default.
+  `PromptContext.variant` (on the `buildSystemPromptParts` export) is removed too.
+- **behavior change: an unset `systemPrompt` now resolves to the full default
+  harness**, not the prior 2-line minimal prompt — `undefined` and the
+  `claude_code` preset converge to the same prompt. A string systemPrompt is
+  still owned verbatim; `append` remains preset-only.
+- `src/engine/prompts.ts`: deleted `minimalStable` / `defaultHarnessStable` (v1) /
+  `V2` / `V3` / `V4`; the sole builder is renamed `defaultHarnessStable` and
+  composes from the fragment store (`assembleMainLoop`, byte-locked by
+  `prompt-assembler.test` / `v5-mainloop-golden.json`, unchanged).
+- tests/docs: `prompts.test.ts` / `query.test.ts` / `harness-base-export.test.ts`
+  retargeted to the single default (+ new locks that `undefined` and the preset
+  match); `ARCHITECTURE.md` updated; the `--variant` dimension removed from the
+  `cache-probe` / `ab-benchmark` integration probes.
+
 ## 0.32.0 — 2026-07-09
 
 - **feat (prompt-composition observability — black-pool ContextRing "上下文构成"

--- a/projects/bpt-agent-sdk/docs/ARCHITECTURE.md
+++ b/projects/bpt-agent-sdk/docs/ARCHITECTURE.md
@@ -96,9 +96,10 @@ genuinely internal or leaked material is used.
   reverse-engineered from the publicly distributed CLI; archived under
   `Public-Info-Pool/Reference/Claude-Code-System-Prompts/`) with tool
   references adapted to this SDK's tools and CLI-only fragments omitted.
-  `undefined` → minimal default. String → verbatim. Preset `claude_code` →
-  the default harness prompt (no explicit `variant` → `v5`, the comprehensive
-  faithful reproduction); `append` concatenated after two newlines.
+  String → verbatim. Both `undefined` and the `claude_code` preset → the single
+  default harness prompt (a comprehensive faithful reproduction of the official
+  main loop; there is no variant selection); `append` (preset only) is
+  concatenated after two newlines.
 
 `engine/accumulator.ts`
 - `export class MessageAccumulator` — feed `RawMessageStreamEvent`s, produce

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/engine/prompt-assembler.ts
+++ b/projects/bpt-agent-sdk/src/engine/prompt-assembler.ts
@@ -6,7 +6,7 @@
  * the ordered body, dropping any fragment whose tool gate is not satisfied.
  * Same context in => byte-identical output out (the cached-prefix invariant).
  *
- * This reproduces defaultHarnessStableV5 byte-for-byte (golden-locked in
+ * This reproduces the default harness prompt byte-for-byte (golden-locked in
  * tests/prompt-assembler.test.ts). Fragments carry provenance + a faithful flag
  * so a build-from-archive check (subsequent Track B phase) can hold them to the
  * upstream reconstruction.

--- a/projects/bpt-agent-sdk/src/engine/prompt-fragments.ts
+++ b/projects/bpt-agent-sdk/src/engine/prompt-fragments.ts
@@ -16,8 +16,8 @@
  * red-line tests). Fragments with a `gate` are emitted only when the gate holds
  * (e.g. the Agent clause only when the Agent tool is in the set).
  *
- * This is the initial migration of defaultHarnessStableV5 into the store; the
- * assembler reproduces v5 byte-for-byte (golden-locked in tests). Adding the
+ * This is the initial migration of the default harness prompt into the store;
+ * the assembler reproduces it byte-for-byte (golden-locked in tests). Adding the
  * build-from-archive generator + tool-description / sub-agent / generator
  * surfaces are subsequent Track B phases.
  */

--- a/projects/bpt-agent-sdk/src/engine/prompts.ts
+++ b/projects/bpt-agent-sdk/src/engine/prompts.ts
@@ -3,16 +3,15 @@
  *
  * Positioning (keeper ruling 2026-07-04): OPEN REPRODUCTION from PUBLIC
  * information, with attribution — not a clean-room black box.
- * - Variants v1-v3 are original compositions from public prompt-engineering
- *   guidance + open-source agent practice.
- * - Variant v4 is a faithful reproduction of the official Claude Code main-loop
- *   prompt, assembled from the PUBLIC prompt reconstruction (Piebald-AI
- *   snapshot, MIT, reverse-engineered from the publicly distributed CLI;
- *   archived under Public-Info-Pool/Reference/Claude-Code-System-Prompts/),
- *   with tool references adapted to THIS SDK's tools and CLI-only fragments
- *   (feedback channels, sandbox specifics) omitted.
- * The `claude_code` preset selects this SDK's default harness prompt for
- * drop-in call-site compatibility.
+ *
+ * There is ONE harness prompt: a comprehensive faithful reproduction of the
+ * official Claude Code main-loop system prompt, assembled from the PUBLIC prompt
+ * reconstruction (Piebald-AI snapshot, MIT, reverse-engineered from the publicly
+ * distributed CLI; archived under Public-Info-Pool/Reference/Claude-Code-System-Prompts/),
+ * with tool references adapted to THIS SDK's tools and CLI-only fragments
+ * omitted. Both an unset `systemPrompt` and the `claude_code` preset resolve to
+ * it — there is no variant selection (the earlier v1-v4 BPT experiment ladder
+ * was collapsed to this single default, keeper ruling 2026-07-08).
  */
 
 import type { Options } from '../types.js';
@@ -41,19 +40,6 @@ export type PromptContext = {
   cwd: string;
   toolNames: string[];
   /**
-   * Harness-prompt variant (BPT experiment). 'v1' = the terse original;
-   * 'v2' = a richer prompt composed from PUBLIC prompt-engineering guidance +
-   * open-source agent practice; 'v3' = v2 plus verify-before-finishing,
-   * no-hard-coding, delegation guidance, and a style example; 'v4' = a faithful
-   * reproduction of the official main-loop prompt from the PUBLIC prompt
-   * reconstruction, tool references adapted to this SDK; 'v5' = a COMPREHENSIVE
-   * faithful reproduction of the official main-loop prompt (fuller doing-tasks /
-   * tool-use discipline / executing-actions / communication clauses) — fidelity
-   * to the official, adapted to our tools (open reproduction, see file header).
-   * Only affects the `claude_code` preset / default path. Default 'v1'.
-   */
-  variant?: 'v1' | 'v2' | 'v3' | 'v4' | 'v5';
-  /**
    * Runtime environment facts. When present, an `<env>` block reproducing the
    * official runtime-assembly context is rendered into the volatile tail.
    */
@@ -80,7 +66,7 @@ export type PromptContext = {
 export type SystemPromptParts = {
   stable: string;
   /**
-   * The base harness portion of `stable` (the vN harness prompt only), WITHOUT
+   * The base harness portion of `stable` (the harness prompt only), WITHOUT
    * the appended project-instructions / append tail. Shared across projects, so
    * worth caching as its own reusable segment. Invariant: `base + project ===
    * stable` byte-for-byte (project carries its own leading separators).
@@ -137,250 +123,48 @@ function environmentBlock(cwd: string, env: EnvironmentContext): string {
  * are supplied, else the bare working directory. Either way the cwd is present
  * so relative-path guidance stays valid.
  */
-function volatileTail(ctx: PromptContext, withPathGuidance: boolean): string {
+function volatileTail(ctx: PromptContext): string {
   const lines = ctx.environment
     ? [environmentBlock(ctx.cwd, ctx.environment)]
     : [`Working directory: ${ctx.cwd}`];
-  if (withPathGuidance) {
-    lines.push('Treat relative paths as relative to this directory and prefer absolute paths in tool calls.');
-  }
-  return lines.join('\n');
-}
-
-/** Stable part of the minimal default (no cwd). */
-function minimalStable(): string {
-  return [
-    'You are a coding agent running inside the bpt-agent-sdk harness.',
-    'Use the available tools when they help you complete the task accurately, and report results concisely.',
-  ].join('\n');
-}
-
-/** Stable part of the full default harness prompt (no cwd). */
-function defaultHarnessStable(ctx: PromptContext): string {
-  const lines: string[] = [
-    'You are an autonomous coding agent running inside the bpt-agent-sdk harness. You help the user by inspecting files, running commands, and making precise edits in their project.',
-    '',
-  ];
-  if (ctx.toolNames.length > 0) {
-    lines.push(`Available tools: ${ctx.toolNames.join(', ')}.`);
-  }
-  lines.push(
-    'Tool guidance:',
-    '- Read files before editing them, and keep edits minimal and targeted.',
-    '- Prefer dedicated file tools (Read, Write, Edit, Glob, Grep) over shell commands for inspecting or modifying files.',
-    '- Base every claim on actual tool output; if a tool call fails, say so instead of guessing.',
-    '- When a task is complete, summarize what changed briefly and accurately.',
-    '',
-    'Safety: never run destructive or irreversible commands (deleting files or branches, force-pushing, dropping databases, mass overwrites) unless the user has explicitly requested that exact operation.',
-  );
+  lines.push('Treat relative paths as relative to this directory and prefer absolute paths in tool calls.');
   return lines.join('\n');
 }
 
 /**
- * Stable part of the v2 harness prompt (no cwd). Written from PUBLIC
- * prompt-engineering guidance and common open-source agent practice — it is
- * richer than v1 because it encodes more real behavioral discipline (plan,
- * gather context first, parallel read-only lookups, verify after editing,
- * ground claims in tool output, clean stop conditions), NOT because it is
- * padded. Open reproduction: original composition from PUBLIC prompt-engineering
- * guidance + open-source practice, no verbatim proprietary clone.
- */
-function defaultHarnessStableV2(ctx: PromptContext): string {
-  const lines: string[] = [
-    'You are an autonomous software-engineering agent operating inside the bpt-agent-sdk harness. You complete the user\'s task end to end by inspecting the project, running commands, and making precise edits — always using the available tools rather than guessing.',
-    '',
-  ];
-  if (ctx.toolNames.length > 0) {
-    lines.push(`Available tools: ${ctx.toolNames.join(', ')}.`, '');
-  }
-  lines.push(
-    'Approach:',
-    '- Before acting, form a brief plan: what you must learn, and the smallest set of steps that accomplishes the task.',
-    '- Gather context first. Read the relevant files and search the project before changing anything; never assume a file\'s contents or a path you have not verified.',
-    '- When several independent read-only lookups would help (reading different files, separate searches), issue them together rather than one at a time.',
-    '',
-    'Making changes:',
-    '- Keep edits minimal and targeted; change only what the task requires and match the surrounding style.',
-    '- Read a file immediately before editing it, and read the result back afterward to confirm the change landed as intended.',
-    '- Prefer the dedicated file tools (Read, Write, Edit, Glob, Grep) over shell commands for inspecting or modifying files.',
-    '',
-    'Grounding and honesty:',
-    '- Base every statement on actual tool output. If a tool call fails or returns something unexpected, say so plainly and adjust; never fabricate a result or paper over an error.',
-    '- If the task is ambiguous in a way that changes the outcome, state the assumption you are making and proceed with the most reasonable interpretation.',
-    '',
-    'Finishing:',
-    '- Stop when the task is complete; do not perform work the user did not request.',
-    '- End with a short, accurate summary of what you changed and how you verified it.',
-    '',
-    'Safety: never run destructive or irreversible commands (deleting files or branches, force-pushing, dropping databases, mass overwrites) unless the user has explicitly requested that exact operation.',
-  );
-  return lines.join('\n');
-}
-
-/**
- * Stable part of the v3 harness prompt (no cwd). v2 + four techniques the
- * public best-practices comparison flagged as missing/partial, each a genuine
- * behavioral discipline (not padding): verify-before-finishing, solve the
- * general problem (no hard-coding to a check), when-to-delegate guidance, and
- * one concrete style example for the closing summary. Open reproduction:
- * original composition from PUBLIC prompt-engineering guidance + open-source
- * practice, no verbatim proprietary clone.
- */
-function defaultHarnessStableV3(ctx: PromptContext): string {
-  const lines: string[] = [
-    'You are an autonomous software-engineering agent operating inside the bpt-agent-sdk harness. You complete the user\'s task end to end by inspecting the project, running commands, and making precise edits — always using the available tools rather than guessing.',
-    '',
-  ];
-  if (ctx.toolNames.length > 0) {
-    lines.push(`Available tools: ${ctx.toolNames.join(', ')}.`, '');
-  }
-  lines.push(
-    'Approach:',
-    '- Before acting, form a brief plan: what you must learn, and the smallest set of steps that accomplishes the task.',
-    '- Gather context first. Read the relevant files and search the project before changing anything; never assume a file\'s contents or a path you have not verified.',
-    '- When several independent read-only lookups would help (reading different files, separate searches), issue them together rather than one at a time.',
-    '',
-    'Making changes:',
-    '- Keep edits minimal and targeted; change only what the task requires and match the surrounding style.',
-    '- Read a file immediately before editing it, and read the result back afterward to confirm the change landed as intended.',
-    '- Prefer the dedicated file tools (Read, Write, Edit, Glob, Grep) over shell commands for inspecting or modifying files.',
-    '- Solve the general problem, not just the example. Do not hard-code an output to satisfy a specific check or test; write code that also works for inputs beyond the ones you were given.',
-    '',
-    'Grounding and honesty:',
-    '- Base every statement on actual tool output. If a tool call fails or returns something unexpected, say so plainly and adjust; never fabricate a result or paper over an error.',
-    '- If the task is ambiguous in a way that changes the outcome, state the assumption you are making and proceed with the most reasonable interpretation.',
-    '',
-  );
-  // Delegation guidance names the Agent tool — include it only when subagents
-  // are configured (query.ts registers the Agent tool only then), else the
-  // prompt would reference a tool the run cannot call.
-  if (ctx.toolNames.includes('Agent')) {
-    lines.push(
-      'Delegation:',
-      '- Delegate to a subagent (via the Agent tool) only when a subtask is large or independent enough to benefit — broad multi-file exploration, or a self-contained unit that can run in parallel. For a quick lookup or a single search, do it directly; do not spawn a subagent when a direct tool call is faster.',
-      '',
-    );
-  }
-  lines.push(
-    'Finishing:',
-    '- Before finishing, verify your work against the task\'s success criteria: re-read the files you changed, and where a test or check exists, run it and confirm it passes.',
-    '- Stop when the task is complete; do not perform work the user did not request.',
-    '- End with a short, accurate summary of what changed and how you verified it — for example: "Fixed the off-by-one in calc.mjs:12; confirmed total([1,2,3,4]) now returns 10."',
-    '',
-    'Safety: never run destructive or irreversible commands (deleting files or branches, force-pushing, dropping databases, mass overwrites) unless the user has explicitly requested that exact operation.',
-  );
-  return lines.join('\n');
-}
-
-/**
- * Stable part of the v4 harness prompt (no cwd): a FAITHFUL REPRODUCTION of the
- * official Claude Code main-loop system prompt, assembled from the PUBLIC prompt
- * reconstruction (Piebald-AI snapshot v2.1.x, MIT, reverse-engineered from the
- * publicly distributed CLI; archived under
+ * The default harness prompt (no cwd): a COMPREHENSIVE faithful reproduction of
+ * the official Claude Code main-loop system prompt — the fuller set of
+ * doing-tasks, tool-use discipline, executing-actions-with-care, outcome-first
+ * communication, and code-style clauses the everyday coding loop actually sends.
+ * Assembled from the PUBLIC prompt reconstruction (Piebald-AI snapshot, MIT,
+ * reverse-engineered from the publicly distributed CLI; archived under
  * Public-Info-Pool/Reference/Claude-Code-System-Prompts/). Open reproduction
- * from public information with attribution (keeper ruling 2026-07-04). The
- * behavioral / communication clauses are reproduced faithfully; tool references
- * are adapted to THIS SDK's tools; CLI-only fragments (feedback channels,
- * sandbox specifics, tools this SDK does not ship) are omitted so the prompt
- * never references a tool that is not present.
+ * with attribution (keeper ruling 2026-07-04/05). The goal is FIDELITY to the
+ * official prompt; tool references are adapted to THIS SDK's tools, and clauses
+ * referencing tools/features this SDK does not ship are omitted (never reference
+ * an absent tool). The large stable prefix crosses the effective caching
+ * threshold so the prefix is actually cached/reused across turns — a measured
+ * A/B against a terse prompt showed this is ~3x cheaper in multi-turn (95% vs 0%
+ * cache hit) at equal correctness, which is why it is the single default.
  */
-function defaultHarnessStableV4(ctx: PromptContext): string {
-  const lines: string[] = [
-    // intro (interactive-agent-intro-short)
-    'You are an interactive agent that helps users with software engineering tasks.',
-    '',
-  ];
-  if (ctx.toolNames.length > 0) {
-    lines.push(`Available tools: ${ctx.toolNames.join(', ')}.`, '');
-  }
-  lines.push(
-    // doing-tasks-software-engineering-focus
-    'The user will primarily request you to perform software engineering tasks. These may include solving bugs, adding new functionality, refactoring code, explaining code, and more. When given an unclear or generic instruction, consider it in the context of these software engineering tasks and the current working directory. For example, if the user asks you to change "methodName" to snake case, do not reply with just "method_name", instead find the method in the code and modify the code.',
-    '',
-    // doing-tasks-no-unnecessary-additions
-    "Don't add features, refactor, or introduce abstractions beyond what the task requires. A bug fix doesn't need surrounding cleanup; a one-shot operation doesn't need a helper. Don't design for hypothetical future requirements. Three similar lines is better than a premature abstraction. No half-finished implementations either.",
-    '',
-    // doing-tasks-no-unnecessary-error-handling
-    "Don't add error handling, fallbacks, or validation for scenarios that can't happen. Trust internal code and framework guarantees. Only validate at system boundaries (user input, external APIs). Don't use feature flags or backwards-compatibility shims when you can just change the code.",
-    '',
-    // doing-tasks-no-compatibility-hacks
-    'Avoid backwards-compatibility hacks like renaming unused _vars, re-exporting types, adding // removed comments for removed code, etc. If you are certain that something is unused, you can delete it completely.',
-    '',
-    // doing-tasks-ambitious-tasks
-    'You are highly capable and often allow users to complete ambitious tasks that would otherwise be too complex or take too long. You should defer to user judgement about whether a task is too large to attempt.',
-    '',
-    // doing-tasks-security
-    'Be careful not to introduce security vulnerabilities such as command injection, XSS, SQL injection, and other OWASP top 10 vulnerabilities. If you notice that you wrote insecure code, immediately fix it. Prioritize writing safe, secure, and correct code.',
-    '',
-    // tool-use discipline (adapted to this SDK's tools; official prefers
-    // dedicated tools over shell and batches independent read-only calls)
-    'Prefer the dedicated file tools (Read, Write, Edit, Glob, Grep) over shell commands for inspecting or modifying files. Read a file before editing it. When several independent read-only lookups would help, issue them together rather than one at a time. Base every claim on actual tool output; if a tool call fails, say so instead of guessing.',
-    '',
-    // outcome-first-communication-style (IS_TEXT_OUTPUT_VISIBLE_TO_USER resolved
-    // to the visible branch, since the SDK consumer reads the final message)
-    'Communicating with the user:',
-    "Your text output is what the user reads; they usually can't see your thinking or the raw tool results. Write it for a teammate who stepped away and is catching up, not for a log file: they don't know the codenames or shorthand you created along the way, and they didn't watch your process unfold. Before your first tool call, say in a sentence what you're about to do; while working, give brief updates when you find something load-bearing or change direction.",
-    '',
-    'Everything the user needs from this turn — answers, summaries, findings, conclusions, deliverables — must be in the final text message of your turn, with no tool calls after it. Keep text between tool calls to brief status notes. If something important appeared only mid-turn or in your thinking, restate it in that final message.',
-    '',
-    'Lead with the outcome. Your first sentence after finishing should answer "what happened" or "what did you find" — the thing the user would ask for if they said "just give me the TLDR." Supporting detail and reasoning come after, for readers who want them.',
-    '',
-    'Being readable and being concise are different things, and readable matters more. Keep output short by being selective about what you include (drop details that don\'t change what the reader would do next), not by compressing into fragments, abbreviations, arrow chains, or jargon. Write what you include in complete sentences with the technical terms spelled out. Match the response to the question: a simple question gets a direct answer in prose, not headers and sections.',
-    '',
-    // tone-and-style-code-references
-    'When referencing specific functions or pieces of code include the pattern file_path:line_number to allow the user to easily navigate to the source code location.',
-    '',
-    'Write code that reads like the surrounding code: match its comment density, naming, and idiom. Default to writing no comments; only write a code comment to state a constraint the code itself can\'t show. Don\'t create planning, decision, or analysis documents unless the user asks for them — work from conversation context, not intermediate files.',
-    '',
-    'Safety: never run destructive or irreversible commands (deleting files or branches, force-pushing, dropping databases, mass overwrites) unless the user has explicitly requested that exact operation.',
-  );
-  return lines.join('\n');
-}
-
-/**
- * Stable part of the v5 harness prompt (no cwd): a COMPREHENSIVE faithful
- * reproduction of the official Claude Code main-loop system prompt — the fuller
- * set of doing-tasks, tool-use discipline, executing-actions-with-care,
- * outcome-first communication, and code-style clauses the everyday coding loop
- * actually sends. Assembled from the PUBLIC prompt reconstruction (Piebald-AI
- * snapshot, MIT, reverse-engineered from the publicly distributed CLI; archived
- * under Public-Info-Pool/Reference/Claude-Code-System-Prompts/). Open
- * reproduction with attribution (keeper ruling 2026-07-04/05). The goal is
- * FIDELITY to the official prompt (not size); tool references are adapted to
- * THIS SDK's tools, and clauses referencing tools/features this SDK does not
- * ship are omitted (never reference an absent tool). A comfortably large stable
- * prefix is a byproduct, and — per the 2026-07-05 cache probe — it also crosses
- * Haiku's effective caching threshold so the prefix is actually cached/reused.
- */
-function defaultHarnessStableV5(ctx: PromptContext): string {
-  // Migrated to the fragment-store assembler (Track B): assembleMainLoop
-  // composes the main-loop prompt from prompt-fragments.ts and reproduces
-  // the prior inline v5 byte-for-byte (golden-locked in prompt-assembler.test).
+function defaultHarnessStable(ctx: PromptContext): string {
+  // Composed by the fragment-store assembler (assembleMainLoop) from
+  // prompt-fragments.ts; byte-locked by prompt-assembler.test / v5-mainloop-golden.
   return assembleMainLoop({ toolNames: ctx.toolNames });
 }
 
 /**
  * Build the system prompt split into stable prefix + volatile (cwd) tail.
- * - undefined          -> minimal default (stable) + cwd tail
  * - string             -> the caller's text is treated as entirely stable
  *   (we cannot know which parts vary), with no volatile tail
- * - claude_code preset -> this SDK's default harness prompt (stable, v1 or v2
- *   per ctx.variant) + cwd tail, with optional `append` in the stable segment
+ * - undefined OR the claude_code preset -> this SDK's single default harness
+ *   prompt + cwd tail, with optional `append` (preset only) in the stable
+ *   segment. There is no variant selection: both paths converge to one prompt.
  */
 export function buildSystemPromptParts(
   opt: Options['systemPrompt'],
   ctx: PromptContext,
 ): SystemPromptParts {
-  if (opt === undefined) {
-    const stable = minimalStable();
-    return {
-      stable,
-      base: stable,
-      project: '',
-      volatile: volatileTail(ctx, false),
-      parts: [{ role: 'base', label: 'base', estTokens: estimateTextTokens(stable) }],
-    };
-  }
   if (typeof opt === 'string') {
     return {
       stable: opt,
@@ -392,7 +176,7 @@ export function buildSystemPromptParts(
   }
   // Segments form is composed by the caller and handled upstream (query.ts);
   // if it ever reaches here, flatten it defensively rather than throw.
-  if (opt.type === 'segments') {
+  if (opt !== undefined && opt.type === 'segments') {
     const stable = opt.segments.map((s) => s.text).join('\n\n');
     return {
       stable,
@@ -406,25 +190,10 @@ export function buildSystemPromptParts(
       })),
     };
   }
-  // Default (no explicit variant) emulates the official Claude Code harness:
-  // v5 is the comprehensive faithful reproduction. A measured v1-vs-v5 A/B
-  // showed v5 is ~3x CHEAPER in multi-turn (95% vs 0% cache hit — v1's tiny
-  // prompt sits below the effective cache threshold, so nothing caches and
-  // every turn re-sends at full price; v5's big stable prefix caches and is
-  // read back at ~10% cost) at equal correctness. Explicit v1-v4 remain
-  // available as opt-in for a terser prompt.
-  const base =
-    ctx.variant === 'v5'
-      ? defaultHarnessStableV5(ctx)
-      : ctx.variant === 'v4'
-        ? defaultHarnessStableV4(ctx)
-        : ctx.variant === 'v3'
-          ? defaultHarnessStableV3(ctx)
-          : ctx.variant === 'v2'
-            ? defaultHarnessStableV2(ctx)
-            : ctx.variant === 'v1'
-              ? defaultHarnessStable(ctx)
-              : defaultHarnessStableV5(ctx);
+  // undefined OR the claude_code preset -> the single default harness prompt,
+  // a comprehensive faithful reproduction of the official Claude Code main loop
+  // assembled from the fragment store.
+  const base = defaultHarnessStable(ctx);
   // The appended stable tail (project instructions + append). Carries its own
   // leading `\n\n` separators so `base + project === stable` byte-for-byte,
   // and so it can cache as its own reusable segment (the 2nd system breakpoint)
@@ -448,14 +217,16 @@ export function buildSystemPromptParts(
       estTokens: estimateTextTokens(block),
     });
   }
-  if (opt.append !== undefined && opt.append.length > 0) {
+  // `append` is preset-only; the undefined path has no append to carry.
+  if (opt !== undefined && opt.append !== undefined && opt.append.length > 0) {
     project += `\n\n${opt.append}`;
     parts.push({ role: 'append', label: 'append', estTokens: estimateTextTokens(opt.append) });
   }
   // BPT-EXTENSION: labeled append segments, emitted after `append`, in order.
   // Byte-identical to concatenating their text via `append`; labels are metadata
-  // that flow only into `parts` (never onto the wire).
-  if (Array.isArray(opt.appendSegments)) {
+  // that flow only into `parts` (never onto the wire). Preset-only (opt-guarded,
+  // like `append`): the undefined path has no segments to carry.
+  if (opt !== undefined && Array.isArray(opt.appendSegments)) {
     for (const seg of opt.appendSegments) {
       if (seg !== null && typeof seg.text === 'string' && seg.text.length > 0) {
         project += `\n\n${seg.text}`;
@@ -464,7 +235,7 @@ export function buildSystemPromptParts(
     }
   }
   const stable = base + project;
-  return { stable, base, project, volatile: volatileTail(ctx, true), parts };
+  return { stable, base, project, volatile: volatileTail(ctx), parts };
 }
 
 /**

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -720,15 +720,11 @@ export function query(args: {
       : undefined;
     sessionGitBranch = environment?.gitBranch;
     const projectInstructions = loadProjectInstructions(cwd, options.settingSources);
-    // Pass the variant through as-is: when harnessPromptVariant is unset,
-    // buildSystemPromptParts applies its default (v5, the faithful official
-    // reproduction) on the claude_code preset path. Resolving undefined to a
-    // concrete 'v1' here would override that default and pin the real API to
-    // the terse prompt regardless of the promoted default.
+    // There is one harness prompt: buildSystemPromptParts resolves both an unset
+    // systemPrompt and the claude_code preset to the same comprehensive default.
     const promptParts = buildSystemPromptParts(sp, {
       cwd,
       toolNames: [...builtinTools.keys()],
-      variant: options.harnessPromptVariant,
       environment,
       projectInstructions,
     });

--- a/projects/bpt-agent-sdk/src/types.ts
+++ b/projects/bpt-agent-sdk/src/types.ts
@@ -1311,14 +1311,6 @@ export type Options = {
   enableFileCheckpointing?: boolean;
   /** Defer MCP tool schemas behind a ToolSearch tool. undefined -> auto. */
   toolSearch?: boolean;
-  /** BPT experiment: harness system-prompt variant for the `claude_code`
-   *  preset / default path. 'v1' (default) = the terse original; 'v2'/'v3' =
-   *  richer prompts composed from PUBLIC prompt-engineering practice; 'v4' = a
-   *  faithful reproduction of the official main-loop prompt from the PUBLIC
-   *  prompt reconstruction (open reproduction, tool refs adapted); 'v5' = a
-   *  COMPREHENSIVE faithful reproduction (fuller official main-loop clauses).
-   *  A/B knob for measuring quality/cost/cache before promoting a new default. */
-  harnessPromptVariant?: 'v1' | 'v2' | 'v3' | 'v4' | 'v5';
 
   // -------------------------------------------------------------------------
   // Official Options fields ACCEPTED at runtime but NOT acted on (T2-3,

--- a/projects/bpt-agent-sdk/tests/harness-base-export.test.ts
+++ b/projects/bpt-agent-sdk/tests/harness-base-export.test.ts
@@ -7,8 +7,8 @@
  *
  * These tests pin the acceptance criteria: the export is reachable from the
  * entry, it IS the same function the engine uses (so `.base` matches what preset
- * mode injects), `.base` is the vN harness prose only (no append / project /
- * <env> tail), and toolNames / variant flow through.
+ * mode injects), `.base` is the harness prose only (no append / project /
+ * <env> tail), and toolNames flow through.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -42,20 +42,17 @@ describe('harness-base constructor export', () => {
     expect(buildSystemPromptParts).toBe(engineBuildParts);
   });
 
-  it('.base is the V5 default harness prose for the claude_code preset', () => {
+  it('.base is the default harness prose for the claude_code preset', () => {
     const { base } = buildSystemPromptParts(PRESET, { cwd: '', toolNames: TOOLS });
     expect(base).toContain(
       'You are an interactive agent that helps users with software engineering tasks.',
     );
-    // V5 is the comprehensive reproduction — comfortably large (the ~11.7k-char
-    // preset base the request sizes), far bigger than the terse v1.
+    // The comprehensive reproduction — comfortably large (the ~11.7k-char preset
+    // base the request sizes).
     expect(base.length).toBeGreaterThan(5000);
-    const v1 = buildSystemPromptParts(PRESET, {
-      cwd: '',
-      toolNames: TOOLS,
-      variant: 'v1',
-    }).base;
-    expect(v1.length).toBeLessThan(base.length);
+    // undefined resolves to the SAME single default (the variant ladder is gone).
+    const fromUndefined = buildSystemPromptParts(undefined, { cwd: '', toolNames: TOOLS }).base;
+    expect(fromUndefined).toBe(base);
   });
 
   it('flows toolNames into the base (Available-tools line + tool-gated fragments)', () => {

--- a/projects/bpt-agent-sdk/tests/integration/ab-benchmark.mjs
+++ b/projects/bpt-agent-sdk/tests/integration/ab-benchmark.mjs
@@ -45,9 +45,6 @@ if (args.compare === true && positional.length === 2) {
 const ENGINE = args.engine === 'official' ? 'official' : 'bpt';
 const MODEL = typeof args.model === 'string' ? args.model : 'claude-haiku-4-5-20251001';
 const OUT = typeof args.out === 'string' ? args.out : `ab-report-${ENGINE}.json`;
-// --variant v1|v2: this SDK's harness-prompt variant (BPT experiment). Only
-// meaningful for --engine=bpt; ignored by the official engine.
-const VARIANT = ['v1', 'v2', 'v3', 'v4', 'v5'].includes(args.variant) ? args.variant : undefined;
 // --repeat N: run each task N times and report the MEDIAN of the metrics
 // (denoises single-sample outliers, e.g. one slow/retried turn). Default 1.
 const REPEAT = Math.max(1, Number.parseInt(args.repeat, 10) || 1);
@@ -307,18 +304,12 @@ async function runTask(task) {
         maxTurns: 8,
         persistSession: false,
         // The BPT arm runs the real shipped harness: the claude_code preset,
-        // whose default variant is v5 (the faithful official reproduction).
-        // This makes the standalone A/B and the vs-official comparison reflect
-        // what an actual integration gets, not a stripped-down prompt. A
-        // harnessPromptVariant only takes effect on this preset path, so the
-        // preset MUST be present (leaving it off silently ignored the variant —
-        // the bug that made an earlier v1-vs-v4 run look identical). The
-        // official engine ships its own prompt; we pass nothing extra to it.
+        // the single comprehensive faithful reproduction of the official main
+        // loop. This makes the standalone A/B and the vs-official comparison
+        // reflect what an actual integration gets. The official engine ships its
+        // own prompt; we pass nothing extra to it.
         ...(ENGINE === 'bpt'
-          ? {
-              systemPrompt: { type: 'preset', preset: 'claude_code' },
-              ...(VARIANT ? { harnessPromptVariant: VARIANT } : {}),
-            }
+          ? { systemPrompt: { type: 'preset', preset: 'claude_code' } }
           : {}),
         ...(task.options ?? {}),
       },
@@ -438,7 +429,6 @@ for (const task of selected) {
 const report = {
   engine: ENGINE,
   model: MODEL,
-  variant: VARIANT,
   repeat: REPEAT,
   at: new Date().toISOString(),
   tasks: rows,
@@ -517,9 +507,7 @@ function compareReports(fileA, fileB) {
   const byId = (rep) => new Map(rep.tasks.map((t) => [t.id, t]));
   const mb = byId(b);
   const rn = a.repeat || b.repeat ? ` (median of ${a.repeat ?? 1}/${b.repeat ?? 1})` : '';
-  const va = a.variant ? `/${a.variant}` : '';
-  const vb = b.variant ? `/${b.variant}` : '';
-  console.log(`A=${a.engine}${va}(${a.model})  B=${b.engine}${vb}(${b.model})${rn}\n`);
+  console.log(`A=${a.engine}(${a.model})  B=${b.engine}(${b.model})${rn}\n`);
   console.log('| # | task | ok A/B | turns A/B | cost A/B | wall ms A/B | cacheHit A/B |');
   console.log('|---|------|--------|-----------|----------|-------------|--------------|');
   for (const ta of a.tasks) {

--- a/projects/bpt-agent-sdk/tests/integration/cache-probe.mjs
+++ b/projects/bpt-agent-sdk/tests/integration/cache-probe.mjs
@@ -13,7 +13,7 @@
  * short-single-run artifact. No theorizing — the per-turn numbers decide.
  *
  * Usage: ANTHROPIC_API_KEY=... node tests/integration/cache-probe.mjs \
- *   [--model=claude-haiku-4-5-20251001] [--runs=3] [--variant=v1|v4]
+ *   [--model=claude-haiku-4-5-20251001] [--runs=3] [--big]
  * Exit: 0 ok, 2 no key (skipped).
  */
 
@@ -29,7 +29,6 @@ const args = Object.fromEntries(
 );
 const MODEL = typeof args.model === 'string' ? args.model : 'claude-haiku-4-5-20251001';
 const RUNS = Math.max(1, Number.parseInt(args.runs, 10) || 3);
-const VARIANT = ['v1', 'v2', 'v3', 'v4', 'v5'].includes(args.variant) ? args.variant : undefined;
 // --big: inflate the system prompt COMFORTABLY above the 2048 Haiku floor
 // (~4500 tokens of filler) to test whether caching becomes reliable when the
 // stable prefix is big (like the official's), isolating "marginal-size zone"
@@ -71,17 +70,11 @@ async function runOnce(i) {
         allowDangerouslySkipPermissions: true,
         maxTurns: 8,
         persistSession: false,
-        // A harnessPromptVariant only takes effect on the claude_code preset
-        // path, so selecting a variant REQUIRES also selecting the preset (else
-        // the minimal default prompt is used and the variant is ignored).
+        // --big appends filler to push the stable prefix well above the Haiku
+        // cache floor; otherwise the plain default harness prompt is used.
         ...(BIG
           ? { systemPrompt: { type: 'preset', preset: 'claude_code', append: BIG_APPEND } }
-          : VARIANT
-            ? {
-                harnessPromptVariant: VARIANT,
-                systemPrompt: { type: 'preset', preset: 'claude_code' },
-              }
-            : {}),
+          : {}),
       },
     });
     for await (const msg of q) {
@@ -94,7 +87,7 @@ async function runOnce(i) {
 }
 
 console.log(
-  `cache-probe: model=${MODEL} ${BIG ? 'BIG-prefix(~4.5k tok filler)' : `variant=${VARIANT ?? 'v1(default)'}`} runs=${RUNS}, back-to-back\n`,
+  `cache-probe: model=${MODEL} ${BIG ? 'BIG-prefix(~4.5k tok filler)' : 'default-harness'} runs=${RUNS}, back-to-back\n`,
 );
 let firstRunWroteAt = null;
 for (let i = 1; i <= RUNS; i++) {

--- a/projects/bpt-agent-sdk/tests/prompts.test.ts
+++ b/projects/bpt-agent-sdk/tests/prompts.test.ts
@@ -1,14 +1,14 @@
 /**
- * Harness system-prompt construction: stable/volatile split + v1/v2/v3 variant.
+ * Harness system-prompt construction: stable/volatile split + the single
+ * default harness prompt (the v1-v4 variant ladder was collapsed, 2026-07-08).
  */
 
 import { describe, expect, it } from 'vitest';
 import { buildSystemPromptParts, buildSystemPrompt } from '../src/engine/prompts.js';
 
-const ctx = (variant?: 'v1' | 'v2' | 'v3' | 'v4' | 'v5') => ({
+const ctx = () => ({
   cwd: '/tmp/run-xyz',
   toolNames: ['Read', 'Write', 'Bash'],
-  variant,
 });
 const preset = { type: 'preset' as const, preset: 'claude_code' as const };
 
@@ -31,95 +31,37 @@ describe('system prompt split', () => {
   });
 });
 
-describe('harness prompt v1/v2 variant', () => {
-  it('defaults to v5 (faithful official reproduction) when no variant is given', () => {
-    // The claude_code preset with no explicit variant emulates the official
-    // harness: a measured A/B showed v5 is ~3x cheaper in multi-turn at equal
-    // correctness (95% vs 0% cache hit), so it is the default.
-    const def = buildSystemPromptParts(preset, ctx()).stable;
-    const explicitV5 = buildSystemPromptParts(preset, ctx('v5')).stable;
-    expect(def).toBe(explicitV5);
-    expect(def).toContain('Doing tasks:');
-    expect(def).not.toContain('/tmp/run-xyz');
+describe('the default harness prompt', () => {
+  it('undefined and the claude_code preset resolve to the SAME single default', () => {
+    // The v1-v4 variant ladder was collapsed (keeper ruling 2026-07-08): both an
+    // unset systemPrompt and the preset produce ONE comprehensive harness prompt.
+    const fromUndefined = buildSystemPromptParts(undefined, ctx()).base;
+    const fromPreset = buildSystemPromptParts(preset, ctx()).base;
+    expect(fromUndefined).toBe(fromPreset);
+    expect(fromPreset).toContain('Doing tasks:');
+    expect(fromPreset).not.toContain('/tmp/run-xyz');
   });
 
-  it('v1 is still available as an explicit terse opt-in', () => {
-    const v1 = buildSystemPromptParts(preset, ctx('v1')).stable;
-    expect(v1).toContain('Tool guidance:');
-    // and it is meaningfully smaller than the v5 default
-    const v5 = buildSystemPromptParts(preset, ctx('v5')).stable;
-    expect(v1.length).toBeLessThan(v5.length);
-  });
-
-  it('v2 is the richer self-authored prompt and is larger than v1', () => {
-    const v1 = buildSystemPromptParts(preset, ctx('v1')).stable;
-    const v2 = buildSystemPromptParts(preset, ctx('v2')).stable;
-    expect(v2).not.toBe(v1);
-    expect(v2.length).toBeGreaterThan(v1.length);
-    // v2 encodes real behavioral discipline, not padding.
-    expect(v2).toContain('Approach:');
-    expect(v2).toContain('Grounding and honesty:');
-    expect(v2).toContain('Finishing:');
-    // both keep the cwd out of the cached (stable) segment
-    expect(v2).not.toContain('/tmp/run-xyz');
-  });
-
-  it('v3 adds the four flagged disciplines on top of v2 and is larger still', () => {
-    const v2 = buildSystemPromptParts(preset, ctx('v2')).stable;
-    const v3 = buildSystemPromptParts(preset, ctx('v3')).stable;
-    expect(v3).not.toBe(v2);
-    expect(v3.length).toBeGreaterThan(v2.length);
-    // the four techniques the public best-practices comparison flagged as missing
-    expect(v3).toContain('verify your work against'); // verify-before-finishing
-    expect(v3).toContain('Do not hard-code'); // solve the general problem
-    expect(v3).toContain('for example:'); // one concrete style example
-    // when-to-delegate guidance is present ONLY when the Agent tool is shipped
-    const v3Agent = buildSystemPromptParts(preset, {
-      cwd: '/tmp/run-xyz',
-      toolNames: ['Read', 'Write', 'Bash', 'Agent'],
-      variant: 'v3',
-    }).stable;
-    expect(v3Agent).toContain('Delegation:');
-    // still keeps the cwd out of the cached (stable) segment
-    expect(v3).not.toContain('/tmp/run-xyz');
-  });
-
-  it('v4 faithfully reproduces official main-loop clauses, tool refs adapted, cwd out', () => {
-    const v4 = buildSystemPromptParts(preset, ctx('v4')).stable;
-    // faithful official clauses (reproduced from the public reconstruction)
-    expect(v4).toContain('You are an interactive agent that helps users with software engineering tasks.');
-    expect(v4).toContain('Lead with the outcome.');
-    expect(v4).toContain('file_path:line_number');
-    // tool references adapted to THIS SDK's tools
-    expect(v4).toContain('Read, Write, Edit, Glob, Grep');
-    // cwd stays out of the cached (stable) segment
-    expect(v4).not.toContain('/tmp/run-xyz');
-    // and it does not reference tools this SDK does not ship
-    expect(v4).not.toContain('Workflow');
-  });
-
-  it('v5 is a comprehensive faithful reproduction, larger than v4, tool-adapted, cwd out', () => {
-    const v4 = buildSystemPromptParts(preset, ctx('v4')).stable;
-    const v5 = buildSystemPromptParts(preset, ctx('v5')).stable;
-    expect(v5.length).toBeGreaterThan(v4.length);
-    // fuller official main-loop sections present in v5
-    expect(v5).toContain('Doing tasks:');
-    expect(v5).toContain('Tool use:');
-    expect(v5).toContain('Executing actions with care:');
-    expect(v5).toContain('Communicating with the user:');
+  it('is the comprehensive faithful reproduction of the official main loop', () => {
+    const stable = buildSystemPromptParts(preset, ctx()).stable;
+    // fuller official main-loop sections
+    expect(stable).toContain('Doing tasks:');
+    expect(stable).toContain('Tool use:');
+    expect(stable).toContain('Executing actions with care:');
+    expect(stable).toContain('Communicating with the user:');
     // faithful official clauses
-    expect(v5).toContain('Measure twice, cut once.');
-    expect(v5).toContain('file_path:line_number');
-    // official main-loop clauses that must be reproduced (act-when-ready + safety)
-    expect(v5).toContain('When you have enough information to act, act.');
-    expect(v5).toContain('Assist with authorized security testing');
+    expect(stable).toContain('You are an interactive agent that helps users with software engineering tasks.');
+    expect(stable).toContain('Measure twice, cut once.');
+    expect(stable).toContain('When you have enough information to act, act.');
+    expect(stable).toContain('Assist with authorized security testing');
+    expect(stable).toContain('file_path:line_number');
     // tool references adapted to THIS SDK (dedicated-tools-over-bash redirects)
-    expect(v5).toContain('Use Grep (NOT grep or rg)');
+    expect(stable).toContain('Use Grep (NOT grep or rg)');
     // does not reference tools this SDK does not ship
-    expect(v5).not.toContain('Workflow');
-    expect(v5).not.toContain('computer-use');
+    expect(stable).not.toContain('Workflow');
+    expect(stable).not.toContain('computer-use');
     // cwd stays out of the cached stable segment
-    expect(v5).not.toContain('/tmp/run-xyz');
+    expect(stable).not.toContain('/tmp/run-xyz');
   });
 
   it('an environment context renders the <env> block in the volatile tail', () => {
@@ -168,27 +110,24 @@ describe('harness prompt v1/v2 variant', () => {
     expect(volatile).not.toContain('Always use tabs.');
   });
 
-  it('RED LINE: never names the Agent tool when it is not in the tool set (v5 + v3)', () => {
+  it('RED LINE: never names the Agent tool when it is not in the tool set', () => {
     // query.ts registers the Agent tool only when subagents are configured, so
     // the default prompt must not instruct the model to use it.
     const noAgent = { cwd: '/tmp/x', toolNames: ['Read', 'Write', 'Bash', 'TodoWrite'] };
-    for (const v of ['v3', 'v5'] as const) {
-      const stable = buildSystemPromptParts(preset, { ...noAgent, variant: v }).stable;
-      expect(stable).not.toContain('Agent tool');
-      expect(stable).not.toContain('via the Agent tool');
-      expect(stable).not.toContain('specialized agents');
-    }
+    const stable = buildSystemPromptParts(preset, noAgent).stable;
+    expect(stable).not.toContain('Agent tool');
+    expect(stable).not.toContain('via the Agent tool');
+    expect(stable).not.toContain('specialized agents');
   });
 
-  it('includes the Agent guidance when the Agent tool IS in the set (v5 + v3)', () => {
+  it('includes the Agent guidance when the Agent tool IS in the set', () => {
     const withAgent = { cwd: '/tmp/x', toolNames: ['Read', 'Bash', 'Agent'] };
-    expect(buildSystemPromptParts(preset, { ...withAgent, variant: 'v5' }).stable).toContain('Agent tool');
-    expect(buildSystemPromptParts(preset, { ...withAgent, variant: 'v3' }).stable).toContain('via the Agent tool');
+    expect(buildSystemPromptParts(preset, withAgent).stable).toContain('Agent tool');
   });
 
-  it('gates each tool-specific clause on that tool being present (v5)', () => {
+  it('gates each tool-specific clause on that tool being present', () => {
     // A restricted tool set drops the clauses naming absent tools.
-    const minimal = { cwd: '/tmp/x', toolNames: ['Read', 'Bash'], variant: 'v5' as const };
+    const minimal = { cwd: '/tmp/x', toolNames: ['Read', 'Bash'] };
     const stable = buildSystemPromptParts(preset, minimal).stable;
     expect(stable).not.toContain('TodoWrite tool');
     expect(stable).not.toContain('AskUserQuestion tool');
@@ -197,11 +136,9 @@ describe('harness prompt v1/v2 variant', () => {
     expect(stable).toContain('Doing tasks:');
   });
 
-  it('append text lands in the stable segment for all variants', () => {
+  it('append text lands in the stable segment', () => {
     const withAppend = { ...preset, append: 'EXTRA_INSTRUCTION' };
-    for (const v of ['v1', 'v2', 'v3', 'v4', 'v5'] as const) {
-      expect(buildSystemPromptParts(withAppend, ctx(v)).stable).toContain('EXTRA_INSTRUCTION');
-    }
+    expect(buildSystemPromptParts(withAppend, ctx()).stable).toContain('EXTRA_INSTRUCTION');
   });
 });
 

--- a/projects/bpt-agent-sdk/tests/query.test.ts
+++ b/projects/bpt-agent-sdk/tests/query.test.ts
@@ -454,11 +454,10 @@ describe('prompt cache: stable prefix does not drift across turns (a read can hi
     expect(JSON.stringify(tools).length).toBeGreaterThan(6000);
   });
 
-  it('claude_code preset with no explicit variant resolves to the v5 default on the wire', async () => {
-    // Locks the promoted default THROUGH the real query() path: query.ts must
-    // pass harnessPromptVariant through as-is so buildSystemPromptParts applies
-    // its v5 default. A regression that pins undefined -> 'v1' here would ship
-    // the terse prompt while the unit default claimed v5.
+  it('the claude_code preset resolves to the default harness on the wire', async () => {
+    // Locks the single default harness THROUGH the real query() path: the v1-v4
+    // variant ladder was collapsed (2026-07-08), so the preset always ships the
+    // comprehensive faithful reproduction.
     const fetchStub = stubFetch(makeSSEFetch([textReplyEvents('done')]));
     const q = query({
       prompt: 'hello',
@@ -472,19 +471,18 @@ describe('prompt cache: stable prefix does not drift across turns (a read can hi
     await collect(q);
     const sys = fetchStub.requests[0]!.body.system as Array<{ text?: string }>;
     const stable = sys[0]?.text ?? '';
-    expect(stable).toContain('Doing tasks:'); // v5 marker
-    expect(stable).toContain('Measure twice, cut once.'); // v5 marker
-    expect(stable).not.toContain('Tool guidance:'); // v1 marker absent
+    expect(stable).toContain('Doing tasks:');
+    expect(stable).toContain('Measure twice, cut once.');
   });
 
-  it('an explicit harnessPromptVariant:v1 still selects the terse prompt on the wire', async () => {
+  it('an unset systemPrompt resolves to the SAME default harness on the wire', async () => {
+    // Post-collapse: undefined no longer ships the minimal 2-line prompt; it
+    // converges to the same comprehensive default as the preset.
     const fetchStub = stubFetch(makeSSEFetch([textReplyEvents('done')]));
     const q = query({
       prompt: 'hello',
       options: baseOptions({
         provider: { apiKey: 'test-key' },
-        systemPrompt: { type: 'preset', preset: 'claude_code' },
-        harnessPromptVariant: 'v1',
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
       }),
@@ -492,8 +490,8 @@ describe('prompt cache: stable prefix does not drift across turns (a read can hi
     await collect(q);
     const sys = fetchStub.requests[0]!.body.system as Array<{ text?: string }>;
     const stable = sys[0]?.text ?? '';
-    expect(stable).toContain('Tool guidance:'); // v1 marker
-    expect(stable).not.toContain('Doing tasks:'); // v5 marker absent
+    expect(stable).toContain('Doing tasks:');
+    expect(stable).toContain('Measure twice, cut once.');
   });
 });
 


### PR DESCRIPTION
## 概述

把主循环提示词的 v1–v4 变体阶梯收敛为**单一默认**（守密人裁定 2026-07-08）：只保留 v5（官方主循环忠实复刻），移除 `harnessPromptVariant` 选择旋钮，并让**未指定 `systemPrompt` 也走同一默认 harness**（不再是原来的 2 行极简）。此前实测 A/B 已证明 v5 因大 stable 前缀吃上缓存、多轮反而约 3 倍便宜，故作唯一默认。

> **已 rebase 到最新 main（0.32.0 = prompt-composition #545）**：#545 触及同一批文件，冲突已解、**两处改动共存**；一处语义修正见下。版本因 0.32.0 被 #545 占用而取 **0.33.0**。

---

## 变更类型

- [x] 其他：**破坏性 API 收敛** —— 移除公开 Options 字段 + 统一默认行为

---

## 破坏性变更

- **移除 `Options.harnessPromptVariant`**（及导出的 `PromptContext.variant`）。此前传 `'v1'..'v4'` 的调用方现统一得到单一默认。
- **`systemPrompt` 未指定现解析为完整默认 harness**（不再是 2 行极简）——`undefined` 与 `claude_code` 预设**收敛到同一提示词**；字符串仍逐字采用；`append` 仍仅预设可用。

## 实现明细

- `src/engine/prompts.ts`：删除 `minimalStable` + `defaultHarnessStable`(v1)/`V2`/`V3`/`V4`；唯一构造器（重命名为 `defaultHarnessStable`）经 `assembleMainLoop` 装配（`v5-mainloop-golden` 字节锁不变）；`volatileTail` 始终附路径指引。
- `src/types.ts` / `src/query.ts`：移除字段定义与传参。
- 测试：`prompts.test.ts` / `query.test.ts` / `harness-base-export.test.ts` 改指单一默认，新增「undefined 与 preset 一致」锁；`cache-probe.mjs` / `ab-benchmark.mjs` 移除 `--variant` 维度；`docs/ARCHITECTURE.md` 更新。
- **rebase 冲突修正**：#545 的 `opt.appendSegments`（写于「undefined 走 minimalStable」时代）未守卫 `opt !== undefined`；本 PR 让 undefined 落到该路径，已补守卫（与 `append` 一致），否则 undefined 会抛错。
- 版本 `0.32.0(main) → 0.33.0` + CHANGELOG（本条置于 #545 的 0.32.0 之上）。

---

## 安全声明

- [x] 不含 BIAV 内网 / 黑池 / 未发布数据；仅收敛银芯自有 SDK 的公开 API。
- [x] 不引入 emoji
- [x] 未改动 memory 主控台档案

---

## 验证清单

- [x] `npm run typecheck` 通过；`npm run build` 通过
- [x] `npm test`：**67 文件、1517 项通过，2 跳过**（含 #545 新增测试）
- [x] 端到端：dist 入口不再暴露 `harnessPromptVariant`；`buildSystemPromptParts(undefined,…).base === buildSystemPromptParts(preset,…).base`；`undefined.parts` 不因 appendSegments 抛错
- [x] `v5-mainloop-golden.json` 字节锁未变
- [x] CI（unit / conformance / test）在 rebase 后的提交上全绿

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcCr7DPBJTRqnM4JGbwP9n