### PR TITLE
fix(news): backfill_gap writes via archive_layout — repair post-4R path rot

### DIFF
--- a/projects/news/scripts/backfill_gap.py
+++ b/projects/news/scripts/backfill_gap.py
@@ -25,10 +25,12 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(me
 logger = logging.getLogger(__name__)
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-PLATFORMS_DIR = _REPO_ROOT / 'projects' / 'news' / 'data' / 'platforms'
+# 4R 迁移后全量档案层现址（旧 projects/news/data/platforms 已废，2026-07-12 修复）
+ARCHIVE_DIR = _REPO_ROOT / 'Public-Info-Pool' / 'Record' / 'Community'
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import news_common  # 日志脱敏单一真源（H3）
+import archive_layout  # noqa: E402  归档布局单一真相源（2026-07-02 P0-1）
 
 
 def _gap_bound(env_name: str, default: datetime, end_of_day: bool) -> datetime:
@@ -68,9 +70,9 @@ def _archive_items(source: str, items: list[dict]):
             continue
 
     for date_str, date_items in by_date.items():
-        out_dir = PLATFORMS_DIR / source
-        out_dir.mkdir(parents=True, exist_ok=True)
-        out_path = out_dir / f'{date_str}.json'
+        platform, region, subtype = archive_layout.resolve_write_layout(source)
+        out_path = ARCHIVE_DIR / archive_layout.build_relpath(platform, region, subtype, date_str)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
 
         existing = []
         if out_path.exists():
@@ -455,11 +457,15 @@ def backfill_steam_reviews():
 def cleanup_empty_placeholders():
     """Remove empty placeholder files created by repair_gaps.py for the gap period."""
     removed = 0
-    for source_dir in sorted(PLATFORMS_DIR.iterdir()):
+    gap_dates = []
+    d = GAP_START
+    while d.date() <= GAP_END.date():
+        gap_dates.append(d.strftime('%Y-%m-%d'))
+        d += timedelta(days=1)
+    for source_dir in sorted(ARCHIVE_DIR.iterdir()):
         if not source_dir.is_dir():
             continue
-        for day in range(13, 26):
-            date_str = f'2026-04-{day:02d}'
+        for date_str in gap_dates:
             path = source_dir / f'{date_str}.json'
             if not path.exists():
                 continue

--- a/tests/test_backfill_gap.py
+++ b/tests/test_backfill_gap.py
@@ -1,7 +1,7 @@
 """backfill_gap 纯逻辑 + 各平台回溯函数（网络全打桩）单测。
 
 requests / global_collectors._get / subprocess (curl) 一律 mock；归档写入
-monkeypatch PLATFORMS_DIR 到 tmp 目录，绝不污染真实 data/platforms、绝不触网。
+monkeypatch ARCHIVE_DIR 到 tmp 目录，绝不污染真实 Community 归档、绝不触网。
 """
 
 import json
@@ -41,7 +41,7 @@ class TestGapBound(unittest.TestCase):
 
 class TestArchiveItems(unittest.TestCase):
     def _patch_dir(self, d):
-        return mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d))
+        return mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d))
 
     def test_buckets_by_utc8_date(self):
         with tempfile.TemporaryDirectory() as d:
@@ -103,7 +103,7 @@ class TestCleanupEmptyPlaceholders(unittest.TestCase):
                 {"_gap_repaired": True, "items": [{"url": "x"}]}), encoding="utf-8")
             (sdir / "2026-04-17.json").write_text(json.dumps(
                 {"items": []}), encoding="utf-8")  # not repaired flag
-            with mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)):
+            with mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)):
                 removed = backfill_gap.cleanup_empty_placeholders()
             self.assertEqual(removed, 1)
             self.assertFalse((sdir / "2026-04-15.json").exists())
@@ -113,7 +113,7 @@ class TestCleanupEmptyPlaceholders(unittest.TestCase):
     def test_ignores_non_directories(self):
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "loose.txt").write_text("x")
-            with mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)):
+            with mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)):
                 self.assertEqual(backfill_gap.cleanup_empty_placeholders(), 0)
 
 
@@ -132,7 +132,7 @@ class TestBackfillReddit(unittest.TestCase):
     def test_collects_items_in_gap(self):
         in_gap = backfill_gap.GAP_START.timestamp() + 3600
         with tempfile.TemporaryDirectory() as d, \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import requests as _req
@@ -178,7 +178,7 @@ class TestBackfillYoutube(unittest.TestCase):
         ]}
         with tempfile.TemporaryDirectory() as d, \
                 mock.patch.dict(backfill_gap.os.environ, {"YOUTUBE_API_KEY": "k"}), \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)):
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)):
             import global_collectors as gc
             with mock.patch.object(gc, "_get", side_effect=[search_resp, stats_resp] * 3):
                 n = backfill_gap.backfill_youtube()
@@ -204,7 +204,7 @@ class TestBackfillBilibili(unittest.TestCase):
              "arcurl": "url", "play": 20000, "favorites": 1, "author": "a"}
         ]}}
         with tempfile.TemporaryDirectory() as d, \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import global_collectors as gc
@@ -229,7 +229,7 @@ class TestBackfillWeibo(unittest.TestCase):
         empty.json.return_value = {"data": {"cards": []}}
         with tempfile.TemporaryDirectory() as d, \
                 mock.patch.dict(backfill_gap.os.environ, {}, clear=True), \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import requests as _req
@@ -254,7 +254,7 @@ class TestBackfillSteam(unittest.TestCase):
         empty.returncode = 0
         empty.stdout = json.dumps({"reviews": [], "cursor": "next2"})
         with tempfile.TemporaryDirectory() as d, \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import subprocess as sp

--- a/tests/test_backfill_gap_more.py
+++ b/tests/test_backfill_gap_more.py
@@ -1,7 +1,7 @@
 """backfill_gap 补充覆盖：异常分支 / 边界过滤 / 分页短路 / main 编排。
 
 补 tests/test_backfill_gap.py 未触及的错误/边界路径。网络全打桩，归档写入
-monkeypatch PLATFORMS_DIR 到 tmp，绝不触网、绝不污染真实 data/platforms。
+monkeypatch ARCHIVE_DIR 到 tmp，绝不触网、绝不污染真实 Community 归档。
 """
 
 import json
@@ -19,7 +19,7 @@ import backfill_gap  # noqa: E402
 
 class TestArchiveItemsEdge(unittest.TestCase):
     def _patch_dir(self, d):
-        return mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d))
+        return mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d))
 
     def test_gap_repaired_placeholder_existing_cleared(self):
         # 已有文件标记 _gap_repaired 且 items 为空 → existing 被清空，新条目正常合并 (81-83)
@@ -58,13 +58,13 @@ def _reddit_resp(children, after=None, status=200):
 
 class TestBackfillRedditEdge(unittest.TestCase):
     # backfill_reddit() archives collected in-gap posts via _archive_items, which
-    # writes under PLATFORMS_DIR. Redirect it to a tmp dir for EVERY test in this
+    # writes under ARCHIVE_DIR. Redirect it to a tmp dir for EVERY test in this
     # class so an in-gap collection (e.g. test_pagination_sleep_and_continue) can
     # never leak a real file into projects/news/data/platforms/ (test isolation).
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self._patch = mock.patch.object(
-            backfill_gap, "PLATFORMS_DIR", Path(self._tmp.name))
+            backfill_gap, "ARCHIVE_DIR", Path(self._tmp.name))
         self._patch.start()
         self.addCleanup(self._tmp.cleanup)
         self.addCleanup(self._patch.stop)
@@ -130,7 +130,7 @@ class TestBackfillBilibiliEdge(unittest.TestCase):
         empty = mock.MagicMock()
         empty.json.return_value = {"data": {"result": []}}
         with tempfile.TemporaryDirectory() as d, \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import global_collectors as gc
@@ -141,7 +141,7 @@ class TestBackfillBilibiliEdge(unittest.TestCase):
     def test_exception_sleeps_and_breaks(self):
         # _get 抛异常 → except: time.sleep(5); break (280-283)
         with tempfile.TemporaryDirectory() as d, \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import global_collectors as gc
@@ -165,7 +165,7 @@ class TestBackfillWeiboEdge(unittest.TestCase):
         empty.json.return_value = {"data": {"cards": []}}
         with tempfile.TemporaryDirectory() as d, \
                 mock.patch.dict(backfill_gap.os.environ, {"WEIBO_COOKIE": "SUB=abc"}), \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import requests as _req
@@ -186,7 +186,7 @@ class TestBackfillWeiboEdge(unittest.TestCase):
         empty.json.return_value = {"data": {"cards": []}}
         with tempfile.TemporaryDirectory() as d, \
                 mock.patch.dict(backfill_gap.os.environ, {}, clear=True), \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import requests as _req
@@ -209,7 +209,7 @@ class TestBackfillWeiboEdge(unittest.TestCase):
         empty.json.return_value = {"data": {"cards": []}}
         with tempfile.TemporaryDirectory() as d, \
                 mock.patch.dict(backfill_gap.os.environ, {}, clear=True), \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import requests as _req
@@ -223,7 +223,7 @@ class TestBackfillWeiboEdge(unittest.TestCase):
         # requests.get 抛异常 → except break (356-358)
         with tempfile.TemporaryDirectory() as d, \
                 mock.patch.dict(backfill_gap.os.environ, {}, clear=True), \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import requests as _req
@@ -258,7 +258,7 @@ class TestBackfillSteamEdge(unittest.TestCase):
             {"timestamp_created": before_gap, "review": "y", "author": {"steamid": "s2"}},
         ], "cursor": "next"})
         with tempfile.TemporaryDirectory() as d, \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import subprocess as sp
@@ -274,7 +274,7 @@ class TestBackfillSteamEdge(unittest.TestCase):
              "author": {"steamid": "s1"}, "votes_up": 5},
         ], "cursor": "*"})  # 与初始 cursor '*' 相同 → break
         with tempfile.TemporaryDirectory() as d, \
-                mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)), \
+                mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)), \
                 mock.patch.object(backfill_gap, "time") as t:
             t.sleep = lambda *_: None
             import subprocess as sp
@@ -299,7 +299,7 @@ class TestCleanupEdge(unittest.TestCase):
             sdir = Path(d) / "reddit"
             sdir.mkdir(parents=True)
             (sdir / "2026-04-15.json").write_text("{broken", encoding="utf-8")
-            with mock.patch.object(backfill_gap, "PLATFORMS_DIR", Path(d)):
+            with mock.patch.object(backfill_gap, "ARCHIVE_DIR", Path(d)):
                 removed = backfill_gap.cleanup_empty_placeholders()
         self.assertEqual(removed, 0)
 


### PR DESCRIPTION
## 概要

T30 第 11 条点火的 gap backfill（run [29178222234](https://github.com/lightproud/brain-in-a-vat/actions/runs/29178222234)）55 秒即失败：`FileNotFoundError: projects/news/data/platforms`。

**真因**：`backfill_gap.py` 上次成功运行是 2026-04-26（4R 迁移前），仍写迁移前旧路径、绕过 `archive_layout` 单一真相源——正是该纪律（2026-07-02 P0-1「写方读方一律 import」）要抓的漏网写方。

## 修复

- 写档改经 `archive_layout.resolve_write_layout` + `build_relpath`（顺带修正 steam/youtube 的 region+subtype 子层——旧平铺写法连布局也是错的）
- `cleanup_empty_placeholders` 从硬编码 2026-04 窗口改为按 env 传入的缺口区间、扫 Community 归档根
- 两个单测文件补丁目标同步 `PLATFORMS_DIR` → `ARCHIVE_DIR`（39 例全绿）

## 验证

- 全量单测 2794 通过 / 10 跳过，零失败
- 合并后将重新 dispatch `backfill-gap.yml`（2026-05-13 → 07-09）验证真实跑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126yFFnR4WgK2i8RL2BEbQj

---
_Generated by [Claude Code](https://claude.ai/code/session_0126yFFnR4WgK2i8RL2BEbQj)_