### PR TITLE
chore: rebuild OKF bundle (pointer concept for bpt-sdk OPENAI-PROTOCOL doc)

### DIFF
--- a/okf/assets/assets-archive-integrity.md
+++ b/okf/assets/assets-archive-integrity.md
@@ -4,7 +4,7 @@ title: "archive-integrity"
 description: "archive-integrity 事实数据"
 resource: "/assets/data/archive-integrity.json"
 tags: ["data_layer:curated", "fact-bible", "diagnostics", "snapshot"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/assets-card-system.md
+++ b/okf/assets/assets-card-system.md
@@ -4,7 +4,7 @@ title: "card-system"
 description: "card-system 事实数据"
 resource: "/assets/data/card-system.json"
 tags: ["data_layer:curated", "fact-bible"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/assets-chat-onboarding-snippet.md
+++ b/okf/assets/assets-chat-onboarding-snippet.md
@@ -4,7 +4,7 @@ title: "chat-onboarding-snippet"
 description: "你将分析【忘却前夜】（Morimens）的社区数据。所有原始数据托管在公开 GitHub 仓库 `lightproud/brain-in-a-vat`。请通过 raw.githubusercontent.com 直接 fetch 文件——不需要登录，无 rate limit 困扰下可自由读取。"
 resource: "/assets/data/chat-onboarding-snippet.md"
 tags: ["data_layer:curated", "fact-bible"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/assets-design-decisions.md
+++ b/okf/assets/assets-design-decisions.md
@@ -4,7 +4,7 @@ title: "design-decisions"
 description: "design-decisions 事实数据"
 resource: "/assets/data/design-decisions.json"
 tags: ["data_layer:curated", "fact-bible"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/assets-images.md
+++ b/okf/assets/assets-images.md
@@ -4,7 +4,7 @@ title: "公开图像资产"
 description: "立绘 / CG 等公开图像资产目录（10.0MB），二进制本体原地。"
 resource: "/assets/images/"
 tags: ["data_layer:curated", "fact-bible", "media:image"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/assets-interview-2026-04.md
+++ b/okf/assets/assets-interview-2026-04.md
@@ -4,7 +4,7 @@ title: "interview-2026-04"
 description: "interview-2026-04 事实数据（total_questions=53）"
 resource: "/assets/data/interview-2026-04.json"
 tags: ["data_layer:curated", "fact-bible"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/assets-narrative-structure.md
+++ b/okf/assets/assets-narrative-structure.md
@@ -4,7 +4,7 @@ title: "narrative-structure"
 description: "忘却前夜叙事结构数据库 — 事实圣经核心文件"
 resource: "/assets/data/narrative-structure.json"
 tags: ["data_layer:curated", "fact-bible"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/assets-readme.md
+++ b/okf/assets/assets-readme.md
@@ -4,7 +4,7 @@ title: "README"
 description: "python assets/data/validate.py"
 resource: "/assets/data/README.md"
 tags: ["data_layer:curated", "fact-bible"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/assets-sentinel-baseline.md
+++ b/okf/assets/assets-sentinel-baseline.md
@@ -4,7 +4,7 @@ title: "sentinel-baseline"
 description: "sentinel-baseline 事实数据"
 resource: "/assets/data/sentinel-baseline.json"
 tags: ["data_layer:curated", "fact-bible", "diagnostics", "snapshot"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/assets-version.md
+++ b/okf/assets/assets-version.md
@@ -4,7 +4,7 @@ title: "VERSION"
 description: "事实圣经 (Fact Bible)"
 resource: "/assets/data/VERSION.md"
 tags: ["data_layer:curated", "fact-bible"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/persona-erica-speech-canon.md
+++ b/okf/assets/persona-erica-speech-canon.md
@@ -4,7 +4,7 @@ title: "erica-speech-canon"
 description: "**接入银芯的 AI 使用建议**："
 resource: "/assets/data/character-personas/erica-speech-canon.md"
 tags: ["data_layer:curated", "persona", "character:erica"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/assets/persona-erica.md
+++ b/okf/assets/persona-erica.md
@@ -4,7 +4,7 @@ title: "erica"
 description: "erica 角色人格数据"
 resource: "/assets/data/character-personas/erica.json"
 tags: ["data_layer:curated", "persona", "character:erica"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-appstore.md
+++ b/okf/community/community-appstore.md
@@ -4,7 +4,7 @@ title: "appstore 社区全量档案"
 description: "appstore 平台全量档案层（分析镜头）：百级条（精确值见指针本体）/ 33 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/appstore/global/"
 tags: ["data_layer:full_archive", "platform:appstore", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-bilibili.md
+++ b/okf/community/community-bilibili.md
@@ -4,7 +4,7 @@ title: "bilibili 社区全量档案"
 description: "bilibili 平台全量档案层（分析镜头）：千级条（精确值见指针本体）/ 7 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/bilibili/"
 tags: ["data_layer:full_archive", "platform:bilibili", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-discord.md
+++ b/okf/community/community-discord.md
@@ -4,7 +4,7 @@ title: "discord 社区全量档案"
 description: "discord 平台全量档案层（分析镜头）：百万级条（精确值见指针本体）/ 35 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/discord/"
 tags: ["data_layer:full_archive", "platform:discord", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-google-play.md
+++ b/okf/community/community-google-play.md
@@ -4,7 +4,7 @@ title: "google_play 社区全量档案"
 description: "google_play 平台全量档案层（分析镜头）：千级条（精确值见指针本体）/ 32 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/google_play/global/"
 tags: ["data_layer:full_archive", "platform:google_play", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-index.md
+++ b/okf/community/community-index.md
@@ -4,7 +4,7 @@ title: "社区全量档案分析索引"
 description: "全量社区档案静态分析台账：百万级 条（精确值见指针本体）/ 14 平台，词典法零 ML。discord 全量历史 2026-06-21 de-tier 后永驻 git（Record/Community/discord/），直接读取，无需从 Rele"
 resource: "/projects/news/index/community_index.json"
 tags: ["data_layer:full_archive", "kind:analysis-index", "zero-ml"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-pixiv.md
+++ b/okf/community/community-pixiv.md
@@ -4,7 +4,7 @@ title: "pixiv 社区全量档案"
 description: "pixiv 平台全量档案层（分析镜头）：百级条（精确值见指针本体）/ 30 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/pixiv/"
 tags: ["data_layer:full_archive", "platform:pixiv", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-reddit.md
+++ b/okf/community/community-reddit.md
@@ -4,7 +4,7 @@ title: "reddit 社区全量档案"
 description: "reddit 平台全量档案层（分析镜头）：千级条（精确值见指针本体）/ 4 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/reddit/"
 tags: ["data_layer:full_archive", "platform:reddit", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-ruliweb.md
+++ b/okf/community/community-ruliweb.md
@@ -4,7 +4,7 @@ title: "ruliweb 社区全量档案"
 description: "ruliweb 平台全量档案层（分析镜头）：百级条（精确值见指针本体）/ 9 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/ruliweb/"
 tags: ["data_layer:full_archive", "platform:ruliweb", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-steam.md
+++ b/okf/community/community-steam.md
@@ -4,7 +4,7 @@ title: "steam 社区全量档案"
 description: "steam 平台全量档案层（分析镜头）：千级条（精确值见指针本体）/ 24 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/steam/global/review/"
 tags: ["data_layer:full_archive", "platform:steam", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-stopgame.md
+++ b/okf/community/community-stopgame.md
@@ -4,7 +4,7 @@ title: "stopgame 社区全量档案"
 description: "stopgame 平台全量档案层（分析镜头）：几十条或更少条（精确值见指针本体）/ 4 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/stopgame/"
 tags: ["data_layer:full_archive", "platform:stopgame", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-taptap.md
+++ b/okf/community/community-taptap.md
@@ -4,7 +4,7 @@ title: "taptap 社区全量档案"
 description: "taptap 平台全量档案层（分析镜头）：百级条（精确值见指针本体）/ 2 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/taptap/cn/post/"
 tags: ["data_layer:full_archive", "platform:taptap", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-timeline.md
+++ b/okf/community/community-timeline.md
@@ -4,7 +4,7 @@ title: "社区活动时序（全量）"
 description: "全量社区月度时序：2016-02..2026-07（81 月），vol_index 抓量异常（本月量÷前6月中位数）。"
 resource: "/projects/news/index/community_index.json"
 tags: ["data_layer:full_archive", "kind:timeseries", "zero-ml"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-weibo.md
+++ b/okf/community/community-weibo.md
@@ -4,7 +4,7 @@ title: "weibo 社区全量档案"
 description: "weibo 平台全量档案层（分析镜头）：千级条（精确值见指针本体）/ 4 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/weibo/"
 tags: ["data_layer:full_archive", "platform:weibo", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-weixin.md
+++ b/okf/community/community-weixin.md
@@ -4,7 +4,7 @@ title: "weixin 社区全量档案"
 description: "weixin 平台全量档案层（分析镜头）：千级条（精确值见指针本体）/ 57 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/weixin/"
 tags: ["data_layer:full_archive", "platform:weixin", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-youtube-comments.md
+++ b/okf/community/community-youtube-comments.md
@@ -4,7 +4,7 @@ title: "youtube_comments 社区全量档案"
 description: "youtube_comments 平台全量档案层（分析镜头）：千级条（精确值见指针本体）/ 4 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/youtube_comments/"
 tags: ["data_layer:full_archive", "platform:youtube_comments", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/community/community-youtube.md
+++ b/okf/community/community-youtube.md
@@ -4,7 +4,7 @@ title: "youtube 社区全量档案"
 description: "youtube 平台全量档案层（分析镜头）：千级条（精确值见指针本体）/ 15 个月。长窗口分析 / 情感长尾 / 完整性审计走此全量层。"
 resource: "/Public-Info-Pool/Record/Community/youtube/global/video/"
 tags: ["data_layer:full_archive", "platform:youtube", "lens:analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/extracted/extracted-art-assets.md
+++ b/okf/extracted/extracted-art-assets.md
@@ -4,7 +4,7 @@ title: "art_assets"
 description: "一手可读解包源「art_assets」：2 文件 / 2.6MB。processed/*.json 的上游权威（血缘：extracted 原始→processed 派生）。"
 resource: "/projects/wiki/data/extracted/art_assets/"
 tags: ["data_layer:full_archive", "first-hand-unpack", "upstream-of:processed", "content:art-assets"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/extracted/extracted-categorized.md
+++ b/okf/extracted/extracted-categorized.md
@@ -4,7 +4,7 @@ title: "categorized"
 description: "一手可读解包源「categorized」：14 文件 / 22.8MB。processed/*.json 的上游权威（血缘：extracted 原始→processed 派生）。"
 resource: "/projects/wiki/data/extracted/categorized/"
 tags: ["data_layer:full_archive", "first-hand-unpack", "upstream-of:processed", "content:categorized"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/extracted/extracted-lua-tables.md
+++ b/okf/extracted/extracted-lua-tables.md
@@ -4,7 +4,7 @@ title: "lua_tables"
 description: "一手可读解包源「lua_tables」：24 文件 / 18.7MB。processed/*.json 的上游权威（血缘：extracted 原始→processed 派生）。"
 resource: "/projects/wiki/data/extracted/lua_tables/"
 tags: ["data_layer:full_archive", "first-hand-unpack", "upstream-of:processed", "content:lua-tables"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/extracted/extracted-readme.md
+++ b/okf/extracted/extracted-readme.md
@@ -4,7 +4,7 @@ title: "extracted 说明"
 description: "游戏使用 **LuaT0** 自定义字节码格式（Lua 5.4 变体，format byte 0x30），配合 Themida 加壳保护解密算法。"
 resource: "/projects/wiki/data/extracted/README.md"
 tags: ["data_layer:curated", "documentation"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/kb_index.json
+++ b/okf/kb_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-09",
+  "generated": "2026-07-10",
   "meta": {
     "data_layer": "curated_knowledge",
     "source": "okf/ bundle (concept frontmatter + body + graph edges)",
@@ -7,13 +7,13 @@
     "tokenizer": "silver_tokenizer FMM（领域词典，零 ML）"
   },
   "stats": {
-    "concepts": 336,
+    "concepts": 337,
     "edges": 401,
-    "terms": 5805,
+    "terms": 5808,
     "by_type": {
       "character": 72,
       "dataset": 107,
-      "documentation": 94,
+      "documentation": 95,
       "knowledge-pointer": 43,
       "reference": 17,
       "research": 3
@@ -25,7 +25,7 @@
       "extracted": 4,
       "memory": 47,
       "news-output": 23,
-      "projects": 22,
+      "projects": 23,
       "resource": 71,
       "sources": 17,
       "story": 11,
@@ -34,7 +34,7 @@
     },
     "by_tier": {
       "skeleton": 128,
-      "search": 208
+      "search": 209
     }
   },
   "sections": {
@@ -64,7 +64,7 @@
     },
     "projects": {
       "index": "/projects/index.md",
-      "count": 22
+      "count": 23
     },
     "resource": {
       "index": "/resource/index.md",
@@ -2608,6 +2608,20 @@
       "title": "bpt-agent-sdk ONBOARDING",
       "description": "Goal: get a new maintainer from zero to \\\"I can make a change safely and prove",
       "resource": "/projects/bpt-agent-sdk/docs/ONBOARDING.md",
+      "tags": [
+        "data_layer:curated",
+        "design-doc",
+        "sub-project:bpt-agent-sdk"
+      ],
+      "section": "projects",
+      "tier": "search",
+      "degree": 0
+    },
+    "/projects/bpt-sdk-doc-openai-protocol.md": {
+      "type": "documentation",
+      "title": "bpt-agent-sdk OPENAI-PROTOCOL",
+      "description": "The SDK can drive an **OpenAI-compatible Chat Completions endpoint** instead of",
+      "resource": "/projects/bpt-agent-sdk/docs/OPENAI-PROTOCOL.md",
       "tags": [
         "data_layer:curated",
         "design-doc",
@@ -9410,6 +9424,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -9605,6 +9620,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/project-bpt-agent-sdk.md",
@@ -10116,6 +10132,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/project-bpt-agent-sdk.md",
@@ -10240,6 +10257,7 @@
     ],
     "chat": [
       "/assets/assets-chat-onboarding-snippet.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/resource/resource-proposal-bpt-sdk-openai-compat-wire-20260708.md"
     ],
     "ci": [
@@ -10418,7 +10436,8 @@
       "/resource/resource-proposal-bpt-sdk-openai-compat-wire-20260708.md"
     ],
     "compatible": [
-      "/projects/bpt-sdk-doc-architecture.md"
+      "/projects/bpt-sdk-doc-architecture.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md"
     ],
     "completion": [
       "/resource/resource-repo-engineering-bpt-agent-sdk-completion-audit-20260703.md",
@@ -10426,6 +10445,7 @@
       "/resource/resource-repo-engineering-bpt-sdk-completion-inventory-20260705.md"
     ],
     "completions": [
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/resource/resource-proposal-bpt-sdk-openai-compat-wire-20260708.md"
     ],
     "concept": [
@@ -10538,6 +10558,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -10849,6 +10870,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -11155,6 +11177,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -11431,6 +11454,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -11515,6 +11539,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -11527,6 +11552,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -11568,6 +11594,9 @@
     "drift": [
       "/projects/bpt-sdk-doc-compat.md"
     ],
+    "drive": [
+      "/projects/bpt-sdk-doc-openai-protocol.md"
+    ],
     "drop": [
       "/wiki-data/wiki-data-drops-by-item.md"
     ],
@@ -11602,6 +11631,9 @@
       "/unpacked/unpacked-sproto.md",
       "/unpacked/unpacked-text-cn.md",
       "/unpacked/unpacked-vue.md"
+    ],
+    "endpoint": [
+      "/projects/bpt-sdk-doc-openai-protocol.md"
     ],
     "engine": [
       "/projects/news-archive-sources-registry.md",
@@ -12424,6 +12456,9 @@
     "insights": [
       "/resource/resource-community-analysis-jp-discord-insights-202606.md"
     ],
+    "instead": [
+      "/projects/bpt-sdk-doc-openai-protocol.md"
+    ],
     "instructions": [
       "/memory/memory-ext-karpathy-coding-principles.md"
     ],
@@ -12764,6 +12799,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -13273,6 +13309,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -13630,6 +13667,7 @@
       "/resource/resource-repo-engineering-oss-cc-engine-designs-survey-20260704.md"
     ],
     "openai": [
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/resource/resource-proposal-bpt-sdk-openai-compat-wire-20260708.md"
     ],
     "orchestrated": [
@@ -14116,6 +14154,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/news-archive-sources-registry.md",
@@ -14165,6 +14204,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/news-archive-sources-registry.md",
@@ -14263,6 +14303,7 @@
       "/memory/contribution-protocol.md",
       "/memory/memory-ext-active-contribution-protocol.md",
       "/memory/memory-ext-bpt-guidance-protocol.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/resource/resource-repo-engineering-bpt-sdk-official-arm-protocol-profile-20260705.md"
     ],
     "prototype": [
@@ -14895,6 +14936,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/project-bpt-agent-sdk.md",
@@ -15263,6 +15305,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/news-archive-sources-registry.md",
@@ -16497,6 +16540,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -16748,6 +16792,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -17047,6 +17092,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -18193,6 +18239,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -19106,6 +19153,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -19353,6 +19401,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -21124,6 +21173,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -24187,6 +24237,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -24954,6 +25005,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -25552,6 +25604,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -29220,6 +29273,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -29745,6 +29799,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -30062,6 +30117,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -30442,6 +30498,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -30711,6 +30768,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -32323,6 +32381,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -32727,6 +32786,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -33277,6 +33337,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -33928,6 +33989,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -34297,6 +34359,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -40994,6 +41057,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -41640,6 +41704,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -42617,6 +42682,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -42855,6 +42921,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -44007,6 +44074,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/project-bpt-agent-sdk.md",
@@ -44278,6 +44346,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/project-bpt-agent-sdk.md",
@@ -44556,6 +44625,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -44855,6 +44925,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -45111,6 +45182,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -45173,6 +45245,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -45729,6 +45802,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/doc-testing-strategy.md",
@@ -46147,6 +46221,7 @@
       "/projects/bpt-sdk-doc-onboarding.md"
     ],
     "openai": [
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/resource/resource-proposal-bpt-sdk-openai-compat-wire-20260708.md"
     ],
     "orchestrated": [
@@ -46384,6 +46459,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/news-archive-sources-registry.md",
@@ -46421,6 +46497,7 @@
     ],
     "protocol": [
       "/memory/contribution-protocol.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/resource/resource-repo-engineering-bpt-sdk-official-arm-protocol-profile-20260705.md"
     ],
     "prototype": [
@@ -46621,6 +46698,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/project-bpt-agent-sdk.md",
@@ -46771,6 +46849,7 @@
       "/projects/bpt-sdk-doc-errors.md",
       "/projects/bpt-sdk-doc-migration.md",
       "/projects/bpt-sdk-doc-onboarding.md",
+      "/projects/bpt-sdk-doc-openai-protocol.md",
       "/projects/bpt-sdk-doc-positioning.md",
       "/projects/bpt-sdk-doc-subagents.md",
       "/projects/news-archive-sources-registry.md",

--- a/okf/news-output/news-output-all.md
+++ b/okf/news-output/news-output-all.md
@@ -4,7 +4,7 @@ title: "输出展示层 · 全平台聚合"
 description: "全平台最新快照聚合（抽样，非全量）。 抽样/展示用途，非全量档案层。"
 resource: "/projects/news/output/all-latest.json"
 tags: ["data_layer:output", "aggregate", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-appstore.md
+++ b/okf/news-output/news-output-appstore.md
@@ -4,7 +4,7 @@ title: "输出展示层 · appstore 最新快照"
 description: "appstore 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/appstore-latest.json"
 tags: ["data_layer:output", "platform:appstore", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-arca-live.md
+++ b/okf/news-output/news-output-arca-live.md
@@ -4,7 +4,7 @@ title: "输出展示层 · arca_live 最新快照"
 description: "arca_live 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/arca_live-latest.json"
 tags: ["data_layer:output", "platform:arca_live", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-bahamut.md
+++ b/okf/news-output/news-output-bahamut.md
@@ -4,7 +4,7 @@ title: "输出展示层 · bahamut 最新快照"
 description: "bahamut 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/bahamut-latest.json"
 tags: ["data_layer:output", "platform:bahamut", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-bilibili.md
+++ b/okf/news-output/news-output-bilibili.md
@@ -4,7 +4,7 @@ title: "输出展示层 · bilibili 最新快照"
 description: "bilibili 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/bilibili-latest.json"
 tags: ["data_layer:output", "platform:bilibili", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-discord.md
+++ b/okf/news-output/news-output-discord.md
@@ -4,7 +4,7 @@ title: "输出展示层 · discord 最新快照"
 description: "discord 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/discord-latest.json"
 tags: ["data_layer:output", "platform:discord", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-feed.md
+++ b/okf/news-output/news-output-feed.md
@@ -4,7 +4,7 @@ title: "输出展示层 · RSS/Atom 订阅"
 description: "24h 热点 RSS 2.0 订阅源。 抽样/展示用途，非全量档案层。"
 resource: "/projects/news/output/feed.xml"
 tags: ["data_layer:output", "aggregate", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-google-play.md
+++ b/okf/news-output/news-output-google-play.md
@@ -4,7 +4,7 @@ title: "输出展示层 · google_play 最新快照"
 description: "google_play 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/google_play-latest.json"
 tags: ["data_layer:output", "platform:google_play", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-newsjs.md
+++ b/okf/news-output/news-output-newsjs.md
@@ -4,7 +4,7 @@ title: "输出展示层 · 合并流"
 description: "合并全量层 news.json（构建期快照）。 抽样/展示用途，非全量档案层。"
 resource: "/projects/news/output/news.json"
 tags: ["data_layer:output", "aggregate", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-note-com.md
+++ b/okf/news-output/news-output-note-com.md
@@ -4,7 +4,7 @@ title: "输出展示层 · note_com 最新快照"
 description: "note_com 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/note_com-latest.json"
 tags: ["data_layer:output", "platform:note_com", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-official.md
+++ b/okf/news-output/news-output-official.md
@@ -4,7 +4,7 @@ title: "输出展示层 · official 最新快照"
 description: "official 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/official-latest.json"
 tags: ["data_layer:output", "platform:official", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-pixiv.md
+++ b/okf/news-output/news-output-pixiv.md
@@ -4,7 +4,7 @@ title: "输出展示层 · pixiv 最新快照"
 description: "pixiv 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/pixiv-latest.json"
 tags: ["data_layer:output", "platform:pixiv", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-reddit.md
+++ b/okf/news-output/news-output-reddit.md
@@ -4,7 +4,7 @@ title: "输出展示层 · reddit 最新快照"
 description: "reddit 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/reddit-latest.json"
 tags: ["data_layer:output", "platform:reddit", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-ruliweb.md
+++ b/okf/news-output/news-output-ruliweb.md
@@ -4,7 +4,7 @@ title: "输出展示层 · ruliweb 最新快照"
 description: "ruliweb 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/ruliweb-latest.json"
 tags: ["data_layer:output", "platform:ruliweb", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-steam-discussion.md
+++ b/okf/news-output/news-output-steam-discussion.md
@@ -4,7 +4,7 @@ title: "输出展示层 · steam_discussion 最新快照"
 description: "steam_discussion 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/steam_discussion-latest.json"
 tags: ["data_layer:output", "platform:steam_discussion", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-steam.md
+++ b/okf/news-output/news-output-steam.md
@@ -4,7 +4,7 @@ title: "输出展示层 · steam 最新快照"
 description: "steam 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/steam-latest.json"
 tags: ["data_layer:output", "platform:steam", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-stopgame.md
+++ b/okf/news-output/news-output-stopgame.md
@@ -4,7 +4,7 @@ title: "输出展示层 · stopgame 最新快照"
 description: "stopgame 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/stopgame-latest.json"
 tags: ["data_layer:output", "platform:stopgame", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-taptap-review.md
+++ b/okf/news-output/news-output-taptap-review.md
@@ -4,7 +4,7 @@ title: "输出展示层 · taptap_review 最新快照"
 description: "taptap_review 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/taptap_review-latest.json"
 tags: ["data_layer:output", "platform:taptap_review", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-taptap.md
+++ b/okf/news-output/news-output-taptap.md
@@ -4,7 +4,7 @@ title: "输出展示层 · taptap 最新快照"
 description: "taptap 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/taptap-latest.json"
 tags: ["data_layer:output", "platform:taptap", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-twitter.md
+++ b/okf/news-output/news-output-twitter.md
@@ -4,7 +4,7 @@ title: "输出展示层 · twitter 最新快照"
 description: "twitter 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/twitter-latest.json"
 tags: ["data_layer:output", "platform:twitter", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-weibo.md
+++ b/okf/news-output/news-output-weibo.md
@@ -4,7 +4,7 @@ title: "输出展示层 · weibo 最新快照"
 description: "weibo 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/weibo-latest.json"
 tags: ["data_layer:output", "platform:weibo", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-weixin.md
+++ b/okf/news-output/news-output-weixin.md
@@ -4,7 +4,7 @@ title: "输出展示层 · weixin 最新快照"
 description: "weixin 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/weixin-latest.json"
 tags: ["data_layer:output", "platform:weixin", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/news-output/news-output-youtube.md
+++ b/okf/news-output/news-output-youtube.md
@@ -4,7 +4,7 @@ title: "输出展示层 · youtube 最新快照"
 description: "youtube 输出展示层最新快照（抽样选样，非全量）。长窗口分析 / 完整性审计 / 情感长尾须改用全量档案层（见 community/ 与 sources/ 的 full_archive 指针，lesson #30）。"
 resource: "/projects/news/output/youtube-latest.json"
 tags: ["data_layer:output", "platform:youtube", "sampled"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/bpt-sdk-doc-architecture.md
+++ b/okf/projects/bpt-sdk-doc-architecture.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk ARCHITECTURE"
 description: "Independent agent harness with a `@anthropic-ai/claude-agent-sdk`-compatible"
 resource: "/projects/bpt-agent-sdk/docs/ARCHITECTURE.md"
 tags: ["data_layer:curated", "design-doc", "sub-project:bpt-agent-sdk"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/bpt-sdk-doc-compat.md
+++ b/okf/projects/bpt-sdk-doc-compat.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk COMPAT"
 description: "Target surface: `@anthropic-ai/claude-agent-sdk` public API (npm 0.3.201; chased from the 0.3.199 baseline 2026-07-05, keeper ruling, zero conformance drift) as"
 resource: "/projects/bpt-agent-sdk/docs/COMPAT.md"
 tags: ["data_layer:curated", "design-doc", "sub-project:bpt-agent-sdk"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/bpt-sdk-doc-concurrency.md
+++ b/okf/projects/bpt-sdk-doc-concurrency.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk CONCURRENCY"
 description: "The SDK supports true parallelism at three levels: **many conversations** over"
 resource: "/projects/bpt-agent-sdk/docs/CONCURRENCY.md"
 tags: ["data_layer:curated", "design-doc", "sub-project:bpt-agent-sdk"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/bpt-sdk-doc-errors.md
+++ b/okf/projects/bpt-sdk-doc-errors.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk ERRORS"
 description: "Every error class in `src/errors.ts` carries a machine-readable, stable"
 resource: "/projects/bpt-agent-sdk/docs/ERRORS.md"
 tags: ["data_layer:curated", "design-doc", "sub-project:bpt-agent-sdk"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/bpt-sdk-doc-migration.md
+++ b/okf/projects/bpt-sdk-doc-migration.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk MIGRATION"
 description: "Audience: the BPT Desktop (Electron) codebase currently importing the official"
 resource: "/projects/bpt-agent-sdk/docs/MIGRATION.md"
 tags: ["data_layer:curated", "design-doc", "sub-project:bpt-agent-sdk"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/bpt-sdk-doc-onboarding.md
+++ b/okf/projects/bpt-sdk-doc-onboarding.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk ONBOARDING"
 description: "Goal: get a new maintainer from zero to \"I can make a change safely and prove"
 resource: "/projects/bpt-agent-sdk/docs/ONBOARDING.md"
 tags: ["data_layer:curated", "design-doc", "sub-project:bpt-agent-sdk"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/bpt-sdk-doc-openai-protocol.md
+++ b/okf/projects/bpt-sdk-doc-openai-protocol.md
@@ -1,0 +1,16 @@
+---
+type: "documentation"
+title: "bpt-agent-sdk OPENAI-PROTOCOL"
+description: "The SDK can drive an **OpenAI-compatible Chat Completions endpoint** instead of"
+resource: "/projects/bpt-agent-sdk/docs/OPENAI-PROTOCOL.md"
+tags: ["data_layer:curated", "design-doc", "sub-project:bpt-agent-sdk"]
+timestamp: "2026-07-10"
+---
+
+# 指针概念
+
+> 放指针不放本体：本体权威在 `projects/bpt-agent-sdk/docs/OPENAI-PROTOCOL.md`，本 concept 仅描述与定位、不复刻正文。
+
+- 本体路径：`projects/bpt-agent-sdk/docs/OPENAI-PROTOCOL.md`
+- 摘要：The SDK can drive an **OpenAI-compatible Chat Completions endpoint** instead of
+- 标签：data_layer:curated · design-doc · sub-project:bpt-agent-sdk

--- a/okf/projects/bpt-sdk-doc-positioning.md
+++ b/okf/projects/bpt-sdk-doc-positioning.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk POSITIONING"
 description: "**BPT Agent SDK = 一套稳定兼容的调用「表面」 + 一个我们完全掌控、比原版更简单更可靠的独立「引擎」。**"
 resource: "/projects/bpt-agent-sdk/docs/POSITIONING.md"
 tags: ["data_layer:curated", "design-doc", "sub-project:bpt-agent-sdk"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/bpt-sdk-doc-subagents.md
+++ b/okf/projects/bpt-sdk-doc-subagents.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk SUBAGENTS"
 description: "Goal: wire a host (BPT) to the SDK's subagent surface the way Claude Code uses"
 resource: "/projects/bpt-agent-sdk/docs/SUBAGENTS.md"
 tags: ["data_layer:curated", "design-doc", "sub-project:bpt-agent-sdk"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/doc-testing-strategy.md
+++ b/okf/projects/doc-testing-strategy.md
@@ -4,7 +4,7 @@ title: "测试策略"
 description: "银芯的测试不靠单一数字护城。三层护栏各管一件事，互相补盲："
 resource: "/docs/testing-strategy.md"
 tags: ["data_layer:curated", "engineering-doc"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/entry-claude-md.md
+++ b/okf/projects/entry-claude-md.md
@@ -4,7 +4,7 @@ title: "CLAUDE.md（AI 统一入口 · 运行时强约束权威）"
 description: "银芯是黑池的「眼睛和耳朵」：采集 + 整理外部信息往黑池送，黑池吃完不吐回。"
 resource: "/CLAUDE.md"
 tags: ["data_layer:curated", "entry-point", "runtime-authority"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/entry-readme.md
+++ b/okf/projects/entry-readme.md
@@ -4,7 +4,7 @@ title: "README.md（人 + AI 共用主入口）"
 description: "忘却前夜（忘卻前夜 / Morimens）的**社区知识平台 + 黑池信息入口**。本仓库由忘却前夜官方授权制作人维护，引用公开可查阅的游戏资料。"
 resource: "/README.md"
 tags: ["data_layer:curated", "entry-point"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/extracted-lua-inventory.md
+++ b/okf/projects/extracted-lua-inventory.md
@@ -4,7 +4,7 @@ title: "解包 lua 清单"
 description: "逐条列 .luac 本体位置的清单（1608 条），字节码本体在 Releases「解包」桶。"
 resource: "/extracted_lua/lua_scripts_inventory.csv"
 tags: ["data_layer:curated", "manifest", "binary-assets-pointer"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/extracted-lua-readme.md
+++ b/okf/projects/extracted-lua-readme.md
@@ -4,7 +4,7 @@ title: "解包提取说明"
 description: "**不能保证 639 份 archive 脚本全部覆盖。** 原因："
 resource: "/extracted_lua/README_提取说明.md"
 tags: ["data_layer:curated", "engineering-doc"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/index.md
+++ b/okf/projects/index.md
@@ -1,4 +1,4 @@
-# 入口文档 + 子项目上下文 + 藏宝图 + 设计/工程文档 (22)
+# 入口文档 + 子项目上下文 + 藏宝图 + 设计/工程文档 (23)
 
 仓库最高权威入口（CLAUDE.md / README.md）+ 各子项目 CONTEXT.md（动手前必读）+ RELEASES.md 藏宝图 + bpt-agent-sdk/site 设计文档 + 工程文档 + 归档注册表的导航指针。
 
@@ -17,6 +17,7 @@
 * [bpt-agent-sdk ERRORS](/projects/bpt-sdk-doc-errors.md) - Every error class in `src/errors.ts` carries a machine-readable, stable
 * [bpt-agent-sdk MIGRATION](/projects/bpt-sdk-doc-migration.md) - Audience: the BPT Desktop (Electron) codebase currently importing the official
 * [bpt-agent-sdk ONBOARDING](/projects/bpt-sdk-doc-onboarding.md) - Goal: get a new maintainer from zero to "I can make a change safely and prove
+* [bpt-agent-sdk OPENAI-PROTOCOL](/projects/bpt-sdk-doc-openai-protocol.md) - The SDK can drive an **OpenAI-compatible Chat Completions endpoint** instead of
 * [bpt-agent-sdk POSITIONING](/projects/bpt-sdk-doc-positioning.md) - **BPT Agent SDK = 一套稳定兼容的调用「表面」 + 一个我们完全掌控、比原版更简单更可靠的独立「引擎」。**
 * [bpt-agent-sdk SUBAGENTS](/projects/bpt-sdk-doc-subagents.md) - Goal: wire a host (BPT) to the SDK's subagent surface the way Claude Code uses
 * [site design · morimens-design-system-guide.html](/projects/site-design-morimens-design-system-guide.md) - site 设计系统权威（morimens-design-system-guide.html，21.2KB）：设计令牌 / 组件规范来源。

--- a/okf/projects/news-archive-sources-registry.md
+++ b/okf/projects/news-archive-sources-registry.md
@@ -4,7 +4,7 @@ title: "archive_sources.json（归档注册表）"
 description: "T2 数据层归档声明式注册表：哪些来源归档到哪、如何驱逐（archive_engine 读它干活）。"
 resource: "/projects/news/scripts/archive_sources.json"
 tags: ["data_layer:curated", "registry", "sub-project:news"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/project-bpt-agent-sdk.md
+++ b/okf/projects/project-bpt-agent-sdk.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk 子项目上下文"
 description: "BPT Agent SDK：独立重实现（independent reimplementation）的 TypeScript agent 框架，公开调用面"
 resource: "/projects/bpt-agent-sdk/CONTEXT.md"
 tags: ["data_layer:curated", "sub-project-context", "milestone"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/project-game.md
+++ b/okf/projects/project-game.md
@@ -4,7 +4,7 @@ title: "game 子项目上下文"
 description: "**game = 守密人个人兴趣项目（主）+ 未来扩展可能 ⓐⓒ（备）**"
 resource: "/projects/game/CONTEXT.md"
 tags: ["data_layer:curated", "sub-project-context", "milestone"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/project-news.md
+++ b/okf/projects/project-news.md
@@ -4,7 +4,7 @@ title: "news 子项目上下文"
 description: "**news = 银芯二核心使命之 #1「黑池信息入口」核心载体**"
 resource: "/projects/news/CONTEXT.md"
 tags: ["data_layer:curated", "sub-project-context", "milestone"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/project-site.md
+++ b/okf/projects/project-site.md
@@ -4,7 +4,7 @@ title: "site 子项目上下文"
 description: "**site = 银芯使命对外门户 / 三轴（site·news·wiki）发现入口**（非任一单一使命的载体；使命#2「社区共建知识底座」载体为 wiki，见 CLAUDE.md §1.2）"
 resource: "/projects/site/CONTEXT.md"
 tags: ["data_layer:curated", "sub-project-context", "milestone"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/project-wiki.md
+++ b/okf/projects/project-wiki.md
@@ -4,7 +4,7 @@ title: "wiki 子项目上下文"
 description: "**wiki = 银芯二核心使命之 #2「社区共建知识底座」核心载体**（CLAUDE.md §1.2）。"
 resource: "/projects/wiki/CONTEXT.md"
 tags: ["data_layer:curated", "sub-project-context", "milestone"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/releases-treasure-map.md
+++ b/okf/projects/releases-treasure-map.md
@@ -4,7 +4,7 @@ title: "Releases 藏宝图"
 description: "合并自 art-assets-v2 + audio-assets-v1 + audio-raw-v1 + video-assets-v1 + （2026-06-21）原 `unpacked-data`。约 10.9 GB："
 resource: "/RELEASES.md"
 tags: ["data_layer:curated", "treasure-map", "binary-assets-pointer"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/site-design-morimens-design-system-guide.md
+++ b/okf/projects/site-design-morimens-design-system-guide.md
@@ -4,7 +4,7 @@ title: "site design · morimens-design-system-guide.html"
 description: "site 设计系统权威（morimens-design-system-guide.html，21.2KB）：设计令牌 / 组件规范来源。"
 resource: "/projects/site/design/morimens-design-system-guide.html"
 tags: ["data_layer:curated", "design-system", "sub-project:site"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/projects/site-design-morimens-design-tokens.md
+++ b/okf/projects/site-design-morimens-design-tokens.md
@@ -4,7 +4,7 @@ title: "site design · morimens-design-tokens.css"
 description: "site 设计系统权威（morimens-design-tokens.css，6.7KB）：设计令牌 / 组件规范来源。"
 resource: "/projects/site/design/morimens-design-tokens.css"
 tags: ["data_layer:curated", "design-system", "sub-project:site"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-community-analysis-community-deep-analysis-20260518-26.md
+++ b/okf/resource/resource-community-analysis-community-deep-analysis-20260518-26.md
@@ -4,7 +4,7 @@ title: "community-deep-analysis-20260518-26"
 description: "◇ ◇ ◇（格式：html/md/pdf）"
 resource: "/Public-Info-Pool/Resource/community-analysis/community-deep-analysis-20260518-26.md"
 tags: ["data_layer:curated", "deliverable", "topic:community-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-community-analysis-jp-discord-insights-202606.md
+++ b/okf/resource/resource-community-analysis-jp-discord-insights-202606.md
@@ -4,7 +4,7 @@ title: "jp-discord-insights-202606"
 description: "1. **社区已固化为「超小圈子高密度沙龙」。/ コミュニティは「超小圏子の高密度サロン」に固化。**（格式：md）"
 resource: "/Public-Info-Pool/Resource/community-analysis/jp-discord-insights-202606.md"
 tags: ["data_layer:curated", "deliverable", "topic:community-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-community-analysis-light-selfreport-crosscheck-20260705.md
+++ b/okf/resource/resource-community-analysis-light-selfreport-crosscheck-20260705.md
@@ -4,7 +4,7 @@ title: "light-selfreport-crosscheck-20260705"
 description: "未使用输出展示层。（格式：md）"
 resource: "/Public-Info-Pool/Resource/community-analysis/light-selfreport-crosscheck-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:community-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-community-analysis-producer-light-evaluation-20260704.md
+++ b/okf/resource/resource-community-analysis-producer-light-evaluation-20260704.md
@@ -4,7 +4,7 @@ title: "producer-light-evaluation-20260704"
 description: "（7,565,639 条 / 17 平台，索引 `projects/news/index/community_index.json`，（格式：md）"
 resource: "/Public-Info-Pool/Resource/community-analysis/producer-light-evaluation-20260704.md"
 tags: ["data_layer:curated", "deliverable", "topic:community-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-community-analysis-saya-collab-community-report-20260603-r2.md
+++ b/okf/resource/resource-community-analysis-saya-collab-community-report-20260603-r2.md
@@ -4,7 +4,7 @@ title: "saya-collab-community-report-20260603-r2"
 description: "**一句话结论**：联动在中、英、日、韩四语区均获**高声量、整体正向**反响，核心好评是「制作方还原诚意」（续用原作 CV、邀原作曲师回归、Nitroplus 监修角色设定）；并形成显著**双向引流**（为《忘却前夜》拉新 + 促玩家回补《沙耶之歌》原作）。负面集中于「抽卡付费节奏」与「沙耶幼态形象的内容分级顾虑」两点，**均非针对联动质量或 IP 还原本身**；俄语区目前为讨论空白。（格式：md）"
 resource: "/Public-Info-Pool/Resource/community-analysis/saya-collab-community-report-20260603-r2.md"
 tags: ["data_layer:curated", "deliverable", "topic:community-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-community-analysis-saya-collab-community-report-20260603-r3.md
+++ b/okf/resource/resource-community-analysis-saya-collab-community-report-20260603-r3.md
@@ -4,7 +4,7 @@ title: "saya-collab-community-report-20260603-r3"
 description: "**901 条强信号用户原声分类统计**（已剔除官方公告、维护通知、PV 搬运等噪声）：（格式：md）"
 resource: "/Public-Info-Pool/Resource/community-analysis/saya-collab-community-report-20260603-r3.md"
 tags: ["data_layer:curated", "deliverable", "topic:community-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-community-analysis-saya-collab-community-report-20260603.md
+++ b/okf/resource/resource-community-analysis-saya-collab-community-report-20260603.md
@@ -4,7 +4,7 @@ title: "saya-collab-community-report-20260603"
 description: "**一句话结论**：联动在中日英三语社区均获**高声量、整体正向**反响，玩家普遍认可制作方「还原诚意」（续用原作 CV、音乐致敬）；并产生显著的**双向引流**——既为《忘却前夜》带来新玩家，也促使大量玩家回头补完《沙耶之歌》原作。（格式：md）"
 resource: "/Public-Info-Pool/Resource/community-analysis/saya-collab-community-report-20260603.md"
 tags: ["data_layer:curated", "deliverable", "topic:community-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-community-analysis-saya-collab-voices-fulldetail-20260603.md
+++ b/okf/resource/resource-community-analysis-saya-collab-voices-fulldetail-20260603.md
@@ -4,7 +4,7 @@ title: "saya-collab-voices-fulldetail-20260603"
 description: "community-analysis 产物（xlsx）（格式：xlsx）"
 resource: "/Public-Info-Pool/Resource/community-analysis/saya-collab-voices-fulldetail-20260603.xlsx"
 tags: ["data_layer:curated", "deliverable", "topic:community-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-community-analysis-volunteer-management-deep-dive-202606.md
+++ b/okf/resource/resource-community-analysis-volunteer-management-deep-dive-202606.md
@@ -4,7 +4,7 @@ title: "volunteer-management-deep-dive-202606"
 description: "这是一支**高知自驱、靠「热爱 + 被看见」维系的精英翻译志愿军**，质量极高但结构极脆。一句话定性：**质量不缺，缺的是「让人能持续干活」的供给与冗余**——项目压在 3 个人身上（官方 Ace + 志愿者 omnichromia + arkaether），11 个语种里已有 5 个停摆、4 个衰退，而最大的士气杀手不是氛围，是「努力被系统性作废」。（格式：md）"
 resource: "/Public-Info-Pool/Resource/community-analysis/volunteer-management-deep-dive-202606.md"
 tags: ["data_layer:curated", "deliverable", "topic:community-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-daily-news-morimens-daily-20260601-r2.md
+++ b/okf/resource/resource-daily-news-morimens-daily-20260601-r2.md
@@ -4,7 +4,7 @@ title: "morimens-daily-20260601-r2"
 description: "◇ ◇ ◇（格式：html/md/pdf）"
 resource: "/Public-Info-Pool/Resource/daily-news/morimens-daily-20260601-r2.md"
 tags: ["data_layer:curated", "deliverable", "topic:daily-news"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-daily-news-morimens-daily-20260601.md
+++ b/okf/resource/resource-daily-news-morimens-daily-20260601.md
@@ -4,7 +4,7 @@ title: "morimens-daily-20260601"
 description: "◇ ◇ ◇（格式：html/md/pdf）"
 resource: "/Public-Info-Pool/Resource/daily-news/morimens-daily-20260601.md"
 tags: ["data_layer:curated", "deliverable", "topic:daily-news"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-daily-news-morimens-daily-20260602-r2.md
+++ b/okf/resource/resource-daily-news-morimens-daily-20260602-r2.md
@@ -4,7 +4,7 @@ title: "morimens-daily-20260602-r2"
 description: "◇ ◇ ◇（格式：html/md/pdf）"
 resource: "/Public-Info-Pool/Resource/daily-news/morimens-daily-20260602-r2.md"
 tags: ["data_layer:curated", "deliverable", "topic:daily-news"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-daily-news-morimens-daily-full-20260602.md
+++ b/okf/resource/resource-daily-news-morimens-daily-full-20260602.md
@@ -4,7 +4,7 @@ title: "morimens-daily-full-20260602"
 description: "◇ ◇ ◇（格式：html/md/pdf）"
 resource: "/Public-Info-Pool/Resource/daily-news/morimens-daily-full-20260602.md"
 tags: ["data_layer:curated", "deliverable", "topic:daily-news"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-daily-news-morimens-period-20260512-0603.md
+++ b/okf/resource/resource-daily-news-morimens-period-20260512-0603.md
@@ -4,7 +4,7 @@ title: "morimens-period-20260512-0603"
 description: "◇ ◇ ◇（格式：html/md/pdf）"
 resource: "/Public-Info-Pool/Resource/daily-news/morimens-period-20260512-0603.md"
 tags: ["data_layer:curated", "deliverable", "topic:daily-news"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-daily-news-morimens-window-20260602.md
+++ b/okf/resource/resource-daily-news-morimens-window-20260602.md
@@ -4,7 +4,7 @@ title: "morimens-window-20260602"
 description: "◇ ◇ ◇（格式：html/md/pdf）"
 resource: "/Public-Info-Pool/Resource/daily-news/morimens-window-20260602.md"
 tags: ["data_layer:curated", "deliverable", "topic:daily-news"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-data-diagnostics-bpt-sdk-comparison-baseline-20260705.md
+++ b/okf/resource/resource-data-diagnostics-bpt-sdk-comparison-baseline-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-comparison-baseline-20260705"
 description: "**⚠ 重大更正（2026-07-05 晚，见 §4）**：第 1 节「v4 无可测收益」结论**作废**——发现 A/B harness 有测量 bug（未设 `systemPrompt` preset，`harnessPromptVariant` 被静默忽略），**两臂实际都跑了极简默认提示词**，故「无差异」是假象。修复后 v1-vs-**v5** 真对照翻案：v5（忠实再现官方主循环、~3774 tok）在硬任务上 **~3× 便宜**（$0.0089 vs $0.0（格式：md）"
 resource: "/Public-Info-Pool/Resource/data-diagnostics/bpt-sdk-comparison-baseline-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:data-diagnostics"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-data-diagnostics-bpt-sdk-i18n-cost-investigation-20260708.md
+++ b/okf/resource/resource-data-diagnostics-bpt-sdk-i18n-cost-investigation-20260708.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-i18n-cost-investigation-20260708"
 description: "守密人两次「不对劲」都对;艾瑞卡据实纠正。（格式：md）"
 resource: "/Public-Info-Pool/Resource/data-diagnostics/bpt-sdk-i18n-cost-investigation-20260708.md"
 tags: ["data_layer:curated", "deliverable", "topic:data-diagnostics"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-data-diagnostics-bpt-sdk-l5-revalidation-v0182-20260707.md
+++ b/okf/resource/resource-data-diagnostics-bpt-sdk-l5-revalidation-v0182-20260707.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-l5-revalidation-v0182-20260707"
 description: "**Gate B：bpt 88/90 (97.8%) vs 官方 77/90 (85.6%)，delta +12.2pp，容忍 −5pp → PASS。跑满 180/180，花 $2.1920 < $5 帽。判定：最新 v0.18.2 未回归 gate B。**（格式：md）"
 resource: "/Public-Info-Pool/Resource/data-diagnostics/bpt-sdk-l5-revalidation-v0182-20260707.md"
 tags: ["data_layer:curated", "deliverable", "topic:data-diagnostics"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-data-diagnostics-discord-compaction-further-savings-20260622.md
+++ b/okf/resource/resource-data-diagnostics-discord-compaction-further-savings-20260622.md
@@ -4,7 +4,7 @@ title: "discord-compaction-further-savings-20260622"
 description: "硬约束：仓库总纲「可检索 text→git」——**grep 存活是采信前提**。（格式：md）"
 resource: "/Public-Info-Pool/Resource/data-diagnostics/discord-compaction-further-savings-20260622.md"
 tags: ["data_layer:curated", "deliverable", "topic:data-diagnostics"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-data-diagnostics-discord-data-retention-diagnosis-202606.md
+++ b/okf/resource/resource-data-diagnostics-discord-data-retention-diagnosis-202606.md
@@ -4,7 +4,7 @@ title: "discord-data-retention-diagnosis-202606"
 description: "`projects/news/data/discord/channels/` 现存 **3.3 GB / 12803 个 jsonl**，（格式：md）"
 resource: "/Public-Info-Pool/Resource/data-diagnostics/discord-data-retention-diagnosis-202606.md"
 tags: ["data_layer:curated", "deliverable", "topic:data-diagnostics"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-data-diagnostics-grep-ripgrep-crossover-20260707.md
+++ b/okf/resource/resource-data-diagnostics-grep-ripgrep-crossover-20260707.md
@@ -4,7 +4,7 @@ title: "grep-ripgrep-crossover-20260707"
 description: "**拐点不由「仓库大小」单独决定，而由「这次查询是否必须全量扫描整个语料」决定。** 命中 250 条早停的查询几乎与仓库大小无关（恒 ~140ms）；必须全扫的查询（稀有词 / count / `head_limit:0` / 命中不足 250）成本**线性于总字节，且 97% 花在串行 `fs.readFile` 上，不是正则**。后者在 4K–12K 文件仓上比 ripgrep 慢 **87–127 倍**。（格式：md）"
 resource: "/Public-Info-Pool/Resource/data-diagnostics/grep-ripgrep-crossover-20260707.md"
 tags: ["data_layer:curated", "deliverable", "topic:data-diagnostics"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-data-diagnostics-wiki-data-gap-registry-20260602.md
+++ b/okf/resource/resource-data-diagnostics-wiki-data-gap-registry-20260602.md
@@ -4,7 +4,7 @@ title: "wiki-data-gap-registry-20260602"
 description: "本文件登记 wiki 角色数据库（`projects/wiki/data/db/characters.json`）从客户端解包源（格式：md）"
 resource: "/Public-Info-Pool/Resource/data-diagnostics/wiki-data-gap-registry-20260602.md"
 tags: ["data_layer:curated", "deliverable", "topic:data-diagnostics"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-game-analysis-bug-fault-report-20260518-26.md
+++ b/okf/resource/resource-game-analysis-bug-fault-report-20260518-26.md
@@ -4,7 +4,7 @@ title: "bug-fault-report-20260518-26"
 description: "◇ ◇ ◇（格式：html/md/pdf）"
 resource: "/Public-Info-Pool/Resource/game-analysis/bug-fault-report-20260518-26.md"
 tags: ["data_layer:curated", "deliverable", "topic:game-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-game-analysis-role-action-recommendations-202605.md
+++ b/okf/resource/resource-game-analysis-role-action-recommendations-202605.md
@@ -4,7 +4,7 @@ title: "role-action-recommendations-202605"
 description: "◇ ◇ ◇（格式：html/md/pdf）"
 resource: "/Public-Info-Pool/Resource/game-analysis/role-action-recommendations-202605.md"
 tags: ["data_layer:curated", "deliverable", "topic:game-analysis"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-methodology-knowledge-engineering-primer-20260704.md
+++ b/okf/resource/resource-methodology-knowledge-engineering-primer-20260704.md
@@ -4,7 +4,7 @@ title: "knowledge-engineering-primer-20260704"
 description: "「什么都接上了、但没有结构」不是黑池特有。银芯 2026 上半年踩过同型的坑：（格式：md）"
 resource: "/Public-Info-Pool/Resource/methodology/knowledge-engineering-primer-20260704.md"
 tags: ["data_layer:curated", "deliverable", "topic:methodology"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-ai-collaboration-method-202603.md
+++ b/okf/resource/resource-proposal-ai-collaboration-method-202603.md
@@ -4,7 +4,7 @@ title: "ai-collaboration-method-202603"
 description: "proposal 产物（html）（格式：html）"
 resource: "/Public-Info-Pool/Resource/proposal/ai-collaboration-method-202603.html"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-biav-project-plan-202603.md
+++ b/okf/resource/resource-proposal-biav-project-plan-202603.md
@@ -4,7 +4,7 @@ title: "biav-project-plan-202603"
 description: "proposal 产物（html/pdf）（格式：html/pdf）"
 resource: "/Public-Info-Pool/Resource/proposal/biav-project-plan-202603.html"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-bpt-desktop-cowork-experience-design-20260708.md
+++ b/okf/resource/resource-proposal-bpt-desktop-cowork-experience-design-20260708.md
@@ -4,7 +4,7 @@ title: "bpt-desktop-cowork-experience-design-20260708"
 description: "**不含任何黑池数据**；产品本体（BPT Desktop）在黑池侧构建，银芯只出**设计情报 + 对接缝**。（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/bpt-desktop-cowork-experience-design-20260708.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-bpt-prompt-assembly-layer-design-20260705.md
+++ b/okf/resource/resource-proposal-bpt-prompt-assembly-layer-design-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-prompt-assembly-layer-design-20260705"
 description: "bpt-agent-sdk 是官方 Claude Code / Claude Agent SDK 的干净重实现（clean-room reimplementation）。它的 agent-loop 要向模型发系统提示词。官方的系统提示词**不是一根字符串**——上游 README 明确写「Claude Code doesn't just have one single string」。它是一个**片段库（fragment store）**：553 个带 HTML 注释头的 m（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/bpt-prompt-assembly-layer-design-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-bpt-prompt-layering-design-20260704.md
+++ b/okf/resource/resource-proposal-bpt-prompt-layering-design-20260704.md
@@ -4,7 +4,7 @@ title: "bpt-prompt-layering-design-20260704"
 description: "BPT 在内网 SVN 免安装部署、按个人/团队目录分数据。提示词注入分多层（硬编码核心 → 团队 → 个人 → 项目工作目录），（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/bpt-prompt-layering-design-20260704.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-bpt-sdk-openai-compat-wire-20260708.md
+++ b/okf/resource/resource-proposal-bpt-sdk-openai-compat-wire-20260708.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-openai-compat-wire-20260708"
 description: "给 BPT Agent SDK 增加一条 **OpenAI 兼容 Chat Completions 线**——作为兄弟 `Transport` 压在现有（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/bpt-sdk-openai-compat-wire-20260708.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-bpt-sdk-reproduction-scope-ledger-20260704.md
+++ b/okf/resource/resource-proposal-bpt-sdk-reproduction-scope-ledger-20260704.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-reproduction-scope-ledger-20260704"
 description: "**全做**。官方有的能力我们都在 BPT 引擎里再现一遍，用公开还原作蓝本、适配我们工具、明确署名。唯一的排序逻辑是**依赖**——（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/bpt-sdk-reproduction-scope-ledger-20260704.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-bpt-sdk-roadmap-20260705.md
+++ b/okf/resource/resource-proposal-bpt-sdk-roadmap-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-roadmap-20260705"
 description: "引擎主体（v0.1–v0.5）+ 提示词装配层（Track B）已成并入 main；G 系列（引擎效率机制 + 保真收尾，含 G8 决策落档）收官 v0.5；（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/bpt-sdk-roadmap-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-bpt-sdk-session-manager-20260706.md
+++ b/okf/resource/resource-proposal-bpt-sdk-session-manager-20260706.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-session-manager-20260706"
 description: "**痛点一：连接浪费（无共享）。** 现状每个 `query()` 自带一份 `AnthropicTransport`（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/bpt-sdk-session-manager-20260706.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-bpt-sdk-v06-remaining-execution-roadmap-20260705.md
+++ b/okf/resource/resource-proposal-bpt-sdk-v06-remaining-execution-roadmap-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-v06-remaining-execution-roadmap-20260705"
 description: "**首批（本会话）已实现并全绿**：G-VERIFY（三态验证器）+ G-SUMMARY（摘要安全守卫 + away-summary）。详见下「## 已落」。（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/bpt-sdk-v06-remaining-execution-roadmap-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-internal-ai-platform-plan-202604.md
+++ b/okf/resource/resource-proposal-internal-ai-platform-plan-202604.md
@@ -4,7 +4,7 @@ title: "internal-ai-platform-plan-202604"
 description: "制作人 Light 提出将 BIAV 从个人 AI 终端扩展为团队级内部 AI 工具平台，替代 Qoder，核心逻辑：（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/internal-ai-platform-plan-202604.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-silver-core-maintenance-cadence-20260702.md
+++ b/okf/resource/resource-proposal-silver-core-maintenance-cadence-20260702.md
@@ -4,7 +4,7 @@ title: "silver-core-maintenance-cadence-20260702"
 description: "M7 验收 =「二核心使命基础设施齐备 + 自动化跑稳 + 至少一种贡献流程跑顺」。（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/silver-core-maintenance-cadence-20260702.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-silver-core-vector-leg-design-20260705.md
+++ b/okf/resource/resource-proposal-silver-core-vector-leg-design-20260705.md
@@ -4,7 +4,7 @@ title: "silver-core-vector-leg-design-20260705"
 description: "守密人 2026-07-05 裁定 **(A)**：银芯**解除「零 ML 红线」**、自建一条向量检索腿，嵌入源选 **Voyage API**。（格式：md）"
 resource: "/Public-Info-Pool/Resource/proposal/silver-core-vector-leg-design-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-proposal-wiki-prototype-202603.md
+++ b/okf/resource/resource-proposal-wiki-prototype-202603.md
@@ -4,7 +4,7 @@ title: "wiki-prototype-202603"
 description: "proposal 产物（html）（格式：html）"
 resource: "/Public-Info-Pool/Resource/proposal/wiki-prototype-202603.html"
 tags: ["data_layer:curated", "deliverable", "topic:proposal"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-agent-sdk-completion-audit-20260703.md
+++ b/okf/resource/resource-repo-engineering-bpt-agent-sdk-completion-audit-20260703.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk-completion-audit-20260703"
 description: "小学生比喻：拿着对方最新出厂说明书逐页清点自家仿制机——「有」「有一半」「只留了接口没通电」「压根没有」「本来就故意不装」五种贴纸逐个零件贴。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-agent-sdk-completion-audit-20260703.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-agent-sdk-completion-matrix-20260703.md
+++ b/okf/resource/resource-repo-engineering-bpt-agent-sdk-completion-matrix-20260703.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk-completion-matrix-20260703"
 description: "repo-engineering 产物（json）（格式：json）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-agent-sdk-completion-matrix-20260703.json"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-agent-sdk-evaluation-20260706.md
+++ b/okf/resource/resource-repo-engineering-bpt-agent-sdk-evaluation-20260706.md
@@ -4,7 +4,7 @@ title: "bpt-agent-sdk-evaluation-20260706"
 description: "**健康度：优。** 这是银芯迄今工程完成度最高的产物——1414 单测全绿、类型与构建零错、（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-agent-sdk-evaluation-20260706.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-desktop-ui-reference-20260704-r2.md
+++ b/okf/resource/resource-repo-engineering-bpt-desktop-ui-reference-20260704-r2.md
@@ -4,7 +4,7 @@ title: "bpt-desktop-ui-reference-20260704-r2"
 description: "对接表增 TodoWrite / AskUserQuestion / compact_boundary / thinking / 斜杠命令五行、（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-reference-20260704-r2.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-desktop-ui-roadmap-20260705.md
+++ b/okf/resource/resource-repo-engineering-bpt-desktop-ui-roadmap-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-desktop-ui-roadmap-20260705"
 description: "怎么接」，本档回答「先建哪块、每步验收什么」。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-desktop-ui-roadmap-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-completion-inventory-20260705.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-completion-inventory-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-completion-inventory-20260705"
 description: "比喻：①查「家里电器齐不齐」，②查「每个插头针脚形状对不对」，③把电表箱打开看「进户线接法跟官方图纸差在哪」。三张验收单本次并成一张总表。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-completion-inventory-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-conformance-campaign-report-20260705.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-conformance-campaign-report-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-conformance-campaign-report-20260705"
 description: "元数据之上；官方请求体零读取零持久化（`assertContentBlind` 逐产物自审）（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-conformance-campaign-report-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-conformance-suite-design-20260705-r2.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-conformance-suite-design-20260705-r2.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-conformance-suite-design-20260705-r2"
 description: "**门禁按甲、覆盖按乙**：验收线与权重服务 **BPT Desktop 换装信心**（关键路径严格、（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-conformance-suite-design-20260705-r2.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-engine-alignment-handoff-20260705-r4.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-engine-alignment-handoff-20260705-r4.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-engine-alignment-handoff-20260705-r4"
 description: "（PR #453 / #463 / #466 / #467 / #469），不在此单。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-engine-alignment-handoff-20260705-r4.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-engine-alignment-handoff-20260705-r5.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-engine-alignment-handoff-20260705-r5.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-engine-alignment-handoff-20260705-r5"
 description: "其实只是便签没跟着更新。本档就是把便签换成「已完工验收单」。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-engine-alignment-handoff-20260705-r5.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-harness-utils-20260708.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-harness-utils-20260708.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-harness-utils-20260708"
 description: "repo-engineering 产物（html）（格式：html）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-harness-utils-20260708.html"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-l5-failure-dissection-20260705.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-l5-failure-dissection-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-l5-failure-dissection-20260705"
 description: "含 `conformance-l5.json` + 54 份 L6 官方臂公开流留痕（`l5-traces/official/*.json`）。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-l5-failure-dissection-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-l5-fullround-report-20260705.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-l5-fullround-report-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-l5-fullround-report-20260705"
 description: "**Gate B 是一致性套件蓝图(L5)里唯一的端到端验收门禁。** 定义(`run-l5.mjs`):（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-l5-fullround-report-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-official-arm-protocol-profile-20260705.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-official-arm-protocol-profile-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-official-arm-protocol-profile-20260705"
 description: "**架构裁定：活体差分成立。** L1-L4 可让两引擎每次 CI 都对同一台内容盲仿真器活体对跑，（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-official-arm-protocol-profile-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-official-docs-interface-audit-20260705.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-official-docs-interface-audit-20260705.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-official-docs-interface-audit-20260705"
 description: "小学生比喻：上次（07-03）是清点「家里每样电器有没有」，这次是拿着说明书核对「每个插头的针脚形状对不对」——电器基本都添齐了，这次专挑针脚不合的。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-official-docs-interface-audit-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-official-semantics-audit-20260707.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-official-semantics-audit-20260707.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-official-semantics-audit-20260707"
 description: "审计过程中,3 个子代理独立发现 **thinking-signature 修复的源码不在 main**——只剩编译出的 `.d.ts`,`src/engine/thinking-provenance.ts` 缺失、loop 逐字重放。追查:**PR #505 因 pre-push 钩子 rebase 与复用分支的交互,推送的分支不含实际提交 → 合并了空 diff**;#506 随后只把版本号刷成 0.14.0,使 main **标称 0.14.0 却无修复代码**。已从 （格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-official-semantics-audit-20260707.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-prompt-cache-milestone-20260704.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-prompt-cache-milestone-20260704.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-prompt-cache-milestone-20260704"
 description: "这条线回答的是守密人一个忧虑——「整体效率低下会累积成巨大差别」。做法不是拍脑袋优化，而是（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-prompt-cache-milestone-20260704.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-bpt-sdk-prompt-corpus-20260708.md
+++ b/okf/resource/resource-repo-engineering-bpt-sdk-prompt-corpus-20260708.md
@@ -4,7 +4,7 @@ title: "bpt-sdk-prompt-corpus-20260708"
 description: "repo-engineering 产物（html）（格式：html）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/bpt-sdk-prompt-corpus-20260708.html"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-claude-desktop-ui-structure-20260704-r2.md
+++ b/okf/resource/resource-repo-engineering-claude-desktop-ui-structure-20260704-r2.md
@@ -4,7 +4,7 @@ title: "claude-desktop-ui-structure-20260704-r2"
 description: "演进方向」调和句、§8 增 auto 模式落差行、§8 许可证表述补核验标签）（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-structure-20260704-r2.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-claude-desktop-ui-wireframe-20260704.md
+++ b/okf/resource/resource-repo-engineering-claude-desktop-ui-wireframe-20260704.md
@@ -4,7 +4,7 @@ title: "claude-desktop-ui-wireframe-20260704"
 description: "repo-engineering 产物（html）（格式：html）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/claude-desktop-ui-wireframe-20260704.html"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-kb-vector-remaining-handoff-20260705.md
+++ b/okf/resource/resource-repo-engineering-kb-vector-remaining-handoff-20260705.md
@@ -4,7 +4,7 @@ title: "kb-vector-remaining-handoff-20260705"
 description: "银芯已建向量检索腿（§八「厚锚撑向量」的活体参照实现，守密人 2026-07-05 裁定(A) 解除零 ML 红线，**scoped**：白盒脊柱仍零 ML，只加隔离 ML 向量长尾腿；§1.1-HC 黑池防火墙无涉，只吃银芯自有公开社区档案）。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/kb-vector-remaining-handoff-20260705.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-markdown-consistency-audit-20260628.md
+++ b/okf/resource/resource-repo-engineering-markdown-consistency-audit-20260628.md
@@ -4,7 +4,7 @@ title: "markdown-consistency-audit-20260628"
 description: "**状态报告**：动态编排扫描完毕。覆盖全仓 **300** 个 md 档案，账本抽取 **744** 条可验证声明（落在 246 个档案），按 14 条矛盾轴狩猎出 35 条候选，经对抗式验证确认 **32 条真矛盾**、剔除 3 条假阳性。严重度分布：**高 14 / 中 14 / 低 4**。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/markdown-consistency-audit-20260628.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-news-collector-merge-plan-202606.md
+++ b/okf/resource/resource-repo-engineering-news-collector-merge-plan-202606.md
@@ -4,7 +4,7 @@ title: "news-collector-merge-plan-202606"
 description: "日期：2026-06-02（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/news-collector-merge-plan-202606.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-official-cc-prompt-architecture-inference-20260704.md
+++ b/okf/resource/resource-repo-engineering-official-cc-prompt-architecture-inference-20260704.md
@@ -4,7 +4,7 @@ title: "official-cc-prompt-architecture-inference-20260704"
 description: "**能，而且能推断出相当完整的架构骨架。** 官方「系统提示词」不是一整块，而是 `tools/updatePrompts.js` 揭示的**片段合成树**——553 文件坍缩成 **~40 个不同调用点**，其余是主循环片段或逐工具描述。片段合成的粒度**本身就是架构**：系统提示词是按环境**在请求组装期条件拼接**出来的，不是存成整块的。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/official-cc-prompt-architecture-inference-20260704.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-oss-cc-engine-designs-survey-20260704.md
+++ b/okf/resource/resource-repo-engineering-oss-cc-engine-designs-survey-20260704.md
@@ -4,7 +4,7 @@ title: "oss-cc-engine-designs-survey-20260704"
 description: "Research deliverable for `projects/bpt-agent-sdk`. Goal: survey notable open-source Claude Code（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/oss-cc-engine-designs-survey-20260704.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-repo-audit-20260603-r2.md
+++ b/okf/resource/resource-repo-engineering-repo-audit-20260603-r2.md
@@ -4,7 +4,7 @@ title: "repo-audit-20260603-r2"
 description: "round1 的 35 条修复推送后，本轮 5 路代理在**修复后基线**上复审，三轴并行：回归审查 + 遗留复核 + 新扫描。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/repo-audit-20260603-r2.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-repo-audit-20260603.md
+++ b/okf/resource/resource-repo-engineering-repo-audit-20260603.md
@@ -4,7 +4,7 @@ title: "repo-audit-20260603"
 description: "动态编排工作流派发 5 路并行审计代理，分区无重叠：（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/repo-audit-20260603.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-repo-health-assessment-20260602.md
+++ b/okf/resource/resource-repo-engineering-repo-health-assessment-20260602.md
@@ -4,7 +4,7 @@ title: "repo-health-assessment-20260602"
 description: "代码工程质量本身扎实——防御式错误处理、原子写、单一真相源、共享 helper 抽取、CI 自愈/防腐机制成熟。系统性扣分集中在三处结构性落差：（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/repo-health-assessment-20260602.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-repo-wide-orchestrated-review-20260609.md
+++ b/okf/resource/resource-repo-engineering-repo-wide-orchestrated-review-20260609.md
@@ -4,7 +4,7 @@ title: "repo-wide-orchestrated-review-20260609"
 description: "代码层整体健康度中上：共享模块收敛良好（io_utils / text_utils / lua_parse 均带回归测试）、防御性异常处理普遍、workflow 脚本引用零断链、wiki frontmatter 与仓内链接零错误。但存在三类系统性问题：（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/repo-wide-orchestrated-review-20260609.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-retired-modules-audit-202606.md
+++ b/okf/resource/resource-repo-engineering-retired-modules-audit-202606.md
@@ -4,7 +4,7 @@ title: "retired-modules-audit-202606"
 description: "CLAUDE.md §1.4 记载「做梦 + 会话蒸馏」自动环与三会话钩子于 2026-06-14 退役（决策见 `memory/decisions.md`）。覆盖率审计中一批 `scripts/` 与 `projects/news/scripts/` 模块覆盖率极低（0–22%），疑似死代码。本报告核查其真实存活状态。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/retired-modules-audit-202606.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-test-coverage-analysis-202606.md
+++ b/okf/resource/resource-repo-engineering-test-coverage-analysis-202606.md
@@ -4,7 +4,7 @@ title: "test-coverage-analysis-202606"
 description: "现有 5 个测试档案分别覆盖：`lua_parse`（95%）、`text_utils`（100%）、（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/test-coverage-analysis-202606.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/resource/resource-repo-engineering-test-coverage-analysis-20260702.md
+++ b/okf/resource/resource-repo-engineering-test-coverage-analysis-20260702.md
@@ -4,7 +4,7 @@ title: "test-coverage-analysis-20260702"
 description: "结论先行：**整体覆盖健康，四层护栏（行覆盖 / 变异 / 真集成 / 数据纪律）结构成熟**。（格式：md）"
 resource: "/Public-Info-Pool/Resource/repo-engineering/test-coverage-analysis-20260702.md"
 tags: ["data_layer:curated", "deliverable", "topic:repo-engineering"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-config.md
+++ b/okf/unpacked/unpacked-config.md
@@ -4,7 +4,7 @@ title: "config"
 description: "客户端解包lua 字节码子集（binary，非明文）「config」：149 文件 / 90.7MB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/config/"
 tags: ["data_layer:full_archive", "content:config", "encoding:luac", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-ejoysdk-lua.md
+++ b/okf/unpacked/unpacked-ejoysdk-lua.md
@@ -4,7 +4,7 @@ title: "ejoysdk_lua"
 description: "客户端解包lua 字节码子集（binary，非明文）「ejoysdk_lua」：588 文件 / 9.3MB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/ejoysdk_lua/"
 tags: ["data_layer:full_archive", "content:ejoysdk-lua", "encoding:luac", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-foundation.md
+++ b/okf/unpacked/unpacked-foundation.md
@@ -4,7 +4,7 @@ title: "foundation"
 description: "客户端解包lua 字节码子集（binary，非明文）「foundation」：77 文件 / 652.5KB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/foundation/"
 tags: ["data_layer:full_archive", "content:foundation", "encoding:luac", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-game-data-all.md
+++ b/okf/unpacked/unpacked-game-data-all.md
@@ -4,7 +4,7 @@ title: "全部游戏数据"
 description: "客户端解包text 子集（明文）「全部游戏数据」：14 文件 / 41.3MB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/全部游戏数据/"
 tags: ["data_layer:full_archive", "content:game-data-all", "encoding:text", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-game-text.md
+++ b/okf/unpacked/unpacked-game-text.md
@@ -4,7 +4,7 @@ title: "游戏文本"
 description: "客户端解包text 子集（明文）「游戏文本」：11 文件 / 45.4MB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/游戏文本/"
 tags: ["data_layer:full_archive", "content:game-text", "encoding:text", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-gamelauncher.md
+++ b/okf/unpacked/unpacked-gamelauncher.md
@@ -4,7 +4,7 @@ title: "gamelauncher"
 description: "客户端解包lua 字节码子集（binary，非明文）「gamelauncher」：3 文件 / 8.2KB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/gamelauncher/"
 tags: ["data_layer:full_archive", "content:gamelauncher", "encoding:luac", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-gamescript.md
+++ b/okf/unpacked/unpacked-gamescript.md
@@ -4,7 +4,7 @@ title: "gamescript"
 description: "客户端解包lua 字节码子集（binary，非明文）「gamescript」：2295 文件 / 22.9MB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/gamescript/"
 tags: ["data_layer:full_archive", "content:gamescript", "encoding:luac", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-gameupdate.md
+++ b/okf/unpacked/unpacked-gameupdate.md
@@ -4,7 +4,7 @@ title: "gameupdate"
 description: "客户端解包text 子集（明文）「gameupdate」：127 文件 / 119.1KB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/gameupdate/"
 tags: ["data_layer:full_archive", "content:gameupdate", "encoding:text", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-lua-tables.md
+++ b/okf/unpacked/unpacked-lua-tables.md
@@ -4,7 +4,7 @@ title: "Lua表还原"
 description: "客户端解包text 子集（明文）「Lua表还原」：24 文件 / 18.7MB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/Lua表还原/"
 tags: ["data_layer:full_archive", "content:lua-tables", "encoding:text", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-share.md
+++ b/okf/unpacked/unpacked-share.md
@@ -4,7 +4,7 @@ title: "share"
 description: "客户端解包lua 字节码子集（binary，非明文）「share」：299 文件 / 2.0MB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/share/"
 tags: ["data_layer:full_archive", "content:share", "encoding:luac", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-sproto.md
+++ b/okf/unpacked/unpacked-sproto.md
@@ -4,7 +4,7 @@ title: "sproto"
 description: "客户端解包text 子集（明文）「sproto」：1 文件 / 2.7KB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/sproto/"
 tags: ["data_layer:full_archive", "content:sproto", "encoding:text", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-text-cn.md
+++ b/okf/unpacked/unpacked-text-cn.md
@@ -4,7 +4,7 @@ title: "text_cn"
 description: "客户端解包lua 字节码子集（binary，非明文）「text_cn」：69 文件 / 28.1MB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/text_cn/"
 tags: ["data_layer:full_archive", "content:text-cn", "encoding:luac", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/unpacked/unpacked-vue.md
+++ b/okf/unpacked/unpacked-vue.md
@@ -4,7 +4,7 @@ title: "vue"
 description: "客户端解包lua 字节码子集（binary，非明文）「vue」：39 文件 / 322.7KB。一手解包，本体原地。"
 resource: "/Public-Info-Pool/Reference/Game-Unpacked/vue/"
 tags: ["data_layer:full_archive", "content:vue", "encoding:luac", "first-hand-unpack"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-aliases.md
+++ b/okf/wiki-data/wiki-data-aliases.md
@@ -4,7 +4,7 @@ title: "aliases"
 description: "aliases 数据集"
 resource: "/projects/wiki/data/processed/aliases.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:index"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-banners-by-character.md
+++ b/okf/wiki-data/wiki-data-banners-by-character.md
@@ -4,7 +4,7 @@ title: "banners_by_character"
 description: "生成 2026-04-26T15:18:18+00:00"
 resource: "/projects/wiki/data/processed/banners_by_character.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:gameplay"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-cg-gallery.md
+++ b/okf/wiki-data/wiki-data-cg-gallery.md
@@ -4,7 +4,7 @@ title: "cg_gallery"
 description: "art_assets/manifest.json (UnityPy extraction) · total_cg=404 · 生成 2026-04-12"
 resource: "/projects/wiki/data/processed/cg_gallery.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:gameplay"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-character-index.md
+++ b/okf/wiki-data/wiki-data-character-index.md
@@ -4,7 +4,7 @@ title: "character_index"
 description: "生成 2026-06-17"
 resource: "/projects/wiki/data/processed/character_index.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:index"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-character-skills.md
+++ b/okf/wiki-data/wiki-data-character-skills.md
@@ -4,7 +4,7 @@ title: "character_skills"
 description: "[[toc]]"
 resource: "/projects/wiki/data/processed/character_skills.md"
 tags: ["data_layer:curated", "community-sourced", "version-volatile", "domain:gameplay"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-drops-by-item.md
+++ b/okf/wiki-data/wiki-data-drops-by-item.md
@@ -4,7 +4,7 @@ title: "drops_by_item"
 description: "db/stages.json · total_drop_references=0 · 生成 2026-04-26T15:18:18+00:00"
 resource: "/projects/wiki/data/processed/drops_by_item.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:gameplay"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-feature-unlock.md
+++ b/okf/wiki-data/wiki-data-feature-unlock.md
@@ -4,7 +4,7 @@ title: "feature_unlock"
 description: "FeatureUnlock.lua (runtime memory extraction) · total_features=318 · 生成 2026-04-25"
 resource: "/projects/wiki/data/processed/feature_unlock.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:gameplay"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-item-stories.md
+++ b/okf/wiki-data/wiki-data-item-stories.md
@@ -4,7 +4,7 @@ title: "item_stories"
 description: "Item.lua (runtime memory extraction) · total_with_story=375 · 生成 2026-04-12"
 resource: "/projects/wiki/data/processed/item_stories.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:story"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-language-config.md
+++ b/okf/wiki-data/wiki-data-language-config.md
@@ -4,7 +4,7 @@ title: "language_config"
 description: "LanguageConfig.lua (runtime memory extraction) · total_entries=3045 · 生成 2026-04-26"
 resource: "/projects/wiki/data/processed/language_config.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:localization"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-panel-text.md
+++ b/okf/wiki-data/wiki-data-panel-text.md
@@ -4,7 +4,7 @@ title: "panel_text"
 description: "PanelText.lua (runtime memory extraction) · total_entries=3163 · 生成 2026-04-26"
 resource: "/projects/wiki/data/processed/panel_text.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:localization"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-potency.md
+++ b/okf/wiki-data/wiki-data-potency.md
@@ -4,7 +4,7 @@ title: "potency"
 description: "AwakerPotency.lua (runtime memory extraction) · total_potencies=1035 · 生成 2026-04-25"
 resource: "/projects/wiki/data/processed/potency.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:gameplay"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-stages.md
+++ b/okf/wiki-data/wiki-data-stages.md
@@ -4,7 +4,7 @@ title: "stages"
 description: "Stage.lua + StageGroup.lua (runtime memory extraction) · total_stages=5709 · 生成 2026-04-25"
 resource: "/projects/wiki/data/processed/stages.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:gameplay"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-story-character-map.md
+++ b/okf/wiki-data/wiki-data-story-character-map.md
@@ -4,7 +4,7 @@ title: "story_character_map"
 description: "CollectionHall.lua · total_entries=1026 · 生成 2026-06-16"
 resource: "/projects/wiki/data/processed/story_character_map.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:story"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-summon.md
+++ b/okf/wiki-data/wiki-data-summon.md
@@ -4,7 +4,7 @@ title: "summon"
 description: "Summon.lua (runtime memory extraction) · total_banners=366 · 生成 2026-04-25"
 resource: "/projects/wiki/data/processed/summon.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:gameplay"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-tasks.md
+++ b/okf/wiki-data/wiki-data-tasks.md
@@ -4,7 +4,7 @@ title: "tasks"
 description: "Task.lua (runtime memory extraction) · total_tasks=6317 · 生成 2026-04-25"
 resource: "/projects/wiki/data/processed/tasks.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:gameplay"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-update-notices.md
+++ b/okf/wiki-data/wiki-data-update-notices.md
@@ -4,7 +4,7 @@ title: "update_notices"
 description: "UpdateNotices.lua (game update/maintenance notices) · total_entries=2697 · 生成 2026-04-26"
 resource: "/projects/wiki/data/processed/update_notices.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:localization"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-voice-character-map.md
+++ b/okf/wiki-data/wiki-data-voice-character-map.md
@@ -4,7 +4,7 @@ title: "voice_character_map"
 description: "Voice.lua + AwakerConfig.lua text matching · total_voice_entries=2562 · 生成 2026-04-26"
 resource: "/projects/wiki/data/processed/voice_character_map.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:story"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-voice-lines.md
+++ b/okf/wiki-data/wiki-data-voice-lines.md
@@ -4,7 +4,7 @@ title: "voice_lines"
 description: "Voice.lua (runtime memory extraction) · total_lines=2543 · 生成 2026-04-12"
 resource: "/projects/wiki/data/processed/voice_lines.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:story"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-data-world-lore.md
+++ b/okf/wiki-data/wiki-data-world-lore.md
@@ -4,7 +4,7 @@ title: "world_lore"
 description: "CollectionHall.lua (runtime memory extraction) · total_entries=1026 · 生成 2026-04-12"
 resource: "/projects/wiki/data/processed/world_lore.json"
 tags: ["data_layer:curated", "unpacked-bootstrap", "domain:story"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-schema-banners-schema.md
+++ b/okf/wiki-data/wiki-schema-banners-schema.md
@@ -4,7 +4,7 @@ title: "banners.schema.json"
 description: "wiki 数据模型 schema 定义（banners.schema），派生 JSON 的契约来源。"
 resource: "/projects/wiki/data/schemas/banners.schema.json"
 tags: ["data_layer:curated", "schema", "contract"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-schema-characters-processed-schema.md
+++ b/okf/wiki-data/wiki-schema-characters-processed-schema.md
@@ -4,7 +4,7 @@ title: "characters.processed.schema.json"
 description: "wiki 数据模型 schema 定义（characters.processed.schema），派生 JSON 的契约来源。"
 resource: "/projects/wiki/data/schemas/characters.processed.schema.json"
 tags: ["data_layer:curated", "schema", "contract"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-schema-characters-schema.md
+++ b/okf/wiki-data/wiki-schema-characters-schema.md
@@ -4,7 +4,7 @@ title: "characters.schema.json"
 description: "wiki 数据模型 schema 定义（characters.schema），派生 JSON 的契约来源。"
 resource: "/projects/wiki/data/schemas/characters.schema.json"
 tags: ["data_layer:curated", "schema", "contract"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-schema-items-schema.md
+++ b/okf/wiki-data/wiki-schema-items-schema.md
@@ -4,7 +4,7 @@ title: "items.schema.json"
 description: "wiki 数据模型 schema 定义（items.schema），派生 JSON 的契约来源。"
 resource: "/projects/wiki/data/schemas/items.schema.json"
 tags: ["data_layer:curated", "schema", "contract"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-schema-meta-schema.md
+++ b/okf/wiki-data/wiki-schema-meta-schema.md
@@ -4,7 +4,7 @@ title: "meta.schema.json"
 description: "wiki 数据模型 schema 定义（meta.schema），派生 JSON 的契约来源。"
 resource: "/projects/wiki/data/schemas/meta.schema.json"
 tags: ["data_layer:curated", "schema", "contract"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-schema-realms-schema.md
+++ b/okf/wiki-data/wiki-schema-realms-schema.md
@@ -4,7 +4,7 @@ title: "realms.schema.json"
 description: "wiki 数据模型 schema 定义（realms.schema），派生 JSON 的契约来源。"
 resource: "/projects/wiki/data/schemas/realms.schema.json"
 tags: ["data_layer:curated", "schema", "contract"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-schema-stages-schema.md
+++ b/okf/wiki-data/wiki-schema-stages-schema.md
@@ -4,7 +4,7 @@ title: "stages.schema.json"
 description: "wiki 数据模型 schema 定义（stages.schema），派生 JSON 的契约来源。"
 resource: "/projects/wiki/data/schemas/stages.schema.json"
 tags: ["data_layer:curated", "schema", "contract"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念

--- a/okf/wiki-data/wiki-schema-trinkets-schema.md
+++ b/okf/wiki-data/wiki-schema-trinkets-schema.md
@@ -4,7 +4,7 @@ title: "trinkets.schema.json"
 description: "wiki 数据模型 schema 定义（trinkets.schema），派生 JSON 的契约来源。"
 resource: "/projects/wiki/data/schemas/trinkets.schema.json"
 tags: ["data_layer:curated", "schema", "contract"]
-timestamp: "2026-07-09"
+timestamp: "2026-07-10"
 ---
 
 # 指针概念


### PR DESCRIPTION
## Summary

Generated-artifact follow-up to #548: the OKF bundle consistency guard regenerated the bundle after `docs/OPENAI-PROTOCOL.md` landed —

- +1 `documentation` pointer concept (`okf/projects/bpt-sdk-doc-openai-protocol.md`, 336 -> 337 concepts)
- `kb_index.json` inverted index resynced (+3 terms)
- generated timestamps re-stamped to 2026-07-10 across pointer concepts

No source-of-truth content changed; pointers only (放指针不放本体). Repo pytest already ran green (2680 passed) against this regenerated state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8hw4yfXpUJ58QMY2x5Rtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8hw4yfXpUJ58QMY2x5Rtp)_