### PR TITLE
fix(ci): backfill workflows stage Public-Info-Pool archives — second rot layer

### DIFF
--- a/.github/workflows/backfill-gap.yml
+++ b/.github/workflows/backfill-gap.yml
@@ -47,7 +47,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A projects/news/data/
+          # backfill_gap.py writes archives to Public-Info-Pool (4R layout, 2026-07-12 fix);
+          # projects/news/data/ still holds state files (gap_report etc.)
+          git add -A Public-Info-Pool/Record/Community/ projects/news/data/
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/.github/workflows/backfill-news.yml
+++ b/.github/workflows/backfill-news.yml
@@ -90,7 +90,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add projects/news/data/
+          # backfill_platforms.py writes archives to Public-Info-Pool (4R layout);
+          # projects/news/data/ still holds state files
+          git add Public-Info-Pool/Record/Community/ projects/news/data/
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else


### PR DESCRIPTION
## 概要

#618 修了脚本层，验证跑（run [29178595928](https://github.com/lightproud/brain-in-a-vat/actions/runs/29178595928)）证明回填逻辑已通——**991 条**（bilibili 129 / steam 712 等）成功写盘，但 workflow 提交步仍只 `git add projects/news/data/`（旧路径），新归档在 runner 上被静默丢弃（日志尾「No changes to commit」）。

## 修复

- `backfill-gap.yml` / `backfill-news.yml` 提交步同时暂存 `Public-Info-Pool/Record/Community/`（归档现址）与 `projects/news/data/`（状态文件仍在）
- `backfill-news.yml` 属同型潜伏锈：它跑的 `backfill_platforms.py` 自 2026-07-02 起就写 4R 布局，提交步一直没跟上

## 验证

- 全量单测 2913 通过 / 10 跳过
- 合并后第三次 dispatch `backfill-gap.yml` 实证数据真正落 main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126yFFnR4WgK2i8RL2BEbQj

---
_Generated by [Claude Code](https://claude.ai/code/session_0126yFFnR4WgK2i8RL2BEbQj)_