### PR TITLE
版本守卫三方对账：CHANGELOG 锚定堵「双源一致地错」盲区 (T11)

### DIFF
--- a/memory/todo.md
+++ b/memory/todo.md
@@ -41,7 +41,7 @@
 | C5 | B 类官方骨架提示词再现裁定 | `decisions.md` 2026-07-10（「结构再现 + 文本自写」默认，随 v0.39 工单落档） |
 | C6 | 委派引擎四缝（coordinator/SendMessage、ExitPlanMode、调度归宿、通知面） | ExitPlanMode/Monitor/Workflow 等随 PR #480；O-B2 SendMessage + coordinator 预设随 PR #567（v0.42.0，2026-07-10） |
 | T3 | CI required `test` 检查是否重启 | **定谳：维持自查自合**（守密人 2026-07-10 AskUserQuestion，覆盖同日节拍表条③——撞车经呈报后守密人选「以 UI 答复为准」）；`decisions.md` 同日「CI required 检查维持自查自合」条 + methodology「维护态节拍」节已双向同步 |
-| T11 | 版本守卫三方对账升级：`check-version-bump.mjs` 加 CHANGELOG 最新条目号对账，堵「双源一致地错」盲区 | `projects/silver-core-sdk/scripts/check-version-bump.mjs` 三方对账（version.ts + package.json + CHANGELOG 最新 `## X.Y.Z`）+ 测试 `tests/version-guard-changelog.test.ts`（含 lesson #45 负控）；分支 `claude/todo-implementation-0sht7h` |
+| T11 | 版本守卫三方对账升级：`check-version-bump.mjs` 加 CHANGELOG 最新条目号对账，堵「双源一致地错」盲区 | `projects/silver-core-sdk/scripts/check-version-bump.mjs` 三方对账（version.ts + package.json + CHANGELOG 最新 `## X.Y.Z`）+ 测试 `tests/version-guard-changelog.test.ts`（含 lesson #45 负控）；PR #575 |
 
 ---
 

--- a/memory/todo.md
+++ b/memory/todo.md
@@ -23,7 +23,6 @@
 | T8 | 黑池侧派工包开工：UI M0–M4 + 命令框架五模块（图纸 + 消费手册已齐，开工在黑池侧） | 黑池输入 | `.../bpt-desktop-command-impl-plan-20260710.md` + `.../silver-core-sdk-command-consumer-manual-20260710.md` | 开 |
 | T9 | twitter 源重启与否（三选项已成文：官方 API 按量 recent search + 日读硬顶 ~\$15-30/月 / 第三方转售商灰色 ~\$3-10/月 / 退役；Playwright 登录抓取已排除——ToS 硬约束）；守密人「未来再说」，不设期限 | 裁定 | `memory/decisions.md` 2026-07-10「twitter 源挂账」条 + `memory/project-status.md` News 节零产出四源段 | 开 |
 | T10 | B 类首批骨架命令文本自写（review / simplify 结构再现版 + loop 固定模式命令卡）——方案二期 M3 内建源前置件；裁定已清（C5），差的是产出本身 | 预算 | `.../bpt-desktop-command-impl-plan-20260710.md` §3 二期 + `decisions.md` 2026-07-10 裁定① | 开 |
-| T11 | 版本守卫三方对账升级：`check-version-bump.mjs` 加 CHANGELOG 最新条目号 vs `version.ts` 对账，堵「双源一致地错」盲区（v0.38 带 0.37.1 上线实证） | 预算 | `memory/lessons-learned.md` #45 Fix(4) | 开 |
 | T12 | 命令行为观测续册：A 类 P0 组（/clear /resume /compact /help——须守密人会话内触发，艾瑞卡不可自触）+ /loop 动态自调步模式实测 | 预算 | `.../cc-command-behavior-observations-20260710.md` 待观测清单 | 开 |
 | T13 | 动态自调步（ScheduleWakeup 同构的壳层唤醒原语，方案三期 P2 单独立项；开工前先测 BPT 自身缓存分层） | 黑池输入 | `.../bpt-desktop-command-impl-plan-20260710.md` §2 M4 + §4 | 开 |
 | T14 | D/E 类注册源（插件 / MCP prompts）需求档——待黑池侧壳层插件面设计定稿后另立 | 黑池输入 | `.../bpt-desktop-command-framework-requirements-20260710.md` §6.3 | 开 |
@@ -42,6 +41,7 @@
 | C5 | B 类官方骨架提示词再现裁定 | `decisions.md` 2026-07-10（「结构再现 + 文本自写」默认，随 v0.39 工单落档） |
 | C6 | 委派引擎四缝（coordinator/SendMessage、ExitPlanMode、调度归宿、通知面） | ExitPlanMode/Monitor/Workflow 等随 PR #480；O-B2 SendMessage + coordinator 预设随 PR #567（v0.42.0，2026-07-10） |
 | T3 | CI required `test` 检查是否重启 | **定谳：维持自查自合**（守密人 2026-07-10 AskUserQuestion，覆盖同日节拍表条③——撞车经呈报后守密人选「以 UI 答复为准」）；`decisions.md` 同日「CI required 检查维持自查自合」条 + methodology「维护态节拍」节已双向同步 |
+| T11 | 版本守卫三方对账升级：`check-version-bump.mjs` 加 CHANGELOG 最新条目号对账，堵「双源一致地错」盲区 | `projects/silver-core-sdk/scripts/check-version-bump.mjs` 三方对账（version.ts + package.json + CHANGELOG 最新 `## X.Y.Z`）+ 测试 `tests/version-guard-changelog.test.ts`（含 lesson #45 负控）；分支 `claude/todo-implementation-0sht7h` |
 
 ---
 

--- a/projects/silver-core-sdk/scripts/check-version-bump.mjs
+++ b/projects/silver-core-sdk/scripts/check-version-bump.mjs
@@ -8,84 +8,155 @@
  * this package, or package.json dependencies) must also change
  * package.json's version. Docs/tests/CI-only changes need no bump.
  *
+ * Three-way version reconciliation (standing invariants, checked on every
+ * run regardless of the diff): package.json "version", src/version.ts
+ * SDK_VERSION, and the latest "## X.Y.Z" heading in CHANGELOG.md must all
+ * agree. The two-source (version.ts <-> package.json) mutual check alone
+ * cannot catch a "consistently wrong" pair - lesson #45: v0.38.0 shipped
+ * self-reporting SDK_VERSION 0.37.1 because a rebase took the base side on
+ * BOTH files while CHANGELOG.md correctly said 0.38.0; the two files agreed
+ * with each other on the stale number and the guard went green. Anchoring to
+ * CHANGELOG's latest entry as the third source closes that blind spot and, as
+ * a bonus, enforces the "add one CHANGELOG line per bump" half of the
+ * discipline that was previously unchecked.
+ *
  * Runs in CI against the merge commit (squash-merge discipline: one merge =
- * one commit on main): compares HEAD to HEAD~1. Tolerant by design - when
- * the diff cannot be computed (shallow clone without a parent, repo root
- * mismatch), it reports and exits 0 rather than red-flagging unrelated CI.
+ * one commit on main): compares HEAD to HEAD~1. Tolerant by design for the
+ * diff portion - when the diff cannot be computed (shallow clone without a
+ * parent, repo root mismatch), it reports and exits 0 rather than
+ * red-flagging unrelated CI. The three-way reconciliation is NOT tolerant:
+ * package.json / src/version.ts / CHANGELOG.md are present in every checkout
+ * regardless of fetch-depth, so a mismatch there is always a real defect.
  *
  * Usage: node scripts/check-version-bump.mjs  (cwd: projects/silver-core-sdk)
  */
 
 import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 const PKG_DIR_RE = /^projects\/silver-core-sdk\//;
 
-// --- src/version.ts sync guard (audit 2026-07-10 D9) ------------------------
-// SDK_VERSION mirrors package.json "version" inside shipped runtime code (the
-// User-Agent / init claude_code_version source). Drift = shipping a build that
-// misreports itself; red immediately, independent of the diff logic below.
-try {
-  const pkgVersion = JSON.parse(readFileSync('package.json', 'utf8')).version;
-  const versionTs = readFileSync('src/version.ts', 'utf8');
-  const m = versionTs.match(/SDK_VERSION = '([^']+)'/);
-  if (m === null || m[1] !== pkgVersion) {
-    console.error(
-      `version-bump guard FAILED: src/version.ts SDK_VERSION (${m?.[1] ?? 'missing'}) ` +
-        `!= package.json version (${pkgVersion}). Keep them identical in the same commit.`,
-    );
-    process.exit(1);
-  }
-} catch (err) {
-  console.error(`version-bump guard FAILED: cannot verify src/version.ts sync: ${err}`);
-  process.exit(1);
+/**
+ * The latest released version declared in CHANGELOG.md: the first "## X.Y.Z"
+ * heading scanning from the top. The rename preamble mentions versions in
+ * prose ("as of 0.41.0", "since 0.6.2") but those are never "## " headings,
+ * so they cannot be mistaken for the latest entry. Returns null when the text
+ * has no version heading at all.
+ *
+ * Exported (and the executable body is gated behind the main-module check
+ * below) so tests can exercise the parse without running the guard.
+ */
+export function latestChangelogVersion(changelogText) {
+  const m = changelogText.match(/^##\s+(\d+\.\d+\.\d+)\b/m);
+  return m ? m[1] : null;
 }
 
 function git(args) {
   return execSync(`git ${args}`, { encoding: 'utf8' }).trim();
 }
 
-let changed;
-try {
-  changed = git('diff --name-only HEAD~1 HEAD').split('\n').filter(Boolean);
-} catch {
-  console.log('version-bump guard: cannot diff HEAD~1 (shallow/root commit) - skipping.');
-  process.exit(0);
+function runGuard() {
+  // --- three-way version reconciliation (standing invariants) -------------
+  // Source of truth is package.json "version"; version.ts and CHANGELOG.md
+  // must both agree with it. Any disagreement reds immediately, independent
+  // of the diff logic that follows.
+  let pkgVersion;
+  try {
+    pkgVersion = JSON.parse(readFileSync('package.json', 'utf8')).version;
+    const versionTs = readFileSync('src/version.ts', 'utf8');
+    const m = versionTs.match(/SDK_VERSION = '([^']+)'/);
+    if (m === null || m[1] !== pkgVersion) {
+      console.error(
+        `version-bump guard FAILED: src/version.ts SDK_VERSION (${m?.[1] ?? 'missing'}) ` +
+          `!= package.json version (${pkgVersion}). Keep them identical in the same commit.`,
+      );
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(`version-bump guard FAILED: cannot verify src/version.ts sync: ${err}`);
+    process.exit(1);
+  }
+
+  // CHANGELOG.md latest entry is the third source (lesson #45 Fix(4)): it
+  // caught nothing before, yet it is the one file a mistaken rebase left
+  // CORRECT while both version.ts and package.json went stale together.
+  try {
+    const changelog = readFileSync('CHANGELOG.md', 'utf8');
+    const clVersion = latestChangelogVersion(changelog);
+    if (clVersion === null) {
+      console.error(
+        'version-bump guard FAILED: no "## X.Y.Z" version entry found in CHANGELOG.md. ' +
+          'Every release adds a "## <version>" heading; without one the ledger cannot be reconciled.',
+      );
+      process.exit(1);
+    }
+    if (clVersion !== pkgVersion) {
+      console.error(
+        `version-bump guard FAILED: CHANGELOG.md latest entry (${clVersion}) ` +
+          `!= package.json version (${pkgVersion}). Every version bump adds a matching ` +
+          `"## <version>" CHANGELOG entry; a mismatch means the shipped runtime version and ` +
+          `the consumer-facing ledger disagree (lesson #45: v0.38.0 shipped self-reporting ` +
+          `0.37.1 straight past the two-source mutual check - the CHANGELOG was the only ` +
+          `source still correct).`,
+      );
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(`version-bump guard FAILED: cannot verify CHANGELOG.md sync: ${err}`);
+    process.exit(1);
+  }
+
+  // --- diff-based "runtime change needs a bump" logic ---------------------
+  let changed;
+  try {
+    changed = git('diff --name-only HEAD~1 HEAD').split('\n').filter(Boolean);
+  } catch {
+    console.log('version-bump guard: cannot diff HEAD~1 (shallow/root commit) - skipping.');
+    process.exit(0);
+  }
+
+  const runtimeChanged = changed.some(
+    (f) => PKG_DIR_RE.test(f) && /^projects\/silver-core-sdk\/src\//.test(f),
+  );
+
+  let depsChanged = false;
+  let versionChanged = false;
+  if (changed.includes('projects/silver-core-sdk/package.json')) {
+    // ":(top)" anchors the pathspec at the repo root: this script runs with
+    // cwd = projects/silver-core-sdk in CI, where a bare repo-root-relative
+    // pathspec silently matches nothing (empty patch -> false negative).
+    const patch = git('diff HEAD~1 HEAD -- ":(top)projects/silver-core-sdk/package.json"');
+    versionChanged = /^[+-]\s*"version":/m.test(patch);
+    depsChanged = /^[+-]\s*"[^"]+":\s*"[^"]+"/m.test(
+      patch
+        .split('\n')
+        .filter((l) => /"(dependencies|devDependencies)"/.test(l) || /^[+-]/.test(l))
+        .join('\n'),
+    ) && /"dependencies"|"devDependencies"/.test(patch);
+  }
+
+  if (!runtimeChanged && !depsChanged) {
+    console.log('version-bump guard: no shipped-runtime change in this commit - OK.');
+    process.exit(0);
+  }
+  if (versionChanged) {
+    console.log('version-bump guard: runtime changed AND version bumped - OK.');
+    process.exit(0);
+  }
+  console.error(
+    'version-bump guard FAILED: this commit changes shipped runtime content ' +
+      '(projects/silver-core-sdk/src/ or dependencies) but package.json "version" ' +
+      'is unchanged. Consumers pin npm-pack tarballs BY VERSION - same-version ' +
+      'different-content builds cannot be pinned, rolled back, or audited. ' +
+      'Bump patch for fixes, minor for new capability, and add a CHANGELOG.md line.',
+  );
+  process.exit(1);
 }
 
-const runtimeChanged = changed.some(
-  (f) => PKG_DIR_RE.test(f) && /^projects\/silver-core-sdk\/src\//.test(f),
-);
-
-let depsChanged = false;
-let versionChanged = false;
-if (changed.includes('projects/silver-core-sdk/package.json')) {
-  // ":(top)" anchors the pathspec at the repo root: this script runs with
-  // cwd = projects/silver-core-sdk in CI, where a bare repo-root-relative
-  // pathspec silently matches nothing (empty patch -> false negative).
-  const patch = git('diff HEAD~1 HEAD -- ":(top)projects/silver-core-sdk/package.json"');
-  versionChanged = /^[+-]\s*"version":/m.test(patch);
-  depsChanged = /^[+-]\s*"[^"]+":\s*"[^"]+"/m.test(
-    patch
-      .split('\n')
-      .filter((l) => /"(dependencies|devDependencies)"/.test(l) || /^[+-]/.test(l))
-      .join('\n'),
-  ) && /"dependencies"|"devDependencies"/.test(patch);
+// Run the guard only when executed as a script; stay side-effect-free when
+// imported (so tests can import latestChangelogVersion without the guard
+// reading files / diffing / calling process.exit).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runGuard();
 }
-
-if (!runtimeChanged && !depsChanged) {
-  console.log('version-bump guard: no shipped-runtime change in this commit - OK.');
-  process.exit(0);
-}
-if (versionChanged) {
-  console.log('version-bump guard: runtime changed AND version bumped - OK.');
-  process.exit(0);
-}
-console.error(
-  'version-bump guard FAILED: this commit changes shipped runtime content ' +
-    '(projects/silver-core-sdk/src/ or dependencies) but package.json "version" ' +
-    'is unchanged. Consumers pin npm-pack tarballs BY VERSION - same-version ' +
-    'different-content builds cannot be pinned, rolled back, or audited. ' +
-    'Bump patch for fixes, minor for new capability, and add a CHANGELOG.md line.',
-);
-process.exit(1);

--- a/projects/silver-core-sdk/tests/version-guard-changelog.test.ts
+++ b/projects/silver-core-sdk/tests/version-guard-changelog.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Three-way version reconciliation for the version-bump guard (T11, lesson
+ * #45 Fix(4)). The guard used to check only src/version.ts <-> package.json,
+ * a two-source mutual check that goes green when BOTH sources are
+ * consistently wrong - which is exactly what shipped v0.38.0 self-reporting
+ * 0.37.1 (a rebase took the base side on both files; CHANGELOG.md was the
+ * only source still correct). Anchoring to CHANGELOG.md's latest "## X.Y.Z"
+ * heading as a third source closes that blind spot.
+ *
+ * These tests exercise the pure parser plus the reconciliation predicate, and
+ * assert the invariant holds on the real repo right now.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { latestChangelogVersion } from '../scripts/check-version-bump.mjs';
+
+const PKG = join(__dirname, '..');
+
+describe('latestChangelogVersion (CHANGELOG parse)', () => {
+  it('returns the first "## X.Y.Z" heading from the top', () => {
+    const changelog = [
+      '# Changelog',
+      '',
+      '## 0.43.0 — 2026-07-10',
+      'newest entry',
+      '',
+      '## 0.42.0 — 2026-07-09',
+      'older entry',
+    ].join('\n');
+    expect(latestChangelogVersion(changelog)).toBe('0.43.0');
+  });
+
+  it('ignores version mentions in prose (only "## " headings count)', () => {
+    // The real CHANGELOG preamble says "as of 0.41.0" / "since 0.6.2" in
+    // prose above the first heading; those must never be read as the latest.
+    const changelog = [
+      '# Changelog',
+      '',
+      'Renamed as of 0.41.0; discipline in force since 0.6.2.',
+      '',
+      '## 0.43.0 — 2026-07-10',
+      'body',
+    ].join('\n');
+    expect(latestChangelogVersion(changelog)).toBe('0.43.0');
+  });
+
+  it('returns null when there is no version heading', () => {
+    expect(latestChangelogVersion('# Changelog\n\nno entries yet\n')).toBeNull();
+  });
+});
+
+describe('three-way reconciliation predicate', () => {
+  const changelogTop = (v: string) => `# Changelog\n\n## ${v} — 2026-07-10\nbody\n`;
+
+  it('agrees when all three sources match', () => {
+    const pkgVersion = '0.43.0';
+    const sdkVersion = '0.43.0';
+    const clVersion = latestChangelogVersion(changelogTop('0.43.0'));
+    expect(sdkVersion).toBe(pkgVersion);
+    expect(clVersion).toBe(pkgVersion);
+  });
+
+  it('reds the lesson #45 scenario: version.ts/package.json agree but stale', () => {
+    // The exact bug: both files consistently wrong at 0.37.1, CHANGELOG at
+    // 0.38.0. The two-source check passes; the CHANGELOG anchor catches it.
+    const pkgVersion = '0.37.1';
+    const sdkVersion = '0.37.1';
+    const clVersion = latestChangelogVersion(changelogTop('0.38.0'));
+    expect(sdkVersion).toBe(pkgVersion); // two-source mutual check: green
+    expect(clVersion).not.toBe(pkgVersion); // three-way anchor: red
+  });
+});
+
+describe('real-repo invariant (would red if drift shipped)', () => {
+  it('CHANGELOG latest == package.json version == src/version.ts SDK_VERSION', () => {
+    const pkgVersion = JSON.parse(readFileSync(join(PKG, 'package.json'), 'utf8')).version;
+    const sdkVersion = readFileSync(join(PKG, 'src', 'version.ts'), 'utf8').match(
+      /SDK_VERSION = '([^']+)'/,
+    )?.[1];
+    const clVersion = latestChangelogVersion(readFileSync(join(PKG, 'CHANGELOG.md'), 'utf8'));
+    expect(sdkVersion).toBe(pkgVersion);
+    expect(clVersion).toBe(pkgVersion);
+  });
+});


### PR DESCRIPTION
## 概述

为 `silver-core-sdk` 版本守卫 `scripts/check-version-bump.mjs` 增加 **CHANGELOG 第三方对账**，把原「`version.ts` ↔ `package.json` 双源互证」升级为「三方对账」，堵住「双源一致地错」盲区（挂账 T11，lesson #45 Fix(4)）。

盲区实证：v0.38.0 曾自报 `SDK_VERSION 0.37.1` 上线——rebase 期间 `version.ts` / `package.json` 双双取到基底旧值，两文件互相一致地错、守卫绿灯，唯 `CHANGELOG.md` 记录正确。现以 CHANGELOG 最新 `## X.Y.Z` 条目作第三锚，三源须全等。

---

## 变更类型

- [x] Bug 修复（CI 守卫盲区）
- [x] 其他：CI 守卫增强 + 对应测试

---

## 来源声明

- [x] 不涉及游戏数据；变更为工程 CI 守卫逻辑，依据为 `memory/lessons-learned.md` #45 与挂账 `memory/todo.md` T11（均仓内公开档案）。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **仅改工程脚本 / 测试 / 台账**，不上传任何内部资产。
- [x] **同意按 MIT License 提交。**

---

## 验证清单

- [x] 守卫脚本直接运行当前 main 状态：`node scripts/check-version-bump.mjs` → 三方对账静默通过，exit 0
- [x] 负控（复现 lesson #45 场景：双源一致 0.37.1、CHANGELOG 记 0.38.0）→ 守卫 red，exit 1
- [x] SDK 全量测试 `npm test`：78 文件 / 1663 通过（含新增 `tests/version-guard-changelog.test.ts` 6 项）
- [x] `npm run typecheck` 通过
- [x] 不引入 emoji
- [x] 未改 `memory/decisions.md` / `memory/lessons-learned.md`；仅按台账「清账不删行」纪律更新 `memory/todo.md`（T11 移入「已清」）

**改动清单**
- `projects/silver-core-sdk/scripts/check-version-bump.mjs`：抽出纯函数 `latestChangelogVersion()`、加 CHANGELOG 对账（standing invariant，独立于 diff 逻辑）、用 main-module 门控隔离副作用以便被测试导入。
- `projects/silver-core-sdk/tests/version-guard-changelog.test.ts`：解析用例 + lesson #45 负控 + 真仓不变式断言。
- `memory/todo.md`：T11 销案。

> 说明：本 PR 仅动 `scripts/` 与 `tests/`，不涉 `src/` 运行时或依赖，故守卫不要求版本号 bump，CHANGELOG 无需新增条目，三方对账仍全 = 0.43.0。

---

## 关联 Issue

- Refs T11（`memory/todo.md`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6qrhMy8ba8ePVW6fowPS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6qrhMy8ba8ePVW6fowPS9)_