### PR TITLE
fix(bpt-agent-sdk): port empty-stream retry arm (断流继续臂) to OpenAI transport (v0.37.1)

### DIFF
--- a/projects/bpt-agent-sdk/CHANGELOG.md
+++ b/projects/bpt-agent-sdk/CHANGELOG.md
@@ -11,6 +11,37 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.37.1 — 2026-07-10
+
+**Port the empty-stream retry arm (断流继续臂) to the OpenAI-protocol transport.**
+The 0.36.0 fix taught `AnthropicTransport` to self-heal an HTTP 200 that closes
+with ZERO SSE events (a replay-safe gateway non-start) instead of crashing the
+turn, but the OpenAI translating transport (0.35.0) shipped without that arm —
+`OpenAIChatTransport.streamRequest` issued the request once and, on a clean
+close with zero chunks (no `[DONE]`, no `finish_reason`), threw an unretryable,
+unsalvageable `APIConnectionError` (`midStreamTruncation` false because
+`chunkCount === 0`) that took down the whole `query()` turn. On any
+OpenAI-compatible gateway (DeepSeek / vLLM / one-api) exhibiting the same
+throttle-under-fan-out shape, main conversation and subagents alike died where
+the Anthropic arm would have recovered.
+
+- **fix:** `OpenAIChatTransport.streamRequest` now wraps request+stream in the
+  same `for (;;)` retry loop. A clean close with `chunkCount === 0` re-issues
+  the whole request (exponential backoff + jitter, honoring the caller abort),
+  bounded by the same `maxRetries` budget; on exhaustion it throws a
+  retryable-class `APIConnectionError` with the stable code `empty_stream`
+  ("empty stream (HTTP 200, zero SSE chunks) after N attempt(s)"). The retry
+  lives INSIDE the transport, so subagents self-heal with no host involvement.
+- **unchanged semantics preserved:** chunks-then-clean-close-without-marker is
+  still a MID-STREAM truncation (`midStreamTruncation: true`, E3 salvage, never
+  retried); a mid-stream network ERROR still routes through `mapStreamError` and
+  stays terminal. `streamRequest` is a deliberate per-arm copy (translation vs
+  raw passthrough), so it is not a transport twin — noted for
+  `tests/transport-twin-drift.test.ts`.
+- **tests:** `tests/transport-openai.test.ts` gains the mirror suite (heal on
+  retry, exhaustion → `empty_stream`, `maxRetries: 0` still throws, `onRetry`
+  network-level shape, abort-during-backoff wins).
+
 ## 0.36.0 — 2026-07-09
 
 **Retry an empty stream (HTTP 200, zero SSE events) instead of crashing the turn**

--- a/projects/bpt-agent-sdk/docs/OPENAI-PROTOCOL.md
+++ b/projects/bpt-agent-sdk/docs/OPENAI-PROTOCOL.md
@@ -95,10 +95,16 @@ makes cost metrics and `maxBudgetUsd` enforceable for non-Claude models.
 | `usage.prompt_tokens` / `completion_tokens` / `prompt_tokens_details.cached_tokens` | `input_tokens` (minus cached) / `output_tokens` / `cache_read_input_tokens` |
 
 Retry policy (408/429/5xx + network errors, exponential backoff + jitter,
-`retry-after` honored), the stream idle watchdog, per-request timeouts and the
+`retry-after` honored), the **empty-stream retry** (a clean HTTP 200 that
+closes with zero SSE chunks — no `[DONE]`, no `finish_reason` — is a
+replay-safe non-start, re-issued within the `maxRetries` budget rather than
+crashing the turn; on exhaustion it throws `APIConnectionError` code
+`empty_stream`), the stream idle watchdog, per-request timeouts and the
 concurrency semaphore all mirror the Anthropic transport; the same
 `ProviderConfig` knobs (`maxRetries`, `timeoutMs`, `streamIdleTimeoutMs`,
-`maxConcurrentRequests`) apply. Non-2xx errors surface as `APIStatusError`
+`maxConcurrentRequests`) apply. A mid-stream drop *after* chunks (a truncated
+turn) is never retried — it degrades gracefully via the engine's E3 salvage.
+Non-2xx errors surface as `APIStatusError`
 with the error type **normalized to Messages API vocabulary** by status
 (`401 -> authentication_error`, `429 -> rate_limit_error`, ...) so engine-side
 handling is provider-agnostic.

--- a/projects/bpt-agent-sdk/package-lock.json
+++ b/projects/bpt-agent-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.34.1",
+  "version": "0.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bpt-agent-sdk",
-      "version": "0.34.1",
+      "version": "0.37.1",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/bpt-agent-sdk/package.json
+++ b/projects/bpt-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpt-agent-sdk",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "BPT Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/bpt-agent-sdk/src/transport/openai.ts
+++ b/projects/bpt-agent-sdk/src/transport/openai.ts
@@ -600,98 +600,147 @@ export class OpenAIChatTransport implements Transport {
     const timeoutMs = this.provider.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const maxRetries = resolveMaxRetries(this.provider, this.env);
 
-    // ---- request phase: retries allowed -----------------------------------
-    const { response, signal, timeoutSignal } = await this.requestWithRetries(
-      bodyJson,
-      headers,
-      callerSignal,
-      timeoutMs,
-      maxRetries,
-      onRetry,
-    );
-
-    // ---- streaming phase: NEVER retried ------------------------------------
-    // OpenAI-protocol servers/gateways report the correlation id as
-    // x-request-id (some proxies keep Anthropic's request-id); capture either
-    // so APIStatusError carries the same diagnosability as the Anthropic arm.
-    const requestId =
-      response.headers.get('x-request-id') ??
-      response.headers.get('request-id') ??
-      undefined;
-    if (!response.body) {
-      throw new APIConnectionError('Chat Completions response has no body');
-    }
-    const idleMs = resolveStreamIdleMs(this.provider, this.env);
-    const idleController = idleMs > 0 ? new AbortController() : undefined;
-    const streamSignal = idleController
-      ? AbortSignal.any([signal, idleController.signal])
-      : signal;
-    let idleTimer: ReturnType<typeof setTimeout> | undefined;
-    const resetIdle = (): void => {
-      if (!idleController) return;
-      if (idleTimer) clearTimeout(idleTimer);
-      idleTimer = setTimeout(() => idleController.abort(), idleMs);
-      (idleTimer as { unref?: () => void }).unref?.();
-    };
-    const translator = new OpenAIStreamTranslator(req.model);
-    let chunkCount = 0;
-    let doneSeen = false;
-    try {
-      resetIdle();
-      for await (const frame of parseSSE(response.body, streamSignal)) {
-        resetIdle();
-        const data = frame.data.trim();
-        if (data === '[DONE]') {
-          doneSeen = true;
-          break;
-        }
-        let parsed: OpenAIChunk;
-        try {
-          parsed = JSON.parse(data) as OpenAIChunk;
-        } catch (err) {
-          throw new APIConnectionError(
-            `Malformed Chat Completions SSE payload after ${chunkCount} chunk(s): ` +
-              data.slice(0, 120),
-            err,
-            'sse_malformed_frame',
-          );
-        }
-        if (parsed.error !== undefined && parsed.error !== null) {
-          const info = extractOpenAIError(parsed.error);
-          throw new APIStatusError(500, info.type, info.message, requestId);
-        }
-        chunkCount += 1;
-        yield* translator.feed(parsed);
-      }
-      // A stream that ends CLEANLY but carried neither [DONE] nor any
-      // finish_reason never reached its end-of-message marker: the connection
-      // was cut mid-turn (proxy timeout, server restart). Do NOT fabricate an
-      // end_turn success from the half-received answer — surface it as a
-      // truncated turn so the engine's E3 salvage applies, matching the
-      // Anthropic arm's semantics. (Audit 2026-07-10 P1-2.)
-      if (!doneSeen && !translator.sawFinishReason()) {
-        const failure = new APIConnectionError(
-          `Chat Completions stream ended without [DONE] or finish_reason after ` +
-            `${chunkCount} chunk(s); treating as a truncated turn`,
-        );
-        failure.midStreamTruncation = chunkCount > 0;
-        throw failure;
-      }
-      yield* translator.finish();
-    } catch (err) {
-      throw mapStreamError(
-        err,
+    // Empty-stream retry (断流继续臂): an HTTP 200 whose SSE body carries ZERO
+    // chunks before closing CLEANLY is a replay-SAFE non-start — the gateway
+    // accepted the request but delivered nothing (an idealab-style throttle
+    // shape observed under concurrent fan-out). Unlike a mid-stream drop
+    // (chunks already yielded, which must never replay a partially consumed
+    // turn), zero chunks means zero consumption, so re-issuing the whole
+    // request is safe. Retried HERE, inside the transport, so BOTH the main
+    // conversation and subagents (which run on this same transport, out of
+    // reach of any host-level retry) self-heal without the caller seeing the
+    // empty stream. Bounded by the same maxRetries budget; on exhaustion we
+    // surface a retryable-class `empty_stream` APIConnectionError. This mirrors
+    // AnthropicTransport's arm — a LOCAL copy because the streaming bodies
+    // genuinely differ (translation vs raw passthrough), so streamRequest is
+    // NOT a transport twin (see tests/transport-twin-drift.test.ts). A network
+    // ERROR mid-stream (parseSSE throws) still routes through the catch below
+    // and is NEVER retried, empty or not.
+    let emptyStreamRetries = 0;
+    for (;;) {
+      // ---- request phase: retries allowed ---------------------------------
+      const { response, signal, timeoutSignal } = await this.requestWithRetries(
+        bodyJson,
+        headers,
         callerSignal,
-        timeoutSignal,
         timeoutMs,
-        chunkCount,
-        idleController?.signal,
-        idleMs,
+        maxRetries,
+        onRetry,
       );
-    } finally {
-      if (idleTimer) clearTimeout(idleTimer);
+
+      // ---- streaming phase: NEVER retried once a chunk is delivered --------
+      // OpenAI-protocol servers/gateways report the correlation id as
+      // x-request-id (some proxies keep Anthropic's request-id); capture either
+      // so APIStatusError carries the same diagnosability as the Anthropic arm.
+      const requestId =
+        response.headers.get('x-request-id') ??
+        response.headers.get('request-id') ??
+        undefined;
+      if (!response.body) {
+        throw new APIConnectionError('Chat Completions response has no body');
+      }
+      const idleMs = resolveStreamIdleMs(this.provider, this.env);
+      const idleController = idleMs > 0 ? new AbortController() : undefined;
+      const streamSignal = idleController
+        ? AbortSignal.any([signal, idleController.signal])
+        : signal;
+      let idleTimer: ReturnType<typeof setTimeout> | undefined;
+      const resetIdle = (): void => {
+        if (!idleController) return;
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => idleController.abort(), idleMs);
+        (idleTimer as { unref?: () => void }).unref?.();
+      };
+      const translator = new OpenAIStreamTranslator(req.model);
+      let chunkCount = 0;
+      let doneSeen = false;
+      try {
+        resetIdle();
+        for await (const frame of parseSSE(response.body, streamSignal)) {
+          resetIdle();
+          const data = frame.data.trim();
+          if (data === '[DONE]') {
+            doneSeen = true;
+            break;
+          }
+          let parsed: OpenAIChunk;
+          try {
+            parsed = JSON.parse(data) as OpenAIChunk;
+          } catch (err) {
+            throw new APIConnectionError(
+              `Malformed Chat Completions SSE payload after ${chunkCount} chunk(s): ` +
+                data.slice(0, 120),
+              err,
+              'sse_malformed_frame',
+            );
+          }
+          if (parsed.error !== undefined && parsed.error !== null) {
+            const info = extractOpenAIError(parsed.error);
+            throw new APIStatusError(500, info.type, info.message, requestId);
+          }
+          chunkCount += 1;
+          yield* translator.feed(parsed);
+        }
+      } catch (err) {
+        throw mapStreamError(
+          err,
+          callerSignal,
+          timeoutSignal,
+          timeoutMs,
+          chunkCount,
+          idleController?.signal,
+          idleMs,
+        );
+      } finally {
+        if (idleTimer) clearTimeout(idleTimer);
+      }
+
+      // The stream ended without throwing. A [DONE] terminator or any
+      // finish_reason means the message reached its end-of-message marker:
+      // synthesize the terminal message_delta/message_stop and finish.
+      if (doneSeen || translator.sawFinishReason()) {
+        yield* translator.finish();
+        this.debug(`openai transport: stream completed after ${chunkCount} chunk(s)`);
+        return;
+      }
+
+      // No end-of-message marker. ZERO chunks => an empty stream (replay-safe):
+      // retry the whole request within the shared budget, like the Anthropic
+      // arm's idealab-throttle self-heal. Any caller abort observed here wins.
+      if (chunkCount === 0) {
+        if (callerSignal?.aborted) throw new AbortError();
+        if (emptyStreamRetries < maxRetries) {
+          emptyStreamRetries += 1;
+          this.debug(
+            `openai transport: empty stream (HTTP 200, zero SSE chunks); ` +
+              `retry ${emptyStreamRetries}/${maxRetries}`,
+          );
+          // Surface it like a network-level retry (no HTTP status) so the loop
+          // emits an api_retry observability message, same as a dropped socket.
+          onRetry?.({ attempt: emptyStreamRetries, maxRetries });
+          await this.backoff(emptyStreamRetries, undefined, callerSignal);
+          continue;
+        }
+        throw new APIConnectionError(
+          `Chat Completions returned an empty stream (HTTP 200, zero SSE chunks) ` +
+            `after ${emptyStreamRetries + 1} attempt(s)`,
+          undefined,
+          'empty_stream',
+        );
+      }
+
+      // Chunks arrived but no [DONE]/finish_reason: a MID-STREAM connection drop
+      // (proxy timeout, server restart). Do NOT fabricate an end_turn success
+      // from the half-received answer — surface it as a truncated turn so the
+      // engine's E3 salvage applies, matching the Anthropic arm. NEVER retried
+      // (replaying a partially consumed turn is unsafe). (Audit 2026-07-10 P1-2.)
+      const failure = new APIConnectionError(
+        `Chat Completions stream ended without [DONE] or finish_reason after ` +
+          `${chunkCount} chunk(s); treating as a truncated turn`,
+      );
+      failure.midStreamTruncation = true;
+      throw failure;
     }
-    this.debug(`openai transport: stream completed after ${chunkCount} chunk(s)`);
   }
 
   /** Same retry policy as AnthropicTransport: 408/429/5xx + network errors

--- a/projects/bpt-agent-sdk/src/version.ts
+++ b/projects/bpt-agent-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.37.0';
+export const SDK_VERSION = '0.37.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `bpt-agent-sdk/${SDK_VERSION}`;

--- a/projects/bpt-agent-sdk/tests/transport-openai.test.ts
+++ b/projects/bpt-agent-sdk/tests/transport-openai.test.ts
@@ -23,7 +23,7 @@ import {
   APIStatusError,
   ConfigurationError,
 } from '../src/errors.js';
-import type { StreamRequest } from '../src/internal/contracts.js';
+import type { RetryInfo, StreamRequest } from '../src/internal/contracts.js';
 import type { RawMessageStreamEvent } from '../src/types.js';
 
 const enc = new TextEncoder();
@@ -835,6 +835,104 @@ describe('OpenAIChatTransport stream-fault quadrant', () => {
     const err = (await captureError(collect(transport.stream(REQ)))) as APIStatusError;
     expect(err).toBeInstanceOf(APIStatusError);
     expect(err.requestId).toBe('req_openai_123');
+  });
+});
+
+describe('OpenAIChatTransport empty-stream retry (idealab throttle self-heal)', () => {
+  // A CLEAN HTTP 200 whose SSE body carries zero chunks (no [DONE], no
+  // finish_reason) — the replay-safe non-start the 断流继续臂 heals. Distinct
+  // from the quadrant's ECONNRESET-before-any-chunk case (a stream ERROR, which
+  // stays terminal). Mirrors AnthropicTransport's empty-stream retry.
+  function emptyStream(): Response {
+    return new Response(streamFromChunks([]), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  }
+
+  it('retries an empty stream (HTTP 200, zero SSE chunks) then completes on the healed retry', async () => {
+    // Pin backoff jitter so the single retry waits a deterministic ~500ms.
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(emptyStream()) // 200, empty body -> replay-safe non-start
+      .mockResolvedValueOnce(okStream(TEXT_CHUNKS)); // healed: a real stream
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({ provider: { apiKey: 'k' }, env: {}, debug: noop });
+    const events = await collect(transport.stream(REQ));
+    expect(events.at(-1)?.type).toBe('message_stop');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('never returns normally on an empty stream: persistent empties exhaust the budget into an empty_stream APIConnectionError', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(emptyStream())
+      .mockResolvedValueOnce(emptyStream());
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({
+      provider: { apiKey: 'k', maxRetries: 1 },
+      env: {},
+      debug: noop,
+    });
+    const err = (await captureError(collect(transport.stream(REQ)))) as APIConnectionError;
+    expect(err).toBeInstanceOf(APIConnectionError);
+    expect(err.code).toBe('empty_stream');
+    expect(err.message).toMatch(/empty stream/i);
+    expect(err.message).toMatch(/after 2 attempt\(s\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // initial + 1 retry
+  });
+
+  it('with maxRetries 0 an empty stream is not retried but STILL becomes a diagnosable empty_stream', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(emptyStream());
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({
+      provider: { apiKey: 'k', maxRetries: 0 },
+      env: {},
+      debug: noop,
+    });
+    const err = (await captureError(collect(transport.stream(REQ)))) as APIConnectionError;
+    expect(err).toBeInstanceOf(APIConnectionError);
+    expect(err.code).toBe('empty_stream');
+    expect(err.message).toMatch(/after 1 attempt\(s\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('an empty-stream retry fires onRetry with a network-level shape (no HTTP status), like a dropped socket', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(emptyStream())
+      .mockResolvedValueOnce(okStream(TEXT_CHUNKS));
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({ provider: { apiKey: 'k' }, env: {}, debug: noop });
+    const retries: RetryInfo[] = [];
+    const events = await collect(
+      transport.stream({ ...REQ, onRetry: (info) => retries.push(info) }),
+    );
+    expect(events.at(-1)?.type).toBe('message_stop');
+    expect(retries).toHaveLength(1);
+    expect(retries[0]).toMatchObject({ attempt: 1 });
+    expect(retries[0]!.status).toBeUndefined();
+  });
+
+  it('a caller abort during the empty-stream backoff wins over the retry', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(emptyStream())
+      .mockResolvedValueOnce(okStream(TEXT_CHUNKS));
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({ provider: { apiKey: 'k' }, env: {}, debug: noop });
+    const ac = new AbortController();
+    // Abort while the transport is backing off before the retry fetch.
+    const onRetry = (): void => ac.abort();
+    const err = await captureError(
+      collect(transport.stream({ ...REQ, signal: ac.signal, onRetry })),
+    );
+    expect(err).toBeInstanceOf(AbortError);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // never reached the retry fetch
   });
 });
 


### PR DESCRIPTION
## 概述

把 0.36.0 给 `AnthropicTransport` 加的**空流重试臂（断流继续臂）**补齐到 OpenAI 协议传输层。守密人反馈「bpt-agent-sdk 的 OpenAI 协议还没兼容断流继续臂」——本 PR 修复该缺口，v0.37.1。

**根因（小学生比喻）**：Anthropic 那台自动售货机吞了币却没出货（HTTP 200 但零 SSE 事件、重放安全的「假启动」）时会自己退币重来；OpenAI 这台（0.35.0 引入的翻译传输层）吞了币没出货就直接死机，也不退币——整轮 `query()` 崩掉，跑在同一传输层上的子代理更是当场死亡、宿主层重试够不着。

- `OpenAIChatTransport.streamRequest` 原本只发一次请求；干净关闭且零 chunk（无 `[DONE]`、无 `finish_reason`）时抛出**不可重试、不可挽救**的 `APIConnectionError`（`midStreamTruncation` 为 false，因 `chunkCount === 0`）。
- 任何 OpenAI 兼容网关（DeepSeek / vLLM / one-api）出现同款「扇出限流」形状时，主对话与子代理都会死在 Anthropic 臂本可自愈的地方。

---

## 变更类型

- [x] Bug 修复
- 影响面：`src/transport/openai.ts`（发货运行时），按版本纪律 bump patch `0.37.0 → 0.37.1`。

**修法**：把请求 + 流式包进与 Anthropic 臂同款的 `for (;;)` 重试环——干净关闭且 `chunkCount === 0` 时在共享 `maxRetries` 预算内重发整请求（指数退避 + 抖动、尊重调用方 abort），预算耗尽抛可重试类 `APIConnectionError`、稳定错误码 `empty_stream`。重试住在传输层内部，子代理无需宿主介入即自愈。

**保持不变的语义**：
- 已吐 chunk 再干净断裂（无终止标记）= **中途截断**（`midStreamTruncation: true`、走引擎 E3 挽救、绝不重试）。
- 流式途中的网络 ERROR 仍经 `mapStreamError` 判定、保持终局。
- `streamRequest` 是刻意的**逐臂副本**（翻译 vs 原样透传，流式主体本就不同），非传输孪生——已在注释与 `tests/transport-twin-drift.test.ts` 语境注明；孪生守卫仍全绿（9/9），未因本次改动漂移。

---

## 来源声明

不适用：本 PR 为纯工程改动（传输层弹性修复），不涉及任何游戏数据 / Wiki 内容 / 翻译，无外部素材引用。

## 安全声明

不适用（C1 AI 会话工程改动）：不含任何黑池 / 内网 / 未发布渠道数据；仅改银芯→黑池单向输出物 `bpt-agent-sdk` 自身传输层代码，§1.1-HC 防火墙无涉。

---

## 验证清单

- [x] `npm run typecheck` — exit 0
- [x] `npm run build` — exit 0
- [x] 定向：`tests/transport-openai.test.ts` + `tests/transport-twin-drift.test.ts` + `tests/transport.test.ts` = 105 pass（含 5 条新镜像用例 + 孪生守卫 9 条）
- [x] 全量：`npm test` = **1604 pass / 2 skipped**（2 skip 为无 bwrap 时跳过的沙箱隔离测试）
- [x] 不引入 emoji
- [x] 未动 `memory/decisions.md` / `memory/lessons-learned.md`

**新增镜像测试**（对齐 Anthropic 臂）：空流重试后自愈、持续空流耗尽预算 → `empty_stream`、`maxRetries: 0` 仍抛不返回、`onRetry` 网络级形状（无 HTTP status）、退避期间调用方 abort 优先。

## 关联 Issue

- Refs: 守密人 2026-07-10 会话派单「OpenAI 协议兼容断流继续臂」
- 承接：#547（0.36.0 Anthropic 臂空流重试）· #548（0.35.0 OpenAI 协议支持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFDDJhgzFY8fiA5xL8iprV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFDDJhgzFY8fiA5xL8iprV)_