### PR TITLE
fix(ci): self-healing conflict resolution in update-news push retry loop

### DIFF
--- a/.github/workflows/update-news.yml
+++ b/.github/workflows/update-news.yml
@@ -99,8 +99,20 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "chore: update community news [skip ci]"
+            # 冲突自愈重试（2026-07-10）：dispatch 轮与整点轮竞态时，pull --rebase
+            # 会在输出快照文件上冲突；旧循环冲突后既不解决也不 abort，四次重试
+            # 全死在 "unmerged files"。机器快照以本轮新数据为准（rebase 中
+            # theirs = 本轮提交），解不掉则 abort 后重拉再试。
             for i in 1 2 3 4; do
-              git pull --rebase origin main && git push origin main && exit 0
+              if git pull --rebase origin main; then
+                git push origin main && exit 0
+              else
+                git checkout --theirs . 2>/dev/null || true
+                git add -A
+                git -c core.editor=true rebase --continue \
+                  && git push origin main && exit 0
+                git rebase --abort 2>/dev/null || true
+              fi
               echo "Push attempt $i failed, retrying in ${i}s..."
               sleep $i
             done


### PR DESCRIPTION
## 概要

修复 update-news 推送重试循环的「假重试」缺陷（实证：run 29114263528——手动 dispatch 轮与整点轮竞态，`pull --rebase` 在输出快照文件冲突后，旧循环既不解决也不 abort，四次重试全死在 `unmerged files`）。

新循环：机器快照冲突按**本轮新数据为准**自动解决（rebase 中 theirs = 本轮提交），解不掉则 `rebase --abort` 后重拉再试。

该 run 的采集段同时给出两个修复源的 **CI 首轮实证**：Bahamut 30 帖（26 条入流）、Note.com 25 条——#563 修复在 Actions 环境成立。

纯 CI 配置改动；yaml 校验通过，全量 pytest **2717 passed / 4 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVyxbkwoHXancQUkEJs5vX

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVyxbkwoHXancQUkEJs5vX)_