### PR TITLE
feat(silver-core-sdk): memory governance P0 set — mounts / incognito / tool-call log / claim audit (v0.48.0)

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -195,6 +195,17 @@
   两组阻塞性开放问题已挂账：`memory/todo.md` #T25（Phase 1：评分模型版本 / 成本预算 + 20 题题目
   来源）、#T26（Phase 3：沙箱工作区选型）。前置文档 SCS-REQ-001 = 记忆系统需求书
   （`projects/silver-core-sdk/docs/MEMORY.md`，M1/M2 已落地，见下两条）。
+- **记忆治理 P0 组落地（v0.48.0，2026-07-11，spec S1–S4，守密人 0711 需求书派发）**：需求书
+  《记忆系统、隐私治理与会议记录支持》SDK 侧收口（归档 `projects/silver-core-sdk/docs/MEMORY-GOVERNANCE.md`）。
+  S1 作用域路由（`options.memory.mounts` 按 query 声明子树 read-only/read-write，工具层在 R4 之上
+  强制：只读拒写 / 挂载外拒读写 / 祖先目录列目录按挂载可见性过滤 / rename 双端 / R6 索引挂载可读才注入）；
+  S2 无痕原语（`options.incognito` 零持久化：转录不落盘、memory 只读降级 view 可用、R7 两写回合关断、
+  S3 记录抑制；泄漏测试清单落集成测试，标记词全盘 grep 零残留）；S3 结构化工具调用日志（每次派发
+  一条 `tool_call` JSONL 记录：名/截断参数/时间戳/序号/成败/耗时/摘要，子代理带 parent_tool_use_id，
+  `getSessionToolCalls` 读回）；S4 声明核验（`auditToolClaims` 检出「嘴上说调了、日志无记录」，
+  漏报优先压低）。S5 由按 query 组合满足（team-ro 会话与 team-rw synthesis 同 store 并存入测试）、
+  S6 预留由 S3 记录携 session_id 兑现。+32 测试（全量 1812 绿）。挂账：`memory/todo.md`
+  #T27（无痕 memory 读权限待拍板，现默认保留）、#T28（BPT 侧多用户隔离 / 计费归属回填）。
 - **记忆系统 M2 落地（v0.47.0，2026-07-11，spec R7–R9，随 M1 同日；spec r1 全量收口）**：R7 压缩前
   落盘回合（auto 触发将至先注入一次写入机会、PreCompact 可 deny、每折叠周期恰一次）+ 会话正常终结
   进度卡回合（abort/错误不触发；回合 result 被吸收，任务自身 result 仍为流内最后一个）；R8 治理限额

--- a/memory/todo.md
+++ b/memory/todo.md
@@ -30,6 +30,8 @@
 | T24 | fanart 月桶「日日下载整月重传」带宽站岗：随月内天数线性涨（历史 ~150MB/月，月末单次两三百 MB），当前可接受；若未来体量失控再议按日资产分桶（代价 = 回到「资产散乱」老问题，2026-06-21 整理前形态），无异常不动 | 观察 | PR [#587](https://github.com/lightproud/brain-in-a-vat/pull/587) 合并总结体余项 2 + `.github/workflows/collect-fanart.yml` 上传步 | 开 |
 | T25 | Silver Core SDK 自我改进闭环（SCS-REQ-002）Phase 1 双裁定：① 行为评估 LLM 评分固定用哪个模型版本、成本预算多少；② 20 题评估集题目来源（从历史失败会话提炼 vs 人工构造）。两项均阻塞 Phase 1（环二评估基准），环三夜间改进任务依赖环二先行（需求书硬序） | 裁定 | `memory/active/self-improvement-requirements.md` §8 开放问题 #1/#2 | 开 |
 | T26 | Silver Core SDK 自我改进闭环（SCS-REQ-002）Phase 3 沙箱工作区实现选型：容器隔离 vs 独立 checkout 目录（工程决策），阻塞 Phase 3（环三夜间改进任务）；前置 Phase 1、2 完成，不急裁 | 裁定 | `memory/active/self-improvement-requirements.md` §8 开放问题 #3 | 开 |
+| T27 | 无痕会话（S2 `options.incognito`）memory **读权限**是否保留：v0.48.0 默认保留（view 可用，「知道你但不记录你」，需求书自荐方案待拍板）；若裁「全禁」，消费侧 `disallowedTools:['memory']` 即达、SDK 零改动 | 裁定 | 0711 记忆治理需求书 §7 待决表 + `projects/silver-core-sdk/docs/MEMORY-GOVERNANCE.md` S2 节 | 开 |
+| T28 | BPT 侧多用户 session 隔离与 token 计费归属现状回填：S1 挂载已按 query 实例化落地（SDK 侧不阻塞），BPT 接线时按其用户体系把 `{userId}` 实例化进 mounts 并核对计费归属口径 | 黑池输入 | 0711 记忆治理需求书 §7 待决表 + `projects/silver-core-sdk/docs/MEMORY-GOVERNANCE.md` S1 节 | 开 |
 
 ## 已清（销案引）
 

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,33 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.48.0 — 2026-07-11
+
+**Memory governance P0 set (spec S1–S4, BPT-EXTENSION — docs/MEMORY-GOVERNANCE.md)**:
+the SDK-layer footing for BPT's team/personal memory partitioning, incognito
+mode and auditability. S1 scope routing: `options.memory.mounts` declares
+per-query subtree rights (`read-only` / `read-write`), enforced at the tool
+layer on top of R4 traversal protection — writes outside a read-write mount
+and any access outside every mount are rejected with structured errors,
+ancestor-directory listings are FILTERED to mount-visible entries (user A
+never sees user B's names), rename is gated at both ends, and the resident
+index (R6) only injects when `/memories/MEMORY.md` is mount-readable. S2
+incognito primitive: `options.incognito` forces zero SDK-side persistence —
+transcript writes off (`sessionStore` combination is a ConfigurationError),
+memory degraded to read-only (view stays; the five writes return
+`INCOGNITO_MEMORY_ERROR`), both R7 write rounds off, S3 records off; the
+leak-test checklist from the requirements doc runs as integration tests
+(marker-grep across every SDK-writable root). S3 structured tool-call log:
+one `tool_call` JSONL record per dispatched tool_use block (root loop AND
+subagents, `parent_tool_use_id`-stamped) with name / truncated input JSON /
+timestamp / seq / status / duration / result summary, `type`-distinguishable
+from message lines and joinable to the untruncated tool_use block via
+tool_use_id; read back with `getSessionToolCalls()`. S4 claim verification:
+`auditToolClaims` / `auditSessionToolClaims` flag assistant turns that CLAIM
+a tool action with no backing record (default zh+en memory-write detector,
+consumer-extensible; low-miss over precision by design). +32 tests, full
+suite 1812 green.
+
 ## 0.47.0 — 2026-07-11
 
 **Memory system M2 (spec R7–R9, BPT-EXTENSION `options.memory` — docs/MEMORY.md)**:

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -66,6 +66,21 @@ src/
 
 ## 当前状态
 
+**v0.48.0(2026-07-11):记忆治理 P0 组(spec S1–S4)落地**——守密人 0711 派发《记忆系统、
+隐私治理与会议记录支持》需求书(归档 `docs/MEMORY-GOVERNANCE.md`)的 SDK 侧收口。
+S1 作用域路由:`options.memory.mounts` 按 query 声明子树权限(read-only / read-write),
+工具层在 R4 穿越防护之上强制执行——只读挂载点拒写、挂载点外拒读写、祖先目录列目录按
+挂载可见性过滤(用户 A 看不到用户 B 的目录名)、rename 双端校验、R6 常驻索引仅在
+MEMORY.md 挂载可读时注入。S2 无痕原语:`options.incognito` 一键零持久化(转录不落盘、
+memory 降级只读 view 可用、R7 两写回合关断、S3 记录抑制、sessionStore 组合报配置错误),
+需求书泄漏测试清单直接落为集成测试(标记词全盘 grep 零残留)。S3 结构化工具调用日志:
+每次 tool_use 派发在会话 JSONL 写一条 `tool_call` 记录(名/截断参数/时间戳/序号/成败/
+耗时/摘要;子代理带 parent_tool_use_id),`getSessionToolCalls` 读回,经 tool_use_id 与
+tool_use 块对齐可全量重放。S4 声明核验:`auditToolClaims`/`auditSessionToolClaims` 检出
+「嘴上说调了、日志无记录」轮次(中英文记忆写入探测器默认集,漏报优先压低)。S5 由既有
+按 query 组合满足(同一 store 上 team-ro 用户会话与 team-rw synthesis 任务并存已入测试)、
+S6 架构预留由 S3 记录携 session_id 兑现。+32 测试,全量 1812 绿。
+
 **v0.47.0(2026-07-11):记忆系统 M2(spec R7–R9)落地,spec 全量收口**——R7 压缩前落盘回合
 (auto 触发将至先注入一次记忆写入机会、PreCompact 钩子可 deny、每折叠周期恰一次)+ 会话正常
 终结进度卡回合(abort/错误不触发,回合 result 被吸收、任务自身 result 仍为流内最后一个);

--- a/projects/silver-core-sdk/docs/MEMORY-GOVERNANCE.md
+++ b/projects/silver-core-sdk/docs/MEMORY-GOVERNANCE.md
@@ -1,0 +1,198 @@
+# Memory governance, incognito sessions and the structured tool-call log (spec S1–S6)
+
+Archived requirements + implementation record for the 2026-07-11 keeper
+dispatch《Silver Core SDK 需求说明:记忆系统、隐私治理与会议记录支持》(Draft v1,
+source: the BPT memory-system discussion series — recall → voice input →
+team/personal governance → incognito → meeting notes). This layer sits ON TOP
+of the memory system itself (spec R1–R9, `docs/MEMORY.md`): R1–R9 built the
+tool; S1–S6 make it governable in a multi-user application.
+
+Problem statement (from the dispatch): BPT is implementing a three-layer
+memory architecture (L1 hand-written instruction cards / L2 model-written
+working memory / L3 nightly synthesis) with team/personal partitioning under
+"radical transparency + an incognito escape hatch". The SDK lacked three
+pieces of infrastructure — memory permission routing, an incognito session
+primitive, and a structured tool-call log — without which the application can
+only approximate those guarantees in fragile prompt-level ways.
+
+Status: **S1 + S2 + S3 (all P0) and S4 (P1) shipped in v0.48.0.** S5 is
+satisfied by existing per-query composition (documented below, no new
+runtime); S6 is an architectural reservation honored by the S3 record design.
+
+## S1 — Memory scope routing and permission enforcement (P0, shipped)
+
+`options.memory.mounts` declares which `/memories` subtrees a query may touch
+and with what rights:
+
+```ts
+const q = query({ prompt, options: {
+  memory: {
+    mounts: [
+      { path: '/memories/team',        mode: 'read-only'  },
+      { path: '/memories/users/alice', mode: 'read-write' },
+    ],
+  },
+}});
+```
+
+Semantics (enforced at the SDK tool layer in `src/tools/memory/memory-tool.ts`,
+AFTER R4 path validation and BEFORE the store is called — never via the system
+prompt):
+
+- **Write commands** (create / str_replace / insert / delete / rename) must
+  target a `read-write` mount. A write into a read-only mount returns a
+  structured error naming the writable mounts; a write outside every mount
+  returns an error naming all mounts, so the model can reroute.
+- **rename is gated at both ends** — moving a file OUT of read-only territory
+  is a write there too.
+- **Reads** must land inside a mount. A strict ANCESTOR directory of a mount
+  (e.g. `/memories` itself) stays viewable so the protocol's "view your memory
+  directory first" navigation works, but its listing is FILTERED to entries on
+  the path to (or inside) a mount: user A's session never sees user B's
+  directory names. Viewing a non-mounted sibling path directly is rejected.
+- **Resident index (R6)** only injects when `/memories/MEMORY.md` is readable
+  under the mounts — the injection is a read and obeys the same routing.
+- **No `mounts`** = unrestricted `/memories` (pre-S1 behavior). An empty array
+  is a `ConfigurationError` (it would make everything inaccessible); so are
+  malformed mount paths and modes.
+
+Mounts are **per-query state**: the embedder instantiates them from its own
+session context, which is what the acceptance demanded ("挂载点按会话上下文
+实例化而非全局固定"). Traversal attacks (`../`, absolute paths, URL-encoded
+variants) are rejected by the R4 layer before mounts are even consulted.
+
+Acceptance mapping (tests: `tests/memory-mounts.test.ts`):
+
+- [x] writes against `/memories/team` (ro) → structured rejection
+- [x] reads/writes in the session's own rw mount → pass through
+- [x] `../` / absolute escapes → rejected (R4 stacks under S1)
+- [x] enforcement at the SDK layer, zero prompt dependence
+- [x] user A cannot read or write user B's directory (incl. filtered listings)
+
+## S2 — Incognito session primitive (P0, shipped)
+
+`options.incognito: true` makes the "exists only in memory" promise a
+one-flag SDK guarantee:
+
+1. **Memory degrades to read-only** — `view` stays available ("knows you,
+   doesn't record you"), the five write commands return the exported
+   `INCOGNITO_MEMORY_ERROR` constant. Pending-decision note: the dispatch left
+   "keep read access?" open for the keeper; the shipped default keeps reads
+   (the doc's own recommendation). If ruled otherwise, disable the tool with
+   `disallowedTools: ['memory']` or `memory: { enabled: false }` — no SDK
+   change needed.
+2. **Zero SDK-side persistence** — the session transcript is not written
+   (`persistSession` forced off), no `tool_call` records (S3) are written, and
+   both R7 memory write rounds (compaction flush, session-end progress card)
+   are disabled. Combining with `sessionStore` is a `ConfigurationError`.
+3. **Data-source-level exclusion** — downstream consumers that read sessions
+   through the SDK surfaces (`listSessions` / `getSessionMessages` /
+   `getSessionToolCalls`) see nothing for the session: there is no transcript
+   to scan, not merely a filtered one.
+
+Promise boundary (state this in any consumer-facing copy): incognito means
+**nothing enters SDK storage or the memory store**. Requests are still sent to
+the configured model API and remain subject to its commercial terms; files the
+model edits in the WORKSPACE via Write/Edit/Bash are the user's own actions
+and are outside this promise (as is any consumer-configured `debugFile`, which
+carries metadata-level lines).
+
+The leak-test checklist from the dispatch runs as integration tests
+(`tests/incognito.test.ts`): a lured write is rejected with zero memory
+artifacts; a unique marker token ("purple-whale-protocol") greps to zero
+residue across every SDK-writable root after the run; the same script WITHOUT
+incognito does persist (the test discriminates); export surfaces return empty.
+
+## S3 — Structured tool-call log (P0, shipped)
+
+Origin lesson (from the dispatch): a real tool call whose transcript kept only
+the text was later misjudged as a fabricated call. Text is not evidence;
+dispatch-time telemetry is.
+
+Every dispatched tool_use block — root loop AND subagents — now also persists
+one `tool_call` record to the session JSONL, at the same level as the message
+lines:
+
+```json
+{"type":"tool_call","uuid":"…","session_id":"…","seq":3,
+ "timestamp":"2026-07-11T07:00:00.000Z","tool_use_id":"toolu_…",
+ "tool_name":"memory","tool_input":"{\"command\":\"create\",…}",
+ "status":"ok","duration_ms":12,"result_summary":"File created successfully…",
+ "parent_tool_use_id":"toolu_task_…"}
+```
+
+- `status` 'error' covers execution failures, permission denials, hook stops
+  and unknown tools alike (detail in `result_summary`); aborts record
+  `[aborted]` before rethrowing, so the audit trail never loses a dispatched
+  call.
+- `tool_input` is JSON truncated at 2048 chars; the UNTRUNCATED input lives in
+  the assistant message's tool_use block under the same `tool_use_id`, so full
+  replay ("传了什么、拿回了什么") joins on that key. `duration_ms` spans the
+  whole dispatch pipeline (hooks + gate + execution).
+- `parent_tool_use_id` is stamped on subagent calls (the spawning Task block),
+  keeping child work attributable in the same session file.
+- Consumers read records back with `getSessionToolCalls(sessionId, options)`
+  (local JSONL or an external `sessionStore`); `type` distinguishes tool calls
+  from text without parsing natural language, and `timestamp`/`seq` keep them
+  alignable with the message sequence — the Layer-3 synthesis contract.
+- Persist-gated: `persistSession: false` and incognito (S2) write none.
+- Recording is dispatch-time telemetry in the engine
+  (`src/engine/tool-dispatch.ts` → `EngineDeps.onToolRecord` → the query
+  layer's session append), never reconstruction from message content.
+
+Tests: `tests/tool-call-log.test.ts`.
+
+## S4 — Tool-claim verification helper (P1, shipped as a reference implementation)
+
+`auditToolClaims({ assistantTexts, toolCalls, detectors? })` flags assistant
+texts that CLAIM a tool action with no backing record in the S3 log;
+`auditSessionToolClaims(sessionId, options)` is the persisted-session
+convenience form (the "flag suspicious turns when the loop ends" entry point).
+
+The default detector set covers memory-write claims in zh + en ("已写入记忆" /
+"I've saved that to memory" / subject-less "saved it to memory"), backed only
+by a SUCCESSFUL memory write command in the records — a failed write or a
+`view` does not back a write claim. Detectors are consumer-extensible
+(`ToolClaimDetector`: a claim regex + a record predicate). Heuristic by
+design: false positives go to human review; the patterns are deliberately
+broad because the spec prioritizes low miss rate ("误报可接受,漏报优先压低").
+Session-scoped matching (not per-turn alignment) for the same reason: a claim
+summarizing an earlier turn's real call must not be flagged.
+
+Tests: `tests/tool-call-log.test.ts` (S4 describe block).
+
+## S5 — Batch task runner and per-task model selection (P1, satisfied by composition)
+
+No new runtime was added; the acceptance criteria fall out of existing
+per-query composition, which this doc records as the supported pattern:
+
+- **Non-interactive batch**: `query({ prompt, options })` with a string prompt
+  IS the batch primitive (no interactive surface is required); callers loop
+  over documents, with retry, and write outputs where they choose.
+- **Per-task model**: `options.model` is per-query — a synthesis task on a
+  strong model coexists with interactive sessions on another.
+- **Per-task memory rights**: the S1 acceptance's own proof — the SAME store
+  serves a user session (`/memories/team` read-only) and a synthesis task
+  (`/memories/team` read-write) concurrently, because mounts are per-query
+  (test: "a user session (team ro) and a synthesis task (team rw) coexist on
+  the same store").
+
+If a future dispatch wants a first-class runner (queueing, retry policy,
+output layout), it builds on these three without further SDK hooks.
+
+## S6 — Memory-entry metadata convention (P2, architectural reservation honored)
+
+Nothing to implement in v1 by design. The reservation the spec asked for
+holds: frontmatter conventions (date / source_session / supersedes) are
+BPT-prompt-driven, and `source_session` is recoverable from the SDK side
+because every write is now an S3 record carrying `session_id` + `timestamp` +
+`tool_use_id` — "which session produced this entry" joins the memory file to
+its writing session without any new SDK surface.
+
+## Out of scope (per the dispatch's non-goals)
+
+Real-time voice input (deferred), a semantic-retrieval/embedding stack (stays
+retired), the STT engine itself, and any personnel-information filtering
+system. The BPT-application-layer work items (L2 prompts, L3 synthesis
+pipeline, meeting pipeline, STT selection, "view my memory" UI) live outside
+this repository's SDK scope and are tracked in the dispatch document.

--- a/projects/silver-core-sdk/docs/MEMORY.md
+++ b/projects/silver-core-sdk/docs/MEMORY.md
@@ -7,7 +7,10 @@ the data lives is entirely the consumer's decision (a local directory, an
 intranet share, a database — the SDK never knows).
 
 Status: **M1 shipped in v0.46.0** (spec R1–R6) and **M2 shipped in v0.47.0**
-(spec R7–R9): the full spec surface is implemented, and the R2 acceptance is
+(spec R7–R9). The GOVERNANCE layer on top — scope-routing mounts (S1),
+incognito sessions (S2), the structured tool-call log (S3), claim
+verification (S4) — shipped in **v0.48.0**; see `docs/MEMORY-GOVERNANCE.md`.
+The full R-spec surface is implemented, and the R2 acceptance is
 now CLOSED end to end: the conformance memory axis carries both the mock-wire
 locks AND a field-level differential against a LIVE official-arm capture
 (fixture `tests/conformance/official-memory-wire.json`, captured 2026-07-11 by

--- a/projects/silver-core-sdk/package-lock.json
+++ b/projects/silver-core-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.45.0",
+  "version": "0.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silver-core-sdk",
-      "version": "0.45.0",
+      "version": "0.47.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -750,6 +750,9 @@ export async function* runAgentLoop(
     baseHookFields,
     signal,
     recordTool,
+    // S3 structured tool-call records: threaded from the query layer (root)
+    // or the subagent runtime (children, parentToolUseId stamped).
+    ...(deps.onToolRecord !== undefined ? { onToolRecord: deps.onToolRecord } : {}),
   });
 
   // v0.4: surface buffered task_* / hook_* lifecycle messages (the subagent

--- a/projects/silver-core-sdk/src/engine/tool-dispatch.ts
+++ b/projects/silver-core-sdk/src/engine/tool-dispatch.ts
@@ -28,6 +28,7 @@ import type {
 import type {
   AggregatedHookResult,
   EngineDeps,
+  ToolDispatchRecord,
   ToolResultPayload,
 } from '../internal/contracts.js';
 
@@ -137,13 +138,36 @@ export type ToolDispatcherConfig = {
   signal: AbortSignal;
   /** Per-tool metrics recorder (calls/duration/errors). */
   recordTool: (name: string, ms: number, isError: boolean) => void;
+  /** Structured tool-call telemetry (governance spec S3): one record per
+   *  dispatched block, emitted at dispatch completion. Absent -> no records. */
+  onToolRecord?: (rec: ToolDispatchRecord) => void;
 };
+
+const RECORD_SUMMARY_MAX_CHARS = 500;
+
+/** Head of a tool_result's content for the S3 record; non-text blocks appear
+ *  as their type tag so the record stays small and text-only. */
+function summarizeResultContent(
+  content: ToolResultBlockParam['content'],
+): string {
+  const text =
+    content === undefined
+      ? ''
+      : typeof content === 'string'
+        ? content
+        : content
+            .map((b) => (b.type === 'text' ? b.text : `[${b.type}]`))
+            .join(' ');
+  return text.length > RECORD_SUMMARY_MAX_CHARS
+    ? `${text.slice(0, RECORD_SUMMARY_MAX_CHARS)}…[truncated]`
+    : text;
+}
 
 export function createToolDispatcher(cfg: ToolDispatcherConfig): {
   isReadOnlyTool: (name: string) => boolean;
   executeToolUse: (block: ToolUseBlock) => Promise<ToolExecOutcome>;
 } {
-  const { deps, sessionId, baseHookFields, signal, recordTool } = cfg;
+  const { deps, sessionId, baseHookFields, signal, recordTool, onToolRecord } = cfg;
   /** Full pipeline for one tool_use block: hooks -> gate -> execute -> hooks. */
   /** A tool is read-only if a builtin flags it, or a connected MCP tool's
    * server annotation sets readOnlyHint. Feeds the gate's auto-approve
@@ -156,7 +180,44 @@ export function createToolDispatcher(cfg: ToolDispatcherConfig): {
       .some((t) => t.qualifiedName === name && t.annotations?.readOnlyHint === true);
   };
 
+  /** S3 wrapper: time the whole dispatch and emit one structured record per
+   *  block, including error/deny/stop outcomes. An abort still records (with
+   *  '[aborted]') so the audit trail never loses a dispatched call, then
+   *  rethrows. Absent recorder -> zero overhead passthrough. */
   async function executeToolUse(block: ToolUseBlock): Promise<ToolExecOutcome> {
+    if (onToolRecord === undefined) return dispatchToolUse(block);
+    const startedAt = new Date().toISOString();
+    const t0 = Date.now();
+    const emit = (status: 'ok' | 'error', resultSummary: string): void => {
+      try {
+        onToolRecord({
+          toolUseId: block.id,
+          toolName: block.name,
+          input: block.input,
+          startedAt,
+          durationMs: Date.now() - t0,
+          status,
+          resultSummary,
+        });
+      } catch {
+        // Telemetry must never break a tool dispatch.
+      }
+    };
+    let outcome: ToolExecOutcome;
+    try {
+      outcome = await dispatchToolUse(block);
+    } catch (err) {
+      emit('error', isAbortError(err) ? '[aborted]' : String(err));
+      throw err;
+    }
+    emit(
+      outcome.result.is_error === true ? 'error' : 'ok',
+      summarizeResultContent(outcome.result.content),
+    );
+    return outcome;
+  }
+
+  async function dispatchToolUse(block: ToolUseBlock): Promise<ToolExecOutcome> {
     const toolName = block.name;
     let input = block.input;
 

--- a/projects/silver-core-sdk/src/index.ts
+++ b/projects/silver-core-sdk/src/index.ts
@@ -35,6 +35,7 @@ export { DEFAULT_DEFERRED_BUILTINS, silverCoreToolOptions } from './tools/index.
 export {
   DEFAULT_CARDS_CONFIG,
   DEFAULT_MEMORY_LIMITS,
+  INCOGNITO_MEMORY_ERROR,
   MEMORY_INDEX_PATH,
   MEMORY_ROOT,
   MEMORY_SERVER_TOOL,
@@ -44,8 +45,14 @@ export {
   createLocalMemoryFileOps,
   createMemoryHealth,
   createMemoryStore,
+  describeMounts,
   memoryStoreContractCheckNames,
+  mountAllowsWrite,
+  mountReadAccess,
+  outsideMountsError,
   parseMemoryCards,
+  readOnlyMountError,
+  resolveMemoryMounts,
   runMemoryStoreContractSuite,
   truncateViewBody,
   validateCardsContent,
@@ -62,6 +69,9 @@ export type {
   MemoryLimits,
   MemoryStoreContractReport,
   MemoryStoreContractResult,
+  MountReadAccess,
+  ResolvedMemoryMount,
+  ResolvedMemoryMounts,
 } from './tools/memory/index.js';
 // BPT-EXTENSION (2026-07-08, black-pool ContextRing request): expose the harness
 // system-prompt base constructor so a host can size the built-in harness base —
@@ -90,11 +100,28 @@ export type {
 export { getSessionInfo, listSessions } from './sessions/store.js';
 export {
   getSessionMessages,
+  getSessionToolCalls,
   renameSession,
   tagSession,
   deleteSession,
   forkSession,
 } from './sessions/session-functions.js';
+// Tool-claim verification (BPT-EXTENSION, governance spec S4): flag assistant
+// turns that CLAIM a tool action with no backing record in the S3 structured
+// tool-call log. Heuristic by design — findings go to human review.
+export {
+  DEFAULT_TOOL_CLAIM_DETECTORS,
+  MEMORY_WRITE_CLAIM_DETECTOR,
+  auditSessionToolClaims,
+  auditToolClaims,
+  isMemoryWriteRecord,
+} from './sessions/tool-claims.js';
+export type {
+  AuditToolClaimsArgs,
+  ToolClaimDetector,
+  ToolClaimFinding,
+  ToolClaimRecordView,
+} from './sessions/tool-claims.js';
 export { InMemorySessionStore, encodeProjectKey } from './sessions/store-adapter.js';
 export {
   // v0.6 utility-call product features (generators / classifiers).

--- a/projects/silver-core-sdk/src/internal/contracts.ts
+++ b/projects/silver-core-sdk/src/internal/contracts.ts
@@ -640,6 +640,31 @@ export type EngineDeps = {
    *  shared with the query layer, which drains it at its own yield points;
    *  splice-style — each buffered message is returned exactly once. */
   drainObservability?: () => SDKMessage[];
+  /** Structured tool-call telemetry (BPT-EXTENSION, governance spec S3):
+   *  called once per dispatched tool_use block, at dispatch completion, with
+   *  timing + outcome. The query layer persists these as `tool_call` records
+   *  in the session JSONL (suppressed when persistence is off / incognito).
+   *  The subagent runtime forwards the parent recorder with `parentToolUseId`
+   *  stamped, so child tool calls stay attributable. */
+  onToolRecord?: (rec: ToolDispatchRecord) => void;
+};
+
+/** One dispatched tool_use block's telemetry (governance spec S3). Timing
+ *  spans the WHOLE dispatch pipeline (hooks + permission gate + execution);
+ *  status 'error' covers execution errors, denials, hook stops and unknown
+ *  tools alike — the summary carries the detail. */
+export type ToolDispatchRecord = {
+  toolUseId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  /** ISO timestamp of dispatch start. */
+  startedAt: string;
+  durationMs: number;
+  status: 'ok' | 'error';
+  /** Result content head, truncated at 500 chars ('[aborted]' on abort). */
+  resultSummary: string;
+  /** Set by the subagent runtime: the spawning Task tool_use id. */
+  parentToolUseId?: string;
 };
 
 // ---------------------------------------------------------------------------

--- a/projects/silver-core-sdk/src/query.ts
+++ b/projects/silver-core-sdk/src/query.ts
@@ -46,6 +46,7 @@ import type {
   SystemComposition,
   SystemCompositionPart,
   ToolContext,
+  ToolDispatchRecord,
   Transport,
 } from './internal/contracts.js';
 import { createProviderTransport } from './transport/factory.js';
@@ -97,6 +98,9 @@ import { loadProjectMcpServers } from './mcp/project-config.js';
 
 const DEFAULT_MODEL = 'claude-sonnet-4-5';
 const DEFAULT_MAX_OUTPUT_TOKENS = 8192;
+/** S3 tool-call record: cap on the persisted input JSON (the full input lives
+ *  in the assistant message's tool_use block with the same tool_use_id). */
+const TOOL_RECORD_INPUT_MAX_CHARS = 2048;
 const CLAUDE_CODE_VERSION = SDK_VERSION;
 
 /** Static model list surfaced by supportedModels()/initializationResult(). */
@@ -267,7 +271,17 @@ export function query(args: {
 
   // --- Collaborators ---------------------------------------------------------
   const outer = options.abortController ?? new AbortController();
-  const persist = options.persistSession !== false;
+  // S2 incognito: zero SDK-side persistence. Forces the transcript writes off
+  // (below), degrades memory to read-only (resolveMemoryRuntime), disables the
+  // R7 write rounds and suppresses S3 tool-call records (all persist-gated).
+  const incognito = options.incognito === true;
+  if (incognito && options.sessionStore !== undefined) {
+    throw new ConfigurationError(
+      'sessionStore cannot be combined with incognito:true (an incognito ' +
+        'session persists nothing)',
+    );
+  }
+  const persist = !incognito && options.persistSession !== false;
   if (options.sessionStore !== undefined && !persist) {
     throw new ConfigurationError(
       'sessionStore cannot be combined with persistSession:false',
@@ -333,6 +347,7 @@ export function query(args: {
         memory: options.memory!,
         cwd,
         protocol: options.provider?.protocol === 'openai-chat' ? 'openai-chat' : 'anthropic',
+        incognito,
         debug,
       })
     : null;
@@ -582,6 +597,45 @@ export function query(args: {
     engineConfig.memoryFlush = { prompt: MEMORY_COMPACTION_FLUSH_PROMPT };
   }
 
+  // S3 structured tool-call records (governance spec): one `tool_call` line in
+  // the session JSONL per dispatched tool_use block — same level as the
+  // message lines, machine-readable by `type`, so "the model SAID it called a
+  // tool" is always checkable against "a call actually dispatched"
+  // (getSessionToolCalls / auditToolClaims read them back). Persist-gated:
+  // persistSession:false and incognito (S2) write zero records. The input is
+  // truncated JSON — the untruncated input lives in the assistant message's
+  // tool_use block under the same tool_use_id.
+  let toolCallSeq = 0;
+  const persistToolRecord = (rec: ToolDispatchRecord): void => {
+    if (!persist || resolvedSessionId === '') return;
+    toolCallSeq += 1;
+    let inputJson: string;
+    try {
+      inputJson = JSON.stringify(rec.input) ?? 'null';
+    } catch {
+      inputJson = '"[unserializable input]"';
+    }
+    if (inputJson.length > TOOL_RECORD_INPUT_MAX_CHARS) {
+      inputJson = `${inputJson.slice(0, TOOL_RECORD_INPUT_MAX_CHARS)}…[truncated]`;
+    }
+    store.append(resolvedSessionId, {
+      type: 'tool_call',
+      uuid: randomUUID(),
+      session_id: resolvedSessionId,
+      seq: toolCallSeq,
+      timestamp: rec.startedAt,
+      tool_use_id: rec.toolUseId,
+      tool_name: rec.toolName,
+      tool_input: inputJson,
+      status: rec.status,
+      duration_ms: rec.durationMs,
+      result_summary: rec.resultSummary,
+      ...(rec.parentToolUseId !== undefined
+        ? { parent_tool_use_id: rec.parentToolUseId }
+        : {}),
+    });
+  };
+
   // Subagent runtime: hands out per-depth spawn closures + drains child results
   // and usage. Children get the real (unfiltered) MCP registry and apply their
   // own per-child tool filtering.
@@ -610,6 +664,7 @@ export function query(args: {
     sandbox: sandboxCtx,
     readFilePaths,
     sessionKey: toolSessionKey,
+    onToolRecord: persistToolRecord,
   });
 
   // Memory tool registration — MAIN LOOP ONLY (v1): a cloned map so the
@@ -952,6 +1007,8 @@ export function query(args: {
           requestView,
           drainSubagentResults: () => subagentRuntime.drainCompletedResults(),
           drainObservability,
+          // S3: root-loop tool-call records (children record via the runtime).
+          onToolRecord: persistToolRecord,
           // Memory spec R8: metrics.memoryHealth snapshot source (root only).
           ...(memory !== null ? { memoryHealth: () => memory.health } : {}),
           // Unified tool-search: withhold a cold built-in's schema from this

--- a/projects/silver-core-sdk/src/sessions/session-functions.ts
+++ b/projects/silver-core-sdk/src/sessions/session-functions.ts
@@ -19,6 +19,7 @@ import { ConfigurationError } from '../errors.js';
 
 import type {
   SessionStore as ExternalSessionStore,
+  SDKToolCallRecord,
   SessionKey,
   SessionMessage,
   SessionStoreEntry,
@@ -129,6 +130,34 @@ export async function getSessionMessages(
   const end =
     options.limit !== undefined && options.limit >= 0 ? offset + options.limit : undefined;
   return offset > 0 || end !== undefined ? out.slice(offset, end) : out;
+}
+
+/**
+ * Return the structured tool-call records persisted for a session (governance
+ * spec S3), in write order. Together with getSessionMessages this is the
+ * export surface for synthesis pipelines and audit tools: `type` distinguishes
+ * text from tool calls without parsing natural language, and `timestamp`/`seq`
+ * keep tool calls alignable with the message sequence. An incognito session
+ * (S2) has no transcript, hence no records.
+ */
+export async function getSessionToolCalls(
+  sessionId: string,
+  options: SessionMutationOptions = {},
+): Promise<SDKToolCallRecord[]> {
+  let entries: Record<string, unknown>[];
+  if (options.sessionStore !== undefined) {
+    const loaded = await options.sessionStore.load(mainKey(sessionId, options));
+    entries = (loaded ?? []) as Record<string, unknown>[];
+  } else {
+    entries = await readLocalEntries(sessionId, options);
+  }
+  const out: SDKToolCallRecord[] = [];
+  for (const e of entries) {
+    if (e.type !== 'tool_call') continue;
+    if (typeof e.tool_use_id !== 'string' || typeof e.tool_name !== 'string') continue;
+    out.push(e as unknown as SDKToolCallRecord);
+  }
+  return out;
 }
 
 /** Set the human-readable title for a session (last write wins). The official

--- a/projects/silver-core-sdk/src/sessions/tool-claims.ts
+++ b/projects/silver-core-sdk/src/sessions/tool-claims.ts
@@ -1,0 +1,176 @@
+/**
+ * Tool-claim verification helper (BPT-EXTENSION, memory governance spec S4).
+ *
+ * Reference implementation of the "claimed vs actually called" check: given a
+ * session's assistant texts and its structured tool-call records (spec S3),
+ * flag assistant turns that CLAIM a tool action with no matching record —
+ * e.g. "I've saved that to memory" with no successful memory write dispatched.
+ *
+ * Deliberately heuristic: detectors are regex-based, so false positives are
+ * expected and acceptable (findings go to human review); missing a real
+ * unbacked claim is the failure mode to minimize. The default detector set
+ * covers memory-write claims (zh + en); consumers add their own detectors for
+ * other tools.
+ *
+ * Records come from dispatch-time telemetry (never from parsing the model's
+ * own prose), so a claim can only be "backed" by a call that actually went
+ * through the SDK's tool pipeline.
+ */
+
+import type { SDKToolCallRecord, SessionMessage } from '../types.js';
+import { getSessionMessages, getSessionToolCalls } from './session-functions.js';
+import type { SessionMutationOptions } from './session-functions.js';
+
+/** The record fields a detector may match against (a subset of the full
+ *  SDKToolCallRecord, so hand-built records in tests/pipelines stay easy). */
+export type ToolClaimRecordView = Pick<
+  SDKToolCallRecord,
+  'tool_name' | 'tool_input' | 'status'
+>;
+
+export type ToolClaimDetector = {
+  /** Stable identifier surfaced on findings (e.g. 'memory-write-claim'). */
+  id: string;
+  /** Matches CLAIM language in an assistant text. */
+  claimPattern: RegExp;
+  /** True when a record BACKS the claim (typically: right tool, right
+   *  command shape, status ok). */
+  backedBy: (record: ToolClaimRecordView) => boolean;
+  description?: string;
+};
+
+export type ToolClaimFinding = {
+  detectorId: string;
+  /** Index of the assistant text within the audited sequence. */
+  messageIndex: number;
+  /** uuid of the assistant message, when available. */
+  messageUuid?: string;
+  /** The matched claim snippet (trimmed to its line). */
+  snippet: string;
+  reason: string;
+};
+
+const MEMORY_WRITE_COMMANDS = /"command"\s*:\s*"(create|str_replace|insert|delete|rename)"/;
+
+/** True when a record is a SUCCESSFUL memory write. */
+export function isMemoryWriteRecord(record: ToolClaimRecordView): boolean {
+  return (
+    record.tool_name === 'memory' &&
+    record.status === 'ok' &&
+    MEMORY_WRITE_COMMANDS.test(record.tool_input)
+  );
+}
+
+/**
+ * Default detector: memory-write claims (zh + en). Matches the common shapes
+ * of "I recorded / saved / noted that (to memory)"; backed only by a
+ * successful memory write command in the records.
+ */
+export const MEMORY_WRITE_CLAIM_DETECTOR: ToolClaimDetector = {
+  id: 'memory-write-claim',
+  claimPattern: new RegExp(
+    [
+      // zh: 已记录 / 记下来了 / 已写入记忆 / 已保存到记忆 / 已更新记忆 / 记到记忆里
+      '已记录|记下来了|已经记下|记住了|(已|已经)?(写入|存入|保存到|记录到|更新了?)[^。\\n]{0,6}记忆',
+      '记忆(文件|库|卡)?(已|已经)(更新|写入|保存)',
+      // en: saved/recorded/noted/updated ... memory (subject optional — the
+      // low-miss posture beats precision here, spec S4)
+      '\\b(saved|recorded|noted|wrote|written|stored|updated)\\b[^.\\n]{0,40}\\bmemor(y|ies)\\b',
+      "\\bmemor(y|ies)\\b [^.\\n]{0,20}\\b(updated|saved|recorded)\\b",
+      "(I have|I've|I) (made a note|noted (this|that|it) down)",
+    ].join('|'),
+    'i',
+  ),
+  backedBy: isMemoryWriteRecord,
+  description:
+    'Assistant claims a memory write; backed only by a successful memory ' +
+    'write command (create/str_replace/insert/delete/rename) in the records.',
+};
+
+export const DEFAULT_TOOL_CLAIM_DETECTORS: ToolClaimDetector[] = [
+  MEMORY_WRITE_CLAIM_DETECTOR,
+];
+
+export type AuditToolClaimsArgs = {
+  /** Assistant texts in sequence: raw strings, or {uuid, text} pairs. */
+  assistantTexts: Array<string | { uuid?: string; text: string }>;
+  /** The session's structured tool-call records (spec S3). */
+  toolCalls: ToolClaimRecordView[];
+  /** Detectors to run; defaults to DEFAULT_TOOL_CLAIM_DETECTORS. */
+  detectors?: ToolClaimDetector[];
+};
+
+/**
+ * Flag assistant texts whose tool claims have NO backing record anywhere in
+ * the session. Session-scoped on purpose (not per-turn alignment): a claim
+ * that summarizes an earlier turn's real call must not be flagged, so
+ * precision is traded for the low-miss posture the spec asks for.
+ */
+export function auditToolClaims(args: AuditToolClaimsArgs): ToolClaimFinding[] {
+  const detectors = args.detectors ?? DEFAULT_TOOL_CLAIM_DETECTORS;
+  const findings: ToolClaimFinding[] = [];
+  for (const detector of detectors) {
+    const backed = args.toolCalls.some((r) => detector.backedBy(r));
+    if (backed) continue;
+    for (const [i, entry] of args.assistantTexts.entries()) {
+      const text = typeof entry === 'string' ? entry : entry.text;
+      const match = detector.claimPattern.exec(text);
+      if (match === null) continue;
+      const lineStart = text.lastIndexOf('\n', match.index) + 1;
+      const lineEndRaw = text.indexOf('\n', match.index);
+      const lineEnd = lineEndRaw === -1 ? text.length : lineEndRaw;
+      findings.push({
+        detectorId: detector.id,
+        messageIndex: i,
+        ...(typeof entry !== 'string' && entry.uuid !== undefined
+          ? { messageUuid: entry.uuid }
+          : {}),
+        snippet: text.slice(lineStart, lineEnd).trim(),
+        reason:
+          `Assistant text matches '${detector.id}' but the session's ` +
+          `structured tool-call records contain no backing call`,
+      });
+    }
+  }
+  return findings;
+}
+
+/** Concatenated text blocks of a persisted assistant message. */
+function assistantTextOf(m: SessionMessage): string | null {
+  if (m.type !== 'assistant') return null;
+  const content = (m.message as { content?: unknown }).content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const b of content) {
+    const block = b as { type?: unknown; text?: unknown };
+    if (block.type === 'text' && typeof block.text === 'string') parts.push(block.text);
+  }
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+/**
+ * Convenience wrapper: load a persisted session's assistant texts + tool-call
+ * records and run auditToolClaims over them — the "flag suspicious turns when
+ * the agent loop ends" entry point.
+ */
+export async function auditSessionToolClaims(
+  sessionId: string,
+  options: SessionMutationOptions & { detectors?: ToolClaimDetector[] } = {},
+): Promise<ToolClaimFinding[]> {
+  const { detectors, ...sessionOptions } = options;
+  const [messages, toolCalls] = await Promise.all([
+    getSessionMessages(sessionId, sessionOptions),
+    getSessionToolCalls(sessionId, sessionOptions),
+  ]);
+  const assistantTexts: Array<{ uuid?: string; text: string }> = [];
+  for (const m of messages) {
+    const text = assistantTextOf(m);
+    if (text !== null) assistantTexts.push({ uuid: m.uuid, text });
+  }
+  return auditToolClaims({
+    assistantTexts,
+    toolCalls,
+    ...(detectors !== undefined ? { detectors } : {}),
+  });
+}

--- a/projects/silver-core-sdk/src/subagents/runtime.ts
+++ b/projects/silver-core-sdk/src/subagents/runtime.ts
@@ -62,6 +62,7 @@ import type {
   SpawnSubagentParams,
   SpawnSubagentResult,
   ToolContext,
+  ToolDispatchRecord,
   Transport,
 } from '../internal/contracts.js';
 import type { CanUseTool } from '../types.js';
@@ -175,6 +176,10 @@ export type SubagentRuntimeOptions = {
   readFilePaths?: Set<string>;
   /** Formal per-query WeakMap key threaded into child contexts (F6). */
   sessionKey?: object;
+  /** S3 structured tool-call records: the parent query's recorder. Children
+   *  forward every dispatched call with parentToolUseId stamped, so the
+   *  session audit trail covers subagent tool calls too. */
+  onToolRecord?: (rec: ToolDispatchRecord) => void;
 };
 
 /** task_updated.result carries a bounded preview, not the full child text
@@ -1061,6 +1066,14 @@ export function createSubagentRuntime(
         hooks,
         toolContext: childToolContext,
         debug,
+        // S3: forward the parent recorder with the spawning Task tool_use id
+        // stamped, so the session audit trail attributes child tool calls.
+        ...(opts.onToolRecord !== undefined
+          ? {
+              onToolRecord: (rec: ToolDispatchRecord): void =>
+                opts.onToolRecord!({ ...rec, parentToolUseId: params.toolUseId }),
+            }
+          : {}),
       };
       // Fork seeds the child with a trimmed copy of the parent history plus the
       // delegated task as a trailing user turn; isolated starts from just the

--- a/projects/silver-core-sdk/src/tools/memory/index.ts
+++ b/projects/silver-core-sdk/src/tools/memory/index.ts
@@ -14,8 +14,21 @@ import type { BuiltinTool } from '../../internal/contracts.js';
 import { ConfigurationError } from '../../errors.js';
 import { createLocalFilesystemMemoryStore } from './local-store.js';
 import { createMemoryHealth, createMemoryTool, MEMORY_TOOL_NAME } from './memory-tool.js';
+import { mountReadAccess, resolveMemoryMounts } from './mounts.js';
 
 export { MEMORY_ROOT, MemoryPathError, validateMemoryPath } from './paths.js';
+export {
+  describeMounts,
+  filterAncestorListing,
+  mountAllowsWrite,
+  mountReadAccess,
+  outsideMountsError,
+  readOnlyMountError,
+  resolveMemoryMounts,
+  type MountReadAccess,
+  type ResolvedMemoryMount,
+  type ResolvedMemoryMounts,
+} from './mounts.js';
 export {
   createMemoryStore,
   formatFileSize,
@@ -42,6 +55,7 @@ export {
   createMemoryHealth,
   createMemoryTool,
   memoryCommandSchema,
+  INCOGNITO_MEMORY_ERROR,
   MEMORY_TOOL_NAME,
   type CreateMemoryToolOptions,
 } from './memory-tool.js';
@@ -98,9 +112,16 @@ export function resolveMemoryRuntime(args: {
   cwd: string;
   /** ProviderConfig.protocol ('anthropic' default when undefined). */
   protocol: 'anthropic' | 'openai-chat';
+  /** S2: incognito session — memory degrades to read-only and both R7 write
+   *  rounds are disabled, regardless of the memory options. */
+  incognito?: boolean;
   debug: (msg: string) => void;
 }): MemoryRuntime {
   const { memory, cwd, protocol, debug } = args;
+  const incognito = args.incognito === true;
+  // S1: validate + canonicalize the mount declarations up front (a bad mount
+  // is a consumer configuration error, thrown from query()).
+  const mounts = resolveMemoryMounts(memory.mounts);
 
   const mode = memory.mode ?? (protocol === 'openai-chat' ? 'custom' : 'native');
   if (mode === 'native' && protocol === 'openai-chat') {
@@ -142,15 +163,24 @@ export function resolveMemoryRuntime(args: {
       ...(memory.limits !== undefined ? { limits: memory.limits } : {}),
       ...(memory.schema !== undefined ? { schema: memory.schema } : {}),
       ...(memory.cards !== undefined ? { cards: memory.cards } : {}),
+      ...(mounts !== null ? { mounts } : {}),
+      ...(incognito ? { incognitoReadOnly: true } : {}),
     }),
     ...(mode === 'native' ? { serverTools: [{ ...MEMORY_SERVER_TOOL }] } : {}),
     ...(memory.instructions !== undefined ? { instructions: memory.instructions } : {}),
     health,
-    flushOnCompaction: memory.flushOnCompaction !== false,
-    sessionEndUpdate: memory.sessionEndUpdate !== false,
+    // S2: both R7 rounds are WRITE rounds; an incognito session never runs them.
+    flushOnCompaction: !incognito && memory.flushOnCompaction !== false,
+    sessionEndUpdate: !incognito && memory.sessionEndUpdate !== false,
 
     async buildIndexInjection(): Promise<{ label: string; text: string } | null> {
       if (indexCfg === false || maxLines <= 0 || maxBytes <= 0) return null;
+      // S1: never inject content the session's mounts do not grant read
+      // access to — the resident index is a READ of /memories/MEMORY.md.
+      if (mountReadAccess(mounts, MEMORY_INDEX_PATH) !== 'full') {
+        debug('memory: resident index skipped (not readable under the configured mounts)');
+        return null;
+      }
       let viewed: string;
       try {
         // Ask for one line beyond the cap so line-truncation is detectable

--- a/projects/silver-core-sdk/src/tools/memory/memory-tool.ts
+++ b/projects/silver-core-sdk/src/tools/memory/memory-tool.ts
@@ -39,6 +39,14 @@ import {
   truncateViewBody,
   type MemoryLimits,
 } from './store.js';
+import {
+  filterAncestorListing,
+  mountAllowsWrite,
+  mountReadAccess,
+  outsideMountsError,
+  readOnlyMountError,
+  type ResolvedMemoryMounts,
+} from './mounts.js';
 
 export const MEMORY_TOOL_NAME = 'memory';
 
@@ -170,7 +178,20 @@ export type CreateMemoryToolOptions = {
    *  here); str_replace/insert results are validated in the store engine. */
   schema?: 'cards';
   cards?: Partial<MemoryCardsConfig>;
+  /** S1 scope routing: resolved mounts (null / absent = unrestricted). */
+  mounts?: ResolvedMemoryMounts;
+  /** S2 incognito: reject every write command (view stays available). */
+  incognitoReadOnly?: boolean;
 };
+
+/** S2: the structured error every memory write command returns in an
+ *  incognito session. Model-readable — states the rule, not just "denied". */
+export const INCOGNITO_MEMORY_ERROR =
+  'Error: This is an incognito session — the memory store is read-only. ' +
+  'view remains available, but create, str_replace, insert, delete and ' +
+  'rename are disabled: nothing from this session is recorded.';
+
+const DIRECTORY_LISTING_HEADER = "Here're the files and directories";
 
 /**
  * Build the memory builtin over a store. Constructed per query (like the
@@ -184,7 +205,17 @@ export function createMemoryTool(
   const limits: MemoryLimits = { ...DEFAULT_MEMORY_LIMITS, ...toolOptions.limits };
   const cardsCfg: MemoryCardsConfig = { ...DEFAULT_CARDS_CONFIG, ...toolOptions.cards };
   const health = toolOptions.health;
+  const mounts: ResolvedMemoryMounts = toolOptions.mounts ?? null;
   const bytesOf = (s: string): number => Buffer.byteLength(s, 'utf8');
+  /** S1/S2 write gate: incognito first (session-wide rule), then mount
+   *  routing. Returns the structured error message, or null when allowed. */
+  const writeDenial = (path: string): string | null => {
+    if (toolOptions.incognitoReadOnly === true) return INCOGNITO_MEMORY_ERROR;
+    if (mounts === null || mountAllowsWrite(mounts, path)) return null;
+    return mountReadAccess(mounts, path) === null
+      ? outsideMountsError(mounts, path)
+      : readOnlyMountError(mounts, path);
+  };
   return {
     name: MEMORY_TOOL_NAME,
     description: MEMORY_DESCRIPTION,
@@ -222,12 +253,26 @@ export function createMemoryTool(
         switch (cmd.command) {
           case 'view': {
             const path = validateMemoryPath(cmd.path);
+            // S1 read gate: 'full' inside a mount; 'ancestor' keeps the
+            // navigation path viewable but filters the listing to
+            // mount-visible entries; null is rejected outright.
+            const access = mountReadAccess(mounts, path);
+            if (access === null) {
+              return done(errorResult(outsideMountsError(mounts!, path)));
+            }
+            let viewed = await store.view(path, cmd.view_range);
+            if (access === 'ancestor') {
+              if (!viewed.startsWith(DIRECTORY_LISTING_HEADER)) {
+                // An ancestor of a mount that views as FILE content can only
+                // mean a misconfigured mount nested under a file; never leak
+                // the content.
+                return done(errorResult(outsideMountsError(mounts!, path)));
+              }
+              viewed = filterAncestorListing(mounts!, path, viewed);
+            }
             // Tool-layer truncation (idempotent over the engine's own) so the
             // R8 view cap holds for directly-implemented stores too.
-            const body = truncateViewBody(
-              await store.view(path, cmd.view_range),
-              limits.maxViewChars,
-            );
+            const body = truncateViewBody(viewed, limits.maxViewChars);
             if (health !== undefined) {
               health.reads += 1;
               health.bytesRead += bytesOf(body);
@@ -236,6 +281,8 @@ export function createMemoryTool(
           }
           case 'create': {
             const path = validateMemoryPath(cmd.path);
+            const denied = writeDenial(path);
+            if (denied !== null) return done(errorResult(denied));
             // Tool-layer R8 size cap + R9 cards validation on the full
             // content (the store engine re-checks; this covers direct stores).
             if (bytesOf(cmd.file_text) > limits.maxFileBytes) {
@@ -253,6 +300,8 @@ export function createMemoryTool(
           }
           case 'str_replace': {
             const path = validateMemoryPath(cmd.path);
+            const denied = writeDenial(path);
+            if (denied !== null) return done(errorResult(denied));
             if (health !== undefined) {
               health.writes += 1;
               health.bytesWritten += bytesOf(cmd.new_str ?? '');
@@ -261,6 +310,8 @@ export function createMemoryTool(
           }
           case 'insert': {
             const path = validateMemoryPath(cmd.path);
+            const denied = writeDenial(path);
+            if (denied !== null) return done(errorResult(denied));
             if (health !== undefined) {
               health.writes += 1;
               health.bytesWritten += bytesOf(cmd.insert_text);
@@ -278,6 +329,8 @@ export function createMemoryTool(
                 `Error: Cannot delete the ${MEMORY_ROOT} directory itself`,
               ));
             }
+            const denied = writeDenial(path);
+            if (denied !== null) return done(errorResult(denied));
             if (health !== undefined) health.writes += 1;
             return done({ content: await store.delete(path) });
           }
@@ -289,6 +342,9 @@ export function createMemoryTool(
                 `Error: Cannot rename the ${MEMORY_ROOT} directory itself`,
               ));
             }
+            // S1: a rename is a write at BOTH ends (removal + creation).
+            const denied = writeDenial(oldPath) ?? writeDenial(newPath);
+            if (denied !== null) return done(errorResult(denied));
             if (health !== undefined) health.writes += 1;
             return done({ content: await store.rename(oldPath, newPath) });
           }

--- a/projects/silver-core-sdk/src/tools/memory/mounts.ts
+++ b/projects/silver-core-sdk/src/tools/memory/mounts.ts
@@ -1,0 +1,175 @@
+/**
+ * Memory mount routing (BPT-EXTENSION, memory governance spec S1).
+ *
+ * Options.memory.mounts declares which memory subtrees this query may touch
+ * and with what rights. Enforcement happens at the SDK tool layer — after R4
+ * path validation, BEFORE the store is called — never via prompt discipline:
+ *
+ *  - a write command whose target is not inside a read-write mount is
+ *    rejected with a structured, model-readable error;
+ *  - a path inside no mount at all is rejected for reads too;
+ *  - a directory that is a strict ANCESTOR of a mount stays viewable so the
+ *    model can navigate to its mounts, but its listing is FILTERED down to
+ *    entries on the path to (or inside) a mount — sibling subtrees such as
+ *    another user's directory never appear.
+ *
+ * Mounts are per-query state: the embedder instantiates them from its own
+ * session context (e.g. team read-only + this user's directory read-write for
+ * a user session; team read-write for a synthesis batch task). No mounts
+ * configured -> the whole /memories tree stays read-write (pre-S1 behavior).
+ */
+
+import type { MemoryMount } from '../../types.js';
+import { ConfigurationError } from '../../errors.js';
+import { MEMORY_ROOT, MemoryPathError, validateMemoryPath } from './paths.js';
+
+export type ResolvedMemoryMount = {
+  /** Canonical virtual path (validateMemoryPath output). */
+  path: string;
+  mode: 'read-only' | 'read-write';
+};
+
+/** null = no mounts configured (unrestricted, pre-S1 behavior). */
+export type ResolvedMemoryMounts = ResolvedMemoryMount[] | null;
+
+/**
+ * Validate + canonicalize Options.memory.mounts at query construction time.
+ * A malformed mount is a CONSUMER error (ConfigurationError), unlike a bad
+ * model-supplied path (tool_result error).
+ */
+export function resolveMemoryMounts(
+  mounts: MemoryMount[] | undefined,
+): ResolvedMemoryMounts {
+  if (mounts === undefined) return null;
+  if (mounts.length === 0) {
+    throw new ConfigurationError(
+      'options.memory.mounts must not be empty: an empty mount list would make ' +
+        'every memory path inaccessible (omit mounts for unrestricted access)',
+    );
+  }
+  return mounts.map((m) => {
+    if (m.mode !== 'read-only' && m.mode !== 'read-write') {
+      throw new ConfigurationError(
+        `options.memory.mounts: invalid mode '${String(m.mode)}' for ${String(
+          m.path,
+        )} (expected 'read-only' or 'read-write')`,
+      );
+    }
+    let canonical: string;
+    try {
+      // Trailing slashes collapse in canonicalization, so "/memories/team/"
+      // and "/memories/team" declare the same mount.
+      canonical = validateMemoryPath(m.path);
+    } catch (e) {
+      if (e instanceof MemoryPathError) {
+        throw new ConfigurationError(
+          `options.memory.mounts: invalid mount path ${String(m.path)} — ${e.message}`,
+        );
+      }
+      throw e;
+    }
+    return { path: canonical, mode: m.mode };
+  });
+}
+
+/** True when `path` equals `root` or is a descendant of it. */
+function within(path: string, root: string): boolean {
+  return path === root || path.startsWith(root + '/');
+}
+
+/** True when `path` is a strict ancestor of `mountPath` (incl. MEMORY_ROOT). */
+function isAncestorOf(path: string, mountPath: string): boolean {
+  return path !== mountPath && within(mountPath, path);
+}
+
+export type MountReadAccess =
+  /** Inside a mount: full read access to the subtree. */
+  | 'full'
+  /** Strict ancestor of >=1 mount: viewable for navigation, listing filtered. */
+  | 'ancestor'
+  /** Not reachable from any mount. */
+  | null;
+
+/** Read access classification for one canonical path. */
+export function mountReadAccess(
+  mounts: ResolvedMemoryMounts,
+  path: string,
+): MountReadAccess {
+  if (mounts === null) return 'full';
+  if (mounts.some((m) => within(path, m.path))) return 'full';
+  if (mounts.some((m) => isAncestorOf(path, m.path))) return 'ancestor';
+  return null;
+}
+
+/** True when writes to `path` are allowed (inside a read-write mount). */
+export function mountAllowsWrite(mounts: ResolvedMemoryMounts, path: string): boolean {
+  if (mounts === null) return true;
+  return mounts.some((m) => m.mode === 'read-write' && within(path, m.path));
+}
+
+/** Human/model-readable list of the configured mounts for error messages. */
+export function describeMounts(mounts: ResolvedMemoryMount[]): string {
+  return mounts.map((m) => `${m.path} (${m.mode})`).join(', ');
+}
+
+/** Structured error for a path outside every mount (read or write). */
+export function outsideMountsError(mounts: ResolvedMemoryMount[], path: string): string {
+  return (
+    `Error: ${path} is outside the memory areas mounted for this session. ` +
+    `Accessible mounts: ${describeMounts(mounts)}`
+  );
+}
+
+/** Structured error for a write into read-only territory. */
+export function readOnlyMountError(mounts: ResolvedMemoryMount[], path: string): string {
+  return (
+    `Error: ${path} is read-only in this session — write commands (create, ` +
+    `str_replace, insert, delete, rename) are not permitted there. ` +
+    `Writable mounts: ${
+      mounts.some((m) => m.mode === 'read-write')
+        ? mounts
+            .filter((m) => m.mode === 'read-write')
+            .map((m) => m.path)
+            .join(', ')
+        : '(none)'
+    }`
+  );
+}
+
+/**
+ * Filter a directory-listing view of an ANCESTOR directory down to entries on
+ * the path to (or inside) a mount. The listing format is contract-fixed by the
+ * golden suite (`header\n` then `size\tabsolutePath[/]` lines), so a
+ * line-level filter is stable. The header and the viewed directory's own line
+ * always survive.
+ */
+export function filterAncestorListing(
+  mounts: ResolvedMemoryMount[],
+  viewedDir: string,
+  listing: string,
+): string {
+  const lines = listing.split('\n');
+  const kept: string[] = [];
+  for (const [i, line] of lines.entries()) {
+    if (i === 0) {
+      kept.push(line); // header
+      continue;
+    }
+    const tab = line.indexOf('\t');
+    if (tab < 0) {
+      kept.push(line);
+      continue;
+    }
+    const rawPath = line.slice(tab + 1);
+    const entryPath = rawPath.endsWith('/') ? rawPath.slice(0, -1) : rawPath;
+    if (entryPath === viewedDir || entryPath === MEMORY_ROOT) {
+      kept.push(line);
+      continue;
+    }
+    const visible = mounts.some(
+      (m) => within(entryPath, m.path) || isAncestorOf(entryPath, m.path),
+    );
+    if (visible) kept.push(line);
+  }
+  return kept.join('\n');
+}

--- a/projects/silver-core-sdk/src/types.ts
+++ b/projects/silver-core-sdk/src/types.ts
@@ -1325,6 +1325,20 @@ export interface MemoryStore {
 }
 
 /**
+ * One memory mount declaration (BPT-EXTENSION, memory governance spec S1):
+ * a virtual subtree under `/memories` this query may touch, with its rights.
+ * Mounts are per-query — the embedder instantiates them from its own session
+ * context (e.g. `/memories/team` read-only + `/memories/users/<id>` read-write
+ * for a user session; `/memories/team` read-write for a synthesis batch task).
+ */
+export type MemoryMount = {
+  /** Virtual path under /memories (e.g. '/memories/team'). Trailing slashes
+   *  are tolerated; an invalid path is a ConfigurationError at query(). */
+  path: string;
+  mode: 'read-only' | 'read-write';
+};
+
+/**
  * Memory system configuration (BPT-EXTENSION; docs/MEMORY.md). Presence of
  * the object enables the `memory` tool (set `enabled: false` to keep a shared
  * options spread but switch the system off).
@@ -1355,6 +1369,18 @@ export type MemoryOptions = {
   /** `create` on an existing file overwrites instead of erroring (the
    *  reference behavior; spec R1 opt-in). Default false. */
   createOverwrite?: boolean;
+  /**
+   * Memory scope routing (governance spec S1): the subtrees this query may
+   * touch and with what rights, enforced at the SDK tool layer (never via
+   * prompt discipline). Writes outside a read-write mount and any access
+   * outside every mount are rejected with structured errors; a strict
+   * ancestor directory of a mount stays viewable for navigation with its
+   * listing filtered to mount-visible entries. Omit for unrestricted
+   * access to the whole /memories tree (pre-S1 behavior); an empty array is
+   * a ConfigurationError. The resident index (R6) is only injected when
+   * `/memories/MEMORY.md` is readable under the mounts.
+   */
+  mounts?: MemoryMount[];
   /**
    * Resident memory index (spec R6): at session start the harness reads the
    * head of `/memories/MEMORY.md` (when it exists) into the system prompt so
@@ -1434,6 +1460,43 @@ export type SDKMemoryHealth = {
   indexInjectionTokens: number;
 };
 
+/**
+ * One structured tool-call record (BPT-EXTENSION, memory governance spec S3),
+ * persisted to the session JSONL at the same level as the message lines so
+ * "the model SAID it called a tool" is always checkable against "a tool call
+ * actually happened". Records are written at dispatch time by the engine —
+ * they never depend on reconstructing tool_use blocks from message text.
+ * Read them back with `getSessionToolCalls()`; audit claims against them with
+ * `auditToolClaims()`. Incognito sessions (S2) write none.
+ */
+export type SDKToolCallRecord = {
+  type: 'tool_call';
+  uuid: string;
+  session_id: string;
+  /** 1-based dispatch sequence within one query() run (a resumed session's
+   *  file restarts at 1 for the new run; `timestamp` orders across runs). */
+  seq: number;
+  /** ISO timestamp of dispatch start. */
+  timestamp: string;
+  /** The tool_use block id — joins the record to the full tool_use block
+   *  (untruncated input) persisted in the assistant message. */
+  tool_use_id: string;
+  tool_name: string;
+  /** JSON of the input, truncated at 2048 chars (see tool_use_id for the
+   *  full input). */
+  tool_input: string;
+  /** 'ok' = a tool_result without is_error; 'error' covers execution errors,
+   *  permission denials, hook stops and unknown tools (detail in
+   *  result_summary). */
+  status: 'ok' | 'error';
+  /** Full dispatch duration (hooks + permission gate + execution). */
+  duration_ms: number;
+  /** Result content head, truncated at 500 chars. */
+  result_summary: string;
+  /** Present on a subagent's tool call: the parent Task tool_use id. */
+  parent_tool_use_id?: string;
+};
+
 export type Options = {
   abortController?: AbortController;
   additionalDirectories?: string[];
@@ -1480,6 +1543,23 @@ export type Options = {
    */
   includePromptComposition?: boolean;
   includePartialMessages?: boolean;
+  /**
+   * Incognito session (BPT-EXTENSION, memory governance spec S2): a session
+   * that leaves no SDK-side persistent trace. When true:
+   *  - the session transcript is NOT persisted (persistSession is forced off;
+   *    combining with `sessionStore` is a ConfigurationError);
+   *  - the memory tool degrades to READ-ONLY: `view` stays available ("knows
+   *    you, doesn't record you"), the five write commands are rejected with a
+   *    structured error at the SDK layer;
+   *  - the R7 memory write rounds (compaction flush + session-end progress
+   *    card) are disabled;
+   *  - structured tool-call records (S3) are not written.
+   * Promise boundary: "incognito" means nothing enters SDK storage or the
+   * memory store. Requests are still sent to the configured model API and
+   * remain subject to its terms; workspace files the model edits via
+   * Write/Edit/Bash are the user's own actions and are out of scope.
+   */
+  incognito?: boolean;
   maxBudgetUsd?: number;
   /**
    * @deprecated Official docs mark `maxThinkingTokens` deprecated in favor of

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.47.0';
+export const SDK_VERSION = '0.48.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/incognito.test.ts
+++ b/projects/silver-core-sdk/tests/incognito.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Incognito session tests (governance spec S2) — the LEAK-TEST checklist from
+ * the requirements doc, run through the REAL query() path with a scripted
+ * fetch:
+ *  - luring the model into a memory write ("记下来") -> the write command is
+ *    rejected, /memories has no new or modified file;
+ *  - a unique marker token used in the session survives NOWHERE on disk after
+ *    the run (session dir, memory dir, cwd — recursive grep);
+ *  - the downstream export surfaces (listSessions / getSessionMessages /
+ *    getSessionToolCalls) return nothing for the session: excluded at the
+ *    data-source level, not "not found because unscanned";
+ *  - memory view STAYS available (read-only, "knows you, doesn't record you");
+ *  - both R7 write rounds are disabled;
+ *  - sessionStore + incognito is a configuration error.
+ */
+
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { query } from '../src/query.js';
+import {
+  INCOGNITO_MEMORY_ERROR,
+  createLocalFilesystemMemoryStore,
+  getSessionMessages,
+  getSessionToolCalls,
+  listSessions,
+} from '../src/index.js';
+import { ConfigurationError } from '../src/errors.js';
+import { resolveMemoryRuntime } from '../src/tools/memory/index.js';
+import { InMemorySessionStore } from '../src/sessions/store-adapter.js';
+import type { Options, SDKMessage, SDKResultMessage } from '../src/types.js';
+import type { ToolContext } from '../src/internal/contracts.js';
+import { makeSSEFetch, type SSEFetchStub } from './helpers/sse-fetch.js';
+import { textReplyEvents, toolUseReplyEvents } from './helpers/mock-transport.js';
+
+const MARKER = 'purple-whale-protocol-9f3a7';
+
+let cwd: string;
+let sessionDir: string;
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'bpt-incog-cwd-'));
+  sessionDir = await mkdtemp(join(tmpdir(), 'bpt-incog-sess-'));
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await rm(cwd, { recursive: true, force: true });
+  await rm(sessionDir, { recursive: true, force: true });
+});
+
+function baseOptions(stub: SSEFetchStub, extra: Partial<Options> = {}): Options {
+  return {
+    provider: { apiKey: 'test-key', promptCaching: false, fetch: stub },
+    cwd,
+    sessionDir,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    settingSources: [],
+    ...extra,
+  };
+}
+
+async function collect(prompt: string, options: Options): Promise<SDKMessage[]> {
+  const out: SDKMessage[] = [];
+  for await (const m of query({ prompt, options })) out.push(m);
+  return out;
+}
+
+/** Recursive scan: every file under `dir` whose content contains `needle`. */
+async function grepTree(dir: string, needle: string): Promise<string[]> {
+  const hits: string[] = [];
+  let names: string[] = [];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return hits;
+  }
+  for (const name of names) {
+    const full = join(dir, name);
+    if ((await stat(full)).isDirectory()) {
+      hits.push(...(await grepTree(full, needle)));
+    } else if ((await readFile(full, 'utf8').catch(() => '')).includes(needle)) {
+      hits.push(full);
+    }
+  }
+  return hits;
+}
+
+describe('S2 incognito leak test', () => {
+  it('a lured memory write is rejected and the marker survives nowhere on disk', async () => {
+    const stub = makeSSEFetch([
+      toolUseReplyEvents('memory', {
+        command: 'create',
+        path: '/memories/notes.md',
+        file_text: `remember: ${MARKER}`,
+      }),
+      textReplyEvents(`understood, but nothing about ${MARKER} was recorded`),
+    ]);
+    const messages = await collect(
+      `please write this down: ${MARKER}`,
+      baseOptions(stub, { incognito: true, memory: {} }),
+    );
+    const result = messages.at(-1) as SDKResultMessage;
+    expect(result.type).toBe('result');
+    expect(result.subtype).toBe('success');
+
+    // The write command came back as a structured read-only error.
+    const secondBody = stub.requests[1]!.body;
+    const lastUser = (secondBody['messages'] as Array<Record<string, unknown>>).at(-1)!;
+    const resultJson = JSON.stringify(lastUser['content']);
+    expect(resultJson).toContain('incognito session');
+    expect(resultJson).toContain('read-only');
+    // The exact exported constant is what the model received.
+    expect(resultJson).toContain(JSON.stringify(INCOGNITO_MEMORY_ERROR).slice(1, -1));
+
+    // No memory artifact was created (the store may pre-create its empty base
+    // directory; zero FILES is the promise that matters).
+    const memDir = join(cwd, '.claude', 'memory');
+    expect(await grepTree(memDir, '')).toEqual([]);
+
+    // Marker-grep across every SDK-writable root: zero residue.
+    expect(await grepTree(sessionDir, MARKER)).toEqual([]);
+    expect(await grepTree(cwd, MARKER)).toEqual([]);
+
+    // Data-source-level exclusion: the export surfaces have no such session.
+    expect(await listSessions({ sessionDir })).toEqual([]);
+    const sessionId = result.session_id;
+    expect(await getSessionMessages(sessionId, { sessionDir })).toEqual([]);
+    expect(await getSessionToolCalls(sessionId, { sessionDir })).toEqual([]);
+  });
+
+  it('memory view stays available (read-only incognito, pending-decision default)', async () => {
+    // Seed a memory file OUTSIDE the session (pre-existing knowledge).
+    const store = createLocalFilesystemMemoryStore(join(cwd, '.claude', 'memory'));
+    await store.create('/memories/profile.md', 'the keeper prefers Beijing time');
+
+    const stub = makeSSEFetch([
+      toolUseReplyEvents('memory', { command: 'view', path: '/memories/profile.md' }),
+      textReplyEvents('done'),
+    ]);
+    const messages = await collect(
+      'what do you know about me?',
+      baseOptions(stub, { incognito: true, memory: {} }),
+    );
+    expect((messages.at(-1) as SDKResultMessage).subtype).toBe('success');
+    const secondBody = stub.requests[1]!.body;
+    const lastUser = (secondBody['messages'] as Array<Record<string, unknown>>).at(-1)!;
+    expect(JSON.stringify(lastUser['content'])).toContain('Beijing time');
+  });
+
+  it('disables both R7 write rounds', () => {
+    const runtime = resolveMemoryRuntime({
+      memory: { flushOnCompaction: true, sessionEndUpdate: true },
+      cwd,
+      protocol: 'anthropic',
+      incognito: true,
+      debug: () => {},
+    });
+    expect(runtime.flushOnCompaction).toBe(false);
+    expect(runtime.sessionEndUpdate).toBe(false);
+  });
+
+  it('rejects sessionStore + incognito as a configuration error', () => {
+    const stub = makeSSEFetch([textReplyEvents('hi')]);
+    expect(() =>
+      query({
+        prompt: 'hello',
+        options: baseOptions(stub, {
+          incognito: true,
+          sessionStore: new InMemorySessionStore(),
+        }),
+      }),
+    ).toThrow(ConfigurationError);
+  });
+
+  it('a normal (non-incognito) run of the same script DOES persist — the leak test discriminates', async () => {
+    const stub = makeSSEFetch([
+      toolUseReplyEvents('memory', {
+        command: 'create',
+        path: '/memories/notes.md',
+        file_text: `remember: ${MARKER}`,
+      }),
+      textReplyEvents('saved'),
+    ]);
+    const messages = await collect(
+      `please write this down: ${MARKER}`,
+      baseOptions(stub, { memory: { sessionEndUpdate: false } }),
+    );
+    expect((messages.at(-1) as SDKResultMessage).subtype).toBe('success');
+    expect((await grepTree(sessionDir, MARKER)).length).toBeGreaterThan(0);
+    expect((await grepTree(cwd, MARKER)).length).toBeGreaterThan(0);
+  });
+});

--- a/projects/silver-core-sdk/tests/memory-mounts.test.ts
+++ b/projects/silver-core-sdk/tests/memory-mounts.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Memory scope routing tests (governance spec S1).
+ *
+ * The acceptance list from the requirements doc, executed literally:
+ *  - write commands against a read-only mount are rejected with a structured,
+ *    model-readable error;
+ *  - reads/writes inside the caller's own read-write mount pass through;
+ *  - `../` / absolute-path escapes are rejected (R4 validation still runs
+ *    FIRST — mounts stack on top of, never replace, traversal protection);
+ *  - enforcement is SDK-layer (tool execution), no prompt involved;
+ *  - a session mounted on user A's directory cannot read or write user B's
+ *    (outside-mount paths are rejected; ancestor listings are filtered).
+ * Plus: mount validation errors, rename double-gating, resident-index gating,
+ * and per-call instantiation (two tools over the SAME store with different
+ * mounts — the S5 user-session vs synthesis-task shape).
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createLocalFilesystemMemoryStore,
+  createMemoryTool,
+  describeMounts,
+  filterAncestorListing,
+  mountAllowsWrite,
+  mountReadAccess,
+  outsideMountsError,
+  readOnlyMountError,
+  resolveMemoryMounts,
+} from '../src/tools/memory/index.js';
+import { resolveMemoryRuntime } from '../src/tools/memory/index.js';
+import { ConfigurationError } from '../src/errors.js';
+import type { ToolContext } from '../src/internal/contracts.js';
+import type { MemoryStore } from '../src/types.js';
+
+let baseDir: string;
+let store: MemoryStore;
+
+beforeEach(async () => {
+  baseDir = await mkdtemp(join(tmpdir(), 'bpt-mounts-'));
+  store = createLocalFilesystemMemoryStore(baseDir);
+});
+
+afterEach(async () => {
+  await rm(baseDir, { recursive: true, force: true });
+});
+
+function toolCtx(): ToolContext {
+  return {
+    cwd: '/',
+    additionalDirectories: [],
+    env: {},
+    signal: new AbortController().signal,
+    debug: () => {},
+  };
+}
+
+const TEAM_RO_USER_RW = resolveMemoryMounts([
+  { path: '/memories/team', mode: 'read-only' },
+  { path: '/memories/users/alice', mode: 'read-write' },
+]);
+
+function makeTool(mounts = TEAM_RO_USER_RW) {
+  return createMemoryTool(store, { mounts });
+}
+
+async function exec(
+  tool: ReturnType<typeof createMemoryTool>,
+  input: Record<string, unknown>,
+) {
+  return await tool.execute(input, toolCtx());
+}
+
+describe('resolveMemoryMounts (configuration validation)', () => {
+  it('canonicalizes paths and tolerates trailing slashes', () => {
+    const mounts = resolveMemoryMounts([{ path: '/memories/team/', mode: 'read-only' }]);
+    expect(mounts).toEqual([{ path: '/memories/team', mode: 'read-only' }]);
+  });
+
+  it('rejects an empty mount list, a bad mode, and a non-/memories path', () => {
+    expect(() => resolveMemoryMounts([])).toThrow(ConfigurationError);
+    expect(() =>
+      resolveMemoryMounts([{ path: '/memories/x', mode: 'rw' as 'read-write' }]),
+    ).toThrow(ConfigurationError);
+    expect(() =>
+      resolveMemoryMounts([{ path: '/etc/passwd', mode: 'read-write' }]),
+    ).toThrow(ConfigurationError);
+    expect(() =>
+      resolveMemoryMounts([{ path: '/memories/../etc', mode: 'read-write' }]),
+    ).toThrow(ConfigurationError);
+  });
+
+  it('undefined mounts resolve to null (unrestricted, pre-S1 behavior)', () => {
+    expect(resolveMemoryMounts(undefined)).toBeNull();
+    expect(mountReadAccess(null, '/memories/anything')).toBe('full');
+    expect(mountAllowsWrite(null, '/memories/anything')).toBe(true);
+  });
+
+  it('the structured error builders name the mounts so the model can reroute', () => {
+    const mounts = TEAM_RO_USER_RW!;
+    expect(describeMounts(mounts)).toBe(
+      '/memories/team (read-only), /memories/users/alice (read-write)',
+    );
+    const outside = outsideMountsError(mounts, '/memories/users/bob/x.md');
+    expect(outside).toContain('outside the memory areas mounted');
+    expect(outside).toContain('/memories/team (read-only)');
+    const readOnly = readOnlyMountError(mounts, '/memories/team/x.md');
+    expect(readOnly).toContain('read-only in this session');
+    expect(readOnly).toContain('Writable mounts: /memories/users/alice');
+    // No writable mount at all -> the error says so instead of listing nothing.
+    const noneWritable = readOnlyMountError(
+      resolveMemoryMounts([{ path: '/memories/team', mode: 'read-only' }])!,
+      '/memories/team/x.md',
+    );
+    expect(noneWritable).toContain('(none)');
+  });
+});
+
+describe('S1 acceptance: write routing', () => {
+  it('create / str_replace / delete against the read-only team mount are rejected', async () => {
+    const tool = makeTool();
+    const create = await exec(tool, {
+      command: 'create',
+      path: '/memories/team/notes.md',
+      file_text: 'x',
+    });
+    expect(create.isError).toBe(true);
+    expect(create.content).toContain('read-only in this session');
+    expect(create.content).toContain('/memories/users/alice');
+
+    const sr = await exec(tool, {
+      command: 'str_replace',
+      path: '/memories/team/notes.md',
+      old_str: 'a',
+      new_str: 'b',
+    });
+    expect(sr.isError).toBe(true);
+    expect(sr.content).toContain('read-only in this session');
+
+    const del = await exec(tool, { command: 'delete', path: '/memories/team/notes.md' });
+    expect(del.isError).toBe(true);
+    expect(del.content).toContain('read-only in this session');
+  });
+
+  it('the model reads and writes its own read-write mount normally', async () => {
+    const tool = makeTool();
+    const create = await exec(tool, {
+      command: 'create',
+      path: '/memories/users/alice/log.md',
+      file_text: 'hello\n',
+    });
+    expect(create.isError).not.toBe(true);
+    const view = await exec(tool, {
+      command: 'view',
+      path: '/memories/users/alice/log.md',
+    });
+    expect(view.isError).not.toBe(true);
+    expect(view.content).toContain('hello');
+  });
+
+  it('`../` and out-of-root paths are still rejected (R4 stacks under S1)', async () => {
+    const tool = makeTool();
+    const traversal = await exec(tool, {
+      command: 'create',
+      path: '/memories/users/alice/../bob/x.md',
+      file_text: 'x',
+    });
+    expect(traversal.isError).toBe(true);
+    expect(traversal.content).toContain('would escape');
+
+    const absolute = await exec(tool, {
+      command: 'create',
+      path: '/etc/hosts',
+      file_text: 'x',
+    });
+    expect(absolute.isError).toBe(true);
+    expect(absolute.content).toContain('must start with /memories');
+  });
+
+  it("user A's session cannot write user B's directory (outside every mount)", async () => {
+    const tool = makeTool();
+    const write = await exec(tool, {
+      command: 'create',
+      path: '/memories/users/bob/x.md',
+      file_text: 'x',
+    });
+    expect(write.isError).toBe(true);
+    expect(write.content).toContain('outside the memory areas mounted');
+  });
+
+  it('rename is gated at BOTH ends', async () => {
+    const tool = makeTool();
+    await exec(tool, {
+      command: 'create',
+      path: '/memories/users/alice/a.md',
+      file_text: 'x',
+    });
+    // rw -> ro: rejected.
+    const out = await exec(tool, {
+      command: 'rename',
+      old_path: '/memories/users/alice/a.md',
+      new_path: '/memories/team/a.md',
+    });
+    expect(out.isError).toBe(true);
+    // ro -> rw: rejected (removal from the read-only side is a write there).
+    const seeded = createMemoryTool(store, { mounts: null });
+    await seeded.execute(
+      { command: 'create', path: '/memories/team/t.md', file_text: 'x' },
+      toolCtx(),
+    );
+    const steal = await exec(tool, {
+      command: 'rename',
+      old_path: '/memories/team/t.md',
+      new_path: '/memories/users/alice/t.md',
+    });
+    expect(steal.isError).toBe(true);
+    // rw -> rw: allowed.
+    const ok = await exec(tool, {
+      command: 'rename',
+      old_path: '/memories/users/alice/a.md',
+      new_path: '/memories/users/alice/b.md',
+    });
+    expect(ok.isError).not.toBe(true);
+  });
+});
+
+describe('S1 acceptance: read routing', () => {
+  it("user A cannot view user B's files, and ancestor listings hide B entirely", async () => {
+    const unrestricted = createMemoryTool(store, { mounts: null });
+    await unrestricted.execute(
+      { command: 'create', path: '/memories/users/bob/secret.md', file_text: 'hidden' },
+      toolCtx(),
+    );
+    await unrestricted.execute(
+      { command: 'create', path: '/memories/users/alice/mine.md', file_text: 'mine' },
+      toolCtx(),
+    );
+    await unrestricted.execute(
+      { command: 'create', path: '/memories/team/shared.md', file_text: 'team' },
+      toolCtx(),
+    );
+
+    const tool = makeTool();
+    const direct = await exec(tool, {
+      command: 'view',
+      path: '/memories/users/bob/secret.md',
+    });
+    expect(direct.isError).toBe(true);
+    expect(direct.content).toContain('outside the memory areas mounted');
+
+    // Root view survives for navigation, but bob's subtree is filtered out.
+    const root = await exec(tool, { command: 'view', path: '/memories' });
+    expect(root.isError).not.toBe(true);
+    const listing = String(root.content);
+    expect(listing).toContain('/memories/team');
+    expect(listing).toContain('/memories/users/alice');
+    expect(listing).not.toContain('bob');
+
+    // The read-only team mount is fully readable.
+    const team = await exec(tool, { command: 'view', path: '/memories/team/shared.md' });
+    expect(team.isError).not.toBe(true);
+    expect(team.content).toContain('team');
+  });
+
+  it('filterAncestorListing keeps the header, the viewed dir and mount-path lines only', () => {
+    const mounts = resolveMemoryMounts([
+      { path: '/memories/users/alice', mode: 'read-write' },
+    ])!;
+    const listing = [
+      "Here're the files and directories up to 2 levels deep in /memories, excluding hidden items and node_modules:",
+      '4K\t/memories',
+      '1K\t/memories/scratch.md',
+      '2K\t/memories/users/',
+      '1K\t/memories/users/alice/',
+      '1K\t/memories/users/bob/',
+    ].join('\n');
+    const filtered = filterAncestorListing(mounts, '/memories', listing);
+    expect(filtered).toContain('/memories/users/');
+    expect(filtered).toContain('/memories/users/alice/');
+    expect(filtered).not.toContain('scratch.md');
+    expect(filtered).not.toContain('bob');
+  });
+});
+
+describe('S1/S5: per-call mount instantiation over one store', () => {
+  it('a user session (team ro) and a synthesis task (team rw) coexist on the same store', async () => {
+    const userTool = createMemoryTool(store, {
+      mounts: resolveMemoryMounts([{ path: '/memories/team', mode: 'read-only' }]),
+    });
+    const synthesisTool = createMemoryTool(store, {
+      mounts: resolveMemoryMounts([{ path: '/memories/team', mode: 'read-write' }]),
+    });
+    const denied = await userTool.execute(
+      { command: 'create', path: '/memories/team/decision.md', file_text: 'no' },
+      toolCtx(),
+    );
+    expect(denied.isError).toBe(true);
+    const allowed = await synthesisTool.execute(
+      { command: 'create', path: '/memories/team/decision.md', file_text: 'yes' },
+      toolCtx(),
+    );
+    expect(allowed.isError).not.toBe(true);
+    // And the user session READS what synthesis wrote.
+    const read = await userTool.execute(
+      { command: 'view', path: '/memories/team/decision.md' },
+      toolCtx(),
+    );
+    expect(read.content).toContain('yes');
+  });
+});
+
+describe('S1: resident index injection respects mounts', () => {
+  it('skips injection when /memories/MEMORY.md is not readable under the mounts', async () => {
+    const unrestricted = createMemoryTool(store, { mounts: null });
+    await unrestricted.execute(
+      { command: 'create', path: '/memories/MEMORY.md', file_text: '# index\nteam facts' },
+      toolCtx(),
+    );
+    const runtime = resolveMemoryRuntime({
+      memory: {
+        store,
+        mounts: [{ path: '/memories/users/alice', mode: 'read-write' }],
+      },
+      cwd: '/',
+      protocol: 'anthropic',
+      debug: () => {},
+    });
+    expect(await runtime.buildIndexInjection()).toBeNull();
+
+    const covered = resolveMemoryRuntime({
+      memory: { store, mounts: [{ path: '/memories', mode: 'read-write' }] },
+      cwd: '/',
+      protocol: 'anthropic',
+      debug: () => {},
+    });
+    const injection = await covered.buildIndexInjection();
+    expect(injection).not.toBeNull();
+    expect(injection!.text).toContain('team facts');
+  });
+});

--- a/projects/silver-core-sdk/tests/tool-call-log.test.ts
+++ b/projects/silver-core-sdk/tests/tool-call-log.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Structured tool-call log tests (governance spec S3) + claim-verification
+ * helper tests (spec S4), through the REAL query() path with a scripted fetch.
+ *
+ * S3 acceptance:
+ *  - the session JSONL carries one `tool_call` record per dispatched tool_use
+ *    block — name, truncated input JSON, timestamp, sequence, status,
+ *    duration, result summary — machine-distinguishable by `type`;
+ *  - records stay alignable with the message lines (tool_use_id joins the
+ *    record to the untruncated tool_use block);
+ *  - failures record status 'error' (including unknown tools);
+ *  - persistSession:false and incognito sessions write NO records.
+ *
+ * S4 acceptance:
+ *  - "the output claims a memory write, the log has none" produces a finding;
+ *  - a backed claim produces none.
+ */
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { query } from '../src/query.js';
+import {
+  DEFAULT_TOOL_CLAIM_DETECTORS,
+  MEMORY_WRITE_CLAIM_DETECTOR,
+  auditSessionToolClaims,
+  auditToolClaims,
+  getSessionToolCalls,
+  isMemoryWriteRecord,
+} from '../src/index.js';
+import type { Options, SDKMessage, SDKResultMessage } from '../src/types.js';
+import { makeSSEFetch, type SSEFetchStub } from './helpers/sse-fetch.js';
+import { textReplyEvents, toolUseReplyEvents } from './helpers/mock-transport.js';
+
+let cwd: string;
+let sessionDir: string;
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'bpt-toollog-cwd-'));
+  sessionDir = await mkdtemp(join(tmpdir(), 'bpt-toollog-sess-'));
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await rm(cwd, { recursive: true, force: true });
+  await rm(sessionDir, { recursive: true, force: true });
+});
+
+function baseOptions(stub: SSEFetchStub, extra: Partial<Options> = {}): Options {
+  return {
+    provider: { apiKey: 'test-key', promptCaching: false, fetch: stub },
+    cwd,
+    sessionDir,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    model: 'claude-sonnet-4-5',
+    settingSources: [],
+    ...extra,
+  };
+}
+
+async function collect(prompt: string, options: Options): Promise<SDKMessage[]> {
+  const out: SDKMessage[] = [];
+  for await (const m of query({ prompt, options })) out.push(m);
+  return out;
+}
+
+function sessionIdOf(messages: SDKMessage[]): string {
+  const result = messages.at(-1) as SDKResultMessage;
+  expect(result.type).toBe('result');
+  return result.session_id;
+}
+
+const MEMORY_CREATE = {
+  command: 'create',
+  path: '/memories/notes.md',
+  file_text: 'a fact worth keeping',
+};
+
+describe('S3 structured tool-call records', () => {
+  it('persists one typed record per dispatched call, aligned with the messages', async () => {
+    const stub = makeSSEFetch([
+      toolUseReplyEvents('memory', MEMORY_CREATE, { id: 'toolu_mem_1' }),
+      textReplyEvents('recorded'),
+    ]);
+    const messages = await collect(
+      'remember this',
+      baseOptions(stub, { memory: { sessionEndUpdate: false } }),
+    );
+    const sessionId = sessionIdOf(messages);
+
+    const records = await getSessionToolCalls(sessionId, { sessionDir });
+    expect(records).toHaveLength(1);
+    const rec = records[0]!;
+    expect(rec.type).toBe('tool_call');
+    expect(rec.tool_name).toBe('memory');
+    expect(rec.tool_use_id).toBe('toolu_mem_1');
+    expect(rec.seq).toBe(1);
+    expect(rec.status).toBe('ok');
+    expect(rec.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(rec.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(rec.tool_input).toContain('"command":"create"');
+    expect(rec.result_summary).toContain('File created successfully');
+    expect(rec.session_id).toBe(sessionId);
+
+    // Raw JSONL: `type` distinguishes tool calls from message lines, and the
+    // tool_use_id joins the record to the persisted assistant tool_use block.
+    const raw = await readFile(join(sessionDir, `${sessionId}.jsonl`), 'utf8');
+    const lines = raw
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const toolLines = lines.filter((l) => l.type === 'tool_call');
+    expect(toolLines).toHaveLength(1);
+    const assistantWithToolUse = lines.find(
+      (l) => l.type === 'assistant' && JSON.stringify(l).includes('toolu_mem_1'),
+    );
+    expect(assistantWithToolUse).toBeDefined();
+  });
+
+  it("records status 'error' with the failure detail (unknown tool)", async () => {
+    const stub = makeSSEFetch([
+      toolUseReplyEvents('NoSuchTool', { anything: true }, { id: 'toolu_missing' }),
+      textReplyEvents('hm'),
+    ]);
+    const messages = await collect('call something odd', baseOptions(stub));
+    const records = await getSessionToolCalls(sessionIdOf(messages), { sessionDir });
+    expect(records).toHaveLength(1);
+    expect(records[0]!.status).toBe('error');
+    expect(records[0]!.result_summary).toContain('No such tool');
+  });
+
+  it('truncates an oversized input JSON but keeps the join key', async () => {
+    const stub = makeSSEFetch([
+      toolUseReplyEvents(
+        'memory',
+        {
+          command: 'create',
+          path: '/memories/big.md',
+          file_text: 'x'.repeat(10_000),
+        },
+        { id: 'toolu_big' },
+      ),
+      textReplyEvents('done'),
+    ]);
+    const messages = await collect(
+      'write a big file',
+      baseOptions(stub, { memory: { sessionEndUpdate: false } }),
+    );
+    const records = await getSessionToolCalls(sessionIdOf(messages), { sessionDir });
+    expect(records).toHaveLength(1);
+    expect(records[0]!.tool_input.length).toBeLessThan(3000);
+    expect(records[0]!.tool_input).toContain('…[truncated]');
+    expect(records[0]!.tool_use_id).toBe('toolu_big');
+  });
+
+  it('writes no records under persistSession:false', async () => {
+    const stub = makeSSEFetch([
+      toolUseReplyEvents('memory', MEMORY_CREATE),
+      textReplyEvents('done'),
+    ]);
+    const messages = await collect(
+      'remember this',
+      baseOptions(stub, {
+        persistSession: false,
+        memory: { sessionEndUpdate: false },
+      }),
+    );
+    const records = await getSessionToolCalls(sessionIdOf(messages), { sessionDir });
+    expect(records).toEqual([]);
+  });
+});
+
+describe('S4 tool-claim verification', () => {
+  it('flags a claimed-but-unbacked memory write from the persisted session', async () => {
+    const stub = makeSSEFetch([
+      textReplyEvents("Done — I've saved that to memory for next time."),
+    ]);
+    const messages = await collect('remember this please', baseOptions(stub));
+    const findings = await auditSessionToolClaims(sessionIdOf(messages), { sessionDir });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.detectorId).toBe('memory-write-claim');
+    expect(findings[0]!.snippet).toContain('saved that to memory');
+  });
+
+  it('does not flag when the log carries a backing successful write', async () => {
+    const stub = makeSSEFetch([
+      toolUseReplyEvents('memory', MEMORY_CREATE),
+      textReplyEvents("I've saved that to memory."),
+    ]);
+    const messages = await collect(
+      'remember this please',
+      baseOptions(stub, { memory: { sessionEndUpdate: false } }),
+    );
+    const findings = await auditSessionToolClaims(sessionIdOf(messages), { sessionDir });
+    expect(findings).toEqual([]);
+  });
+
+  it('pure-function form: zh claims, failed writes do not count as backing', () => {
+    const zhFindings = auditToolClaims({
+      assistantTexts: ['分析完毕，已写入记忆。'],
+      toolCalls: [
+        {
+          tool_name: 'memory',
+          status: 'error',
+          tool_input: '{"command":"create","path":"/memories/x.md"}',
+        },
+      ],
+    });
+    expect(zhFindings).toHaveLength(1);
+
+    const backed = auditToolClaims({
+      assistantTexts: ['分析完毕，已写入记忆。'],
+      toolCalls: [
+        {
+          tool_name: 'memory',
+          status: 'ok',
+          tool_input: '{"command":"str_replace","path":"/memories/x.md"}',
+        },
+      ],
+    });
+    expect(backed).toEqual([]);
+
+    // A read does not back a write claim.
+    const readOnly = auditToolClaims({
+      assistantTexts: ['saved it to memory'],
+      toolCalls: [
+        { tool_name: 'memory', status: 'ok', tool_input: '{"command":"view"}' },
+      ],
+    });
+    expect(readOnly).toHaveLength(1);
+  });
+
+  it('exposes the detector building blocks for consumer-defined detectors', () => {
+    expect(DEFAULT_TOOL_CLAIM_DETECTORS).toContain(MEMORY_WRITE_CLAIM_DETECTOR);
+    expect(MEMORY_WRITE_CLAIM_DETECTOR.id).toBe('memory-write-claim');
+    expect(
+      isMemoryWriteRecord({
+        tool_name: 'memory',
+        status: 'ok',
+        tool_input: '{"command":"delete","path":"/memories/x.md"}',
+      }),
+    ).toBe(true);
+    expect(
+      isMemoryWriteRecord({
+        tool_name: 'memory',
+        status: 'ok',
+        tool_input: '{"command":"view","path":"/memories"}',
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- 内部 PR：守密人 0711 需求书派发（艾瑞卡会话） -->

## 概述

落地守密人 2026-07-11 派发《Silver Core SDK 需求说明：记忆系统、隐私治理与会议记录支持》的 SDK 侧全部范围：S1 记忆作用域挂载与权限强制、S2 无痕会话原语、S3 结构化工具调用日志（三项 P0）+ S4 声明核验辅助（P1），S5 由既有按 query 组合满足并入档、S6 架构预留由 S3 记录兑现。版本 v0.48.0，需求书归档 `projects/silver-core-sdk/docs/MEMORY-GOVERNANCE.md`。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [x] 文档完善（CLAUDE.md / BIAV-SC.md / README.md / 子项目 CONTEXT.md）
- [ ] Bug 修复
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 其他（请说明）：silver-core-sdk 新能力（记忆治理 / 无痕会话 / 审计日志），banked 版本 0.47.0 → 0.48.0

要点：

- **S1**：`options.memory.mounts` 按 query 声明子树权限（read-only / read-write），工具层在 R4 穿越防护之上强制执行——只读挂载点拒写、挂载点外拒读写、祖先目录列目录按挂载可见性过滤（用户 A 看不到用户 B 的目录名）、rename 双端校验、R6 常驻索引仅在 MEMORY.md 挂载可读时注入。
- **S2**：`options.incognito` 一键零 SDK 侧持久化——转录不落盘、memory 降级只读（view 保留，五写命令返回结构化 `INCOGNITO_MEMORY_ERROR`）、R7 两写回合关断、S3 记录抑制、与 `sessionStore` 组合报配置错误。需求书泄漏测试清单直接落为集成测试（标记词全盘 grep 零残留 + 非无痕对照组）。
- **S3**：每次 tool_use 派发在会话 JSONL 写一条 `tool_call` 记录（工具名 / 截断参数 JSON / 时间戳 / 序号 / 成败 / 耗时 / 结果摘要；子代理带 `parent_tool_use_id`），`type` 字段机读区分、经 `tool_use_id` 与 tool_use 块对齐可全量重放；`getSessionToolCalls()` 读回。
- **S4**：`auditToolClaims` / `auditSessionToolClaims` 检出「输出声称调用、日志无对应记录」轮次（中英文记忆写入探测器默认集，可扩展；漏报优先压低）。

---

## 来源声明

- [x] 本 PR 不涉及游戏数据；全部为 silver-core-sdk 工程代码与文档，实现依据为守密人派发的需求书与既有公开文档（净室纪律不变）。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不上传内部美术资产、客户端解包原始文件、未公开的剧情草稿等。**
- [x] **同意按 [MIT License](../LICENSE) 提交贡献。**

---

## 验证清单

- [x] SDK 全量单测 `npm test`：89 文件 1812 passed（+32 新测试），typecheck 通过，`check-version-bump.mjs` 三方对账绿
- [x] 仓库级 `pytest tests/`：2703 passed / 10 skipped
- [x] okf/ 生成物未随包（lesson #46 协议，合并后自动重建）
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [x] `memory/` 改动限状态档案（project-status / todo 挂账 T25、T26），未动 decisions.md / lessons-learned.md

---

## 关联 Issue

- Refs：无（守密人会话直接派发）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bke8rakHYzPeq4thZTf9o6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bke8rakHYzPeq4thZTf9o6)_