### PR TITLE
fix(ci): switch 16 direct-push-to-main workflows to deploy-key auth (T31 门禁误伤修复)

### DIFF
--- a/.github/workflows/backfill-gap.yml
+++ b/.github/workflows/backfill-gap.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/backfill-media.yml
+++ b/.github/workflows/backfill-media.yml
@@ -33,6 +33,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/backfill-news.yml
+++ b/.github/workflows/backfill-news.yml
@@ -55,6 +55,8 @@ jobs:
           fi
 
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
         if: steps.check.outputs.skip != 'true'
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/build-analysis-index.yml
+++ b/.github/workflows/build-analysis-index.yml
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/build-capability-registry.yml
+++ b/.github/workflows/build-capability-registry.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/build-okf-bundle.yml
+++ b/.github/workflows/build-okf-bundle.yml
@@ -55,6 +55,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 50
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/collect-comments.yml
+++ b/.github/workflows/collect-comments.yml
@@ -29,6 +29,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/discord-archive-jp.yml
+++ b/.github/workflows/discord-archive-jp.yml
@@ -39,6 +39,8 @@ jobs:
           fi
 
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
         if: steps.guard.outputs.skip == 'false'
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/discord-archive-volunteer.yml
+++ b/.github/workflows/discord-archive-volunteer.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 50
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/discord-archive.yml
+++ b/.github/workflows/discord-archive.yml
@@ -31,6 +31,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/discord-discover-guilds.yml
+++ b/.github/workflows/discord-discover-guilds.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/discord-history-backfill.yml
+++ b/.github/workflows/discord-history-backfill.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 50
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/extract-game-data.yml
+++ b/.github/workflows/extract-game-data.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - name: Download game data from Release
         env:

--- a/.github/workflows/refresh-claude-code-prompts.yml
+++ b/.github/workflows/refresh-claude-code-prompts.yml
@@ -24,6 +24,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/update-news.yml
+++ b/.github/workflows/update-news.yml
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:

--- a/memory/todo.md
+++ b/memory/todo.md
@@ -34,6 +34,7 @@
 | T28 | BPT 侧多用户 session 隔离与 token 计费归属现状回填：S1 挂载已按 query 实例化落地（SDK 侧不阻塞），BPT 接线时按其用户体系把 `{userId}` 实例化进 mounts 并核对计费归属口径 | 黑池输入 | 0711 记忆治理需求书 §7 待决表 + `projects/silver-core-sdk/docs/MEMORY-GOVERNANCE.md` S1 节 | 开 |
 | T29 | git 历史重写禁区站岗：2026-06-21 瘦身删除的 ~3.0G discord 旧档，仅实证 30 月中 3 月在 Releases 有副本；做 git 历史重写前**不得假定其余 27 月安全**（历史 blob 是唯一二次抢救网） | 观察 | 原根目录 `todo.md` 风险提示节（2026-07-11 仓库精简裁定归账后删档，见 `Public-Info-Pool/Resource/repo-engineering/repo-slim-audit-20260711.md` 项 2） | 开 |
 | T30 | pending-discussions 归档遗留开账复核：2026-04-26 定格快照归档时余 18 条未销（采集接入 4 / 日报流程 2 / 事实圣经补全 1 / 站点 Discussions 1 / 数据层审计副产物 6 / 待解锁源 3 / publish_time 污染 1），部分疑已被后续演化覆盖（如 Discussions/Giscus 评论随 2026-07-10 取消社区贡献大概率作废、日报定时已停用），须逐条复核销案或转正式挂账 | 裁定 | `memory/archive/pending-discussions.md`（2026-07-11 仓库精简裁定项 5 归档） | 开 |
+| T31 | 机器直推 main 切 deploy key 通道（T19 门禁误伤修复）：Ruleset 生效后内建 `GITHUB_TOKEN` 直推被 GH013 拦——update-news 断流 4 轮（UTC 0920/1312/1553/1706）+ OKF 重建 2 败实证；「GitHub Actions」不能作 Ruleset bypass 主体系平台限制，bypass 选择器搜不到（守密人截图证实）。16 个直推 workflow 的 checkout 已挂 `secrets.BOT_DEPLOY_KEY`。**待守密人三步**：① Settings→Deploy keys 添加公钥（勾 Allow write access）；② Ruleset bypass 加「Deploy keys」Always allow；③ Settings→Secrets→Actions 建 `BOT_DEPLOY_KEY`=私钥。三步完后合并接线 PR、点火 update-news 复验即销。另注：T3 销案「机器推送无误伤」结论被本次实证推翻（当时验证批次在勾选前，误判） | 裁定 | 本条 + 接线 PR + `update-news` 失败 run [29160997764](https://github.com/lightproud/brain-in-a-vat/actions/runs/29160997764) | 开 |
 
 ## 已清（销案引）
 


### PR DESCRIPTION
<!-- 内部 PR：T19 门禁误伤修复（艾瑞卡会话） -->

## 概述

T19 Ruleset 生效后，内建 `GITHUB_TOKEN` 直推 main 一律被 `GH013: Required status check "test" is expected` 拦下（update-news 断流 4 轮、build-okf-bundle 两败；「GitHub Actions」不能作 Ruleset bypass 主体系平台限制，bypass 选择器搜不到已由守密人截图证实）。本 PR 把 16 个直推 main 的 workflow 的 checkout 步挂上 `ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}`，推送改以 deploy key 身份进行——deploy key 可以进 bypass 列表（Always allow）。挂账 `memory/todo.md` T31。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [ ] 文档完善（CLAUDE.md / BIAV-SC.md / README.md / 子项目 CONTEXT.md）
- [x] Bug 修复
- [x] 其他（请说明）：CI 基础设施接线（16 workflow）+ todo.md 挂账 T31

**合并顺序（硬前提）**：合并前守密人须先完成三步，否则打补丁的 checkout 会因 secret 缺失而全部失败——
1. Settings → Deploy keys → Add：贴入公钥、**勾 Allow write access**；
2. Ruleset → Bypass list → Add bypass → 选 **Deploy keys**、模式 **Always allow**；
3. Settings → Secrets and variables → Actions → New secret：名 `BOT_DEPLOY_KEY`，值为私钥全文。

---

## 来源声明

- [x] 不涉及游戏数据；纯 CI 接线，无外部数据引入。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不上传内部美术资产、客户端解包原始文件、未公开的剧情草稿等。**
- [x] **同意按 [MIT License](../LICENSE) 提交贡献。**

---

## 验证清单

- [x] 全部 33 个 workflow YAML 解析通过（PyYAML safe_load 零报错）
- [x] 仅改 checkout 步 `with` 块（每文件 +2 行）与 todo.md 挂账，零逻辑改动
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [ ] 合并后实证：手动 dispatch `update-news`，推送成功即销 T31

---

## 关联 Issue

- Refs：`memory/todo.md` T31；失败实证 run [29160997764](https://github.com/lightproud/brain-in-a-vat/actions/runs/29160997764)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bke8rakHYzPeq4thZTf9o6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bke8rakHYzPeq4thZTf9o6)_