### PR TITLE
fix(ci): restore prompt_candidate default displaced by run_evals input

### DIFF
--- a/.github/workflows/silver-core-sdk.yml
+++ b/.github/workflows/silver-core-sdk.yml
@@ -58,12 +58,12 @@ on:
         required: false
         type: choice
         options: ['v2', 'v3', 'v4', 'v5']
+        default: 'v5'
       run_evals:
         description: 'Run the two-layer eval suite LIVE (SCS-REQ-002 loop 2: scenario runs on the real API + claude-sonnet-5 judging; keeper budget cap $30/month)'
         required: false
         type: boolean
         default: false
-        default: 'v5'
       prompt_tasks:
         description: 'Task ids for the prompt A/B (e.g. 10,11 = the hard discriminating tasks; empty = all)'
         required: false


### PR DESCRIPTION
## 概述

单行修复:PR #610 的 `run_evals` 输入块误插在 `prompt_candidate` 的 `options` 与其 `default: 'v5'` 之间,孤儿 default 落进 run_evals 块造成重复键——workflow_dispatch 422 解析失败(点火 LIVE 评分时实测)。归位后 `python -c yaml.safe_load` 通过。

## 验证清单

- [x] YAML 解析通过(对话内实测)
- [x] 纯 workflow 文件改动,双套测试射程外(不涉 src / 档案)

## 关联

- Refs:PR #610;LIVE 首轮评分点火(守密人「2开始吧」)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrYSYWGSEKi5ysva5VDB8a)_