### PR TITLE
fix(sdk): retry empty stream (HTTP 200, zero SSE events) instead of crashing the turn

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,56 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.36.0 — 2026-07-09
+
+**Retry an empty stream (HTTP 200, zero SSE events) instead of crashing the turn**
+(black-pool request). Under concurrent fan-out the idealab gateway occasionally
+answered a request with HTTP 200 but a body that closed with ZERO SSE events —
+not even `message_start`. The transport's streaming loop `for await`-ed nothing,
+returned normally, and the engine fell through to `accumulator.finalize()`, which
+threw a raw `Protocol error: finalize before message_start` OUTSIDE the streaming
+try/catch — an uncaught crash of the whole `query()` turn. Subagents run on the
+same transport out of reach of any host-level retry, so a fan-out child that hit
+this died outright (the black-pool `streamSdkPinned` symptom patch only covered
+the main conversation).
+
+- **root cause: empty stream ≠ mid-stream truncation.** A drop *after* events
+  (`eventCount > 0`) is a truncated turn — never replayable, salvaged by E3. An
+  empty stream (`eventCount === 0`) is a replay-SAFE non-start: zero events
+  consumed, zero yielded. It had no dedicated handling and fell to finalize's
+  raw throw.
+- **fix: transport-internal empty-stream retry.** `AnthropicTransport.streamRequest`
+  now wraps the request+stream in a retry loop: a stream that ends with zero
+  events is re-issued (exponential backoff + jitter, honoring the caller abort),
+  bounded by the same `maxRetries` budget. Because the retry lives INSIDE the
+  transport, both the main conversation AND subagents self-heal with no host
+  involvement. The transport now NEVER returns a zero-event stream normally —
+  it either heals to a real stream or, on budget exhaustion, throws a
+  retryable-class `APIConnectionError` with the new stable code `empty_stream`
+  (message: "empty stream (HTTP 200, zero SSE events) after N attempt(s)"). The
+  finalize raw-throw is therefore unreachable from empty streams even at
+  `maxRetries: 0`.
+- **observability: an empty-stream retry fires `onRetry`** with a network-level
+  shape (no HTTP status), so the loop emits an `api_retry` message exactly like a
+  dropped socket.
+- **new error code:** `empty_stream` added to the `ErrorCode` union (append-only;
+  attached by the transport at its throw site).
+- **unchanged:** normal streams, real mid-stream truncation (E3 salvage,
+  `eventCount > 0`), caller abort, and idle-watchdog timeout all keep their exact
+  behavior — a stalled stream (connected then silent) is still the idle
+  watchdog's job (`stream_idle_timeout`), distinct from an empty stream (closed
+  at once with no event).
+- **deferred (deliberate scope):** the related "subagent stuck on a silent
+  stream" ask — a shorter, per-loop/per-subagent `streamIdleTimeoutMs` — is a
+  separate change to the `StreamRequest` contract + subagent runtime and is NOT
+  in this build. Filed as a follow-up; the current transport-wide
+  `streamIdleTimeoutMs` (default 300000ms) is unchanged.
+- Tests: `tests/transport.test.ts` (empty-stream retry + heal, exhaustion →
+  `empty_stream`, `maxRetries: 0` still throws not returns, `onRetry` shape,
+  abort-during-backoff); `tests/engine.test.ts` (end-to-end: an empty first
+  stream self-heals and the loop yields the assistant reply — the black-pool
+  crash regression). Full suite 1554 pass / 2 skip (rebased onto 0.35.0's
+  OpenAI translating transport; no interaction).
 ## 0.35.0 — 2026-07-09
 
 **OpenAI protocol support** (`provider.protocol: 'openai-chat'`, BPT-EXTENSION).

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/errors.ts
+++ b/projects/bpt-agent-sdk/src/errors.ts
@@ -34,16 +34,21 @@ export type McpErrorCode =
   | 'mcp_unknown_server';
 
 /**
- * All stable error codes. The two `APIConnectionError` scenario codes
- * (`sse_malformed_frame`, `stream_idle_timeout`) are defined here for the
- * transport layer to attach at its throw sites; until wired, transport errors
- * carry the class default `api_connection_failed`.
+ * All stable error codes. The three `APIConnectionError` scenario codes
+ * (`sse_malformed_frame`, `stream_idle_timeout`, `empty_stream`) are defined
+ * here for the transport layer to attach at its throw sites; until wired,
+ * transport errors carry the class default `api_connection_failed`.
  */
 export type ErrorCode =
   | 'aborted'
   | 'api_connection_failed'
   | 'sse_malformed_frame'
   | 'stream_idle_timeout'
+  /** HTTP 200 but the SSE body carried zero events (not even message_start) —
+   *  a replay-safe non-start (observed as an upstream-throttle shape under
+   *  concurrent fan-out). The transport retries internally; this code surfaces
+   *  only after the retry budget is exhausted. */
+  | 'empty_stream'
   | 'api_status_error'
   | 'not_implemented'
   | 'config_invalid'
@@ -74,7 +79,10 @@ export class APIConnectionError extends Error {
     override readonly cause?: unknown,
     code: Extract<
       ErrorCode,
-      'api_connection_failed' | 'sse_malformed_frame' | 'stream_idle_timeout'
+      | 'api_connection_failed'
+      | 'sse_malformed_frame'
+      | 'stream_idle_timeout'
+      | 'empty_stream'
     > = 'api_connection_failed',
   ) {
     super(message);

--- a/projects/bpt-agent-sdk/src/transport/anthropic.ts
+++ b/projects/bpt-agent-sdk/src/transport/anthropic.ts
@@ -145,112 +145,162 @@ export class AnthropicTransport implements Transport {
     const timeoutMs = this.provider.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const maxRetries = resolveMaxRetries(this.provider, this.env);
 
-    // ---- request phase: retries allowed -----------------------------------
-    const { response, signal, timeoutSignal } = await this.requestWithRetries(
-      bodyJson,
-      headers,
-      callerSignal,
-      timeoutMs,
-      maxRetries,
-      onRetry,
-    );
-
-    // ---- streaming phase: NEVER retried ------------------------------------
-    const requestId = response.headers.get('request-id') ?? undefined;
-    if (!response.body) {
-      throw new APIConnectionError('Messages API response has no body');
-    }
-    // Idle watchdog: abort a silently-stalled stream after `idleMs` with no
-    // server event — faster and more diagnosable than the whole-request
-    // timeout. Anthropic emits periodic `ping` events, so a gap this long means
-    // the connection is stuck. `0` disables. Official env analogs
-    // (CLAUDE_ENABLE_STREAM_WATCHDOG / CLAUDE_STREAM_IDLE_TIMEOUT_MS) are
-    // honored below the provider option. (Design ref: Codex
-    // `stream_idle_timeout`; reimplemented, no code copied.)
-    const idleMs = resolveStreamIdleMs(this.provider, this.env);
-    const idleController = idleMs > 0 ? new AbortController() : undefined;
-    const streamSignal = idleController
-      ? AbortSignal.any([signal, idleController.signal])
-      : signal;
-    let idleTimer: ReturnType<typeof setTimeout> | undefined;
-    const resetIdle = (): void => {
-      if (!idleController) return;
-      if (idleTimer) clearTimeout(idleTimer);
-      idleTimer = setTimeout(() => idleController.abort(), idleMs);
-      // Don't let the watchdog alone keep the process alive.
-      (idleTimer as { unref?: () => void }).unref?.();
-    };
-    let eventCount = 0;
-    try {
-      resetIdle();
-      for await (const frame of parseSSE(response.body, streamSignal)) {
-        resetIdle();
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(frame.data);
-        } catch (err) {
-          // Anthropic-native frames ALWAYS carry an event name. An event-less
-          // frame that is not JSON is foreign framing noise from a translating
-          // gateway - the canonical case is an OpenAI-style `data: [DONE]`
-          // terminator appended after the Anthropic event stream (observed on
-          // a corporate gateway's /api/anthropic endpoint, 2026-07-05). The
-          // official client never trips on it because it stops consuming at
-          // message_stop; skipping here aligns tolerance without loosening
-          // anything on real Anthropic frames.
-          if (frame.event === undefined) {
-            this.debug(
-              `transport: skipping event-less non-JSON SSE frame after ${eventCount} event(s): ` +
-                frame.data.slice(0, 120),
-            );
-            continue;
-          }
-          throw new APIConnectionError(
-            `Malformed SSE payload for event "${frame.event}" after ${eventCount} event(s): ` +
-              frame.data.slice(0, 120),
-            err,
-            'sse_malformed_frame',
-          );
-        }
-        if (frame.event === 'error' || isErrorPayload(parsed)) {
-          const info = extractErrorPayload(parsed) ?? {
-            type: 'api_error',
-            message: frame.data,
-          };
-          throw new APIStatusError(
-            statusForErrorType(info.type),
-            info.type,
-            info.message,
-            requestId,
-          );
-        }
-        eventCount += 1;
-        yield parsed as RawMessageStreamEvent;
-        // The Messages API streams exactly one message; message_stop is its
-        // terminal event. Stop consuming here - official-client lifecycle -
-        // so trailing gateway appendices (e.g. `data: [DONE]`) are never
-        // parsed at all and the connection is released promptly. parseSSE's
-        // finally cancels the underlying reader on early return.
-        if ((parsed as { type?: string }).type === 'message_stop') {
-          this.debug(
-            `transport: stream completed at message_stop after ${eventCount} event(s)`,
-          );
-          return;
-        }
-      }
-    } catch (err) {
-      throw mapStreamError(
-        err,
+    // Empty-stream retry: an HTTP 200 whose SSE body carries ZERO events (not
+    // even message_start) before closing is a replay-SAFE non-start — the
+    // gateway accepted the request but delivered nothing (an observed idealab
+    // throttle shape under concurrent fan-out). Unlike a mid-stream drop (which
+    // must never replay a partially consumed turn), zero events means zero
+    // consumption, so re-issuing the whole request is safe. We retry it HERE,
+    // inside the transport, so BOTH the main conversation and subagents (which
+    // run on this same transport, out of reach of any host-level retry) self-
+    // heal without the caller ever seeing the empty stream. Bounded by the same
+    // maxRetries budget; on exhaustion we surface a retryable-class
+    // `empty_stream` APIConnectionError rather than returning a zero-event
+    // stream and letting the engine fall through to accumulator.finalize()'s
+    // raw `Protocol error: finalize before message_start`.
+    let emptyStreamRetries = 0;
+    for (;;) {
+      // ---- request phase: retries allowed ---------------------------------
+      const { response, signal, timeoutSignal } = await this.requestWithRetries(
+        bodyJson,
+        headers,
         callerSignal,
-        timeoutSignal,
         timeoutMs,
-        eventCount,
-        idleController?.signal,
-        idleMs,
+        maxRetries,
+        onRetry,
       );
-    } finally {
-      if (idleTimer) clearTimeout(idleTimer);
+
+      // ---- streaming phase: NEVER retried once an event is delivered -------
+      const requestId = response.headers.get('request-id') ?? undefined;
+      if (!response.body) {
+        throw new APIConnectionError('Messages API response has no body');
+      }
+      // Idle watchdog: abort a silently-stalled stream after `idleMs` with no
+      // server event — faster and more diagnosable than the whole-request
+      // timeout. Anthropic emits periodic `ping` events, so a gap this long
+      // means the connection is stuck. `0` disables. Official env analogs
+      // (CLAUDE_ENABLE_STREAM_WATCHDOG / CLAUDE_STREAM_IDLE_TIMEOUT_MS) are
+      // honored below the provider option. (Design ref: Codex
+      // `stream_idle_timeout`; reimplemented, no code copied.) A STALLED stream
+      // (connected, then silent) is distinct from an EMPTY one (closed at once,
+      // no event): the watchdog handles the former, the eventCount check below
+      // handles the latter.
+      const idleMs = resolveStreamIdleMs(this.provider, this.env);
+      const idleController = idleMs > 0 ? new AbortController() : undefined;
+      const streamSignal = idleController
+        ? AbortSignal.any([signal, idleController.signal])
+        : signal;
+      let idleTimer: ReturnType<typeof setTimeout> | undefined;
+      const resetIdle = (): void => {
+        if (!idleController) return;
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => idleController.abort(), idleMs);
+        // Don't let the watchdog alone keep the process alive.
+        (idleTimer as { unref?: () => void }).unref?.();
+      };
+      let eventCount = 0;
+      try {
+        resetIdle();
+        for await (const frame of parseSSE(response.body, streamSignal)) {
+          resetIdle();
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(frame.data);
+          } catch (err) {
+            // Anthropic-native frames ALWAYS carry an event name. An event-less
+            // frame that is not JSON is foreign framing noise from a translating
+            // gateway - the canonical case is an OpenAI-style `data: [DONE]`
+            // terminator appended after the Anthropic event stream (observed on
+            // a corporate gateway's /api/anthropic endpoint, 2026-07-05). The
+            // official client never trips on it because it stops consuming at
+            // message_stop; skipping here aligns tolerance without loosening
+            // anything on real Anthropic frames.
+            if (frame.event === undefined) {
+              this.debug(
+                `transport: skipping event-less non-JSON SSE frame after ${eventCount} event(s): ` +
+                  frame.data.slice(0, 120),
+              );
+              continue;
+            }
+            throw new APIConnectionError(
+              `Malformed SSE payload for event "${frame.event}" after ${eventCount} event(s): ` +
+                frame.data.slice(0, 120),
+              err,
+              'sse_malformed_frame',
+            );
+          }
+          if (frame.event === 'error' || isErrorPayload(parsed)) {
+            const info = extractErrorPayload(parsed) ?? {
+              type: 'api_error',
+              message: frame.data,
+            };
+            throw new APIStatusError(
+              statusForErrorType(info.type),
+              info.type,
+              info.message,
+              requestId,
+            );
+          }
+          eventCount += 1;
+          yield parsed as RawMessageStreamEvent;
+          // The Messages API streams exactly one message; message_stop is its
+          // terminal event. Stop consuming here - official-client lifecycle -
+          // so trailing gateway appendices (e.g. `data: [DONE]`) are never
+          // parsed at all and the connection is released promptly. parseSSE's
+          // finally cancels the underlying reader on early return.
+          if ((parsed as { type?: string }).type === 'message_stop') {
+            this.debug(
+              `transport: stream completed at message_stop after ${eventCount} event(s)`,
+            );
+            return;
+          }
+        }
+      } catch (err) {
+        throw mapStreamError(
+          err,
+          callerSignal,
+          timeoutSignal,
+          timeoutMs,
+          eventCount,
+          idleController?.signal,
+          idleMs,
+        );
+      } finally {
+        if (idleTimer) clearTimeout(idleTimer);
+      }
+
+      // The stream ended without a terminal message_stop. Zero events => the
+      // body was empty (replay-safe): retry the whole request within the shared
+      // budget instead of returning an unusable zero-event stream. Any caller
+      // abort observed here wins over the retry.
+      if (eventCount === 0) {
+        if (callerSignal?.aborted) throw new AbortError();
+        if (emptyStreamRetries < maxRetries) {
+          emptyStreamRetries += 1;
+          this.debug(
+            `transport: empty stream (HTTP 200, zero SSE events); ` +
+              `retry ${emptyStreamRetries}/${maxRetries}`,
+          );
+          // Surface it like a network-level retry (no HTTP status) so the loop
+          // emits an api_retry observability message, same as a dropped socket.
+          onRetry?.({ attempt: emptyStreamRetries, maxRetries });
+          await this.backoff(emptyStreamRetries, undefined, callerSignal);
+          continue;
+        }
+        throw new APIConnectionError(
+          `Messages API returned an empty stream (HTTP 200, zero SSE events) ` +
+            `after ${emptyStreamRetries + 1} attempt(s)`,
+          undefined,
+          'empty_stream',
+        );
+      }
+
+      // A non-empty stream that ended without message_stop (server closed after
+      // delivering some events): complete normally — the engine finalizes /
+      // salvages whatever arrived. Unchanged from the original single attempt.
+      this.debug(`transport: stream completed after ${eventCount} event(s)`);
+      return;
     }
-    this.debug(`transport: stream completed after ${eventCount} event(s)`);
   }
 
   /**

--- a/projects/bpt-agent-sdk/tests/engine.test.ts
+++ b/projects/bpt-agent-sdk/tests/engine.test.ts
@@ -4,9 +4,10 @@
  * hook runner and MCP registry are minimal recordable fakes.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageAccumulator } from '../src/engine/accumulator.js';
+import { AnthropicTransport } from '../src/transport/anthropic.js';
 import {
   addUsage,
   estimateCostUsd,
@@ -53,6 +54,7 @@ import {
   textReplyEvents,
   toolUseReplyEvents,
 } from './helpers/mock-transport.js';
+import { makeSSEFetch } from './helpers/sse-fetch.js';
 import { stampSigningModel } from '../src/engine/thinking-provenance.js';
 
 // ---------------------------------------------------------------------------
@@ -598,6 +600,50 @@ describe('pricing', () => {
 // ---------------------------------------------------------------------------
 // runAgentLoop
 // ---------------------------------------------------------------------------
+
+describe('runAgentLoop empty-stream self-heal (transport-level retry)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // Regression for the idealab concurrent-fan-out crash: an HTTP 200 with a
+  // zero-event SSE body used to fall through to accumulator.finalize() and
+  // throw a raw `Protocol error: finalize before message_start`, crashing the
+  // turn (and, for subagents on the same transport, the whole child). The
+  // transport now retries the replay-safe empty stream internally, so the loop
+  // self-heals with no host involvement.
+  it('an empty first stream self-heals: the loop retries and yields the assistant reply', async () => {
+    // Pin backoff jitter so the single empty-stream retry waits ~500ms.
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    // 1st fetch: 200 + empty SSE body (zero events). 2nd: a normal text reply.
+    const fetch = makeSSEFetch([[], textReplyEvents('Hello world')]);
+    vi.stubGlobal('fetch', fetch);
+    const transport = new AnthropicTransport({
+      provider: { apiKey: 'k' },
+      env: {},
+      debug: () => {},
+    });
+    const deps = makeDeps(transport);
+    const history = [{ role: 'user' as const, content: 'hi' }];
+
+    const messages = await collect(runAgentLoop(history, deps, makeConfig()));
+
+    const assistant = messages.find((m) => m.type === 'assistant') as
+      | SDKAssistantMessage
+      | undefined;
+    expect(assistant).toBeDefined();
+    expect(assistant!.message.content).toEqual([{ type: 'text', text: 'Hello world' }]);
+    const result = lastResult(messages);
+    expect(result.subtype).toBe('success');
+    if (result.subtype === 'success') expect(result.result).toBe('Hello world');
+    // The empty stream + the healed retry = exactly two fetches, one turn.
+    expect(fetch.requests).toHaveLength(2);
+    expect(result.num_turns).toBe(1);
+    // The empty-stream retry surfaced an api_retry observability message.
+    expect(messages.some((m) => m.type === 'api_retry')).toBe(true);
+  });
+});
 
 describe('runAgentLoop', () => {
   it('happy path: yields assistant message then a success result', async () => {

--- a/projects/bpt-agent-sdk/tests/transport.test.ts
+++ b/projects/bpt-agent-sdk/tests/transport.test.ts
@@ -14,7 +14,7 @@ import {
   APIStatusError,
   ConfigurationError,
 } from '../src/errors.js';
-import type { StreamRequest } from '../src/internal/contracts.js';
+import type { RetryInfo, StreamRequest } from '../src/internal/contracts.js';
 import type { ProviderConfig, RawMessageStreamEvent } from '../src/types.js';
 import { textReplyEvents } from './helpers/mock-transport.js';
 
@@ -98,6 +98,19 @@ function sseResponse(text: string, headers: Record<string, string> = {}): Respon
     status: 200,
     headers: { 'content-type': 'text/event-stream', ...headers },
   });
+}
+
+/** A 200 response whose SSE body closes immediately with ZERO events - the
+ *  "HTTP 200 + empty stream" idealab-throttle shape. */
+function emptySseResponse(): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
 }
 
 /** Minimal successful stream body: ping + message_stop. */
@@ -789,6 +802,78 @@ describe('AnthropicTransport streaming', () => {
     expect(error).toBeInstanceOf(APIConnectionError);
     // idle disabled -> the whole-request timeout is the terminal cause.
     expect((error as Error).message).toMatch(/timed out after 40ms/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AnthropicTransport - empty-stream retry (idealab throttle self-heal)
+// ---------------------------------------------------------------------------
+
+describe('AnthropicTransport empty-stream retry', () => {
+  it('retries an empty stream (HTTP 200, zero SSE events) then completes on the healed retry', async () => {
+    // Pin backoff jitter so the single retry waits a deterministic ~500ms.
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const fetchMock = stubFetch([
+      () => emptySseResponse(), // 200, empty body -> replay-safe non-start
+      () => sseResponse(okSse()), // healed: a real stream
+    ]);
+    const t = makeTransport({ provider: { apiKey: 'k' } });
+    const events = await collect(t.stream(baseReq()));
+    expect(events).toEqual(OK_EVENTS);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('never returns normally on an empty stream: persistent empties exhaust the budget into an empty_stream APIConnectionError', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const fetchMock = stubFetch([
+      () => emptySseResponse(),
+      () => emptySseResponse(),
+    ]);
+    const t = makeTransport({ provider: { apiKey: 'k', maxRetries: 1 } });
+    const err = await captureError(collect(t.stream(baseReq())));
+    // The crux: a diagnosable retryable-class error, NOT a raw
+    // `Protocol error: finalize before message_start` bubbling out of the loop.
+    expect(err).toBeInstanceOf(APIConnectionError);
+    expect((err as APIConnectionError).code).toBe('empty_stream');
+    expect((err as Error).message).toMatch(/empty stream/i);
+    expect((err as Error).message).toMatch(/after 2 attempt\(s\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // initial + 1 retry
+  });
+
+  it('with maxRetries 0 an empty stream is not retried but STILL becomes empty_stream (finalize raw-throw is unreachable)', async () => {
+    const fetchMock = stubFetch([() => emptySseResponse()]);
+    const t = makeTransport({ provider: { apiKey: 'k', maxRetries: 0 } });
+    const err = await captureError(collect(t.stream(baseReq())));
+    expect(err).toBeInstanceOf(APIConnectionError);
+    expect((err as APIConnectionError).code).toBe('empty_stream');
+    expect((err as Error).message).toMatch(/after 1 attempt\(s\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('an empty-stream retry fires onRetry with a network-level shape (no HTTP status), like a dropped socket', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    stubFetch([() => emptySseResponse(), () => sseResponse(okSse())]);
+    const t = makeTransport({ provider: { apiKey: 'k' } });
+    const retries: RetryInfo[] = [];
+    const events = await collect(
+      t.stream(baseReq({ onRetry: (info) => retries.push(info) })),
+    );
+    expect(events).toEqual(OK_EVENTS);
+    expect(retries).toHaveLength(1);
+    expect(retries[0]).toMatchObject({ attempt: 1 });
+    expect(retries[0]!.status).toBeUndefined();
+  });
+
+  it('a caller abort during the empty-stream backoff wins over the retry', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const fetchMock = stubFetch([() => emptySseResponse(), () => sseResponse(okSse())]);
+    const t = makeTransport({ provider: { apiKey: 'k' } });
+    const ac = new AbortController();
+    // Abort while the transport is backing off before the retry fetch.
+    const onRetry = (): void => ac.abort();
+    const err = await captureError(collect(t.stream(baseReq({ signal: ac.signal, onRetry }))));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // never reached the retry fetch
   });
 });
 


### PR DESCRIPTION
## 概述

黑池转派：`bpt-agent-sdk` 在并发 fan-out 下偶发崩溃 `Protocol error: finalize before message_start`。根因是 idealab 网关偶发返回 HTTP 200 但空 SSE 流（零事件、连 `message_start` 都没有就关闭）。本 PR 让 transport 把「空流」当可重试的 replay-safe 非启动来内部重试，主对话 + 子代理两条路径一起自愈，上层无感。版本 0.34.1 → 0.35.0。

**问题链**（小学生比喻：快递员按了门铃却递来一个空盒子——旧代码把空盒子当"没送到"处理，直接摔门崩溃；新代码认出这是"白跑一趟、重按一次门铃就行"）：
- 网关返 200 但流零事件 → transport 的 `for await` 一个事件都没读到、正常返回；
- 引擎落到 `accumulator.finalize()`（在 streaming try/catch **之外**）→ 因从未收到 `message_start` 抛裸 `Protocol error`；
- 该抛出不被 E3 salvage 接住 → 未捕获冒泡 → 崩掉本轮 query；子代理跑在同一 transport、上层够不着 → 子代理直接崩，黑池无法拦截重试。

**修法**（transport 层内部重试，首选方案）：
- 空流（`eventCount === 0`）= 零消费、replay 安全，与「中途截断」（`eventCount > 0`、E3 salvage）本质不同；
- `AnthropicTransport.streamRequest` 把「请求 + 流式消费」包进重试循环，零事件流按同一 `maxRetries` 预算退避重试（尊重 caller abort）；
- transport **绝不再正常返回零事件流**——要么自愈成正常流，要么重试耗尽抛可重试类 `APIConnectionError`（新稳定码 `empty_stream`）→ finalize 裸抛对空流**不可达**（连 `maxRetries: 0` 也是抛干净错而非返回空流）；
- 空流重试触发 `onRetry`（网络级形态、无 HTTP status）→ loop 发 `api_retry` 观测消息，与断 socket 一致。

---

## 变更类型

- [x] Bug 修复
- [ ] 其他（工程产物 `projects/bpt-agent-sdk`，非游戏数据）

---

## 来源声明

> 本 PR 为 SDK 工程代码修复，**不涉及任何游戏数据 / Wiki / 翻译 / 图片**，故公开来源 URL 不适用。缺陷现象与根因由黑池（Light 转派）提供，修复为银芯自有 SDK 源码。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 改动仅为银芯自有 `bpt-agent-sdk` 源码 + 测试 + CHANGELOG，与 §1.1-HC 防火墙同向（银芯→黑池单向输出，黑池不回流）。
- [x] **不上传内部美术资产 / 客户端解包原始文件 / 未公开剧情草稿。** 本 PR 无任何此类内容。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `npm run typecheck`（tsc）exit 0
- [x] 全量单测 `npx vitest run`：**68 文件 / 1533 通过 / 2 跳过（既有）/ 0 失败**
- [x] 新增回归：transport 层（空流重试并自愈 / 持续空流耗尽 → `empty_stream` / `maxRetries: 0` 仍抛不返回 / `onRetry` 形态 / 退避期 abort 优先）；engine 层端到端（空首流自愈、loop 正常吐出助手回复——即黑池崩溃回归）
- [x] 既有四路径行为不变：正常流 / 真·中途截断 E3 salvage（`eventCount > 0`）/ abort / idle 看门狗（stalled = 接通后静默，与空流的「立即关闭」区分）
- [x] 不引入 emoji
- [x] 未动 `memory/decisions.md` / `memory/lessons-learned.md`

**scope 说明**：黑池同批提出的「子代理卡住看门狗可按 loop/子代理维度配更短 idle」为**关联但不同**的问题，涉及 `StreamRequest` 契约 + 子代理运行时改造，**本 PR 未包含**，已作为后续项记入 CHANGELOG 0.35.0「deferred」条。当前 transport 级 `streamIdleTimeoutMs`（默认 300000ms）不变。

---

## 关联 Issue

- 无（黑池经守密人会话转派，无 GitHub issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5DodxW6FXXBY4e7RRMzR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5DodxW6FXXBY4e7RRMzR9)_