### PR TITLE
perf(silver-core-sdk): 响应时间优化过审 — fetch 注入缝 / 惰性看门狗 / 每回合单次构建 / SSE 偏移扫描 (v0.44.0)

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -186,6 +186,19 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **响应时间优化过审（v0.44.0，2026-07-11，守密人「审视 silver core sdk 优化响应时间」派单，已落）**：
+  先测后改——新增零密钥仿真器延迟探针 `tests/integration/perf-overhead.mjs`（30 回合工具环 +
+  8000 事件流两场景，中位数计量）确认引擎本体开销仅 ~1ms/回合，真正大头在网络层。四项落地：
+  ① **`provider.fetch` 注入缝（BPT-EXTENSION，双传输孪生同享）**——Node 内建 fetch 连接池默认
+  ~4 秒空闲即断，工具执行超 4 秒的回合每回合重付 TCP+TLS 握手（约 100-300ms）；消费方注入长
+  keep-alive undici Agent 即消除，配方见新档 `docs/PERFORMANCE.md`（未注入时调用期晚绑定回退全局
+  fetch，测试桩 / setGlobalDispatcher 均照常生效）；② **空闲看门狗惰性重臂**——每 SSE 事件成本从
+  clearTimeout+setTimeout 一对降为一次时间戳写入，单计时器按剩余间隙自重臂、超时语义不变；
+  ③ **工具定义每回合单次构建**——压缩估算与该回合全部流尝试（重放 / fallback 含）共享一次
+  `buildToolDefs()`，全 schema stringify 估算按工具名集缓存；④ **SSE 解析器偏移扫描**——每 chunk
+  仅重切一次缓冲（原先逐行重拷贝，行数二次方）。探针中位数（repeat=9 同机）：30 回合引擎记账
+  29.7ms→18.0ms（-39%）、8000 事件流 CPU 53.3ms→46.3ms。+3 测（注入缝双传输 + 重试路径），
+  **1666 全绿 + 2 skipped（79 文件）**、tsc + build exit 0；孪生纪律测试保持绿。
 - **断线韧性全量落地（v0.43.0，2026-07-10，守密人「全量」裁定，已落）**：承「实际使用时不时断线」
   痛点，落四层兜底模型（设计档 `projects/silver-core-sdk/docs/RESILIENCE.md`，裁定见 decisions.md 同日条）：
   ① **P0-1 有界回合重放**——零采信流失败（零事件 / 零事件卡死 / 打捞落空的废弃残片）回合级重放 2 次

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,37 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.44.0 — 2026-07-11
+
+**Response-time pass** (keeper dispatch 「审视 silver core sdk，优化响应时间」).
+Measured first (`tests/integration/perf-overhead.mjs`, new zero-key
+emulator-driven probe), then trimmed what the engine controls:
+
+- **`provider.fetch` injection seam (BPT-EXTENSION, both transports)**: custom
+  fetch used for every HTTP request the transport issues (retries included).
+  The headline consumer win: Node's built-in fetch pools connections with a
+  ~4s idle keep-alive, so any turn whose tool run exceeds that re-pays a
+  TCP+TLS handshake (~100-300ms) — binding requests to a long-keep-alive
+  undici Agent removes that per-turn tax. Late-bound: when absent, the
+  CURRENT global fetch resolves at call time. Recipes in new
+  `docs/PERFORMANCE.md` (keep-alive agent, first-turn preconnect, perceived
+  latency). Twin discipline held (`requestWithRetries` stays token-identical).
+- **Idle-watchdog lazy re-arm (both transports)**: per-SSE-event cost drops
+  from a clearTimeout+setTimeout pair to one timestamp write; a single timer
+  re-arms for the remaining gap (abort still lands exactly idleMs after the
+  last event). ~1 timer per idle window instead of 1 per event.
+- **One tool-def build per turn (engine loop)**: the compaction estimate and
+  every stream attempt of a turn (replay/fallback included) now share one
+  `buildToolDefs()` product instead of building twice per turn; the tool-def
+  token estimate (a full-schema JSON.stringify) is cached by tool-name set.
+- **SSE parser: offset line scan**: `drainBuffer` re-slices the buffer once
+  per chunk instead of once per line (was quadratic in lines-per-chunk).
+
+Probe medians (repeat=9, same machine): 30-turn tool-loop engine bookkeeping
+29.7ms → 18.0ms (-39%); 8000-delta stream wall 57.4ms → 48.6ms, CPU
+53.3ms → 46.3ms. +3 tests (fetch injection, both transports + retry path);
+1666 passed / 2 skipped.
+
 ## 0.43.0 — 2026-07-10
 
 **Resilience: layered disconnect survival** (keeper ruling 「全量」; design in

--- a/projects/silver-core-sdk/docs/COMPAT.md
+++ b/projects/silver-core-sdk/docs/COMPAT.md
@@ -130,6 +130,7 @@ Per-row detail lives in the sections below; this is the at-a-glance table.
 | `provider.pricing` | BPT-EXTENSION | static internal price table | USD-per-MTok overrides keyed by model-id prefix (win over the static table); makes cost metrics + `maxBudgetUsd` enforceable on non-Claude models (v0.37.0) |
 | `hookFailureMode` | BPT-EXTENSION | hook failures are logged and ignored | `'closed'` turns a throwing/timed-out hook into a deny so hook-enforced policy fails safe; default `'open'` keeps official-parity behavior (v0.37.0) |
 | `provider.cacheTtl` | BPT-EXTENSION | no cache-TTL knob (CLI decides 5m/1h internally; only reports the split in usage) | caller picks `'5m'`/`'1h'` per query (v0.7.1) |
+| `provider.fetch` | BPT-EXTENSION | HTTP stack is internal to the wrapped CLI | custom fetch used for EVERY transport request (both protocols, retries included); the keep-alive/proxy/instrumentation seam — undici's default ~4s idle pool otherwise re-pays TCP+TLS (~100-300ms) each turn whose tool run exceeds it (recipe: docs/PERFORMANCE.md) (v0.44.0) |
 | `provider.promptCaching` | BPT-EXTENSION | no toggle (caching is internal) | caller can turn the whole breakpoint layer off |
 | tool-block cache breakpoint | KEPT-DIVERGENCE | 0 breakpoints on tool blocks | 1 (last tool) — measured to only ever gain cache hits on system-prompt divergence, never lose (E7-03) |
 | `compaction.model` / `preTier` | BPT-EXTENSION | fixed compaction | route summarization to a cheap model + deterministic pre-tier |

--- a/projects/silver-core-sdk/docs/PERFORMANCE.md
+++ b/projects/silver-core-sdk/docs/PERFORMANCE.md
@@ -1,0 +1,99 @@
+# PERFORMANCE — response-time model and recipes
+
+What the SDK controls about response time, what it already does by default,
+and the knobs a consumer (BPT Desktop) can turn. Measured with
+`tests/integration/perf-overhead.mjs` (zero-key, emulator-driven): the engine
+itself adds ~1ms of bookkeeping per turn and ~5µs per SSE event — the real
+latency budget lives in the network and the model, so that is where the
+recipes below aim.
+
+## The latency anatomy of one turn
+
+```
+user turn ──► request assembly ──► TCP/TLS connect? ──► server TTFT ──► stream ──► tool run ──► next turn
+              (~1ms, SDK)           (0ms warm /          (model+cache)   (SDK ~5µs/event)
+                                     100-300ms cold)
+```
+
+- **Request assembly** — history stringify, cache-control shaping, tool defs.
+  Engine-side, already sub-millisecond per turn (tool defs are built once per
+  turn and their token estimate is cached by name-set).
+- **Connection** — see keep-alive below; the one place a consumer can lose
+  100-300ms per turn silently.
+- **Server TTFT** — dominated by prompt size and prompt-cache hits. Prompt
+  caching is ON by default with a 4-breakpoint layout (tools / system x2 /
+  last message); `metrics.cacheHitRatio` on every result tells you whether it
+  is working (steady-state agent loops should sit well above 0.8).
+- **Stream** — the idle watchdog costs one timestamp write per event; the
+  parser re-slices its buffer once per chunk.
+- **Tools** — runs of >= 2 consecutive read-only tools execute concurrently
+  (`Promise.all`, results kept in order); side-effecting tools stay serial.
+
+## Recipe: keep the TLS connection warm across slow turns
+
+Node's built-in fetch (undici) pools connections with a **~4s idle
+keep-alive** by default. An agent whose tool executions (or user think time)
+exceed that pays a fresh TCP+TLS handshake — typically 100-300ms — on **every
+turn**. Inject a fetch bound to a long-keep-alive undici Agent:
+
+```js
+import { Agent } from 'undici';
+import { query } from 'silver-core-sdk';
+
+const keepAlive = new Agent({
+  keepAliveTimeout: 60_000,      // idle pool lifetime between turns
+  keepAliveMaxTimeout: 600_000,  // ceiling when the server hints longer
+});
+
+const q = query({
+  prompt: '...',
+  options: {
+    provider: {
+      apiKey: process.env.ANTHROPIC_API_KEY,
+      fetch: (url, init) => fetch(url, { ...init, dispatcher: keepAlive }),
+    },
+  },
+});
+```
+
+`provider.fetch` (BPT-EXTENSION) is used for **every** request the transport
+issues (both protocols, retries included) and receives exactly what the
+global fetch would have — endpoint URL, headers, body, and the per-attempt
+abort signal. It is also the seam for proxies, mTLS, and instrumentation.
+
+Alternative (process-wide, no per-transport wiring):
+
+```js
+import { Agent, setGlobalDispatcher } from 'undici';
+setGlobalDispatcher(new Agent({ keepAliveTimeout: 60_000 }));
+```
+
+## Recipe: warm the connection before the first turn
+
+The first request of a process pays DNS + TCP + TLS. To overlap that with
+your own startup (the SDK deliberately sends no traffic you did not ask for):
+
+```js
+// Fire-and-forget; any response (401 included) leaves the pool warm.
+fetch('https://api.anthropic.com/v1/messages', {
+  method: 'HEAD', dispatcher: keepAlive,
+}).catch(() => {});
+```
+
+## Recipe: perceived latency
+
+- `includePartialMessages: true` streams `stream_event` deltas so a UI can
+  render tokens as they arrive instead of waiting for the assembled turn;
+  `ttft_ms` rides the events once the first token lands.
+- `metrics.ttftMs` / `perTurn[].apiMs` / `perTool[].totalMs` on every result
+  break a slow run down into "network/model" vs "tools" — measure before
+  tuning.
+
+## Keeping it honest
+
+- `tests/integration/perf-overhead.mjs` — SDK-overhead probe (median of N
+  runs; `--out=report.json` to save). Run it before and after touching a hot
+  path.
+- `tests/integration/ab-benchmark.mjs` — real-API task benchmark (cost,
+  cache-hit ratio, per-tool timings) for changes whose effect only shows on
+  the wire.

--- a/projects/silver-core-sdk/package-lock.json
+++ b/projects/silver-core-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silver-core-sdk",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -413,12 +413,16 @@ export async function* runAgentLoop(
     mirror(turn);
   };
 
-  /** Tool defs are rebuilt each attempt so tool-search "load on demand"
-   *  surfaces newly-loaded schemas per turn — for BOTH deferred MCP tools
-   *  (via deps.mcp.allTools() filtering) and deferred COLD built-ins (via
-   *  deps.isBuiltinDeferred). A cold-and-unloaded built-in is skipped here so
-   *  its schema is not written this turn; it reappears the turn after a
-   *  ToolSearch load. Absent isBuiltinDeferred -> every built-in is inline
+  /** Tool defs are rebuilt once per TURN (loop iteration) so tool-search
+   *  "load on demand" surfaces newly-loaded schemas per turn — for BOTH
+   *  deferred MCP tools (via deps.mcp.allTools() filtering) and deferred COLD
+   *  built-ins (via deps.isBuiltinDeferred). Loads only happen through tool
+   *  execution BETWEEN turns, so one build per iteration (shared by the
+   *  compaction estimate and every stream attempt of that turn, replay and
+   *  fallback included) is equivalent to the previous per-attempt rebuild —
+   *  minus the redundant allocations. A cold-and-unloaded built-in is skipped
+   *  here so its schema is not written this turn; it reappears the turn after
+   *  a ToolSearch load. Absent isBuiltinDeferred -> every built-in is inline
    *  (exact pre-unification behavior). */
   const buildToolDefs = (): APIToolDefinition[] => {
     const defs: APIToolDefinition[] = [];
@@ -508,18 +512,30 @@ export async function* runAgentLoop(
       ? config.systemBlocks.reduce((n, b) => n + (b.text?.length ?? 0), 0)
       : (config.systemPrompt?.length ?? 0) + (config.systemPromptSuffix?.length ?? 0);
   const systemPromptTokens = Math.ceil(systemCharLen / 4);
-  const currentOverheadTokens = (): number =>
-    estimateToolDefsTokens(buildToolDefs()) + systemPromptTokens;
+  // Tool-def token estimate, cached by the tool-NAME set: the estimate walks
+  // a JSON.stringify of every schema, and the def list only changes when the
+  // advertised tool set changes (ToolSearch load / MCP setServers) — which
+  // always changes the name set. Same-name schemas are static objects.
+  let toolDefsEstimateKey: string | undefined;
+  let toolDefsEstimate = 0;
+  const currentOverheadTokens = (defs: APIToolDefinition[]): number => {
+    const key = defs.map((d) => d.name).join(' ');
+    if (key !== toolDefsEstimateKey) {
+      toolDefsEstimate = estimateToolDefsTokens(defs);
+      toolDefsEstimateKey = key;
+    }
+    return toolDefsEstimate + systemPromptTokens;
+  };
 
   /** One streaming attempt; yields partial events, returns the final message.
    *  `sink` (when given) captures usage seen so far so a FAILED attempt's
    *  tokens can be folded into totals before a fallback retry. */
   async function* streamAttempt(
     useModel: string,
+    toolDefs: APIToolDefinition[],
     sink?: UsageSink,
   ): AsyncGenerator<SDKMessage, APIAssistantMessage> {
     const accumulator = new MessageAccumulator();
-    const toolDefs = buildToolDefs();
     // Retry observability: the transport calls onRetry (in the request phase,
     // before any stream event) for each 429/5xx/network retry. We buffer a
     // rate_limit_event (429) / api_retry (else) per retry and yield them at the
@@ -727,12 +743,17 @@ export async function* runAgentLoop(
       if (signal.aborted) throw new AbortError();
       yield* drainObs();
 
+      // ONE tool-def build per turn, shared by the compaction estimate and
+      // every stream attempt below (replay / fallback included) — the set can
+      // only change between turns (tool execution), never mid-turn.
+      const turnToolDefs = buildToolDefs();
+
       // --- Context compaction (only when a shared request view exists). -----
       if (deps.requestView !== undefined && config.compaction?.enabled !== false) {
         const cfg = config.compaction;
         // Recompute the tool-def overhead THIS turn so mid-run tool growth
         // (tool-search / lazy MCP load) is counted in the trigger (finding #11).
-        const overheadTokens = currentOverheadTokens();
+        const overheadTokens = currentOverheadTokens(turnToolDefs);
         const onSummaryCall = (
           m: string,
           u: NonNullableUsage,
@@ -811,7 +832,7 @@ export async function* runAgentLoop(
       replay: for (;;) {
         firstSink = {};
         try {
-          assistant = yield* streamAttempt(model, firstSink);
+          assistant = yield* streamAttempt(model, turnToolDefs, firstSink);
           break;
         } catch (err) {
           if (isAbortError(err)) throw toAbortError(err);
@@ -889,7 +910,7 @@ export async function* runAgentLoop(
             // The retry emits its OWN message_start; downstream consumers of
             // includePartialMessages must treat a fresh message_start as
             // superseding the discarded attempt's partial stream_events.
-            assistant = yield* streamAttempt(model); // 2nd failure -> outer catch
+            assistant = yield* streamAttempt(model, turnToolDefs); // 2nd failure -> outer catch
             break;
           }
           throw err;

--- a/projects/silver-core-sdk/src/transport/anthropic.ts
+++ b/projects/silver-core-sdk/src/transport/anthropic.ts
@@ -79,6 +79,15 @@ export class AnthropicTransport implements Transport {
   private readonly betas: string[] | undefined;
   private readonly credential: ResolvedCredential | null;
   private readonly endpoint: string;
+  /** provider.fetch injection seam. BPT-EXTENSION — lets the consumer bind
+   *  requests to a long-keep-alive undici Agent so turns separated by slow
+   *  tool runs reuse the warm TLS connection (docs/PERFORMANCE.md), or route
+   *  via proxy/instrumented fetch. Undefined -> the CURRENT global fetch is
+   *  resolved at call time (late binding: a later setGlobalDispatcher / test
+   *  stub still applies). */
+  private readonly fetchFn:
+    | ((input: string | URL, init?: RequestInit) => Promise<Response>)
+    | undefined;
   /** Concurrency gate; null when maxConcurrentRequests resolves to 0
    *  (unlimited — the default, so existing single-conversation callers see
    *  zero behavior change). */
@@ -90,6 +99,7 @@ export class AnthropicTransport implements Transport {
     this.debug = cfg.debug;
     this.betas = cfg.betas;
     this.credential = resolveCredential(this.provider, cfg.env);
+    this.fetchFn = this.provider.fetch;
     const maxConcurrent = resolveMaxConcurrent(this.provider, cfg.env);
     this.slots = maxConcurrent > 0 ? new RequestSemaphore(maxConcurrent) : null;
     const base = (
@@ -222,13 +232,29 @@ export class AnthropicTransport implements Transport {
       ];
       const streamSignal =
         signalParts.length > 1 ? AbortSignal.any(signalParts) : signal;
+      // Lazily re-armed: the per-event cost is ONE timestamp write, not a
+      // clearTimeout+setTimeout pair — a stream of thousands of small deltas
+      // no longer churns a timer per event. The single timer wakes at the
+      // earliest possible expiry and either fires (gap since the last event
+      // reached idleMs) or re-arms for exactly the remaining gap, so the
+      // abort still lands idleMs after the LAST event — same semantics as
+      // the per-event reset, at ~1 timer per idle window instead of 1 per
+      // event.
       let idleTimer: ReturnType<typeof setTimeout> | undefined;
-      const resetIdle = (): void => {
-        if (!idleController) return;
-        if (idleTimer) clearTimeout(idleTimer);
-        idleTimer = setTimeout(() => idleController.abort(), idleMs);
+      let lastEventAt = 0;
+      const armIdle = (delay: number): void => {
+        idleTimer = setTimeout(() => {
+          const remaining = idleMs - (Date.now() - lastEventAt);
+          if (remaining <= 0) idleController!.abort();
+          else armIdle(remaining);
+        }, delay);
         // Don't let the watchdog alone keep the process alive.
         (idleTimer as { unref?: () => void }).unref?.();
+      };
+      const resetIdle = (): void => {
+        lastEventAt = Date.now();
+        if (!idleController || idleTimer !== undefined) return;
+        armIdle(idleMs);
       };
       let eventCount = 0;
       try {
@@ -395,7 +421,7 @@ export class AnthropicTransport implements Transport {
         this.debug(
           `transport: POST ${this.endpoint} (attempt ${attempt + 1}/${maxRetries + 1})`,
         );
-        response = await fetch(this.endpoint, {
+        response = await (this.fetchFn ?? fetch)(this.endpoint, {
           method: 'POST',
           headers,
           body: bodyJson,

--- a/projects/silver-core-sdk/src/transport/openai.ts
+++ b/projects/silver-core-sdk/src/transport/openai.ts
@@ -527,6 +527,15 @@ export class OpenAIChatTransport implements Transport {
   private readonly debug: (m: string) => void;
   private readonly credential: ResolvedCredential | null;
   private readonly endpoint: string;
+  /** provider.fetch injection seam. BPT-EXTENSION — lets the consumer bind
+   *  requests to a long-keep-alive undici Agent so turns separated by slow
+   *  tool runs reuse the warm TLS connection (docs/PERFORMANCE.md), or route
+   *  via proxy/instrumented fetch. Undefined -> the CURRENT global fetch is
+   *  resolved at call time (late binding: a later setGlobalDispatcher / test
+   *  stub still applies). */
+  private readonly fetchFn:
+    | ((input: string | URL, init?: RequestInit) => Promise<Response>)
+    | undefined;
   private readonly slots: RequestSemaphore | null;
 
   constructor(cfg: TransportConfig) {
@@ -534,6 +543,7 @@ export class OpenAIChatTransport implements Transport {
     this.env = cfg.env;
     this.debug = cfg.debug;
     this.credential = resolveOpenAICredential(this.provider, cfg.env);
+    this.fetchFn = this.provider.fetch;
     const maxConcurrent = resolveMaxConcurrent(this.provider, cfg.env);
     this.slots = maxConcurrent > 0 ? new RequestSemaphore(maxConcurrent) : null;
     const base = (
@@ -665,12 +675,23 @@ export class OpenAIChatTransport implements Transport {
       ];
       const streamSignal =
         signalParts.length > 1 ? AbortSignal.any(signalParts) : signal;
+      // Lazily re-armed watchdog (see the anthropic twin for the rationale):
+      // per-event cost is one timestamp write; the single timer re-arms for
+      // the remaining gap and still aborts idleMs after the LAST event.
       let idleTimer: ReturnType<typeof setTimeout> | undefined;
-      const resetIdle = (): void => {
-        if (!idleController) return;
-        if (idleTimer) clearTimeout(idleTimer);
-        idleTimer = setTimeout(() => idleController.abort(), idleMs);
+      let lastEventAt = 0;
+      const armIdle = (delay: number): void => {
+        idleTimer = setTimeout(() => {
+          const remaining = idleMs - (Date.now() - lastEventAt);
+          if (remaining <= 0) idleController!.abort();
+          else armIdle(remaining);
+        }, delay);
         (idleTimer as { unref?: () => void }).unref?.();
+      };
+      const resetIdle = (): void => {
+        lastEventAt = Date.now();
+        if (!idleController || idleTimer !== undefined) return;
+        armIdle(idleMs);
       };
       const translator = new OpenAIStreamTranslator(req.model);
       let chunkCount = 0;
@@ -820,7 +841,7 @@ export class OpenAIChatTransport implements Transport {
         this.debug(
           `openai transport: POST ${this.endpoint} (attempt ${attempt + 1}/${maxRetries + 1})`,
         );
-        response = await fetch(this.endpoint, {
+        response = await (this.fetchFn ?? fetch)(this.endpoint, {
           method: 'POST',
           headers,
           body: bodyJson,

--- a/projects/silver-core-sdk/src/transport/sse.ts
+++ b/projects/silver-core-sdk/src/transport/sse.ts
@@ -70,14 +70,18 @@ export async function* parseSSE(
     // 'id', 'retry' and unknown fields are intentionally ignored.
   };
 
-  /** Consume every complete (newline-terminated) line currently buffered. */
+  /** Consume every complete (newline-terminated) line currently buffered.
+   *  Scans by offset and re-slices the buffer ONCE at the end — the previous
+   *  per-line `buffer = buffer.slice(...)` recopied the whole remainder for
+   *  every line, quadratic in lines-per-chunk. */
   const drainBuffer = (): void => {
+    let start = 0;
     let idx: number;
-    while ((idx = buffer.indexOf('\n')) !== -1) {
-      const line = buffer.slice(0, idx);
-      buffer = buffer.slice(idx + 1);
-      handleLine(line);
+    while ((idx = buffer.indexOf('\n', start)) !== -1) {
+      handleLine(buffer.slice(start, idx));
+      start = idx + 1;
     }
+    if (start > 0) buffer = start === buffer.length ? '' : buffer.slice(start);
   };
 
   // Reject a pending read() promptly when the caller aborts; the underlying

--- a/projects/silver-core-sdk/src/types.ts
+++ b/projects/silver-core-sdk/src/types.ts
@@ -1045,6 +1045,20 @@ export type ProviderConfig = {
    * BPT-EXTENSION: the official SDK has no such knob (its CLI owns concurrency).
    */
   maxConcurrentRequests?: number;
+  /**
+   * Custom fetch implementation used for EVERY HTTP request this transport
+   * issues (default: the global fetch). BPT-EXTENSION. The primary use case
+   * is response time: Node's built-in fetch pools connections with a ~4s
+   * idle keep-alive by default, so an agent whose tool executions run longer
+   * than that pays a fresh TCP+TLS handshake (typically 100-300ms) on every
+   * turn. Injecting a fetch bound to an undici Agent with a longer
+   * keepAliveTimeout removes that per-turn tax (recipe: docs/PERFORMANCE.md).
+   * Also the seam for proxies, mTLS, and request instrumentation. The
+   * function receives exactly what the transport would pass to global fetch
+   * (endpoint URL + RequestInit including signal) and must resolve to a
+   * WHATWG Response whose body is the SSE stream.
+   */
+  fetch?: (input: string | URL, init?: RequestInit) => Promise<Response>;
   maxOutputTokens?: number;
   /** Automatic prompt caching via cache_control breakpoints; default true. */
   promptCaching?: boolean;

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.43.0';
+export const SDK_VERSION = '0.44.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/integration/perf-overhead.mjs
+++ b/projects/silver-core-sdk/tests/integration/perf-overhead.mjs
@@ -1,0 +1,145 @@
+/**
+ * SDK-overhead latency probe (zero-key, emulator-driven).
+ *
+ * Measures the latency the SDK ITSELF adds around the model stream — the
+ * response-time budget the engine controls — using the conformance emulator
+ * as an instant local model, so every millisecond measured is client-side
+ * work (request assembly, SSE parsing, accumulation, dispatch, bookkeeping),
+ * not model or network time.
+ *
+ * Scenarios:
+ *   tool-loop    30-turn agent loop (4KB assistant text + one read-only Glob
+ *                per turn) — exercises per-turn request assembly, history
+ *                growth, tool dispatch, compaction estimation.
+ *   event-storm  one turn delivering 8000 small text deltas — exercises the
+ *                per-SSE-event path (parser, watchdog, accumulator).
+ *
+ * Metrics per scenario (median of --repeat runs, default 5):
+ *   wallMs      end-to-end query wall time
+ *   apiMs       engine durationApiMs (stream open -> close; on a localhost
+ *               emulator this is dominated by SDK per-event processing)
+ *   toolMs      sum of per-tool execution time
+ *   overheadMs  wallMs - apiMs - toolMs (pure engine bookkeeping)
+ *   cpuMs       process CPU (user+system) consumed by the run
+ *
+ * Usage:  node tests/integration/perf-overhead.mjs [--repeat=5] [--out=path.json]
+ * Requires `npm run build` first (imports the compiled dist).
+ * NOT part of `npm test`: a timing probe, inherently machine-dependent.
+ */
+
+import { startEmulator, textReply } from '../conformance/emulator.mjs';
+import { query } from '../../dist/index.js';
+
+const args = Object.fromEntries(
+  process.argv.slice(2).filter((a) => a.startsWith('--')).map((a) => {
+    const eq = a.indexOf('=');
+    return eq === -1 ? [a.slice(2), true] : [a.slice(2, eq), a.slice(eq + 1)];
+  }),
+);
+const REPEAT = Math.max(1, Number.parseInt(args.repeat, 10) || 5);
+
+const median = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+};
+
+/** Assistant turn: one sizeable text block + one tool_use (unique ids). */
+function textPlusToolUse(turnIdx, text, name, input) {
+  const id = `msg_perf_${turnIdx}`;
+  return [
+    { type: 'message_start', message: { id, type: 'message', role: 'assistant', model: 'claude-emulator-1', content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 10, output_tokens: 1 } } },
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } },
+    { type: 'content_block_stop', index: 0 },
+    { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: `toolu_perf_${turnIdx}`, name, input: {} } },
+    { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) } },
+    { type: 'content_block_stop', index: 1 },
+    { type: 'message_delta', delta: { stop_reason: 'tool_use', stop_sequence: null }, usage: { output_tokens: 20 } },
+    { type: 'message_stop' },
+  ];
+}
+
+/** One turn made of `n` small text deltas. */
+function deltaStorm(n) {
+  const events = [
+    { type: 'message_start', message: { id: 'msg_perf_storm', type: 'message', role: 'assistant', model: 'claude-emulator-1', content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 10, output_tokens: 1 } } },
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+  ];
+  for (let i = 0; i < n; i++) {
+    events.push({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: `token-${i % 97} ` } });
+  }
+  events.push(
+    { type: 'content_block_stop', index: 0 },
+    { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: n } },
+    { type: 'message_stop' },
+  );
+  return events;
+}
+
+async function runOnce(scripts, promptText) {
+  const emulator = await startEmulator(scripts);
+  const cpu0 = process.cpuUsage();
+  const t0 = performance.now();
+  let metrics;
+  try {
+    const q = query({
+      prompt: promptText,
+      options: {
+        provider: { apiKey: 'perf-key', baseUrl: emulator.url },
+        persistSession: false,
+        maxTurns: 100,
+      },
+    });
+    for await (const msg of q) {
+      if (msg.type === 'result') metrics = msg.metrics;
+    }
+  } finally {
+    await emulator.close();
+  }
+  const wallMs = performance.now() - t0;
+  const cpu = process.cpuUsage(cpu0);
+  const apiMs = metrics?.durationApiMs ?? 0;
+  const toolMs = (metrics?.perTool ?? []).reduce((n, t) => n + t.totalMs, 0);
+  return {
+    wallMs,
+    apiMs,
+    toolMs,
+    overheadMs: wallMs - apiMs - toolMs,
+    cpuMs: (cpu.user + cpu.system) / 1000,
+  };
+}
+
+const FILLER = 'The quick brown fox jumps over the lazy dog. 敏捷的棕毛狐狸跳过了懒狗。'.repeat(60); // ~4KB
+
+function toolLoopScripts(turns) {
+  const scripts = [];
+  for (let i = 0; i < turns; i++) {
+    scripts.push({ kind: 'sse', events: textPlusToolUse(i, FILLER, 'Glob', { pattern: '*.json' }) });
+  }
+  scripts.push({ kind: 'sse', events: textReply('done.') });
+  return scripts;
+}
+
+async function scenario(name, mkScripts, promptText) {
+  const runs = [];
+  for (let i = 0; i < REPEAT; i++) {
+    runs.push(await runOnce(mkScripts(), promptText));
+  }
+  const agg = {};
+  for (const key of ['wallMs', 'apiMs', 'toolMs', 'overheadMs', 'cpuMs']) {
+    agg[key] = Number(median(runs.map((r) => r[key])).toFixed(1));
+  }
+  console.log(`${name.padEnd(12)} wall=${agg.wallMs}ms api=${agg.apiMs}ms tool=${agg.toolMs}ms overhead=${agg.overheadMs}ms cpu=${agg.cpuMs}ms`);
+  return agg;
+}
+
+const report = { node: process.version, repeat: REPEAT, scenarios: {} };
+report.scenarios['tool-loop'] = await scenario('tool-loop', () => toolLoopScripts(30), 'perf probe: run the tool loop');
+report.scenarios['event-storm'] = await scenario('event-storm', () => [{ kind: 'sse', events: deltaStorm(8000) }], 'perf probe: long answer');
+
+if (typeof args.out === 'string') {
+  const { writeFileSync } = await import('node:fs');
+  writeFileSync(args.out, JSON.stringify(report, null, 2));
+  console.log(`report written: ${args.out}`);
+}

--- a/projects/silver-core-sdk/tests/transport-fetch-injection.test.ts
+++ b/projects/silver-core-sdk/tests/transport-fetch-injection.test.ts
@@ -1,0 +1,149 @@
+/**
+ * provider.fetch injection seam (BPT-EXTENSION, response-time work 2026-07-11).
+ *
+ * Both transports must route EVERY HTTP request through the injected fetch
+ * (never the global one) and behave byte-identically otherwise — the seam
+ * exists so a consumer can bind requests to a long-keep-alive undici Agent
+ * (docs/PERFORMANCE.md) or an instrumented/proxied fetch.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AnthropicTransport } from '../src/transport/anthropic.js';
+import { OpenAIChatTransport } from '../src/transport/openai.js';
+import type { StreamRequest } from '../src/internal/contracts.js';
+import type { RawMessageStreamEvent } from '../src/types.js';
+
+const enc = new TextEncoder();
+
+function sseResponse(events: Array<Record<string, unknown>>): Response {
+  const body = events
+    .map((e) => `event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`)
+    .join('');
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode(body));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+const ANTHROPIC_EVENTS = [
+  { type: 'message_start', message: { id: 'msg_1', type: 'message', role: 'assistant', model: 'claude-test-1', content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 1, output_tokens: 1 } } },
+  { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+  { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hi' } },
+  { type: 'content_block_stop', index: 0 },
+  { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 2 } },
+  { type: 'message_stop' },
+];
+
+function openaiSseResponse(): Response {
+  const chunks = [
+    { id: 'chatcmpl-1', model: 'gpt-test', choices: [{ index: 0, delta: { role: 'assistant', content: 'hi' }, finish_reason: null }] },
+    { id: 'chatcmpl-1', model: 'gpt-test', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1 } },
+  ];
+  const body =
+    chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join('') + 'data: [DONE]\n\n';
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode(body));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+function baseReq(): StreamRequest {
+  return {
+    model: 'claude-test-1',
+    max_tokens: 64,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+}
+
+async function collect(gen: AsyncIterable<RawMessageStreamEvent>): Promise<RawMessageStreamEvent[]> {
+  const out: RawMessageStreamEvent[] = [];
+  for await (const e of gen) out.push(e);
+  return out;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('provider.fetch injection', () => {
+  it('AnthropicTransport routes the request through the injected fetch, not the global', async () => {
+    const globalFetch = vi.fn(async () => {
+      throw new Error('global fetch must not be called');
+    });
+    vi.stubGlobal('fetch', globalFetch);
+    const injected = vi.fn(async (_input: string | URL, _init?: RequestInit) =>
+      sseResponse(ANTHROPIC_EVENTS),
+    );
+    const transport = new AnthropicTransport({
+      provider: { apiKey: 'k', fetch: injected },
+      env: {},
+      debug: () => undefined,
+    });
+    const events = await collect(transport.stream(baseReq()));
+    expect(events.at(-1)?.type).toBe('message_stop');
+    expect(injected).toHaveBeenCalledTimes(1);
+    expect(globalFetch).not.toHaveBeenCalled();
+    const [url, init] = injected.mock.calls[0]!;
+    expect(String(url)).toBe('https://api.anthropic.com/v1/messages');
+    // The injected fetch receives the full RequestInit the global would have:
+    // body, headers (credential included) and the per-attempt abort signal.
+    expect(init?.method).toBe('POST');
+    expect((init?.headers as Record<string, string>)['x-api-key']).toBe('k');
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    expect(JSON.parse(String(init?.body)).stream).toBe(true);
+  });
+
+  it('OpenAIChatTransport routes the request through the injected fetch, not the global', async () => {
+    const globalFetch = vi.fn(async () => {
+      throw new Error('global fetch must not be called');
+    });
+    vi.stubGlobal('fetch', globalFetch);
+    const injected = vi.fn(async (_input: string | URL, _init?: RequestInit) =>
+      openaiSseResponse(),
+    );
+    const transport = new OpenAIChatTransport({
+      provider: { protocol: 'openai-chat', apiKey: 'k', fetch: injected },
+      env: {},
+      debug: () => undefined,
+    });
+    const events = await collect(transport.stream({ ...baseReq(), model: 'gpt-test' }));
+    expect(events.at(-1)?.type).toBe('message_stop');
+    expect(injected).toHaveBeenCalledTimes(1);
+    expect(globalFetch).not.toHaveBeenCalled();
+    expect(String(injected.mock.calls[0]![0])).toBe(
+      'https://api.openai.com/v1/chat/completions',
+    );
+  });
+
+  it('retries flow through the injected fetch as well (429 then success)', async () => {
+    const responses: Array<() => Response> = [
+      () =>
+        new Response(
+          JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'slow down' } }),
+          { status: 429, headers: { 'retry-after': '0' } },
+        ),
+      () => sseResponse(ANTHROPIC_EVENTS),
+    ];
+    const injected = vi.fn(async () => responses.shift()!());
+    const transport = new AnthropicTransport({
+      provider: { apiKey: 'k', fetch: injected, maxRetries: 2 },
+      env: {},
+      debug: () => undefined,
+    });
+    const events = await collect(transport.stream(baseReq()));
+    expect(events.at(-1)?.type).toBe('message_stop');
+    expect(injected).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## 概述

守密人派单「审视 silver core sdk，优化响应时间」的落地：先测后改——新增零密钥仿真器延迟探针确认引擎本体开销仅 ~1ms/回合，随后落四项优化（一项面向消费方的最大杠杆 + 三项引擎热路径削减），版本 bump 至 0.44.0。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [ ] 文档完善（CLAUDE.md / BIAV-SC.md / README.md / 子项目 CONTEXT.md）
- [ ] Bug 修复
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 其他（请说明）：silver-core-sdk 性能优化（响应时间）+ 配套测试 / 文档 / 基准探针

### 变更明细

1. **`provider.fetch` 注入缝（BPT-EXTENSION，双传输孪生同享）**：传输层全部 HTTP 请求（含重试）经注入 fetch 发出；未注入时调用期晚绑定回退当前全局 fetch。消费方注入长 keep-alive undici Agent 即可消除「工具执行超 4 秒 → 每回合重付 TCP+TLS 握手（约 100-300ms）」的隐性税。配方见新档 `projects/silver-core-sdk/docs/PERFORMANCE.md`。
2. **空闲看门狗惰性重臂（双传输）**：每 SSE 事件成本从 clearTimeout+setTimeout 一对降为一次时间戳写入；单计时器按剩余间隙自重臂，中止仍精确落在最后事件后 idleMs，语义不变。
3. **引擎环每回合单次构建工具定义**：压缩估算与该回合全部流尝试（重放 / fallback 含）共享一次 `buildToolDefs()`；全 schema stringify 估算按工具名集缓存。
4. **SSE 解析器偏移扫描**：`drainBuffer` 每 chunk 仅重切一次缓冲（原先逐行重拷贝，行数二次方）。

探针中位数（repeat=9 同机 A/B，git stash 对照）：30 回合工具环引擎记账 29.7ms → 18.0ms（-39%）；8000 事件流 CPU 53.3ms → 46.3ms。

---

## 来源声明

- [x] 本 PR 不涉及游戏数据；纯银芯自产工程代码（silver-core-sdk 净室重实现，仅参照公开文档），undici keep-alive 默认值为 Node.js 公开文档事实。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 所有引用素材均来自公开可查阅来源。
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**；不上传内部美术资产、客户端解包原始文件、未公开的剧情草稿等。
- [x] **同意按 [MIT License](../LICENSE) 提交贡献。**

---

## 验证清单

- [x] `npm test`：79 文件、**1666 通过 + 2 skipped**（含新增 3 条注入缝测试：双传输路由 + 重试路径）；孪生纪律测试（`transport-twin-drift`）保持绿
- [x] `npm run typecheck` / `npm run build` exit 0；`scripts/check-version-bump.mjs` 过（package.json / src/version.ts / CHANGELOG 三方一致 0.44.0）
- [x] `pytest tests/test_claude_md*.py`：7 通过（memory/project-status.md 同步条目）
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案

---

## 关联 Issue

- Refs：无（会话直接派单）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAPJa1TdFNoWy6LN3zmnbU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAPJa1TdFNoWy6LN3zmnbU)_