### PR TITLE
fix(news): revive bahamut and note_com collectors; arca_live/twitter dispositions documented

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -63,8 +63,18 @@
 
 ### 实时聚合器
 - **已完成**：前端页面、B站抓取、GitHub Actions 自动化
-- **阻塞**：Twitter/X 需付费 Token（未接入）；bahamut / arca_live / note_com 零产出待核
-  （Arca 实测 PW 选择器超时，`.vrow` 不可见——疑站点改版）
+- **零产出四源处置（2026-07-10 排查+修复，CI 日志 + live 探测定性）**：
+  - [x] **bahamut 已修复**：真因 = `B.php?ajax=1` JSON 接口退役（返回整页 HTML）+
+    `search.php` 需板編（bsn=0 报「沒有傳入板編」）且新版全站搜索纯 JS 渲染——旧双路径
+    注定零产出。改为解析忘卻前夜专板（bsn=78829）列表页 HTML，本地实测 30 帖入流
+  - [x] **note_com 已修复**：真因 = `/api/v3/searches` 已对非浏览器请求一律 403（浏览器头
+    与 cloudscraper 均被拒）。改走 hashtag RSS（`/hashtag/忘却前夜/rss`），本地实测 25 条；
+    RSS 无互动指标 → engagement 恒 0（同 weixin 已知限制）
+  - [ ] **arca_live 不可修（CI 基础设施性封锁）**：Cloudflare 拦 GitHub Actions 机房 IP
+    ——HTTP 403 / PW 挑战页超时 / App API 403 三路全堵；采集器代码本身无恙（住宅 IP
+    侧实测 86 条正常）。**退役 vs 挂账待守密人裁定**
+  - [ ] **twitter 需付费 Token**（TWITTER_BEARER_TOKEN 未配置，静默空）。**买 token vs
+    退役待守密人裁定**
 - **2026-07-02 degraded 排查结论（已修复）**：
   - steam / youtube / official / steam_discussion / appstore / google_play 六源为**假警报**——
     数据自 06-22 起正常写入区服分层新路径（`steam/global/review/` 等），

--- a/projects/news/CONTEXT.md
+++ b/projects/news/CONTEXT.md
@@ -73,9 +73,9 @@
 
 ### 注意事项
 - update-news.yml 每小时运行一次（cron: '0 * * * *'）
-- discord-archive.yml 已从每小时降到每日 1 次（18:00 UTC）+ 每月 1 日月度归档（Global 官方服，数据落 `Public-Info-Pool/Record/Community/discord/` 根）
-- discord-archive-volunteer.yml 每小时 :15（志愿者服务器 guild，数据落 `Public-Info-Pool/Record/Community/discord/guilds/{id}/`）
-- discord-archive-jp.yml 日服服务器归档（数据落 guilds/1377475512716234902/）：**已启用**（JP_GUILD_ID 已填、:45 错峰 cron 在跑，07-10 实测正常落档）
+- discord-archive.yml 已从每小时降到每日 1 次（18:00 UTC）+ 每月 1 日月度归档（Global 官方服，数据落 `Public-Info-Pool/Record/Community/discord/global/`，2026-07-10 方案甲）
+- discord-archive-volunteer.yml 每小时 :15（志愿者服务器 guild，数据落 `Public-Info-Pool/Record/Community/discord/volunteer/`）
+- discord-archive-jp.yml 日服服务器归档（数据落 `Public-Info-Pool/Record/Community/discord/jp/`）：**已启用**（JP_GUILD_ID 已填、:45 错峰 cron 在跑，07-10 实测正常落档）
 - discord-discover-guilds.yml 手动触发：列出 bot 所在全部服务器，发现待接入 guild ID
 - collect-comments.yml 每日 02:00 UTC（2026-06-05 新增）；recover-fanart.yml 手动触发（同日新增）
 - daily-report.yml 定时已停用，仅手动备用（报告改会话内订阅生成）
@@ -94,7 +94,8 @@ bot 已接入日服 Discord，纳入归档计划。归档器（`discord_archiver
    经 Guard 步骤安全跳过——绝不因空 ID 回落到 Global guild。
 
 首跑会全量回溯日服建服至今的历史（归档器对新 guild 的 cold-start 行为），数据隔离落
-`Public-Info-Pool/Record/Community/discord/guilds/{JP_GUILD_ID}/`，与 Global / 志愿者互不污染。
+`Public-Info-Pool/Record/Community/discord/jp/`（2026-07-10 方案甲区服布局；新 guild 须先登记
+`archive_layout.DISCORD_GUILD_REGIONS`，未登记归档响亮失败），与 Global / 志愿者互不污染。
 
 ## 已完成
 - [x] aggregator.py 基础架构（Reddit/Bilibili/Twitter/NGA/TapTap/Steam）
@@ -159,8 +160,10 @@ bot 已接入日服 Discord，纳入归档计划。归档器（`discord_archiver
 
 ## 后续待做（非本周）
 - Reddit 子版块名需确认（r/Morimens 是否存在）
-- Twitter/NGA/TapTap 需配置密钥
-- YouTube 需 API Key（代码已就绪）
+- Twitter 需付费 TWITTER_BEARER_TOKEN（买 token vs 退役待守密人裁定，2026-07-10）
+- arca_live：CI 基础设施性封锁（Cloudflare 拦 GH Actions IP，三路全堵；代码无恙），
+  退役 vs 挂账待守密人裁定（2026-07-10）；bahamut / note_com 同日已修复（详见
+  `memory/project-status.md` News 节）
 
 ## 文件说明
 - `index.html` — 前端展示页面（纯 HTML/CSS/JS，深色主题）

--- a/projects/news/scripts/global_collectors.py
+++ b/projects/news/scripts/global_collectors.py
@@ -969,112 +969,69 @@ def _fetch_google_play_one(gp_package, arch_region, locales):
             logger.debug(f"Google Play ({lang_code}/{country}) failed: {e}")
 
     return items
+# 忘卻前夜 Morimens 哈啦板板編（2026-07-10 实测 https://forum.gamer.com.tw/A.php?bsn=78829）
+BAHAMUT_DEFAULT_BSN = "78829"
+
+
 def fetch_bahamut():
-    """从巴哈姆特 (gamer.com.tw) 搜索忘却前夜讨论。台湾最大游戏社区。"""
-    baha_bsn = os.environ.get("BAHAMUT_BSN", "")  # 版块编号
+    """巴哈姆特忘却前夜专板帖列表（B.php 列表页 HTML）。台湾最大游戏社区。
+
+    2026-07-10 修复（三年零产出真因，CI 日志 + 本地双实测）：
+    - 旧方式1 `B.php?ajax=1` JSON 接口已退役——现返回整页 HTML；
+    - 旧方式2 `search.php` 全站搜索需板編（bsn=0 报「沒有傳入板編」系統訊息），
+      新版全站搜索 search.gamer.com.tw 为纯 JS 渲染，服务端 HTML 零结果。
+    改为解析专板列表页的 `b-list__row` 行结构（默认板編 78829，可用
+    BAHAMUT_BSN 覆盖）。专板即游戏本板，无需关键词过滤；置顶帖一并采集。
+    """
+    baha_bsn = os.environ.get("BAHAMUT_BSN") or BAHAMUT_DEFAULT_BSN
     items = []
-
-    # 方式1: 如果有版块号，直接抓版块
-    if baha_bsn:
-        try:
-            data = _get(
-                f"https://forum.gamer.com.tw/B.php?bsn={baha_bsn}&ajax=1",
-                headers={"Referer": "https://forum.gamer.com.tw"},
-            )
-            if data and data.status_code == 200:
-                try:
-                    result = data.json()
-                    for thread in result.get("data", {}).get("list", []) or []:
-                        gp = int(thread.get("gp", 0))
-                        reply = int(thread.get("reply", 0))
-                        # H4: ctime 为站方原文（日期/相对时间），归一为 ISO
-                        baha_time, baha_approx = news_common.parse_relative_time(thread.get("ctime"))
-                        items.append(_make_item(
-                            title=thread.get("title", ""),
-                            summary="",
-                            source="bahamut",
-                            platform_region="tw",
-                            time_str=baha_time,
-                            url=f"https://forum.gamer.com.tw/C.php?bsn={baha_bsn}&snA={thread.get('snA', '')}",
-                            engagement=gp + reply,
-                            is_hot=gp > 50,
-                            author=thread.get("nick", ""),
-                            lang="zh",
-                            time_is_approximate=not thread.get("ctime"),
-                        ))
-                except (ValueError, KeyError):
-                    pass
-            logger.info(f"Bahamut bsn={baha_bsn}: {len(items)} threads")
-        except Exception as e:
-            logger.warning(f"Bahamut bsn={baha_bsn} failed: {e}")
-
-    # 方式2: 关键词搜索 (HTML scraping — 巴哈搜索不返回可靠的 JSON)
     import re as _re
-    for keyword in KEYWORDS["zh"]:
-        try:
-            resp = _get(
-                "https://forum.gamer.com.tw/search.php",
-                params={"q": keyword, "bsn": "0"},
-                headers={
-                    "Referer": "https://forum.gamer.com.tw",
-                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-                },
-            )
-            if resp and resp.status_code == 200:
-                html = resp.text
-                # Try JSON first (in case ajax works)
-                try:
-                    result = resp.json()
-                    for thread in result.get("data", {}).get("list", []) or []:
-                        gp = int(thread.get("gp", 0))
-                        reply = int(thread.get("reply", 0))
-                        # H4: ctime 为站方原文（日期/相对时间），归一为 ISO
-                        baha_time, baha_approx = news_common.parse_relative_time(thread.get("ctime"))
-                        items.append(_make_item(
-                            title=thread.get("title", ""),
-                            summary="",
-                            source="bahamut",
-                            platform_region="tw",
-                            time_str=baha_time,
-                            url=thread.get("url", ""),
-                            engagement=gp + reply,
-                            is_hot=gp > 50,
-                            author=thread.get("nick", ""),
-                            lang="zh",
-                            time_is_approximate=baha_approx,
-                        ))
-                except (ValueError, KeyError):
-                    # HTML fallback: parse search result page
-                    # Bahamut search results have: <p class="b-list__main__title">
-                    #   <a href="C.php?bsn=...&snA=...">TITLE</a>
-                    for match in _re.finditer(
-                        r'<a[^>]*href="((?:C|Co)\.php\?bsn=\d+[^"]*)"[^>]*>\s*'
-                        r'(.+?)\s*</a>',
-                        html, _re.DOTALL,
-                    ):
-                        url_path, title_html = match.groups()
-                        title = _re.sub(r'<[^>]+>', '', title_html).strip()
-                        if not title:
-                            continue
-                        full_url = f"https://forum.gamer.com.tw/{url_path}"
-                        # Try to extract GP and reply count nearby
-                        items.append(_make_item(
-                            title=title,
-                            summary="",
-                            source="bahamut",
-                            platform_region="tw",
-                            time_str=datetime.now(timezone.utc).isoformat(),
-                            url=full_url,
-                            engagement=0,
-                            is_hot=False,
-                            author="",
-                            lang="zh",
-                            time_is_approximate=True,
-                        ))
-            count = len(items)
-            logger.info(f'Bahamut search "{keyword}": {count} results')
-        except Exception as e:
-            logger.warning(f'Bahamut search "{keyword}" failed: {e}')
+    try:
+        resp = _get(
+            "https://forum.gamer.com.tw/B.php",
+            params={"bsn": baha_bsn},
+            headers={
+                "Referer": "https://forum.gamer.com.tw",
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            },
+        )
+        rows = _re.split(r'<tr class="b-list__row', resp.text)[1:]
+        for row in rows:
+            # 标题两形态：置顶行 <a class="b-list__main__title">…</a>；
+            # 普通行外层大锚点持 href、标题在 <p class="b-list__main__title">…</p>
+            m_title = _re.search(
+                r'b-list__main__title[^>]*>(.*?)</(?:a|p)>', row, _re.DOTALL)
+            m_href = _re.search(r'href="(C\.php\?bsn=\d+&(?:amp;)?snA=\d+[^"]*)"', row)
+            if not m_title or not m_href:
+                continue
+            title = news_common.strip_html(m_title.group(1)).strip()
+            if not title:
+                continue
+            url = "https://forum.gamer.com.tw/" + m_href.group(1).replace("&amp;", "&")
+            m_gp = _re.search(r'b-list__summary__gp[^>]*>\s*([\d,]+)', row)
+            m_int = _re.search(r'title="互動：([\d,]+)"', row)
+            m_author = _re.search(r'b-list__count__user">\s*<a[^>]*>([^<]+)</a>', row, _re.DOTALL)
+            m_time = _re.search(r'b-list__time__edittime">\s*<a[^>]*>([^<]+)</a>', row, _re.DOTALL)
+            gp = int(m_gp.group(1).replace(",", "")) if m_gp else 0
+            interact = int(m_int.group(1).replace(",", "")) if m_int else 0
+            baha_time, baha_approx = news_common.parse_relative_time(
+                m_time.group(1).strip() if m_time else None)
+            items.append(_make_item(
+                title=title,
+                summary="",
+                source="bahamut",
+                platform_region="tw",
+                time_str=baha_time,
+                url=url,
+                engagement=gp + interact,
+                is_hot=gp > 50,
+                author=m_author.group(1).strip() if m_author else "",
+                lang="zh",
+                time_is_approximate=baha_approx,
+            ))
+        logger.info(f"Bahamut bsn={baha_bsn}: {len(items)} threads")
+    except Exception as e:
+        logger.warning(f"Bahamut bsn={baha_bsn} failed: {e}")
 
     return items
 
@@ -1190,46 +1147,69 @@ def fetch_weixin():
 # ─── 日本語プラットフォーム ────────────────────────────────
 
 def fetch_note_com():
-    """从 Note.com 搜索忘却前夜/モリメンス 攻略文章（API v3）。"""
+    """从 note.com 拉忘却前夜/モリメンス hashtag RSS（各返回最新 25 条）。
+
+    2026-07-10 修复（三年零产出真因）：旧路径 /api/v3/searches 已对非浏览器
+    请求一律 403 "Access denied"（完整浏览器头与 cloudscraper 均被拒，本地与
+    CI 双实测）；hashtag RSS（/hashtag/<tag>/rss）为普通网页路由、无此防护。
+    RSS 不含点赞数 → engagement 恒 0、is_hot 恒 False（同 weixin 的已知限制）。
+    """
+    from urllib.parse import quote as _quote
+    from email.utils import parsedate_to_datetime as _rfc822
+    import re as _re
     items = []
-    for keyword in KEYWORDS["ja"]:
+    seen_urls = set()
+    for tag in KEYWORDS["ja"]:
         try:
-            # note.com 对数据中心 IP 返回 403，cloudscraper（浏览器指纹）通过率更高；
-            # _get 对 4xx raise，故直接用 _get_cf 单路径。
-            resp = _get_cf(
-                "https://note.com/api/v3/searches",
-                params={"q": keyword, "size": 20, "sort": "new", "context": "note"},
+            resp = _get(
+                f"https://note.com/hashtag/{_quote(tag)}/rss",
                 headers={
                     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-                    "Referer": "https://note.com/",
-                    "Accept": "application/json",
+                    "Accept-Language": "ja-JP,ja;q=0.9",
                 },
             )
-            if resp.status_code == 200:
-                data = resp.json()
-                # v3 response: data.notes.contents or data.sections[0].contents
-                notes_data = data.get("data", {})
-                contents = (notes_data.get("notes", {}).get("contents", [])
-                           or notes_data.get("sections", [{}])[0].get("contents", [])
-                           if notes_data.get("sections") else [])
-                for note in contents or []:
-                    items.append(_make_item(
-                        title=note.get("name", ""),
-                        summary=note.get("body", ""),
-                        source="note_com",
-                        platform_region="jp",
-                        time_str=note.get("publishAt") or datetime.now(timezone.utc).isoformat(),
-                        url=note.get("noteUrl", ""),
-                        engagement=note.get("likeCount", 0) + note.get("commentCount", 0),
-                        is_hot=note.get("likeCount", 0) > 50,
-                        author=note.get("user", {}).get("nickname", ""),
-                        lang="ja",
-                        time_is_approximate=not note.get("publishAt"),
-                    ))
+            added = 0
+            for m in _re.finditer(r'<item>(.*?)</item>', resp.text, _re.DOTALL):
+                block = m.group(1)
 
-            logger.info(f'Note.com "{keyword}": {len(items)} notes')
+                def _field(name, _block=block):
+                    mm = _re.search(rf'<{name}>(.*?)</{name}>', _block, _re.DOTALL)
+                    if not mm:
+                        return ""
+                    val = mm.group(1).strip()
+                    return _re.sub(r'^<!\[CDATA\[|\]\]>$', '', val).strip()
+
+                url = _field("link") or _field("guid")
+                title = news_common.strip_html(_field("title")).strip()
+                if not url or not title or url in seen_urls:
+                    continue
+                seen_urls.add(url)
+                pub = _field("pubDate")
+                try:
+                    time_str = _rfc822(pub).isoformat() if pub else ""
+                except (TypeError, ValueError):
+                    time_str = ""
+                items.append(_make_item(
+                    title=title,
+                    summary=news_common.strip_html(_field("description"))[:200],
+                    source="note_com",
+                    platform_region="jp",
+                    time_str=time_str or datetime.now(timezone.utc).isoformat(),
+                    url=url,
+                    engagement=0,
+                    is_hot=False,
+                    author=_field("note:creatorName"),
+                    lang="ja",
+                    time_is_approximate=not time_str,
+                ))
+                added += 1
+            logger.info(f'Note.com #{tag} RSS: +{added} notes')
         except Exception as e:
-            logger.warning(f'Note.com "{keyword}" failed: {e}')
+            # 标签不存在（尚无文章）时 RSS 返回 404，属正常态而非故障
+            if '404' in str(e):
+                logger.info(f'Note.com #{tag}: no such hashtag yet (404)')
+            else:
+                logger.warning(f'Note.com #{tag} RSS failed: {e}')
 
     return items
 

--- a/tests/test_global_collectors.py
+++ b/tests/test_global_collectors.py
@@ -492,29 +492,56 @@ class TestFetchPixiv(unittest.TestCase):
 
 
 class TestFetchBahamut(unittest.TestCase):
-    def test_bsn_json_path(self):
-        resp = FakeResp(json_data={"data": {"list": [
-            {"title": "忘却前夜討論", "gp": "60", "reply": "10",
-             "ctime": "2026-06-19", "snA": "5", "nick": "user"},
-        ]}})
-        with mock.patch.dict(gc.os.environ, {"BAHAMUT_BSN": "12345"}, clear=True), \
-                mock.patch.object(gc, "_get", return_value=resp):
-            items = gc.fetch_bahamut()
-        baha = [i for i in items if i["author"] == "user"]
-        self.assertTrue(baha)
-        self.assertEqual(baha[0]["engagement"], 70)
-        self.assertTrue(baha[0]["is_hot"])  # gp 60 > 50
+    # 2026-07-10 重写：ajax JSON / search.php 双路径已死（接口退役），
+    # 采集器改为解析专板 B.php 列表页 HTML（默认 bsn=78829）。
+    BOARD_FIXTURE = (
+    # 置顶行：<a class="b-list__main__title">…</a> 直持 href
+    '<tr class="b-list__row b-list__row--sticky b-list-item">'
+    '<span class="b-list__summary__gp b-gp">60</span>'
+    '<a href="C.php?bsn=78829&amp;snA=581&amp;tnum=1" class="b-list__main__title">'
+    '【情報】置頂公告</a>'
+    '<p class="b-list__count__number"><span title="互動：10">10</span></p>'
+    '<p class="b-list__count__user"><a href="https://home.gamer.com.tw/u1">sticky_user</a></p>'
+    '<p class="b-list__time__edittime"><a href="C.php?bsn=78829&amp;snA=581&amp;last=1">2026-06-19</a></p>'
+    '</tr>'
+    # 普通行：外层大锚点持 href，标题在 <p class="b-list__main__title">…</p>
+    '<tr class="b-list__row b-list-item">'
+    '<a href="C.php?bsn=78829&amp;snA=797&amp;tnum=1">'
+    '<p class="b-list__main__title">【問題】新手求助</p>'
+    '<p class="b-list__brief">正文摘要</p></a>'
+    '<p class="b-list__count__number"><span title="互動：3">3</span></p>'
+    '<p class="b-list__count__user"><a href="https://home.gamer.com.tw/u2">normal_user</a></p>'
+    '<p class="b-list__time__edittime"><a href="C.php?bsn=78829&amp;snA=797&amp;last=1">2026-06-20</a></p>'
+    '</tr>'
+)
 
-    def test_search_html_fallback(self):
-        html = (
-            '<p class="b-list__main__title">'
-            '<a href="C.php?bsn=1&snA=2">忘却前夜搜索结果</a></p>'
-        )
-        resp = FakeResp(text=html, status_code=200)
+    def test_parses_board_rows_both_shapes(self):
+        resp = FakeResp(text=self.BOARD_FIXTURE, status_code=200)
         with mock.patch.dict(gc.os.environ, {}, clear=True), \
                 mock.patch.object(gc, "_get", return_value=resp):
             items = gc.fetch_bahamut()
-        self.assertTrue(any("忘却前夜搜索结果" in i["title"] for i in items))
+        self.assertEqual(len(items), 2)
+        sticky = next(i for i in items if i["author"] == "sticky_user")
+        self.assertEqual(sticky["title"], "【情報】置頂公告")
+        self.assertEqual(sticky["engagement"], 70)   # gp60 + 互動10
+        self.assertTrue(sticky["is_hot"])            # gp 60 > 50
+        self.assertIn("snA=581", sticky["url"])
+        normal = next(i for i in items if i["author"] == "normal_user")
+        self.assertEqual(normal["title"], "【問題】新手求助")
+        self.assertFalse(normal["is_hot"])
+        self.assertTrue(normal["time"].startswith("2026-06-20"))
+
+    def test_bsn_env_override(self):
+        captured = {}
+
+        def fake_get(url, params=None, **k):
+            captured.update(params or {})
+            return FakeResp(text="", status_code=200)
+
+        with mock.patch.dict(gc.os.environ, {"BAHAMUT_BSN": "999"}, clear=True), \
+                mock.patch.object(gc, "_get", side_effect=fake_get):
+            self.assertEqual(gc.fetch_bahamut(), [])
+        self.assertEqual(captured.get("bsn"), "999")
 
 
 class TestFetchWeixin(unittest.TestCase):
@@ -538,26 +565,34 @@ class TestFetchWeixin(unittest.TestCase):
 
 
 class TestFetchNoteCom(unittest.TestCase):
-    def test_collects_notes(self):
-        # 注意：源码取 contents 的三元式仅在 data.sections 存在时才走 notes.contents
-        note = {"name": "攻略", "body": "本文", "publishAt": RECENT,
-                "noteUrl": "https://note/1", "likeCount": 60, "commentCount": 5,
-                "user": {"nickname": "writer"}}
-        resp = FakeResp(json_data={"data": {
-            "notes": {"contents": [note]},
-            "sections": [{"contents": []}],
-        }}, status_code=200)
-        with mock.patch.object(gc, "_get_cf", return_value=resp):
+    # 2026-07-10 重写：/api/v3/searches 已一律 403，采集器改走 hashtag RSS。
+    RSS_FIXTURE = (
+        '<rss><channel>'
+        '<item><title><![CDATA[攻略記事]]></title>'
+        '<description><![CDATA[<p>本文サマリ</p>]]></description>'
+        '<link>https://note.com/w/n/n1</link>'
+        '<note:creatorName> writer </note:creatorName>'
+        '<pubDate>Thu, 09 Jul 2026 12:00:00 +0900</pubDate></item>'
+        '<item><title>重複</title><link>https://note.com/w/n/n1</link></item>'
+        '</channel></rss>'
+    )
+
+    def test_collects_notes_from_rss(self):
+        resp = FakeResp(text=self.RSS_FIXTURE, status_code=200)
+        with mock.patch.object(gc, "_get", return_value=resp):
             items = gc.fetch_note_com()
-        # KEYWORDS["ja"] 2 个关键词
-        self.assertEqual(len(items), 2)
+        # 两个 hashtag 返回同一 fixture，URL 去重后仅 1 条
+        self.assertEqual(len(items), 1)
         it = items[0]
         self.assertEqual(it["source"], "note_com")
-        self.assertEqual(it["engagement"], 65)
-        self.assertTrue(it["is_hot"])  # likeCount 60 > 50
+        self.assertEqual(it["title"], "攻略記事")
+        self.assertEqual(it["author"], "writer")
+        self.assertEqual(it["summary"], "本文サマリ")
+        self.assertTrue(it["time"].startswith("2026-07-09"))
+        self.assertEqual(it["engagement"], 0)  # RSS 无互动指标（已知限制）
 
-    def test_non_200_skipped(self):
-        with mock.patch.object(gc, "_get_cf", return_value=FakeResp(text="", status_code=403)):
+    def test_request_failure_returns_empty(self):
+        with mock.patch.object(gc, "_get", side_effect=RuntimeError("blocked")):
             self.assertEqual(gc.fetch_note_com(), [])
 
 

--- a/tests/test_global_collectors_more.py
+++ b/tests/test_global_collectors_more.py
@@ -349,31 +349,24 @@ class TestFetchPixivExtra(unittest.TestCase):
 # ─── bahamut extra branches ────────────────────────────────
 
 class TestFetchBahamutExtra(unittest.TestCase):
-    def test_bsn_json_value_error_handled(self):
-        # bsn 路径 .json() 抛 ValueError → except (ValueError,KeyError) pass（lines 942-943）
-        # 搜索路径同样失败 → 整体空
-        def fake_get(url, *a, **k):
-            return FakeResp(text="not json", status_code=200)
+    # 2026-07-10 重写：采集器改解析专板 B.php 列表页（旧 ajax/search 双路径退役）。
+    def test_non_row_html_returns_empty(self):
+        with mock.patch.dict(gc.os.environ, {}, clear=True), \
+                mock.patch.object(gc, "_get",
+                                  return_value=FakeResp(text="not a board page", status_code=200)):
+            self.assertEqual(gc.fetch_bahamut(), [])
 
-        with mock.patch.dict(gc.os.environ, {"BAHAMUT_BSN": "9"}, clear=True), \
-                mock.patch.object(gc, "_get", side_effect=fake_get):
-            items = gc.fetch_bahamut()
-        # bsn json 失败被吞，搜索 html 无匹配 → []
-        self.assertEqual(items, [])
-
-    def test_bsn_request_exception_handled(self):
-        # bsn 路径 _get 抛异常 → warning（lines 945-946）；搜索路径也抛异常
-        with mock.patch.dict(gc.os.environ, {"BAHAMUT_BSN": "9"}, clear=True), \
+    def test_request_exception_handled(self):
+        with mock.patch.dict(gc.os.environ, {}, clear=True), \
                 mock.patch.object(gc, "_get", side_effect=RuntimeError("down")):
             self.assertEqual(gc.fetch_bahamut(), [])
 
-    def test_search_html_empty_title_skipped(self):
-        # 搜索 HTML 匹配到 anchor 但 title strip 后为空 → 跳过（line 995）
-        html = ('<a href="C.php?bsn=1&snA=2"><img></a>')
+    def test_row_without_title_skipped(self):
+        html = ('<tr class="b-list__row b-list-item">'
+                '<a href="C.php?bsn=78829&amp;snA=2&amp;tnum=1"><img></a></tr>')
         with mock.patch.dict(gc.os.environ, {}, clear=True), \
                 mock.patch.object(gc, "_get", return_value=FakeResp(text=html, status_code=200)):
-            items = gc.fetch_bahamut()
-        self.assertEqual(items, [])
+            self.assertEqual(gc.fetch_bahamut(), [])
 
 
 # ─── weixin extra branches ─────────────────────────────────
@@ -434,8 +427,14 @@ class TestFetchWeixinExtra(unittest.TestCase):
 
 class TestFetchNoteComExtra(unittest.TestCase):
     def test_request_exception_handled(self):
-        # _get_cf 抛异常 → warning（lines 1168-1169）
-        with mock.patch.object(gc, "_get_cf", side_effect=RuntimeError("blocked")):
+        # RSS 路径 _get 抛异常 → warning 后返回空（2026-07-10 改走 hashtag RSS）
+        with mock.patch.object(gc, "_get", side_effect=RuntimeError("blocked")):
+            self.assertEqual(gc.fetch_note_com(), [])
+
+    def test_missing_hashtag_404_is_quiet(self):
+        # 标签不存在 → 404 归 info（正常态），返回空不告警
+        with mock.patch.object(gc, "_get",
+                               side_effect=RuntimeError("404 Client Error: Not Found")):
             self.assertEqual(gc.fetch_note_com(), [])
 
 


### PR DESCRIPTION
## 概要

按已批节拍表决议④（零产出源 07-19 前修复或明文退役）处置四源，真因全部由 CI 日志 + live 探测坐实：

- **bahamut 已修复**：旧双路径注定零产出——`B.php?ajax=1` JSON 接口已退役（返回整页 HTML）、`search.php` 需板編（bsn=0 报「沒有傳入板編」）且新版全站搜索纯 JS 渲染。改为解析**忘卻前夜专板（bsn=78829）**列表页 HTML，兼容置顶行与普通行两种标题形态。本地实测 **30 帖**（含当日新帖）。
- **note_com 已修复**：`/api/v3/searches` 已对非浏览器请求一律 403（完整浏览器头与 cloudscraper 均被拒）。改走 **hashtag RSS**（`/hashtag/忘却前夜/rss`，普通网页路由无此防护），跨标签 URL 去重、不存在标签的 404 降为 info。本地实测 **25 条**。RSS 无互动指标 → engagement 恒 0（同 weixin 已知限制）。
- **arca_live 不可修（CI 基础设施性封锁）**：Cloudflare 拦 GitHub Actions 机房 IP——HTTP 403 / PW 挑战页超时 / App API 403 三路全堵；采集器代码无恙（住宅侧实测 86 条）。退役 vs 挂账待守密人裁定。
- **twitter**：需付费 TWITTER_BEARER_TOKEN，买 token vs 退役待守密人裁定。

## 验证

- 新旧实现单测全部重写（板页/RSS fixture、双行形态、去重、env 覆盖、静默 404）；
- `pytest tests/` 全量 **2715 passed / 4 skipped**（rebase 后复跑）；
- 合并后将手动触发 update-news 取 CI 实证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVyxbkwoHXancQUkEJs5vX

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVyxbkwoHXancQUkEJs5vX)_