### PR TITLE
self-improve #2 (loop 3): judge verdicts without a valid score are ERROR, never SCORED

### DIFF
--- a/projects/silver-core-sdk/scripts/eval-scoring.mjs
+++ b/projects/silver-core-sdk/scripts/eval-scoring.mjs
@@ -1,0 +1,52 @@
+/**
+ * Judge-verdict parsing and scoring aggregation for runEvals (loop 2).
+ *
+ * Extracted from run-evals.mjs (self-improve #2) after the first branch LIVE
+ * round poisoned two dimension means: the judge occasionally returns a
+ * verdict without a valid `score` (truncated/empty JSON), and treating it as
+ * SCORED fed `undefined` into the mean — the whole dimension collapsed to
+ * null and the REQ-2.2 gate fired -4.86 / -4.0 FALSE regressions. Discipline:
+ * a verdict without a valid integer score 1-5 is an ERROR outcome, never a
+ * score; means are computed over valid scores only and stay honest about how
+ * many results they exclude.
+ *
+ * Import-only module (no side effects) so vitest can pin these rules.
+ */
+
+/** Parse one judge response body (Messages API message shape). */
+export function parseJudgeMessage(body) {
+  const text = (body.content ?? []).find((b) => b.type === 'text')?.text ?? '{}';
+  return { ...JSON.parse(text), judgeUsage: body.usage };
+}
+
+/** A verdict counts only with an integer score in 1..5. */
+export function isValidVerdict(graded) {
+  return (
+    graded !== null &&
+    typeof graded === 'object' &&
+    Number.isInteger(graded.score) &&
+    graded.score >= 1 &&
+    graded.score <= 5
+  );
+}
+
+/**
+ * Per-dimension means over SCORED results with valid scores. Invalid scores
+ * never reach this point when the runner enforces isValidVerdict, but the
+ * filter here is deliberate defense in depth — one bad record must never
+ * null out a whole dimension again.
+ */
+export function computeDimensionMeans(results) {
+  const byDim = {};
+  for (const r of results) {
+    if (r.outcome !== 'SCORED') continue;
+    if (!Number.isInteger(r.score) || r.score < 1 || r.score > 5) continue;
+    (byDim[r.dimension] ??= []).push(r.score);
+  }
+  return Object.fromEntries(
+    Object.entries(byDim).map(([d, s]) => [
+      d,
+      +(s.reduce((a, b) => a + b, 0) / s.length).toFixed(2),
+    ]),
+  );
+}

--- a/projects/silver-core-sdk/scripts/run-evals.mjs
+++ b/projects/silver-core-sdk/scripts/run-evals.mjs
@@ -34,6 +34,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { dumpMemory, getHarnessRunner, seedWorkspace } from './eval-harnesses.mjs';
+import { computeDimensionMeans, isValidVerdict, parseJudgeMessage } from './eval-scoring.mjs';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const JUDGE_MODEL = 'claude-sonnet-5'; // PINNED — keeper ruling 2026-07-11.
@@ -154,11 +155,6 @@ const API_HEADERS = () => ({
   'x-api-key': apiKey,
   'anthropic-version': '2023-06-01',
 });
-
-function parseJudgeMessage(body) {
-  const text = (body.content ?? []).find((b) => b.type === 'text')?.text ?? '{}';
-  return { ...JSON.parse(text), judgeUsage: body.usage };
-}
 
 /** Grade one question with the pinned judge (inline lane). */
 async function judge(question, evidence, judgePrompt) {
@@ -306,6 +302,15 @@ async function runBehavior() {
         const g = graded.get(question.id);
         if (g === undefined || g.error !== undefined) {
           results.push({ ...base, outcome: 'ERROR', note: g?.error ?? 'missing batch result' });
+        } else if (!isValidVerdict(g)) {
+          // A verdict without a valid 1-5 score is NOT a score (self-improve
+          // #2: an undefined score fed the dimension mean and nulled it,
+          // firing false REQ-2.2 regressions).
+          results.push({
+            ...base,
+            outcome: 'ERROR',
+            note: `judge verdict missing/invalid score (got ${JSON.stringify(g.score)})`,
+          });
         } else {
           results.push({ ...base, outcome: 'SCORED', ...g });
         }
@@ -319,7 +324,15 @@ async function runBehavior() {
     for (const { question, base, evidence } of toJudge) {
       try {
         const graded = await judge(question, evidence, judgePrompt);
-        results.push({ ...base, outcome: 'SCORED', ...graded });
+        if (!isValidVerdict(graded)) {
+          results.push({
+            ...base,
+            outcome: 'ERROR',
+            note: `judge verdict missing/invalid score (got ${JSON.stringify(graded.score)})`,
+          });
+        } else {
+          results.push({ ...base, outcome: 'SCORED', ...graded });
+        }
       } catch (err) {
         results.push({ ...base, outcome: 'ERROR', note: String(err).slice(0, 500) });
       }
@@ -335,13 +348,7 @@ async function runBehavior() {
 
 function summarize(baseline, behavior) {
   const scored = behavior.filter((r) => r.outcome === 'SCORED');
-  const byDim = {};
-  for (const r of scored) {
-    (byDim[r.dimension] ??= []).push(r.score);
-  }
-  const dimMeans = Object.fromEntries(
-    Object.entries(byDim).map(([d, s]) => [d, +(s.reduce((a, b) => a + b, 0) / s.length).toFixed(2)]),
-  );
+  const dimMeans = computeDimensionMeans(behavior);
   return {
     generator: 'run-evals.mjs (SCS-REQ-002 REQ-2.1)',
     mode: live ? 'LIVE' : 'STUB',

--- a/projects/silver-core-sdk/tests/eval-scoring.test.ts
+++ b/projects/silver-core-sdk/tests/eval-scoring.test.ts
@@ -1,0 +1,79 @@
+/**
+ * self-improve #2 — judge-verdict validity and mean-poisoning defense
+ * (scripts/eval-scoring.mjs). Reproduces the branch LIVE round failure of
+ * 2026-07-12 (run 29187930045): two judge verdicts came back without a
+ * `score`, were recorded as SCORED, and nulled their whole dimension mean —
+ * firing -4.86 / -4.0 FALSE regressions at the REQ-2.2 gate.
+ */
+import { describe, expect, it } from 'vitest';
+
+// eslint-disable-next-line import/no-relative-packages -- eval-side tooling under test
+import { computeDimensionMeans, isValidVerdict, parseJudgeMessage } from '../scripts/eval-scoring.mjs';
+
+describe('isValidVerdict', () => {
+  it('accepts integer scores 1..5 only', () => {
+    for (const score of [1, 2, 3, 4, 5]) {
+      expect(isValidVerdict({ score, verdict: 'x', rubric_findings: [] })).toBe(true);
+    }
+    for (const score of [0, 6, 3.5, '4', null, undefined, NaN]) {
+      expect(isValidVerdict({ score })).toBe(false);
+    }
+    expect(isValidVerdict(null)).toBe(false);
+    expect(isValidVerdict({})).toBe(false);
+  });
+});
+
+describe('parseJudgeMessage', () => {
+  it('parses a structured verdict and carries judge usage', () => {
+    const body = {
+      content: [{ type: 'text', text: '{"score":4,"verdict":"ok","rubric_findings":[]}' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+    const graded = parseJudgeMessage(body);
+    expect(graded.score).toBe(4);
+    expect(graded.judgeUsage.output_tokens).toBe(5);
+    expect(isValidVerdict(graded)).toBe(true);
+  });
+
+  it('an empty/scoreless reply parses but is NOT a valid verdict', () => {
+    const empty = parseJudgeMessage({ content: [], usage: {} });
+    expect(isValidVerdict(empty)).toBe(false);
+    const scoreless = parseJudgeMessage({
+      content: [{ type: 'text', text: '{"verdict":"hmm","rubric_findings":[]}' }],
+      usage: {},
+    });
+    expect(isValidVerdict(scoreless)).toBe(false);
+  });
+
+  it('a truncated JSON reply throws (callers map it to ERROR)', () => {
+    expect(() =>
+      parseJudgeMessage({ content: [{ type: 'text', text: '{"score":4,"verd' }], usage: {} }),
+    ).toThrow();
+  });
+});
+
+describe('computeDimensionMeans', () => {
+  it('one invalid score never nulls a dimension (the 2026-07-12 poisoning)', () => {
+    const results = [
+      { outcome: 'SCORED', dimension: 'memory_recall', score: 5 },
+      { outcome: 'SCORED', dimension: 'memory_recall', score: 4 },
+      // The poisoned record: SCORED but no score — must be excluded.
+      { outcome: 'SCORED', dimension: 'memory_recall', score: undefined },
+      { outcome: 'ERROR', dimension: 'memory_recall' },
+      { outcome: 'SCORED', dimension: 'token_efficiency', score: 3 },
+    ];
+    expect(computeDimensionMeans(results)).toEqual({
+      memory_recall: 4.5,
+      token_efficiency: 3,
+    });
+  });
+
+  it('a dimension with no valid scores is absent, not null', () => {
+    const means = computeDimensionMeans([
+      { outcome: 'SCORED', dimension: 'disconnect_recovery', score: undefined },
+      { outcome: 'PENDING_HARNESS', dimension: 'disconnect_recovery' },
+    ]);
+    expect(means).toEqual({});
+    expect('disconnect_recovery' in means).toBe(false);
+  });
+});


### PR DESCRIPTION
## 评估对比表（REQ-4.1 首屏）

| 症状（修复前，run [29187930045](https://github.com/lightproud/brain-in-a-vat/actions/runs/29187930045) 实录） | 修复后（确定性单测复现） |
|---|---|
| judge 回包缺 `score` 仍记 SCORED | 判 **ERROR**，note 引用非法值（行内 + Batches 双通道同规） |
| undefined 掺进均值 → memory_recall / disconnect_recovery 均分 = **null** | 均值只算合法分：`{5,4,undefined}` → **4.5**，一条坏记录绝不清空维度 |
| REQ-2.2 门禁误报 `-4.86 / -4.0 REGRESSED`（假阳） | 无合法分的维度**缺席**而非 null，门禁按「有基线无本轮分」路径如实告警 |

本单为评估器基础设施修复：故障触发是随机的（judge 偶发回空/截断），**确定性证明用单测**（6 项，含逐字复现毒化场景）；下一轮例行 LIVE 免费兑现整链验证，不为演示单独烧一轮预算。

## Diff

- `scripts/eval-scoring.mjs`（新，import-only）：`parseJudgeMessage`（自 run-evals 迁出）+ `isValidVerdict`（仅认整数 1–5）+ `computeDimensionMeans`（过滤非法分）
- `scripts/run-evals.mjs`：行内与 Batches 两条判卷通道统一走校验；`summarize` 改用共享均值函数
- `tests/eval-scoring.test.ts`：+6 测试

## 环三纪律自查（REQ-3.1）

- 单一问题（评估器对非法判卷的健壮性）、一 PR 一改动；dc-03 归因波动是**被评估系统**课题、另单处理不夹带
- diff（不含测试）约 60 行，远低于 200 行上限
- 底线层：vitest **1892 绿 + 2 skipped**（+6）、repo pytest **2928 绿**；零发货运行时改动、零版本 bump
- **合并权在守密人（环四 REQ-4.2）**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV)_