### PR TITLE
feat(bpt-agent-sdk): 统一 tool-search — 冷内置 schema 按需加载（非仅 MCP）

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,40 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.34.0 — 2026-07-09
+
+**Unified tool-search: defer COLD BUILT-IN schemas, not just MCP tools** (keeper
+ruling 2026-07-09). Tool-search previously deferred only MCP tool schemas; the
+built-in schemas were always advertised inline every turn (~16k tokens, cold-written
+at the start of every conversation — the single largest fixed request cost, and the
+one the prompt cache does not amortize on a fresh conversation). The ONE `ToolSearch`
+builtin now searches and lazily loads a cold BUILT-IN set through the same registry:
+one shared `loaded` namespace, one catalog. `Workflow` (~4.9k tokens, the largest
+built-in schema) leads the cold set.
+
+- **new: unified deferral, opt-in via `toolSearch: true`.** When set, the cold set
+  (`DEFAULT_DEFERRED_BUILTINS` — Workflow / Monitor / ExitPlanMode / EnterWorktree /
+  WebFetch / WebSearch / the background-shell + task tools / MCP-resource tools) is
+  withheld from the request `tools[]` and lazily loaded on demand — **even with zero
+  MCP servers configured**. The reflexive core (Read/Write/Edit/Bash/Glob/Grep, plus
+  Agent, AskUserQuestion and ToolSearch itself) stays hot. A withheld built-in still
+  EXECUTES if called (has()-stays-true — context-saving, not access control), exactly
+  like a deferred MCP tool, and its schema resurfaces the turn after a ToolSearch load.
+- **unchanged default (drop-in safe): `toolSearch` undefined defers nothing built-in.**
+  Every built-in stays inline exactly as before; MCP-only deferral past the threshold
+  is untouched. `toolSearch: false` still disables all deferral. The conformance wire
+  surface is byte-identical on the default path (`toolNames`/`toolCount` were already
+  excluded from the reference ratchet).
+- **new export: `silverCoreToolOptions()`** — the SVN-world variant bundle
+  (`{ toolSearch: true, disallowedTools: ['EnterWorktree'] }`). The faithful
+  `createBuiltinTools()` factory is UNCHANGED; the variant is a separate opt-in caller
+  surface that additionally REMOVES `EnterWorktree` (git worktrees are unusable under
+  SVN) via the existing bare-`disallowedTools` path — removed, not merely deferred.
+  Pass `{ disableWorktree: false }` to keep it (deferred).
+- **new exports: `DEFAULT_DEFERRED_BUILTINS`** (the cold set) and the
+  `DeferredBuiltinEntry` type / the `DeferredMcpRegistry` cold-built-in surface
+  (`attachColdBuiltins` / `isBuiltinDeferred` / `coldBuiltinCatalog`).
+
 ## 0.33.0 — 2026-07-09
 
 **Collapse the harness-prompt variant ladder to a single default** (keeper ruling

--- a/projects/bpt-agent-sdk/docs/COMPAT.md
+++ b/projects/bpt-agent-sdk/docs/COMPAT.md
@@ -167,7 +167,8 @@ v0.2 implemented most of the P0/P1 gaps the audit flagged. Now **FULL / PARTIAL*
 - **New builtin tools** — WebFetch (streamed + SSRF guard), WebSearch (host
   callback), AskUserQuestion (host callback), TodoWrite; MCP elicitation.
 - **Sessions** — external `SessionStore` mirror; file checkpointing +
-  `rewindFiles`; tool search (deferred MCP schemas); standalone session
+  `rewindFiles`; tool search (deferred MCP schemas + cold built-in schemas via
+  `toolSearch: true`, `silverCoreToolOptions()` variant); standalone session
   functions; Query methods (reconnect/toggle/setMcpServers/rewindFiles/stopTask).
 
 The full observability/status message arm was TYPED in v0.3 (task #16) so the

--- a/projects/bpt-agent-sdk/package-lock.json
+++ b/projects/bpt-agent-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.31.0",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bpt-agent-sdk",
-      "version": "0.31.0",
+      "version": "0.34.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/engine/loop.ts
+++ b/projects/bpt-agent-sdk/src/engine/loop.ts
@@ -439,18 +439,23 @@ export async function* runAgentLoop(
     mirror(turn);
   };
 
-  /** Built-in tool defs are static; MCP tool defs are rebuilt each attempt so
-   *  tool-search "load on demand" surfaces newly-loaded schemas per turn. */
-  const builtinToolDefs: APIToolDefinition[] = [];
-  for (const tool of deps.builtinTools.values()) {
-    builtinToolDefs.push({
-      name: tool.name,
-      description: tool.description,
-      input_schema: tool.inputSchema,
-    });
-  }
+  /** Tool defs are rebuilt each attempt so tool-search "load on demand"
+   *  surfaces newly-loaded schemas per turn — for BOTH deferred MCP tools
+   *  (via deps.mcp.allTools() filtering) and deferred COLD built-ins (via
+   *  deps.isBuiltinDeferred). A cold-and-unloaded built-in is skipped here so
+   *  its schema is not written this turn; it reappears the turn after a
+   *  ToolSearch load. Absent isBuiltinDeferred -> every built-in is inline
+   *  (exact pre-unification behavior). */
   const buildToolDefs = (): APIToolDefinition[] => {
-    const defs = [...builtinToolDefs];
+    const defs: APIToolDefinition[] = [];
+    for (const tool of deps.builtinTools.values()) {
+      if (deps.isBuiltinDeferred?.(tool.name) === true) continue;
+      defs.push({
+        name: tool.name,
+        description: tool.description,
+        input_schema: tool.inputSchema,
+      });
+    }
     for (const entry of deps.mcp.allTools()) {
       defs.push({
         name: entry.qualifiedName,

--- a/projects/bpt-agent-sdk/src/index.ts
+++ b/projects/bpt-agent-sdk/src/index.ts
@@ -22,6 +22,11 @@ export { tool, createSdkMcpServer } from './mcp/sdk-server.js';
 // same way it sizes MCP tools.
 export { enumerateBuiltinToolMetadata } from './tools/index.js';
 export type { BuiltinToolMetadata } from './tools/index.js';
+// Unified tool-search (lazy loading): the default cold built-in set (schemas
+// deferred behind the ToolSearch builtin when options.toolSearch === true) and
+// the 银芯/SVN-world variant options bundle. The faithful createBuiltinTools()
+// factory is unchanged; both of these are opt-in caller surfaces.
+export { DEFAULT_DEFERRED_BUILTINS, silverCoreToolOptions } from './tools/index.js';
 // BPT-EXTENSION (2026-07-08, black-pool ContextRing request): expose the harness
 // system-prompt base constructor so a host can size the built-in harness base —
 // the ~2.9k-token V5 preset prose injected on the `claude_code` preset path — the

--- a/projects/bpt-agent-sdk/src/internal/contracts.ts
+++ b/projects/bpt-agent-sdk/src/internal/contracts.ts
@@ -524,6 +524,18 @@ export type EngineDeps = {
   hooks: HookRunner;
   toolContext: ToolContext;
   debug: (msg: string) => void;
+  /**
+   * Unified tool-search (lazy loading): returns true when a built-in tool's
+   * schema is currently WITHHELD from the request `tools[]` — it is in the
+   * cold set, deferral is active, and the model has not yet loaded it via the
+   * ToolSearch builtin. buildToolDefs() skips such tools so their (often large)
+   * schemas are not cold-written every turn; they resurface the turn after a
+   * ToolSearch load. Absent -> no built-in is ever deferred (every built-in's
+   * schema is advertised inline, the exact pre-unification behavior). The tool
+   * still EXECUTES if called while deferred (has()-stays-true, context-saving
+   * not access control), mirroring deferred MCP tools.
+   */
+  isBuiltinDeferred?: (name: string) => boolean;
   /** Shared, cross-turn request-message view. When present the engine streams
    *  from this array (compactable) instead of `history`, mirrors its own
    *  appended turns into it, and compaction splices it in place. `history`

--- a/projects/bpt-agent-sdk/src/query.ts
+++ b/projects/bpt-agent-sdk/src/query.ts
@@ -63,12 +63,16 @@ import {
 import { JsonlSessionStore, resolveTranscriptPath } from './sessions/store.js';
 import { MirroringSessionStore, encodeProjectKey } from './sessions/store-adapter.js';
 import { FileCheckpointStore } from './sessions/checkpoints.js';
-import { DeferredMcpRegistry, makeToolSearchTool } from './tools/toolsearch.js';
+import {
+  DeferredMcpRegistry,
+  makeToolSearchTool,
+  type DeferredBuiltinEntry,
+} from './tools/toolsearch.js';
 import { appendFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { createBuiltinTools } from './tools/index.js';
+import { createBuiltinTools, DEFAULT_DEFERRED_BUILTINS } from './tools/index.js';
 import { createShellManager } from './tools/shells.js';
 import { peekWorktreeSession } from './tools/enterworktree.js';
 import type { ToolContextWithPermissionGate } from './tools/exitplanmode.js';
@@ -585,11 +589,15 @@ export function query(args: {
     bareDisallowed.length > 0
       ? new ToolFilterMcpRegistry(realMcp, isBareDisallowed)
       : realMcp;
-  // Tool-search: defer MCP tool schemas behind a ToolSearch builtin when
-  // servers are configured (auto-activates past the threshold, or forced by
-  // options.toolSearch). When null, mcpEff === mcp (exact v0.1 behavior).
+  // Tool-search: defer tool schemas behind a ToolSearch builtin. MCP tools
+  // defer when servers are configured (auto-activates past the threshold, or
+  // forced by options.toolSearch). Unified extension: `toolSearch: true` ALSO
+  // defers the cold built-in set (attached below), so it must construct the
+  // registry even with zero MCP servers — that is where the ~16k of resident
+  // built-in schemas is reclaimed. When null, mcpEff === mcp (exact v0.1
+  // behavior: every tool inline).
   const deferred =
-    options.toolSearch !== false && mcpServerCount > 0
+    options.toolSearch !== false && (mcpServerCount > 0 || options.toolSearch === true)
       ? new DeferredMcpRegistry(mcp, { debug })
       : null;
   const mcpEff: McpRegistry = deferred ?? mcp;
@@ -637,6 +645,24 @@ export function query(args: {
     !isBareDisallowed('Agent') &&
     (!Array.isArray(options.tools) || options.tools.includes('Agent'));
   if (wantAgent) builtinTools.set('Agent', createAgentTool(agentNames));
+
+  // Unified tool-search: register the cold built-in set on the deferred registry
+  // so the ONE ToolSearch builtin can lazily load them. Only when the caller
+  // opted in (`toolSearch: true`) — the default path (undefined) never defers a
+  // built-in, keeping the drop-in request shape byte-identical. Built from the
+  // FINAL map, so a bare-disallowed tool is never offered here, and only names
+  // actually present are deferred (the Task quartet XOR TodoWrite). ToolSearch
+  // and Agent are absent from the cold set, so they always stay inline.
+  if (deferred !== null && options.toolSearch === true) {
+    const cold: DeferredBuiltinEntry[] = [];
+    for (const name of DEFAULT_DEFERRED_BUILTINS) {
+      const t = builtinTools.get(name);
+      if (t !== undefined) {
+        cold.push({ name: t.name, description: t.description, inputSchema: t.inputSchema });
+      }
+    }
+    deferred.attachColdBuiltins(cold);
+  }
 
   // Structured-output: normalize the schema option and append the instruction
   // to the STABLE system segment so the requirement survives tool turns and
@@ -1373,6 +1399,12 @@ export function query(args: {
           requestView,
           drainSubagentResults: () => subagentRuntime.drainCompletedResults(),
           drainObservability,
+          // Unified tool-search: withhold a cold built-in's schema from this
+          // turn's tools[] while deferral is active and it is unloaded. Absent
+          // when no deferred registry exists -> every built-in stays inline.
+          ...(deferred !== null
+            ? { isBuiltinDeferred: (name: string) => deferred.isBuiltinDeferred(name) }
+            : {}),
         };
 
         // The engine appends assistant + tool_result-user messages to `history`

--- a/projects/bpt-agent-sdk/src/tools/index.ts
+++ b/projects/bpt-agent-sdk/src/tools/index.ts
@@ -139,3 +139,70 @@ export function enumerateBuiltinToolMetadata(cfg?: {
     inputJsonSchema: t.inputSchema,
   }));
 }
+
+/**
+ * The default COLD set: built-in names whose (often large) schemas are
+ * withheld from the request `tools[]` and lazily loaded via the ToolSearch
+ * builtin when unified tool-search is active (options.toolSearch === true).
+ *
+ * Selection principle (mirrors upstream Claude Code's own resident/deferred
+ * split): the reflexively-used core — Read / Write / Edit / Bash / Glob / Grep,
+ * plus Agent, AskUserQuestion and ToolSearch itself — stays HOT (advertised
+ * inline every turn), because deferring a tool the model reaches for on nearly
+ * every turn only trades a fixed schema cost for an extra round-trip. Everything
+ * here is comparatively cold: its schema is dead weight on the turns it is not
+ * used, and one ToolSearch round-trip is cheap on the turns it is. `Workflow`
+ * is the single largest built-in schema (~4.9k tokens) and leads the set.
+ *
+ * A name here is deferred only if it is actually present in the running
+ * built-in map (e.g. the Task quartet XOR TodoWrite, per CLAUDE_CODE_ENABLE_TASKS),
+ * so listing both surfaces is safe. Deferring NEVER removes a tool — it stays in
+ * createBuiltinTools() (faithful) and still executes if called (has()-stays-true),
+ * exactly like a deferred MCP tool.
+ */
+export const DEFAULT_DEFERRED_BUILTINS: readonly string[] = [
+  'Workflow',
+  'Monitor',
+  'ExitPlanMode',
+  'EnterWorktree',
+  'WebFetch',
+  'WebSearch',
+  'BashOutput',
+  'KillShell',
+  'TaskOutput',
+  'TaskStop',
+  'TaskCreate',
+  'TaskGet',
+  'TaskUpdate',
+  'TaskList',
+  'TodoWrite',
+  'ListMcpResourcesTool',
+  'ReadMcpResourceTool',
+];
+
+/**
+ * The 银芯 (silver-core) / SVN-world tool VARIANT, as a partial `Options` bundle
+ * a deployment spreads into query(). This is the "different calling function"
+ * for the special variant — the faithful `createBuiltinTools()` factory is
+ * UNCHANGED and the SDK's default behavior is untouched; opting into the
+ * variant is a caller decision, not a factory edit.
+ *
+ * It does two things, both through general, already-tested SDK option seams:
+ *  - `toolSearch: true` turns on unified lazy tool-loading (the DEFAULT_DEFERRED_BUILTINS
+ *    cold set defers behind ToolSearch, even with zero MCP servers);
+ *  - `disallowedTools: ['EnterWorktree']` (default on) drops the git-worktree
+ *    tool, which is structurally unusable in an SVN checkout — via the same bare
+ *    disallowedTools path that removes any tool from the request entirely.
+ *
+ * Pass `{ disableWorktree: false }` to keep EnterWorktree (deferred, not removed).
+ */
+export function silverCoreToolOptions(opts: { disableWorktree?: boolean } = {}): {
+  toolSearch: true;
+  disallowedTools?: string[];
+} {
+  const disableWorktree = opts.disableWorktree ?? true;
+  return {
+    toolSearch: true,
+    ...(disableWorktree ? { disallowedTools: ['EnterWorktree'] } : {}),
+  };
+}

--- a/projects/bpt-agent-sdk/src/tools/toolsearch.ts
+++ b/projects/bpt-agent-sdk/src/tools/toolsearch.ts
@@ -39,9 +39,27 @@ export function shouldActivate(opt: boolean | undefined, count: number): boolean
   return count > DEFERRED_THRESHOLD;
 }
 
+/**
+ * A cold (deferrable) built-in tool's wire metadata, registered on the deferred
+ * registry so the ONE ToolSearch builtin can search + load it exactly like a
+ * deferred MCP tool. `name` shares the single `loaded` namespace with MCP
+ * qualified names (built-in names never start with `mcp__`, so no collision).
+ */
+export type DeferredBuiltinEntry = {
+  name: string;
+  description: string;
+  inputSchema: JSONSchema;
+};
+
 export class DeferredMcpRegistry implements McpRegistry {
   private active = false;
+  /** ONE loaded namespace shared by deferred MCP tools (qualified names) and
+   *  deferred cold built-ins (bare names) — the unification seam. */
   private readonly loaded = new Set<string>();
+  /** Cold (deferrable) built-ins, by bare name. Empty -> this registry defers
+   *  MCP only (the exact pre-unification behavior). Attached by query.ts when
+   *  the caller opts into unified tool-search (options.toolSearch === true). */
+  private readonly coldBuiltins = new Map<string, DeferredBuiltinEntry>();
   private readonly debug: (msg: string) => void;
 
   constructor(
@@ -49,6 +67,33 @@ export class DeferredMcpRegistry implements McpRegistry {
     opts: { debug?: (msg: string) => void } = {},
   ) {
     this.debug = opts.debug ?? (() => undefined);
+  }
+
+  /** Register cold built-ins whose schemas defer behind ToolSearch while
+   *  active. Idempotent-additive; call after the final built-in set is known
+   *  (post disallowedTools removal, so a denied tool is never offered here). */
+  attachColdBuiltins(entries: readonly DeferredBuiltinEntry[]): void {
+    for (const e of entries) this.coldBuiltins.set(e.name, e);
+  }
+
+  /** True when a built-in's schema is currently WITHHELD from the request:
+   *  deferral is active, the tool is cold, and it has not been loaded yet.
+   *  buildToolDefs() consults this to skip the tool's schema. */
+  isBuiltinDeferred(name: string): boolean {
+    return this.active && this.coldBuiltins.has(name) && !this.loaded.has(name);
+  }
+
+  /** The cold-built-in catalog ToolSearch searches (union'd with the MCP
+   *  catalog). Every cold built-in stays searchable regardless of load state. */
+  coldBuiltinCatalog(): DeferredBuiltinEntry[] {
+    return [...this.coldBuiltins.values()];
+  }
+
+  /** True when this registry has anything to defer at all (MCP tools or cold
+   *  built-ins) — lets query.ts decide whether ToolSearch is worth wiring even
+   *  with zero MCP servers. */
+  hasDeferrableTools(): boolean {
+    return this.inner.allTools().length > 0 || this.coldBuiltins.size > 0;
   }
 
   // -- pass-through delegation -----------------------------------------------
@@ -120,45 +165,87 @@ export class DeferredMcpRegistry implements McpRegistry {
     return this.active;
   }
 
-  /** Decide activation from the option and the live real-tool count. */
+  /** Decide activation from the option and the live real-tool count. Cold
+   *  built-ins never lower the bar on their own (they are attached only when
+   *  the caller passed toolSearch:true, which shouldActivate already forces
+   *  active), so the MCP-count threshold governs the undefined-option case
+   *  exactly as before. */
   activateIfNeeded(opt: boolean | undefined): void {
     this.active = shouldActivate(opt, this.inner.allTools().length);
-    if (this.active) this.debug(`[toolsearch] active (${this.inner.allTools().length} MCP tools deferred)`);
+    if (this.active) {
+      this.debug(
+        `[toolsearch] active (${this.inner.allTools().length} MCP tools, ` +
+          `${this.coldBuiltins.size} cold built-ins deferred)`,
+      );
+    }
   }
 }
 
-function describeCatalog(catalog: McpToolEntry[]): string {
-  if (catalog.length === 0) return 'No MCP tools are available.';
-  const byServer = new Map<string, string[]>();
+/** A ToolSearch-searchable entry, normalized across the two deferred kinds
+ *  (MCP tools and cold built-ins) so ONE search path covers both — the
+ *  unification. */
+type UnifiedEntry = {
+  /** Key marked loaded + the exact name the model then calls: an MCP qualified
+   *  name or a bare built-in name. */
+  loadKey: string;
+  description?: string;
+  schema: JSONSchema;
+  /** Grouping label for the no-match guidance: the MCP server, or 'built-in'. */
+  group: string;
+};
+
+/** Union of the deferred MCP catalog and the cold-built-in catalog. */
+function unifiedCatalog(reg: DeferredMcpRegistry): UnifiedEntry[] {
+  const entries: UnifiedEntry[] = reg.catalog().map((t) => ({
+    loadKey: t.qualifiedName,
+    description: t.description,
+    schema: t.inputSchema,
+    group: t.serverName,
+  }));
+  for (const b of reg.coldBuiltinCatalog()) {
+    entries.push({
+      loadKey: b.name,
+      description: b.description,
+      schema: b.inputSchema,
+      group: 'built-in',
+    });
+  }
+  return entries;
+}
+
+function describeCatalog(catalog: UnifiedEntry[]): string {
+  if (catalog.length === 0) return 'No additional tools are available to load.';
+  const byGroup = new Map<string, string[]>();
   for (const t of catalog) {
-    let list = byServer.get(t.serverName);
+    let list = byGroup.get(t.group);
     if (list === undefined) {
       list = [];
-      byServer.set(t.serverName, list);
+      byGroup.set(t.group, list);
     }
-    list.push(t.qualifiedName);
+    list.push(t.loadKey);
   }
-  const lines: string[] = ['No tools matched. Available servers and tools:'];
-  for (const [server, names] of byServer) {
-    lines.push(`- ${server}: ${names.join(', ')}`);
+  const lines: string[] = ['No tools matched. Available tools to load:'];
+  for (const [group, names] of byGroup) {
+    lines.push(`- ${group}: ${names.join(', ')}`);
   }
   return lines.join('\n');
 }
 
-function renderMatch(t: McpToolEntry): string {
-  const schema: JSONSchema = t.inputSchema;
+function renderMatch(t: UnifiedEntry): string {
   return (
-    `## ${t.qualifiedName}\n` +
+    `## ${t.loadKey}\n` +
     `${t.description ?? '(no description)'}\n` +
-    `input_schema: ${JSON.stringify(schema)}`
+    `input_schema: ${JSON.stringify(t.schema)}`
   );
 }
 
 /**
- * Build the ToolSearch builtin. execute({query?,names?}) filters the deferred
- * registry's full catalog (substring match on qualifiedName/description, or an
- * exact names[] match), marks the matches loaded, and returns their schemas so
- * the model can call them on the next turn.
+ * Build the ONE ToolSearch builtin. execute({query?,names?}) filters the
+ * unified catalog — deferred MCP tools AND cold built-ins — by substring
+ * (name/description) or an exact names[] match, marks the matches loaded (one
+ * shared namespace), and returns their schemas so the model can call them on
+ * the next turn. A built-in and an MCP tool are loaded through the exact same
+ * path; the caller need not know which kind a name is.
  */
 export function makeToolSearchTool(reg: DeferredMcpRegistry): BuiltinTool {
   return {
@@ -179,7 +266,7 @@ export function makeToolSearchTool(reg: DeferredMcpRegistry): BuiltinTool {
         names: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Exact fully-qualified tool names to load.',
+          description: 'Exact tool names to load (MCP qualified names or built-in names).',
         },
       },
     },
@@ -187,21 +274,21 @@ export function makeToolSearchTool(reg: DeferredMcpRegistry): BuiltinTool {
       input: Record<string, unknown>,
       _ctx: ToolContext,
     ): Promise<ToolResultPayload> {
-      const catalog = reg.catalog();
+      const catalog = unifiedCatalog(reg);
       const names = Array.isArray(input.names)
         ? input.names.filter((n): n is string => typeof n === 'string')
         : undefined;
       const query = typeof input.query === 'string' ? input.query.trim() : '';
 
-      let matched: McpToolEntry[];
+      let matched: UnifiedEntry[];
       if (names !== undefined && names.length > 0) {
         const set = new Set(names);
-        matched = catalog.filter((t) => set.has(t.qualifiedName));
+        matched = catalog.filter((t) => set.has(t.loadKey));
       } else if (query.length > 0) {
         const q = query.toLowerCase();
         matched = catalog.filter(
           (t) =>
-            t.qualifiedName.toLowerCase().includes(q) ||
+            t.loadKey.toLowerCase().includes(q) ||
             (t.description ?? '').toLowerCase().includes(q),
         );
       } else {
@@ -213,7 +300,7 @@ export function makeToolSearchTool(reg: DeferredMcpRegistry): BuiltinTool {
         return { content: describeCatalog(catalog) };
       }
 
-      reg.markLoaded(matched.map((t) => t.qualifiedName));
+      reg.markLoaded(matched.map((t) => t.loadKey));
       const body = matched.map(renderMatch).join('\n\n');
       return {
         content:

--- a/projects/bpt-agent-sdk/tests/toolsearch-builtins.test.ts
+++ b/projects/bpt-agent-sdk/tests/toolsearch-builtins.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unified tool-search: deferring COLD BUILT-IN schemas (not just MCP tools)
+ * behind the ONE ToolSearch builtin, plus the 银芯/SVN-world variant.
+ *
+ * The pre-unification behavior deferred MCP tools only; built-in schemas were
+ * always advertised inline (the ~16k resident cost this reclaims). These tests
+ * pin the new, previously un-pinned invariants:
+ *  - a cold built-in's schema is withheld from the request while deferred, and
+ *    resurfaces the turn after a ToolSearch load (lazy load, one namespace);
+ *  - the drop-in default (toolSearch undefined) is byte-unchanged: no built-in
+ *    is deferred, no ToolSearch appears;
+ *  - the variant DISABLES EnterWorktree (removed, not merely deferred) while the
+ *    faithful createBuiltinTools() factory stays untouched.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  query,
+  silverCoreToolOptions,
+  DEFAULT_DEFERRED_BUILTINS,
+  type Options,
+  type Query,
+  type SDKMessage,
+} from '../src/index.js';
+import {
+  DeferredMcpRegistry,
+  makeToolSearchTool,
+  type DeferredBuiltinEntry,
+} from '../src/tools/toolsearch.js';
+import type { McpRegistry, McpToolEntry, ToolContext } from '../src/internal/contracts.js';
+import { makeSSEFetch, type SSEFetchStub } from './helpers/sse-fetch.js';
+import { textReplyEvents, toolUseReplyEvents } from './helpers/mock-transport.js';
+
+// ---------------------------------------------------------------------------
+// Unit: the cold-built-in surface of DeferredMcpRegistry (the unification seam)
+// ---------------------------------------------------------------------------
+
+function coldEntry(name: string): DeferredBuiltinEntry {
+  return { name, description: `${name} does ${name}`, inputSchema: { type: 'object', properties: {} } };
+}
+function mcpEntry(server: string, name: string): McpToolEntry {
+  return {
+    qualifiedName: `mcp__${server}__${name}`,
+    serverName: server,
+    toolName: name,
+    description: `${name} does ${name}`,
+    inputSchema: { type: 'object', properties: { x: { type: 'string' } } },
+  };
+}
+function fakeRegistry(tools: McpToolEntry[]): McpRegistry {
+  const set = new Set(tools.map((t) => t.qualifiedName));
+  return {
+    async connectAll() {},
+    statuses: () => [],
+    allTools: () => tools,
+    has: (q) => set.has(q),
+    async call() {
+      return { content: [{ type: 'text', text: 'ok' }] };
+    },
+    async listResources() {
+      return [];
+    },
+    async readResource() {
+      return [];
+    },
+    async reconnect() {},
+    setEnabled() {},
+    async setServers() {
+      return { servers: [] };
+    },
+    async closeAll() {},
+  };
+}
+const fakeCtx = {} as ToolContext;
+
+describe('DeferredMcpRegistry — cold built-ins', () => {
+  it('withholds a cold built-in only while active AND unloaded', () => {
+    const reg = new DeferredMcpRegistry(fakeRegistry([]));
+    reg.attachColdBuiltins([coldEntry('Workflow'), coldEntry('Monitor')]);
+    // Inactive: nothing is deferred (the exact pre-unification behavior).
+    expect(reg.isBuiltinDeferred('Workflow')).toBe(false);
+    reg.activateIfNeeded(true);
+    expect(reg.isActive()).toBe(true);
+    // Active + cold + unloaded -> withheld.
+    expect(reg.isBuiltinDeferred('Workflow')).toBe(true);
+    expect(reg.isBuiltinDeferred('Monitor')).toBe(true);
+    // A HOT built-in (never attached) is never deferred.
+    expect(reg.isBuiltinDeferred('Read')).toBe(false);
+    // Loading it (via ToolSearch) surfaces it from the next turn on.
+    reg.markLoaded(['Workflow']);
+    expect(reg.isBuiltinDeferred('Workflow')).toBe(false);
+    expect(reg.isBuiltinDeferred('Monitor')).toBe(true);
+  });
+
+  it('exposes cold built-ins in the searchable catalog even with zero MCP tools', () => {
+    const reg = new DeferredMcpRegistry(fakeRegistry([]));
+    expect(reg.hasDeferrableTools()).toBe(false);
+    reg.attachColdBuiltins([coldEntry('Workflow')]);
+    expect(reg.hasDeferrableTools()).toBe(true);
+    expect(reg.coldBuiltinCatalog().map((e) => e.name)).toEqual(['Workflow']);
+  });
+
+  it('ToolSearch loads a cold built-in and an MCP tool through ONE shared path', async () => {
+    const reg = new DeferredMcpRegistry(fakeRegistry([mcpEntry('gh', 'issue')]), {});
+    reg.attachColdBuiltins([coldEntry('Workflow')]);
+    reg.activateIfNeeded(true);
+    const ts = makeToolSearchTool(reg);
+
+    // Exact-name load of a built-in.
+    const r1 = await ts.execute({ names: ['Workflow'] }, fakeCtx);
+    expect(r1.content as string).toContain('Workflow');
+    expect(r1.content as string).toContain('input_schema');
+    expect(reg.isBuiltinDeferred('Workflow')).toBe(false);
+
+    // Substring query spanning both kinds (the shared `loaded` namespace).
+    const r2 = await ts.execute({ query: 'issue' }, fakeCtx);
+    expect(r2.content as string).toContain('mcp__gh__issue');
+    expect(reg.allTools().map((t) => t.qualifiedName)).toContain('mcp__gh__issue');
+
+    // No match still guides.
+    const r3 = await ts.execute({ query: 'nonexistent-zzz' }, fakeCtx);
+    expect(r3.content as string).toContain('No tools matched');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// e2e: request-shape contract through query()
+// ---------------------------------------------------------------------------
+
+let cwd: string;
+let sessionDir: string;
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'tsb-'));
+  sessionDir = join(cwd, '.sessions');
+});
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await rm(cwd, { recursive: true, force: true });
+});
+
+function baseOptions(extra: Partial<Options> = {}): Options {
+  return {
+    provider: { apiKey: 'test-key', promptCaching: false },
+    sessionDir,
+    cwd,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    ...extra,
+  };
+}
+function stub(scripts: ReadonlyArray<readonly object[]>): SSEFetchStub {
+  const s = makeSSEFetch(scripts);
+  vi.stubGlobal('fetch', s);
+  return s;
+}
+async function drain(q: Query): Promise<SDKMessage[]> {
+  const out: SDKMessage[] = [];
+  for await (const m of q) out.push(m);
+  return out;
+}
+const toolNames = (body: Record<string, unknown>): string[] =>
+  Array.isArray(body.tools) ? body.tools.map((t: { name?: string }) => t.name).filter(Boolean) : [];
+
+const HOT = ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'] as const;
+
+describe('query() — unified built-in deferral', () => {
+  it('toolSearch:true defers the cold built-in schemas even with zero MCP servers', async () => {
+    const f = stub([textReplyEvents('ok')]);
+    await drain(query({ prompt: 'hi', options: baseOptions({ toolSearch: true }) }));
+    const names = toolNames(f.requests[0]!.body);
+    // ToolSearch is the loader — always inline.
+    expect(names).toContain('ToolSearch');
+    // The reflexively-used core stays hot.
+    expect(names).toEqual(expect.arrayContaining([...HOT]));
+    // The cold set is withheld from the first request.
+    for (const cold of ['Workflow', 'Monitor', 'WebFetch', 'WebSearch', 'ExitPlanMode', 'TaskCreate']) {
+      expect(names).not.toContain(cold);
+    }
+  });
+
+  it('the default path (toolSearch undefined) is byte-unchanged: no deferral, no ToolSearch', async () => {
+    const f = stub([textReplyEvents('ok')]);
+    await drain(query({ prompt: 'hi', options: baseOptions() }));
+    const names = toolNames(f.requests[0]!.body);
+    expect(names).not.toContain('ToolSearch');
+    // Every built-in is advertised inline, exactly as before.
+    expect(names).toContain('Workflow');
+    expect(names).toContain('Monitor');
+    expect(names).toContain('WebFetch');
+  });
+
+  it('cuts the advertised tool count vs the inline default', async () => {
+    const fDefault = stub([textReplyEvents('ok')]);
+    await drain(query({ prompt: 'hi', options: baseOptions() }));
+    const defaultCount = toolNames(fDefault.requests[0]!.body).length;
+
+    const fLean = stub([textReplyEvents('ok')]);
+    await drain(query({ prompt: 'hi', options: baseOptions({ toolSearch: true }) }));
+    const leanCount = toolNames(fLean.requests[0]!.body).length;
+
+    // Most of the built-in set is cold, so the request shrinks substantially.
+    expect(leanCount).toBeLessThan(defaultCount);
+    expect(defaultCount - leanCount).toBeGreaterThanOrEqual(10);
+  });
+
+  it('a ToolSearch load surfaces the built-in schema on the NEXT request', async () => {
+    const f = stub([
+      toolUseReplyEvents('ToolSearch', { names: ['Workflow'] }, { id: 'tu1' }),
+      textReplyEvents('done'),
+    ]);
+    await drain(query({ prompt: 'hi', options: baseOptions({ toolSearch: true }) }));
+    // Turn 1: Workflow withheld.
+    expect(toolNames(f.requests[0]!.body)).not.toContain('Workflow');
+    // Turn 2 (after the ToolSearch load): Workflow's schema is now advertised.
+    expect(toolNames(f.requests[1]!.body)).toContain('Workflow');
+  });
+});
+
+describe('silverCoreToolOptions — the SVN-world variant', () => {
+  it('returns the opt-in bundle (worktree disabled by default)', () => {
+    expect(silverCoreToolOptions()).toEqual({
+      toolSearch: true,
+      disallowedTools: ['EnterWorktree'],
+    });
+    expect(silverCoreToolOptions({ disableWorktree: false })).toEqual({ toolSearch: true });
+  });
+
+  it('DISABLES EnterWorktree (removed, not loadable) while Workflow stays DEFERRED (loadable)', async () => {
+    const f = stub([
+      toolUseReplyEvents('ToolSearch', { names: ['EnterWorktree', 'Workflow'] }, { id: 'tu1' }),
+      textReplyEvents('done'),
+    ]);
+    await drain(query({ prompt: 'hi', options: baseOptions({ ...silverCoreToolOptions() }) }));
+
+    const names0 = toolNames(f.requests[0]!.body);
+    expect(names0).toContain('ToolSearch');
+    expect(names0).not.toContain('EnterWorktree'); // removed
+    expect(names0).not.toContain('Workflow'); // deferred
+
+    // ToolSearch can load the DEFERRED tool but not the REMOVED one.
+    const names1 = toolNames(f.requests[1]!.body);
+    expect(names1).toContain('Workflow');
+    expect(names1).not.toContain('EnterWorktree');
+  });
+});
+
+describe('DEFAULT_DEFERRED_BUILTINS', () => {
+  it('leads with the largest schema and keeps the reflexive core hot', () => {
+    expect(DEFAULT_DEFERRED_BUILTINS[0]).toBe('Workflow');
+    for (const hot of [...HOT, 'Agent', 'AskUserQuestion', 'ToolSearch']) {
+      expect(DEFAULT_DEFERRED_BUILTINS).not.toContain(hot);
+    }
+  });
+});


### PR DESCRIPTION
## 概述

把 tool-search 惰性加载从「只 defer MCP 工具」扩到「统一 defer 冷内置工具 schema」。原本内置工具 schema 每轮全量写入请求（约 16k token，每开新对话冷写一次、且新对话下提示缓存不摊销——单个最大固定请求成本）。现由**同一个** `ToolSearch` 内置经**同一个** `DeferredMcpRegistry`、**同一个** loaded 命名空间、**同一份**目录搜索并按需加载冷内置集。`Workflow`（约 4.9k token，最大内置 schema）领衔冷集。

守密人四条裁定对应实现：**(1) 统一**——单一 defer 面覆盖内置 + MCP；**(2) 原厂不变 + 变种入口**——`createBuiltinTools()` 忠实工厂一字未动，新增 `silverCoreToolOptions()` 变种经既有 `disallowedTools` 口子移除 EnterWorktree（SVN 世界不可用，是移除非 defer）；**(3) 不瘦 Workflow 描述**——defer 已在未用时withhold 其 schema，瘦身冒忠实性险而收益边际；**(4) Workflow 判冷**——领衔冷集。

## 变更类型

- [x] Bug 修复 / 工程改进（子项目 `projects/bpt-agent-sdk/` SDK 能力扩展）
- [ ] 其他

## 来源声明

不适用：本 PR 为纯工程代码改动（TypeScript SDK），不含任何游戏数据 / Wiki / 翻译内容，无外部来源需追溯。

## 安全声明

- [x] 本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据；改动全部为 `projects/bpt-agent-sdk/` 内 SDK 源码与测试。
- [x] 未上传任何内部资产 / 解包原始文件 / 未公开草稿。
- [x] 同意按 MIT License 提交。

## 验证清单

- [x] 类型检查通过：`npm run typecheck`（tsc --noEmit 干净）
- [x] 构建通过：`npm run build`
- [x] 全量单测通过：`npm test` → **68 文件 / 1527 通过 / 2 skipped / 0 失败**（含新增 `tests/toolsearch-builtins.test.ts` 10 用例）
- [x] 版本递增守卫通过：`node scripts/check-version-bump.mjs`（0.33.0 → **0.34.0**，新能力 minor bump + CHANGELOG 落账）
- [x] 未引入 emoji（CLAUDE.md 硬约束）
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md` 等归主控台档案

## 关键设计不变量（回归护栏）

- **默认档字节不变**：`toolSearch` 未设 → 内置零 defer、无 ToolSearch，MCP 阈值 defer 逻辑不动。conformance wire 参照面（`toolNames`/`toolCount` 本就排除在 ratchet 外）零扰动。
- **defer ≠ 移除**：冷内置仍留在 `createBuiltinTools()` map（所有「Monitor/Workflow/EnterWorktree/Task 必须在」的现存断言照过），仅从请求 `tools[]` withhold；被调用仍执行（has()-stays-true，省上下文非权限门），ToolSearch 加载后下一轮浮现 schema。
- **开关语义**：`toolSearch: true` 开统一 defer（零 MCP 服务器也生效）；`toolSearch: false` 全关；`undefined` 维持现状。

## 主要文件

- `src/tools/toolsearch.ts`：`DeferredMcpRegistry` 冷内置面（`attachColdBuiltins` / `isBuiltinDeferred` / `coldBuiltinCatalog` / `hasDeferrableTools`）；ToolSearch 搜统一目录。
- `src/engine/loop.ts`：`buildToolDefs()` 每轮过滤冷内置。
- `src/tools/index.ts`：`DEFAULT_DEFERRED_BUILTINS` 冷集 + `silverCoreToolOptions()` 变种入口。
- `src/query.ts`：`toolSearch:true` 下即便零 MCP 也构建 deferred 注册表 + 挂载冷集 + 接线 `EngineDeps.isBuiltinDeferred`。
- `src/internal/contracts.ts`：`EngineDeps.isBuiltinDeferred` 钩子。
- `tests/toolsearch-builtins.test.ts`：新增 10 用例（单元 + e2e）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3VuoqyPCmPf3dgSQQ2KbD

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3VuoqyPCmPf3dgSQQ2KbD)_