### PR TITLE
feat(silver-core-sdk): loop-1 run-signal ledger + daily runtime report (v0.50.0)

### DIFF
--- a/okf/kb_index.json
+++ b/okf/kb_index.json
@@ -7,13 +7,13 @@
     "tokenizer": "silver_tokenizer FMM（领域词典，零 ML）"
   },
   "stats": {
-    "concepts": 359,
+    "concepts": 360,
     "edges": 411,
-    "terms": 6182,
+    "terms": 6186,
     "by_type": {
       "character": 72,
       "dataset": 108,
-      "documentation": 114,
+      "documentation": 115,
       "knowledge-pointer": 45,
       "reference": 17,
       "research": 3
@@ -25,7 +25,7 @@
       "extracted": 3,
       "memory": 48,
       "news-output": 23,
-      "projects": 27,
+      "projects": 28,
       "resource": 86,
       "sources": 20,
       "story": 11,
@@ -34,7 +34,7 @@
     },
     "by_tier": {
       "skeleton": 131,
-      "search": 228
+      "search": 229
     }
   },
   "sections": {
@@ -64,7 +64,7 @@
     },
     "projects": {
       "index": "/projects/index.md",
-      "count": 27
+      "count": 28
     },
     "resource": {
       "index": "/resource/index.md",
@@ -2855,6 +2855,20 @@
       "title": "silver-core-sdk POSITIONING",
       "description": "**Silver Core SDK = 一套稳定兼容的调用「表面」 + 一个我们完全掌控、比原版更简单更可靠的独立「引擎」。**",
       "resource": "/projects/silver-core-sdk/docs/POSITIONING.md",
+      "tags": [
+        "data_layer:curated",
+        "design-doc",
+        "sub-project:silver-core-sdk"
+      ],
+      "section": "projects",
+      "tier": "search",
+      "degree": 0
+    },
+    "/projects/silver-core-sdk-doc-reporting.md": {
+      "type": "documentation",
+      "title": "silver-core-sdk REPORTING",
+      "description": "The signal side of the self-improvement loop: runs leave a facts-only ledger,",
+      "resource": "/projects/silver-core-sdk/docs/REPORTING.md",
       "tags": [
         "data_layer:curated",
         "design-doc",
@@ -9900,6 +9914,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -11123,6 +11138,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -11374,6 +11390,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/resource/resource-data-diagnostics-silver-core-sdk-l5-round-20260711.md",
@@ -11493,6 +11510,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -11819,6 +11837,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -12125,6 +12144,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -12225,6 +12245,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md"
     ],
@@ -12241,6 +12262,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/resource/resource-repo-engineering-bpt-sdk-official-docs-interface-audit-20260705.md"
@@ -12465,6 +12487,7 @@
       "/assets/assets-version.md"
     ],
     "facts": [
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/resource/resource-repo-engineering-repo-slim-audit-20260711.md"
     ],
     "fail": [
@@ -13068,7 +13091,8 @@
       "/projects/silver-core-sdk-doc-migration.md"
     ],
     "improvement": [
-      "/memory/memory-ext-active-self-improvement-requirements.md"
+      "/memory/memory-ext-active-self-improvement-requirements.md",
+      "/projects/silver-core-sdk-doc-reporting.md"
     ],
     "independent": [
       "/projects/project-silver-core-sdk.md",
@@ -13599,6 +13623,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -13818,7 +13843,11 @@
     "learned": [
       "/memory/lessons-learned.md"
     ],
+    "leave": [
+      "/projects/silver-core-sdk-doc-reporting.md"
+    ],
     "ledger": [
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/resource/resource-proposal-bpt-sdk-reproduction-scope-ledger-20260704.md"
     ],
     "leg": [
@@ -13934,6 +13963,7 @@
       "/memory/memory-archive-bpt-guidance-log.md"
     ],
     "loop": [
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/resource/resource-proposal-bpt-prompt-assembly-layer-design-20260705.md",
       "/resource/resource-repo-engineering-bpt-sdk-official-semantics-audit-20260707.md"
     ],
@@ -14150,6 +14180,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/resource/resource-community-analysis-community-deep-analysis-20260518-26.md",
@@ -15067,6 +15098,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -15120,6 +15152,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -15650,6 +15683,9 @@
       "/resource/resource-repo-engineering-bpt-sdk-conformance-campaign-report-20260705.md",
       "/resource/resource-repo-engineering-bpt-sdk-l5-fullround-report-20260705.md"
     ],
+    "reporting": [
+      "/projects/silver-core-sdk-doc-reporting.md"
+    ],
     "reproduction": [
       "/resource/resource-proposal-bpt-sdk-reproduction-scope-ledger-20260704.md"
     ],
@@ -15849,6 +15885,7 @@
       "/projects/silver-core-sdk-doc-resilience.md"
     ],
     "runs": [
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/resource/resource-data-diagnostics-silver-core-sdk-l5-round-20260711.md"
     ],
     "runtime": [
@@ -15953,6 +15990,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/resource/resource-data-diagnostics-bpt-sdk-comparison-baseline-20260705.md",
@@ -15997,6 +16035,7 @@
     ],
     "self": [
       "/memory/memory-ext-active-self-improvement-requirements.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/story/story_search_index.md"
     ],
     "selfreport": [
@@ -16028,6 +16067,12 @@
       "/memory/memory-archive-bpt-strategic-shift-2026-04-19-readme.md",
       "/memory/memory-archive-bpt-strategic-shift-2026-04-19-silver-blackpool-interface.md"
     ],
+    "side": [
+      "/projects/silver-core-sdk-doc-reporting.md"
+    ],
+    "signal": [
+      "/projects/silver-core-sdk-doc-reporting.md"
+    ],
     "signature": [
       "/resource/resource-repo-engineering-bpt-sdk-official-semantics-audit-20260707.md"
     ],
@@ -16047,6 +16092,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/resource/resource-data-diagnostics-silver-core-sdk-l5-round-20260711.md",
@@ -16380,6 +16426,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -17710,6 +17757,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -17981,6 +18029,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -18308,6 +18357,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -19549,6 +19599,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -20521,6 +20572,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -20795,6 +20847,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -22675,6 +22728,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -25944,6 +25998,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -26747,6 +26802,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -27383,6 +27439,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -31254,6 +31311,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -31833,6 +31891,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -32175,6 +32234,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -32599,6 +32659,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -32891,6 +32952,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -34600,6 +34662,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -35033,6 +35096,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -35631,6 +35695,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -36346,6 +36411,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -36739,6 +36805,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -43768,6 +43835,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -44454,6 +44522,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -45488,6 +45557,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -45748,6 +45818,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -47480,6 +47551,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/resource/resource-data-diagnostics-silver-core-sdk-l5-round-20260711.md",
@@ -47587,6 +47659,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -47906,6 +47979,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -48188,6 +48262,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -48263,6 +48338,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md"
     ],
@@ -48868,6 +48944,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -49567,6 +49644,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",
@@ -49714,6 +49792,9 @@
       "/resource/resource-repo-engineering-bpt-sdk-conformance-campaign-report-20260705.md",
       "/resource/resource-repo-engineering-bpt-sdk-l5-fullround-report-20260705.md"
     ],
+    "reporting": [
+      "/projects/silver-core-sdk-doc-reporting.md"
+    ],
     "reproduction": [
       "/resource/resource-proposal-bpt-sdk-reproduction-scope-ledger-20260704.md"
     ],
@@ -49835,6 +49916,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/resource/resource-data-diagnostics-bpt-sdk-comparison-baseline-20260705.md",
@@ -49900,6 +49982,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/resource/resource-data-diagnostics-silver-core-sdk-l5-round-20260711.md",
@@ -50032,6 +50115,7 @@
       "/projects/silver-core-sdk-doc-openai-protocol.md",
       "/projects/silver-core-sdk-doc-performance.md",
       "/projects/silver-core-sdk-doc-positioning.md",
+      "/projects/silver-core-sdk-doc-reporting.md",
       "/projects/silver-core-sdk-doc-resilience.md",
       "/projects/silver-core-sdk-doc-subagents.md",
       "/projects/site-design-morimens-design-system-guide.md",

--- a/okf/projects/index.md
+++ b/okf/projects/index.md
@@ -1,4 +1,4 @@
-# 入口文档 + 子项目上下文 + 藏宝图 + 设计/工程文档 (27)
+# 入口文档 + 子项目上下文 + 藏宝图 + 设计/工程文档 (28)
 
 仓库最高权威入口（CLAUDE.md / README.md）+ 各子项目 CONTEXT.md（动手前必读）+ RELEASES.md 藏宝图 + silver-core-sdk/site 设计文档 + 工程文档 + 归档注册表的导航指针。
 
@@ -22,6 +22,7 @@
 * [silver-core-sdk OPENAI-PROTOCOL](/projects/silver-core-sdk-doc-openai-protocol.md) - The SDK can drive an **OpenAI-compatible Chat Completions endpoint** instead of
 * [silver-core-sdk PERFORMANCE](/projects/silver-core-sdk-doc-performance.md) - What the SDK controls about response time, what it already does by default,
 * [silver-core-sdk POSITIONING](/projects/silver-core-sdk-doc-positioning.md) - **Silver Core SDK = 一套稳定兼容的调用「表面」 + 一个我们完全掌控、比原版更简单更可靠的独立「引擎」。**
+* [silver-core-sdk REPORTING](/projects/silver-core-sdk-doc-reporting.md) - The signal side of the self-improvement loop: runs leave a facts-only ledger,
 * [silver-core-sdk RESILIENCE](/projects/silver-core-sdk-doc-resilience.md) - Audience: consumers running this SDK over imperfect links (corporate
 * [silver-core-sdk SUBAGENTS](/projects/silver-core-sdk-doc-subagents.md) - Goal: wire a host (BPT) to the SDK's subagent surface the way Claude Code uses
 * [site design · morimens-design-system-guide.html](/projects/site-design-morimens-design-system-guide.md) - site 设计系统权威（morimens-design-system-guide.html，21.2KB）：设计令牌 / 组件规范来源。

--- a/okf/projects/silver-core-sdk-doc-reporting.md
+++ b/okf/projects/silver-core-sdk-doc-reporting.md
@@ -1,0 +1,16 @@
+---
+type: "documentation"
+title: "silver-core-sdk REPORTING"
+description: "The signal side of the self-improvement loop: runs leave a facts-only ledger,"
+resource: "/projects/silver-core-sdk/docs/REPORTING.md"
+tags: ["data_layer:curated", "design-doc", "sub-project:silver-core-sdk"]
+timestamp: "2026-07-12"
+---
+
+# 指针概念
+
+> 放指针不放本体：本体权威在 `projects/silver-core-sdk/docs/REPORTING.md`，本 concept 仅描述与定位、不复刻正文。
+
+- 本体路径：`projects/silver-core-sdk/docs/REPORTING.md`
+- 摘要：The signal side of the self-improvement loop: runs leave a facts-only ledger,
+- 标签：data_layer:curated · design-doc · sub-project:silver-core-sdk

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,23 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.50.0 — 2026-07-12
+
+**Self-improvement loop 1 signal side (SCS-REQ-002 REQ-1.1).**
+`options.runLog` mirrors every consumer-facing result message as one
+facts-only JSONL line (`runlog-{date}.jsonl`: subtype, counters, usage,
+cache ratio, cost, transportHealth ledger, per-tool calls/errors, model
+ids — no conversation content; incognito records keep transport/token
+stats but no identity/tag/error per spec §6.4; fire-and-forget appends
+never break the run; observed at the Query-wrapper choke point so every
+result path is covered). `generateRuntimeReport()` folds a rolling
+window (default 24h) of ledger lines into `runtime-report-{date}.md`
+with the four spec sections (传输健康 + 未恢复清单 / token 消耗按场景 /
+工具调用×失败率 / 失败会话仅事实); absent signals render explicit 无数据
+markers, lists are capped with the cap stated, a missing log dir degrades
+instead of throwing. New `docs/REPORTING.md`; +8 tests. REQ-1.2
+compareReports stays pending (P1).
+
 ## 0.49.0 — 2026-07-11
 
 **Self-improvement loop Phase 0 + Phase 1 landing (SCS-REQ-002).** Phase 0

--- a/projects/silver-core-sdk/docs/REPORTING.md
+++ b/projects/silver-core-sdk/docs/REPORTING.md
@@ -1,0 +1,66 @@
+# Runtime reporting (SCS-REQ-002 loop 1)
+
+The signal side of the self-improvement loop: runs leave a facts-only ledger,
+and one call folds the last 24 hours into an agent-readable daily report —
+the replacement for a human trawling dashboards. Spec: REQ-1.1 in
+`memory/active/self-improvement-requirements.md` (repo root).
+
+## Run-signal ledger (`options.runLog`)
+
+```ts
+const q = query({
+  prompt,
+  options: {
+    runLog: { dir: '/var/bpt/runlog', scenario: 'coding' }, // or 'non-coding'
+  },
+});
+```
+
+Every consumer-facing result message is mirrored as ONE JSONL line in
+`{dir}/runlog-{YYYY-MM-DD}.jsonl` (UTC day files): termination subtype,
+turn/duration counters, token usage + cache ratio, cost, the
+transport-health disconnect ledger, per-tool call/error counters, model ids.
+**No conversation content.** Writes are fire-and-forget appends — a ledger
+fault never breaks the run.
+
+**Incognito boundary (spec §6.4):** an incognito session still contributes
+transport/token statistics, but its record carries no session id, no
+scenario tag and no error text, and never appears in the report's
+failed-sessions section.
+
+The record contract is `RunLogRecord` (`src/reporting/run-log.ts`, `v: 1`).
+BPT-side producers that write their own ledger lines must follow it —
+otherwise the report's tool-call section reads their runs as "无数据"
+(spec §6.1).
+
+## Daily report (`generateRuntimeReport`)
+
+```ts
+import { generateRuntimeReport } from 'silver-core-sdk';
+
+const { path, markdown, summary } = await generateRuntimeReport({
+  logDir: '/var/bpt/runlog',          // where the day files live
+  // outDir: default {logDir}/../reports; null = don't write, return only
+  // windowHours: default 24; topN: default 5
+});
+```
+
+Writes `reports/runtime-report-{YYYY-MM-DD}.md` with four sections:
+
+1. **传输健康** — ledger totals by cause + the unrecovered-sessions list
+   (runs that still ended in error despite recorded transport faults);
+2. **token 消耗** — input/output totals, cache hit rate, cost, top consumers
+   split by `scenario` tag;
+3. **工具调用** — tool × calls × failure rate;
+4. **失败会话** — non-success terminations, facts only.
+
+Acceptance properties (tested in `tests/runtime-report.test.ts`): a missing
+signal renders an explicit **无数据** marker (never a silently absent
+section); lists are capped with the cap stated inline (~8K-token target);
+a missing log directory degrades to an all-无数据 report, not a throw; zero
+new runtime dependencies.
+
+## Pending (P1)
+
+`compareReports(dateA, dateB)` — key-metric deltas for loop 3's
+direction-finding (REQ-1.2). Not yet implemented.

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/scripts/run-evals.mjs
+++ b/projects/silver-core-sdk/scripts/run-evals.mjs
@@ -246,8 +246,11 @@ async function runBehavior() {
       for (const phase of phases) {
         // Headless run: no permission callback exists, so tool calls must not
         // stall on approval — the scenarios only touch seeded temp workspaces.
+        // The SDK gates bypassPermissions behind the explicit opt-in flag
+        // (first LIVE round 2026-07-12 run #58 caught the missing pair).
         const { transcript, result } = await runPhase(sdk, phase, ws, {
           permissionMode: 'bypassPermissions',
+          allowDangerouslySkipPermissions: true,
         });
         evidence.phases.push({
           transcript: transcript.slice(0, 200),

--- a/projects/silver-core-sdk/src/index.ts
+++ b/projects/silver-core-sdk/src/index.ts
@@ -7,6 +7,12 @@
  */
 
 export { query } from './query.js';
+// BPT-EXTENSION (SCS-REQ-002 loop 1): run-signal ledger + daily runtime report.
+// RunLogOptions rides the types.js export.
+export { generateRuntimeReport } from './reporting/runtime-report.js';
+export type { RuntimeReportOptions, RuntimeReportResult } from './reporting/runtime-report.js';
+export { buildRunLogRecord, createRunLogSink, runLogFileName } from './reporting/run-log.js';
+export type { RunLogRecord, RunLogSink } from './reporting/run-log.js';
 // BPT-EXTENSION: in-process multi-conversation coordinator (SessionManager /
 // SessionManagerOptions / SessionManagerUsage types ride the types.js export).
 export { createBptSession, runConcurrent } from './session-manager.js';

--- a/projects/silver-core-sdk/src/query.ts
+++ b/projects/silver-core-sdk/src/query.ts
@@ -73,6 +73,7 @@ import {
 import { estimateTextTokens } from './engine/tokens.js';
 import { MEMORY_TOOL_NAME, resolveMemoryRuntime } from './tools/memory/index.js';
 import { createSessionPersistence } from './sessions/persistence.js';
+import { createRunLogSink } from './reporting/run-log.js';
 import { AsyncQueue, createDeferred, type Deferred } from './internal/async.js';
 import { ToolFilterMcpRegistry } from './mcp/tool-filter.js';
 import { SDK_VERSION } from './version.js';
@@ -1621,7 +1622,32 @@ export function query(args: {
   }
 
   // --- Query wrapper -------------------------------------------------------------
-  const inner = run();
+  const innerGen = run();
+
+  // Run-signal ledger (SCS-REQ-002 loop 1): observe every consumer-facing
+  // message at the single choke point all result paths share (engine results,
+  // query-layer synthetic terminals, interrupt results). A thin delegating
+  // proxy — not a generator wrapper — so next()-argument forwarding and
+  // return/throw semantics stay byte-identical.
+  const runLogSink =
+    options.runLog !== undefined
+      ? createRunLogSink({ runLog: options.runLog, incognito, debug })
+      : null;
+  const inner =
+    runLogSink === null
+      ? innerGen
+      : ({
+          next: (...a: [] | [unknown]) =>
+            innerGen.next(...a).then((r) => {
+              if (r.done !== true) runLogSink.observe(r.value);
+              return r;
+            }),
+          return: (v: void | PromiseLike<void>) => innerGen.return(v),
+          throw: (e?: unknown) => innerGen.throw(e),
+          [Symbol.asyncIterator]() {
+            return this;
+          },
+        } as AsyncGenerator<SDKMessage, void>);
 
   // Prime the generator eagerly so initialization (SessionStart hooks,
   // mcp.connectAll, the init system message and initDeferred.resolve) runs at

--- a/projects/silver-core-sdk/src/reporting/run-log.ts
+++ b/projects/silver-core-sdk/src/reporting/run-log.ts
@@ -1,0 +1,148 @@
+/**
+ * Run-signal ledger (self-improvement spec SCS-REQ-002 loop 1 / REQ-1.1).
+ *
+ * Opt-in via Options.runLog: every result message the consumer sees is
+ * mirrored as ONE JSONL line in `{dir}/runlog-{YYYY-MM-DD}.jsonl` (UTC day
+ * files). This is the signal source generateRuntimeReport() aggregates —
+ * facts only, no conversation content: termination subtype, turn/duration
+ * counters, token usage, cost, cache ratio, the transport-health disconnect
+ * ledger, per-tool call/error counters, and model ids.
+ *
+ * Incognito boundary (spec §6.4): an incognito session still contributes
+ * transport-health and token statistics (no content), but its record carries
+ * no session id, no scenario tag and no error text, and is excluded from the
+ * report's failed-sessions section.
+ *
+ * Writes are fire-and-forget appends — a ledger fault must never break the
+ * run (it is observability, not the task).
+ */
+
+import { appendFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import type {
+  RunLogOptions,
+  SDKMessage,
+  SDKResultMessage,
+  SDKTransportHealth,
+} from '../types.js';
+
+export type { RunLogOptions };
+
+/** One ledger line. Field names are the wire contract consumed by
+ *  generateRuntimeReport() and by BPT-side log producers (spec §6.1). */
+export type RunLogRecord = {
+  /** Record schema version (bump on breaking shape changes). */
+  v: 1;
+  ts: string;
+  /** Absent on incognito records. */
+  session_id?: string;
+  /** Consumer-supplied workload tag, e.g. 'coding' / 'non-coding'. Absent on
+   *  incognito records. */
+  scenario?: string;
+  subtype: string;
+  is_error: boolean;
+  num_turns: number;
+  duration_ms: number;
+  duration_api_ms: number;
+  total_cost_usd: number;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens: number;
+    cache_creation_input_tokens: number;
+  };
+  cache_hit_ratio?: number;
+  transport_health?: SDKTransportHealth;
+  per_tool?: Array<{ name: string; calls: number; errors: number }>;
+  models?: string[];
+  incognito?: true;
+  /** First line of the error, when the result is an error. Absent on
+   *  incognito records. */
+  error?: string;
+};
+
+export type RunLogSink = {
+  /** Observe one consumer-facing message; mirrors result messages. */
+  observe(msg: SDKMessage): void;
+};
+
+/** UTC day file name for a timestamp. */
+export function runLogFileName(ts: Date): string {
+  return `runlog-${ts.toISOString().slice(0, 10)}.jsonl`;
+}
+
+export function buildRunLogRecord(
+  msg: SDKResultMessage,
+  opts: { scenario?: string; incognito: boolean; now?: Date },
+): RunLogRecord {
+  const m = msg as SDKResultMessage & { errorMessage?: string };
+  const usage = m.usage;
+  const record: RunLogRecord = {
+    v: 1,
+    ts: (opts.now ?? new Date()).toISOString(),
+    subtype: m.subtype,
+    is_error: m.is_error === true,
+    num_turns: m.num_turns,
+    duration_ms: m.duration_ms,
+    duration_api_ms: m.duration_api_ms,
+    total_cost_usd: m.total_cost_usd,
+    usage: {
+      input_tokens: usage.input_tokens,
+      output_tokens: usage.output_tokens,
+      cache_read_input_tokens: usage.cache_read_input_tokens,
+      cache_creation_input_tokens: usage.cache_creation_input_tokens,
+    },
+  };
+  const metrics = m.metrics;
+  if (metrics?.cacheHitRatio !== undefined) record.cache_hit_ratio = metrics.cacheHitRatio;
+  if (metrics?.transportHealth !== undefined) record.transport_health = metrics.transportHealth;
+  if (metrics?.perTool !== undefined && metrics.perTool.length > 0) {
+    record.per_tool = metrics.perTool.map((t) => ({
+      name: t.name,
+      calls: t.calls,
+      errors: t.errors,
+    }));
+  }
+  if (metrics?.modelUsage !== undefined) {
+    const models = Object.keys(metrics.modelUsage);
+    if (models.length > 0) record.models = models;
+  }
+  if (opts.incognito) {
+    // §6.4: transport/token stats stay; identity, tags and content-adjacent
+    // fields go.
+    record.incognito = true;
+  } else {
+    record.session_id = m.session_id;
+    if (opts.scenario !== undefined) record.scenario = opts.scenario;
+    if (m.is_error === true && typeof m.errorMessage === 'string') {
+      record.error = m.errorMessage.split('\n')[0]!.slice(0, 300);
+    }
+  }
+  return record;
+}
+
+export function createRunLogSink(args: {
+  runLog: RunLogOptions;
+  incognito: boolean;
+  debug: (msg: string) => void;
+}): RunLogSink {
+  const { runLog, incognito, debug } = args;
+  let dirReady: Promise<void> | null = null;
+  const ensureDir = (): Promise<void> => {
+    dirReady ??= mkdir(runLog.dir, { recursive: true }).then(() => undefined);
+    return dirReady;
+  };
+  return {
+    observe(msg: SDKMessage): void {
+      if (msg.type !== 'result') return;
+      const record = buildRunLogRecord(msg, {
+        incognito,
+        ...(runLog.scenario !== undefined ? { scenario: runLog.scenario } : {}),
+      });
+      const line = `${JSON.stringify(record)}\n`;
+      void ensureDir()
+        .then(() => appendFile(join(runLog.dir, runLogFileName(new Date())), line, 'utf8'))
+        .catch((err) => debug(`runLog: append failed (ignored): ${String(err)}`));
+    },
+  };
+}

--- a/projects/silver-core-sdk/src/reporting/runtime-report.ts
+++ b/projects/silver-core-sdk/src/reporting/runtime-report.ts
@@ -1,0 +1,291 @@
+/**
+ * Daily runtime report (self-improvement spec SCS-REQ-002 loop 1 / REQ-1.1).
+ *
+ * generateRuntimeReport() aggregates the run-signal ledger (run-log.ts JSONL
+ * day files) over a rolling window (default 24h) into ONE agent-readable
+ * Markdown file — the replacement for a human trawling dashboards. Four
+ * signal sections, each explicitly marked "无数据" when its signal is absent
+ * (REQ-1.1 acceptance: no silent omissions):
+ *
+ *  1. 传输健康 — transport-health ledger totals by cause, plus the sessions
+ *     whose faults exceeded the recoverable layers (unrecovered list);
+ *  2. token 消耗 — input/output totals, cache hit rate, top consumers split
+ *     by scenario tag;
+ *  3. 工具调用 — tool name × call count × failure rate;
+ *  4. 失败会话 — non-success terminations, facts only (subtype + first error
+ *     line; incognito records are excluded from this section by
+ *     construction — their ledger lines carry no identity or error text).
+ *
+ * Zero runtime dependencies; pure node:fs. The report targets <= 8K tokens:
+ * lists are capped (top N), and the caps are stated inline when they bite.
+ */
+
+import { readdir, readFile, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { RunLogRecord } from './run-log.js';
+
+export type RuntimeReportOptions = {
+  /** Directory holding runlog-*.jsonl day files (RunLogOptions.dir). */
+  logDir: string;
+  /** Output directory; default `{logDir}/../reports`. Set null to skip writing. */
+  outDir?: string | null;
+  /** Window end; default now. */
+  now?: Date;
+  /** Rolling window size; default 24h. */
+  windowHours?: number;
+  /** Cap for every list section; default 5. */
+  topN?: number;
+};
+
+export type RuntimeReportResult = {
+  /** Absolute path of the written file, or null when outDir is null. */
+  path: string | null;
+  markdown: string;
+  /** Machine-readable aggregation (what the Markdown renders). */
+  summary: {
+    window: { from: string; to: string };
+    records: number;
+    sessions: number;
+    incognitoRecords: number;
+    transport: Record<string, number> | null;
+    unrecovered: Array<{ session_id: string; detail: string }>;
+    tokens: {
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheCreation: number;
+      cacheHitRate: number | null;
+      costUsd: number;
+    } | null;
+    tools: Array<{ name: string; calls: number; errors: number }> | null;
+    failures: Array<{ session_id: string; subtype: string; error?: string }> | null;
+  };
+};
+
+function fmtPct(x: number): string {
+  return `${(x * 100).toFixed(1)}%`;
+}
+
+/** Parse every ledger line in the window (bad lines are counted, not fatal). */
+async function readWindow(
+  logDir: string,
+  from: Date,
+  to: Date,
+): Promise<{ records: RunLogRecord[]; badLines: number }> {
+  let names: string[] = [];
+  try {
+    names = (await readdir(logDir)).filter((n) => /^runlog-\d{4}-\d{2}-\d{2}\.jsonl$/.test(n));
+  } catch {
+    return { records: [], badLines: 0 };
+  }
+  // Day files: only days intersecting the window need reading.
+  const fromDay = from.toISOString().slice(0, 10);
+  const toDay = to.toISOString().slice(0, 10);
+  const records: RunLogRecord[] = [];
+  let badLines = 0;
+  for (const name of names.sort()) {
+    const day = name.slice('runlog-'.length, -'.jsonl'.length);
+    if (day < fromDay || day > toDay) continue;
+    const text = await readFile(join(logDir, name), 'utf8');
+    for (const line of text.split('\n')) {
+      if (line.trim().length === 0) continue;
+      try {
+        const rec = JSON.parse(line) as RunLogRecord;
+        const t = new Date(rec.ts).getTime();
+        if (t >= from.getTime() && t <= to.getTime()) records.push(rec);
+      } catch {
+        badLines += 1;
+      }
+    }
+  }
+  return { records, badLines };
+}
+
+export async function generateRuntimeReport(
+  options: RuntimeReportOptions,
+): Promise<RuntimeReportResult> {
+  const now = options.now ?? new Date();
+  const windowMs = (options.windowHours ?? 24) * 3_600_000;
+  const from = new Date(now.getTime() - windowMs);
+  const topN = options.topN ?? 5;
+  const { records, badLines } = await readWindow(options.logDir, from, now);
+
+  const named = records.filter((r) => r.incognito !== true);
+  const sessions = new Set(named.map((r) => r.session_id));
+
+  // 1. transport health
+  const transportRecords = records.filter((r) => r.transport_health !== undefined);
+  let transport: Record<string, number> | null = null;
+  const unrecovered: Array<{ session_id: string; detail: string }> = [];
+  if (transportRecords.length > 0) {
+    transport = {};
+    for (const r of transportRecords) {
+      for (const [k, v] of Object.entries(r.transport_health!)) {
+        transport[k] = (transport[k] ?? 0) + (typeof v === 'number' ? v : 0);
+      }
+      // "Unrecovered" = the run still ended as an error while its ledger shows
+      // transport faults: the recoverable layers were not enough.
+      const faults = Object.values(r.transport_health!).reduce(
+        (a, b) => a + (typeof b === 'number' ? b : 0),
+        0,
+      );
+      if (r.is_error && faults > 0 && r.incognito !== true) {
+        unrecovered.push({
+          session_id: r.session_id ?? '(unknown)',
+          detail: `${r.subtype}; faults=${faults}${r.error !== undefined ? `; ${r.error}` : ''}`,
+        });
+      }
+    }
+  }
+
+  // 2. tokens
+  let tokens: RuntimeReportResult['summary']['tokens'] = null;
+  if (records.length > 0) {
+    const input = records.reduce((a, r) => a + r.usage.input_tokens, 0);
+    const output = records.reduce((a, r) => a + r.usage.output_tokens, 0);
+    const cacheRead = records.reduce((a, r) => a + r.usage.cache_read_input_tokens, 0);
+    const cacheCreation = records.reduce((a, r) => a + r.usage.cache_creation_input_tokens, 0);
+    const denom = input + cacheRead;
+    tokens = {
+      input,
+      output,
+      cacheRead,
+      cacheCreation,
+      cacheHitRate: denom > 0 ? cacheRead / denom : null,
+      costUsd: records.reduce((a, r) => a + r.total_cost_usd, 0),
+    };
+  }
+  const byScenario = new Map<string, RunLogRecord[]>();
+  for (const r of named) {
+    const key = r.scenario ?? '(untagged)';
+    const arr = byScenario.get(key) ?? [];
+    arr.push(r);
+    byScenario.set(key, arr);
+  }
+
+  // 3. tools
+  const toolAgg = new Map<string, { calls: number; errors: number }>();
+  for (const r of records) {
+    for (const t of r.per_tool ?? []) {
+      const cur = toolAgg.get(t.name) ?? { calls: 0, errors: 0 };
+      cur.calls += t.calls;
+      cur.errors += t.errors;
+      toolAgg.set(t.name, cur);
+    }
+  }
+  const tools =
+    toolAgg.size > 0
+      ? [...toolAgg.entries()]
+          .map(([name, v]) => ({ name, ...v }))
+          .sort((a, b) => b.calls - a.calls)
+      : null;
+
+  // 4. failures (named records only — incognito is excluded by construction)
+  const failureRecords = named.filter((r) => r.is_error);
+  const failures =
+    failureRecords.length > 0
+      ? failureRecords.map((r) => ({
+          session_id: r.session_id ?? '(unknown)',
+          subtype: r.subtype,
+          ...(r.error !== undefined ? { error: r.error } : {}),
+        }))
+      : null;
+
+  // ---- render -------------------------------------------------------------
+  const date = now.toISOString().slice(0, 10);
+  const lines: string[] = [
+    `# Runtime report — ${date}`,
+    '',
+    `- window: ${from.toISOString()} → ${now.toISOString()} (${options.windowHours ?? 24}h)`,
+    `- records: ${records.length} (${sessions.size} sessions, ${records.length - named.length} incognito${badLines > 0 ? `, ${badLines} unparseable lines skipped` : ''})`,
+    '',
+    '## 1. 传输健康 (transportHealth)',
+  ];
+  if (transport === null) {
+    lines.push('无数据(窗口内无携带 transport_health 的记录)。');
+  } else {
+    const entries = Object.entries(transport).filter(([, v]) => v > 0);
+    lines.push(
+      entries.length === 0
+        ? '- 全零(窗口内所有运行网络干净)。'
+        : entries.map(([k, v]) => `- ${k}: ${v}`).join('\n'),
+    );
+    lines.push('', '### 未恢复会话');
+    if (unrecovered.length === 0) lines.push('无(所有传输故障均被恢复层吸收)。');
+    else {
+      for (const u of unrecovered.slice(0, topN)) lines.push(`- ${u.session_id}: ${u.detail}`);
+      if (unrecovered.length > topN) lines.push(`- …共 ${unrecovered.length} 条(截断至前 ${topN})`);
+    }
+  }
+  lines.push('', '## 2. token 消耗');
+  if (tokens === null) {
+    lines.push('无数据(窗口内无记录)。');
+  } else {
+    lines.push(
+      `- input ${tokens.input} / output ${tokens.output} / cache_read ${tokens.cacheRead} / cache_creation ${tokens.cacheCreation}`,
+      `- 缓存命中率: ${tokens.cacheHitRate === null ? '无数据(零输入)' : fmtPct(tokens.cacheHitRate)}`,
+      `- 成本合计: $${tokens.costUsd.toFixed(4)}`,
+      '',
+      '### 按场景 top 消耗',
+    );
+    if (byScenario.size === 0) lines.push('无数据(窗口内无具名记录)。');
+    for (const [scenario, rs] of byScenario) {
+      const top = [...rs]
+        .sort((a, b) => b.usage.output_tokens - a.usage.output_tokens)
+        .slice(0, topN);
+      lines.push(`- **${scenario}**(${rs.length} 条):`);
+      for (const r of top) {
+        lines.push(
+          `  - ${r.session_id}: out ${r.usage.output_tokens}, in ${r.usage.input_tokens}, $${r.total_cost_usd.toFixed(4)}`,
+        );
+      }
+    }
+  }
+  lines.push('', '## 3. 工具调用');
+  if (tools === null) {
+    lines.push('无数据(窗口内无携带 per_tool 的记录)。');
+  } else {
+    lines.push('| tool | calls | errors | failure rate |', '|---|---|---|---|');
+    for (const t of tools.slice(0, Math.max(topN * 2, 10))) {
+      lines.push(`| ${t.name} | ${t.calls} | ${t.errors} | ${fmtPct(t.errors / t.calls)} |`);
+    }
+    if (tools.length > Math.max(topN * 2, 10)) {
+      lines.push('', `…共 ${tools.length} 个工具(截断)。`);
+    }
+  }
+  lines.push('', '## 4. 失败会话(仅事实)');
+  if (failures === null) {
+    lines.push('无数据(窗口内无失败的具名会话)。');
+  } else {
+    for (const f of failures.slice(0, topN * 2)) {
+      lines.push(`- ${f.session_id}: ${f.subtype}${f.error !== undefined ? ` — ${f.error}` : ''}`);
+    }
+    if (failures.length > topN * 2) lines.push(`- …共 ${failures.length} 条(截断)。`);
+  }
+  lines.push('');
+  const markdown = lines.join('\n');
+
+  let path: string | null = null;
+  if (options.outDir !== null) {
+    const outDir = options.outDir ?? join(options.logDir, '..', 'reports');
+    await mkdir(outDir, { recursive: true });
+    path = join(outDir, `runtime-report-${date}.md`);
+    await writeFile(path, markdown, 'utf8');
+  }
+
+  return {
+    path,
+    markdown,
+    summary: {
+      window: { from: from.toISOString(), to: now.toISOString() },
+      records: records.length,
+      sessions: sessions.size,
+      incognitoRecords: records.length - named.length,
+      transport,
+      unrecovered,
+      tokens,
+      tools,
+      failures,
+    },
+  };
+}

--- a/projects/silver-core-sdk/src/types.ts
+++ b/projects/silver-core-sdk/src/types.ts
@@ -1343,6 +1343,18 @@ export type MemoryMount = {
  * the object enables the `memory` tool (set `enabled: false` to keep a shared
  * options spread but switch the system off).
  */
+/**
+ * Run-signal ledger options (self-improvement spec SCS-REQ-002 loop 1 /
+ * REQ-1.1; see src/reporting/run-log.ts for the record contract).
+ */
+export type RunLogOptions = {
+  /** Directory for the runlog-{YYYY-MM-DD}.jsonl day files (created on demand). */
+  dir: string;
+  /** Workload tag stamped on every record of this query (e.g. 'coding' /
+   *  'non-coding'); the report's top-consumer split keys on it. */
+  scenario?: string;
+};
+
 export type MemoryOptions = {
   /** Default true when the object is present. */
   enabled?: boolean;
@@ -1717,6 +1729,13 @@ export type Options = {
   /** BPT-EXTENSION: cross-session memory tool (memory_20250818 equivalence);
    *  see MemoryOptions + docs/MEMORY.md. Absent -> no memory tool. */
   memory?: MemoryOptions;
+  /** BPT-EXTENSION (self-improvement spec SCS-REQ-002 loop 1): mirror every
+   *  consumer-facing result message as one JSONL line in
+   *  `{dir}/runlog-{YYYY-MM-DD}.jsonl` — the signal source
+   *  generateRuntimeReport() aggregates. Facts only, no conversation content;
+   *  incognito sessions contribute transport/token statistics but no
+   *  identity, tag or error text. Absent -> no ledger writes. */
+  runLog?: RunLogOptions;
   /** Mirror session transcripts to an external backend (S3/Redis/DB). */
   sessionStore?: SessionStore;
   /** Flush cadence for sessionStore mirror writes. Default 'batched'. */

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.49.0';
+export const SDK_VERSION = '0.50.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/runtime-report.test.ts
+++ b/projects/silver-core-sdk/tests/runtime-report.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Run-signal ledger + daily runtime report (SCS-REQ-002 loop 1 / REQ-1.1):
+ *  - record builder: facts only; the incognito boundary strips identity,
+ *    scenario and error text but keeps transport/token statistics (§6.4);
+ *  - query() wiring: a run with options.runLog leaves one JSONL record per
+ *    consumer-facing result, written through the single choke point;
+ *  - generateRuntimeReport(): four sections aggregate correctly, absent
+ *    signals render an explicit 无数据 marker (never silently omitted),
+ *    window filtering and unrecovered detection work.
+ */
+import { mkdtemp, readFile, readdir, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { query } from '../src/query.js';
+import {
+  buildRunLogRecord,
+  createRunLogSink,
+  generateRuntimeReport,
+  runLogFileName,
+} from '../src/index.js';
+import type { Options, SDKMessage, SDKResultMessage } from '../src/types.js';
+import { makeSSEFetch, type SSEFetchStub } from './helpers/sse-fetch.js';
+import { textReplyEvents } from './helpers/mock-transport.js';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'runlog-test-'));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function resultFixture(over: Partial<SDKResultMessage & { errorMessage: string }> = {}) {
+  return {
+    type: 'result',
+    subtype: 'success',
+    uuid: 'u1',
+    session_id: 'sess-1',
+    is_error: false,
+    num_turns: 2,
+    duration_ms: 1200,
+    duration_api_ms: 900,
+    total_cost_usd: 0.01,
+    stop_reason: 'end_turn',
+    usage: {
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: 400,
+      cache_creation_input_tokens: 20,
+    },
+    metrics: {
+      numTurns: 2,
+      durationMs: 1200,
+      durationApiMs: 900,
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 400,
+        cache_creation_input_tokens: 20,
+      },
+      totalCostUsd: 0.01,
+      cacheHitRatio: 0.8,
+      perTurn: [],
+      perTool: [{ name: 'Read', calls: 3, totalMs: 30, errors: 1 }],
+      modelUsage: { 'claude-test-1': {} },
+      transportHealth: {
+        networkRetries: 2,
+        httpRetries: 0,
+        emptyStreamRetries: 0,
+        midStreamDrops: 1,
+        idleStalls: 0,
+        maxDurationAborts: 0,
+        turnsSalvaged: 1,
+        turnReplays: 0,
+      },
+    },
+    ...over,
+  } as unknown as SDKResultMessage;
+}
+
+describe('buildRunLogRecord', () => {
+  it('captures facts: subtype, counters, usage, transport, tools, models', () => {
+    const rec = buildRunLogRecord(resultFixture(), { incognito: false, scenario: 'coding' });
+    expect(rec.v).toBe(1);
+    expect(rec.session_id).toBe('sess-1');
+    expect(rec.scenario).toBe('coding');
+    expect(rec.usage.cache_read_input_tokens).toBe(400);
+    expect(rec.cache_hit_ratio).toBe(0.8);
+    expect(rec.transport_health?.networkRetries).toBe(2);
+    expect(rec.per_tool).toEqual([{ name: 'Read', calls: 3, errors: 1 }]);
+    expect(rec.models).toEqual(['claude-test-1']);
+  });
+
+  it('incognito strips identity, scenario and error text but keeps stats (§6.4)', () => {
+    const rec = buildRunLogRecord(
+      resultFixture({
+        subtype: 'error_during_execution',
+        is_error: true,
+        errorMessage: 'boom\nsecond line',
+      } as never),
+      { incognito: true, scenario: 'coding' },
+    );
+    expect(rec.incognito).toBe(true);
+    expect(rec.session_id).toBeUndefined();
+    expect(rec.scenario).toBeUndefined();
+    expect(rec.error).toBeUndefined();
+    expect(rec.transport_health).toBeDefined();
+    expect(rec.usage.output_tokens).toBe(50);
+  });
+
+  it('named error records keep only the first error line, capped', () => {
+    const rec = buildRunLogRecord(
+      resultFixture({
+        subtype: 'error_during_execution',
+        is_error: true,
+        errorMessage: `${'x'.repeat(500)}\ntail`,
+      } as never),
+      { incognito: false },
+    );
+    expect(rec.error).toHaveLength(300);
+    expect(rec.error).not.toContain('tail');
+  });
+});
+
+describe('createRunLogSink', () => {
+  it('mirrors result messages only, one line each; non-results are ignored', async () => {
+    const logDir = join(dir, 'sink');
+    const sink = createRunLogSink({
+      runLog: { dir: logDir, scenario: 's' },
+      incognito: false,
+      debug: () => {},
+    });
+    sink.observe({ type: 'system', subtype: 'init' } as never);
+    sink.observe(resultFixture() as never);
+    sink.observe(resultFixture({ session_id: 'sess-9' } as never) as never);
+    await new Promise((r) => setTimeout(r, 50));
+    const lines = (await readFile(join(logDir, runLogFileName(new Date())), 'utf8'))
+      .trim()
+      .split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1]!).session_id).toBe('sess-9');
+  });
+});
+
+describe('query() runLog wiring', () => {
+  it('writes one ledger record per consumer-facing result', async () => {
+    const stub: SSEFetchStub = makeSSEFetch([textReplyEvents('ok')]);
+    const logDir = join(dir, 'runlog');
+    const options: Options = {
+      cwd: dir,
+      sessionDir: join(dir, 'sessions'),
+      provider: { apiKey: 'k', promptCaching: false, fetch: stub },
+      env: { PATH: process.env.PATH, HOME: process.env.HOME },
+      model: 'claude-sonnet-4-5',
+      settingSources: [],
+      runLog: { dir: logDir, scenario: 'eval-fixture' },
+    };
+    const messages: SDKMessage[] = [];
+    for await (const m of query({ prompt: 'hi', options })) messages.push(m);
+    // fire-and-forget append: give the microtask queue one tick
+    await new Promise((r) => setTimeout(r, 50));
+
+    const files = await readdir(logDir);
+    expect(files).toEqual([runLogFileName(new Date())]);
+    const lines = (await readFile(join(logDir, files[0]!), 'utf8')).trim().split('\n');
+    const results = messages.filter((m) => m.type === 'result');
+    expect(lines).toHaveLength(results.length);
+    const rec = JSON.parse(lines[0]!);
+    expect(rec.subtype).toBe('success');
+    expect(rec.scenario).toBe('eval-fixture');
+    expect(typeof rec.session_id).toBe('string');
+  });
+});
+
+describe('generateRuntimeReport', () => {
+  const T0 = new Date('2026-07-11T12:00:00Z');
+
+  async function seedLedger(records: object[], day = '2026-07-11') {
+    const logDir = join(dir, 'ledger');
+    await mkdir(logDir, { recursive: true });
+    await writeFile(
+      join(logDir, `runlog-${day}.jsonl`),
+      records.map((r) => JSON.stringify(r)).join('\n') + '\n',
+    );
+    return logDir;
+  }
+
+  it('aggregates the four sections and writes runtime-report-{date}.md', async () => {
+    const base = buildRunLogRecord(resultFixture(), { incognito: false, scenario: 'coding' });
+    const fail = buildRunLogRecord(
+      resultFixture({
+        session_id: 'sess-2',
+        subtype: 'error_during_execution',
+        is_error: true,
+        errorMessage: 'transport gave up',
+      } as never),
+      { incognito: false, scenario: 'non-coding' },
+    );
+    const ghost = buildRunLogRecord(resultFixture(), { incognito: true });
+    const logDir = await seedLedger(
+      [base, fail, ghost].map((r) => ({ ...r, ts: '2026-07-11T11:00:00Z' })),
+    );
+
+    const report = await generateRuntimeReport({ logDir, now: T0 });
+    expect(report.path).not.toBeNull();
+    expect(report.path).toContain('runtime-report-2026-07-11.md');
+    const md = report.markdown;
+    // 1. transport totals summed across records (3 records x fixture ledger)
+    expect(md).toContain('networkRetries: 6');
+    // unrecovered: the failed named record had faults AND ended as an error
+    expect(md).toContain('sess-2');
+    // 2. tokens + scenario split
+    expect(report.summary.tokens?.input).toBe(300);
+    expect(md).toContain('缓存命中率');
+    expect(md).toContain('**coding**');
+    expect(md).toContain('**non-coding**');
+    // 3. tools table with failure rate
+    expect(md).toContain('| Read | 9 | 3 | 33.3% |');
+    // 4. failures: named only — the incognito record contributes stats, not rows
+    expect(report.summary.failures).toHaveLength(1);
+    expect(report.summary.incognitoRecords).toBe(1);
+    expect(md).toContain('transport gave up');
+  });
+
+  it('absent signals render explicit 无数据 markers, never silent omission', async () => {
+    const logDir = await seedLedger([]);
+    const report = await generateRuntimeReport({ logDir, now: T0, outDir: null });
+    expect(report.path).toBeNull();
+    for (const section of ['## 1. 传输健康', '## 2. token 消耗', '## 3. 工具调用', '## 4. 失败会话']) {
+      expect(report.markdown).toContain(section);
+    }
+    expect(report.markdown.match(/无数据/g)!.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('window filtering drops records outside the rolling window', async () => {
+    const inWin = { ...buildRunLogRecord(resultFixture(), { incognito: false }), ts: '2026-07-11T11:30:00Z' };
+    const outWin = { ...buildRunLogRecord(resultFixture(), { incognito: false }), ts: '2026-07-09T11:30:00Z' };
+    const logDir = await seedLedger([inWin]);
+    await writeFile(
+      join(logDir, 'runlog-2026-07-09.jsonl'),
+      JSON.stringify(outWin) + '\n',
+    );
+    const report = await generateRuntimeReport({ logDir, now: T0, outDir: null });
+    expect(report.summary.records).toBe(1);
+  });
+
+  it('missing log directory degrades to an all-无数据 report, not a throw', async () => {
+    const report = await generateRuntimeReport({
+      logDir: join(dir, 'does-not-exist'),
+      now: T0,
+      outDir: null,
+    });
+    expect(report.summary.records).toBe(0);
+    expect(report.markdown).toContain('无数据');
+  });
+});


### PR DESCRIPTION
<!-- 内部（守密人 / AI 会话）PR -->

## 概述

Phase 2 第一件:环一信号侧落地(REQ-1.1),SDK v0.50.0。

- **`options.runLog` 运行台账**:每条 result 消息镜像为一行 JSONL(终止子类型 / 轮次时长 / token 用量 + 缓存命中率 / 成本 / transportHealth 断流台账 / 逐工具调用×错误 / 模型号——**仅事实,零对话内容**;无痕会话计传输与 token 统计、不留身份/标签/错误文本,合 §6.4 边界;写失败绝不打断运行;拦截点在 Query 包装层单一咽喉,全部 result 路径覆盖)
- **`generateRuntimeReport()`**:滚动窗(默认 24h)聚合为 `runtime-report-{date}.md` 四节(传输健康+未恢复清单 / token 按场景 / 工具×失败率 / 失败会话仅事实);缺信号显式「无数据」、列表截断处注明、目录缺失优雅降级
- **附带修复**:runEvals 场景会话补 `allowDangerouslySkipPermissions`——首轮 LIVE(run #58)12 道可驱动题全部被 SDK 自家安全门拦下(判卷零花费,错误在构造期抛出);STUB 复跑 12 STUB + 8 PENDING、零 error

## 验证清单(对话内测试)

- [x] SDK vitest **1868 绿 + 2 skip**(+9:台账 3 / 报告 4 / 接线 1 / sink 1)
- [x] 仓级 pytest **2792 绿**
- [x] `tsc --noEmit` / `npm run build` 零错;STUB 双层冒烟零 error
- [x] 版本三方对账 v0.50.0;零新增运行时依赖(纯 node:fs)
- [x] 不引入 emoji

## 关联

- Refs:PR #608(Phase 0+1)/ #610(定稿)/ run [#58](https://github.com/lightproud/brain-in-a-vat/actions/runs/29176144516)(首轮 LIVE 读数);REQ-1.2 compareReports 留 P1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrYSYWGSEKi5ysva5VDB8a)_