### PR TITLE
self-improve #3 (loop 3): deterministic mid-text stream cut — dc-03/dc-05 drift was the harness, not the engine

### DIFF
--- a/projects/silver-core-sdk/scripts/eval-harnesses.mjs
+++ b/projects/silver-core-sdk/scripts/eval-harnesses.mjs
@@ -107,8 +107,13 @@ function dumpFiles(ws, names) {
 /**
  * Build a provider.fetch that consults `plan(callIndex)` per transport POST
  * (1-based). Actions: 'pass' | 'fail' (network error before any byte) |
- * { cutAfterEvents: n } (forward the real response, then error the body
- * stream after >= n SSE events have been delivered).
+ * { cutAfterEvents: n } (error the body stream after >= n raw SSE events —
+ * deliberately EARLY cuts, before content commits) |
+ * { cutAfterTextDeltas: n } (error the stream right after the n-th
+ * text_delta event — a guaranteed MID-TEXT truncation. Raw event counts are
+ * fragile against the real API's delta batching: a heavily-batched reply can
+ * finish inside fewer events than the threshold and the "cut" silently never
+ * fires — the dc-03 score drift of 2026-07-12, self-improve #3).
  */
 export function makeFaultFetch(plan) {
   let calls = 0;
@@ -125,6 +130,13 @@ export function makeFaultFetch(plan) {
     if (typeof action === 'object' && action.cutAfterEvents > 0 && res.body !== null) {
       injected.push({ call: calls, action: `cut-after-${action.cutAfterEvents}-events` });
       return cutResponse(res, action.cutAfterEvents);
+    }
+    if (typeof action === 'object' && action.cutAfterTextDeltas > 0 && res.body !== null) {
+      injected.push({
+        call: calls,
+        action: `cut-after-${action.cutAfterTextDeltas}-text-deltas`,
+      });
+      return cutResponseAfterTextDeltas(res, action.cutAfterTextDeltas);
     }
     return res;
   };
@@ -165,6 +177,84 @@ function cutResponse(res, cutAfterEvents) {
         }
       }
       controller.enqueue(value);
+    },
+    cancel(reason) {
+      void reader.cancel(reason).catch(() => {});
+    },
+  });
+  return new Response(stream, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: res.headers,
+  });
+}
+
+const TEXT_DELTA_MARKER = new TextEncoder().encode('text_delta');
+
+/** Index of the first `needle` occurrence in `hay` at/after `from`, or -1. */
+function indexOfBytes(hay, needle, from) {
+  outer: for (let i = from; i + needle.length <= hay.length; i += 1) {
+    for (let j = 0; j < needle.length; j += 1) {
+      if (hay[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+/** Forward the SSE body until the n-th text_delta event completed, then error
+ *  the stream — a deterministic MID-TEXT truncation regardless of how the
+ *  server batches deltas or chunks. Scans the CUMULATIVE byte buffer so a
+ *  marker split across chunk boundaries is still found. */
+function cutResponseAfterTextDeltas(res, n) {
+  const reader = res.body.getReader();
+  let buf = new Uint8Array(0);
+  let delivered = 0; // bytes of buf already enqueued downstream
+  let seen = 0; // completed text_delta events counted so far
+  let scanFrom = 0; // next marker-scan position in buf
+  const stream = new ReadableStream({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        if (delivered < buf.length) controller.enqueue(buf.slice(delivered));
+        controller.close();
+        return;
+      }
+      const merged = new Uint8Array(buf.length + value.length);
+      merged.set(buf, 0);
+      merged.set(value, buf.length);
+      buf = merged;
+      // Count text_delta markers up to the n-th.
+      while (seen < n) {
+        const at = indexOfBytes(buf, TEXT_DELTA_MARKER, scanFrom);
+        if (at === -1) break;
+        seen += 1;
+        scanFrom = at + TEXT_DELTA_MARKER.length;
+      }
+      if (seen === n) {
+        // Cut right after the n-th marker's event terminator '\n\n'. The
+        // terminator search runs on EVERY pull (not only the one that found
+        // the marker), so a terminator arriving in a later chunk still cuts.
+        let end = -1;
+        for (let i = scanFrom; i + 1 < buf.length; i += 1) {
+          if (buf[i] === 10 && buf[i + 1] === 10) {
+            end = i + 2;
+            break;
+          }
+        }
+        if (end !== -1) {
+          controller.enqueue(buf.slice(delivered, end));
+          // Error first, cancel fire-and-forget (see cutResponse: an awaited
+          // cross-process cancel hangs the pull and drains the event loop).
+          controller.error(new TypeError('injected fault: stream cut mid-text'));
+          void reader.cancel().catch(() => {});
+        }
+        // Terminator not arrived yet: hold bytes back and wait for more.
+        return;
+      }
+      // Fewer than n markers so far: forward what we have.
+      controller.enqueue(buf.slice(delivered));
+      delivered = buf.length;
     },
     cancel(reason) {
       void reader.cancel(reason).catch(() => {});
@@ -307,7 +397,11 @@ const RUNNERS = {
   /** Layer 3: mid-final-message cut after partial text flowed; salvage. */
   'dc-03': async ({ sdk }) => {
     const ws = seedWorkspace({});
-    const fetchWrap = makeFaultFetch((i) => (i === 1 ? { cutAfterEvents: 12 } : 'pass'));
+    // Cut after the 2nd text_delta EVENT (not a raw event count): guaranteed
+    // mid-text truncation regardless of API delta batching — raw counts let a
+    // heavily-batched reply finish before the threshold and the fault never
+    // fired (score drift 5->3->1 across the first three rounds).
+    const fetchWrap = makeFaultFetch((i) => (i === 1 ? { cutAfterTextDeltas: 2 } : 'pass'));
     const run = await drive(sdk, ws, {
       prompts: [
         'Count from one to forty as English words, comma-separated, on one line, then say DONE.',
@@ -319,10 +413,12 @@ const RUNNERS = {
       evidence: {
         phases: [phaseEvidence(run)],
         harnessNotes:
-          'Injected: POST #1 stream errored after ~12 SSE events (partial text had flowed); ' +
-          'later POSTs clean. Expected: coherent final output (no repeated prefix / missing ' +
-          'middle), transportHealth records the truncation path (midStreamDrops plus ' +
-          'turnsSalvaged or turnReplays), and usage accounting present for the salvaged turn.',
+          'Injected: POST #1 stream errored right after its 2nd text_delta event — partial ' +
+          'text had flowed, the message was truncated mid-text (deterministic; not a raw ' +
+          'event count). Later POSTs clean. Expected: coherent final output (no repeated ' +
+          'prefix / missing middle), transportHealth records the truncation path ' +
+          '(midStreamDrops plus turnsSalvaged or turnReplays), and usage accounting present ' +
+          'for the salvaged turn. The injected ledger below proves the cut actually fired.',
         injected: fetchWrap.ledger,
       },
     };
@@ -374,7 +470,7 @@ const RUNNERS = {
     const ws = seedWorkspace({});
     const fetchWrap = makeFaultFetch((i) => {
       if (i === 1) return 'fail';
-      if (i === 3) return { cutAfterEvents: 8 };
+      if (i === 3) return { cutAfterTextDeltas: 1 };
       return 'pass';
     });
     const run = await drive(sdk, ws, {
@@ -390,10 +486,11 @@ const RUNNERS = {
         phases: [phaseEvidence(run)],
         harnessNotes:
           'Injected mixed faults: POST #1 request-phase network error (recovered by retry ' +
-          'POST #2), POST #3 mid-stream cut after ~8 events (recovered by replay/salvage). ' +
-          'Expected: exactly these two disconnect events in transportHealth, each in the ' +
-          'matching bucket (networkRetries=1; midStreamDrops=1 with its recovery counter), ' +
-          'success result, zero unrecovered.',
+          'POST #2), POST #3 cut right after its 1st text_delta event — a deterministic ' +
+          'mid-stream truncation (recovered by replay/salvage). Expected: exactly these two ' +
+          'disconnect events in transportHealth, each in the matching bucket ' +
+          '(networkRetries=1; midStreamDrops=1 with its recovery counter), success result, ' +
+          'zero unrecovered. The injected ledger below proves both faults actually fired.',
         injected: fetchWrap.ledger,
       },
     };

--- a/projects/silver-core-sdk/tests/eval-harness-faults.test.ts
+++ b/projects/silver-core-sdk/tests/eval-harness-faults.test.ts
@@ -147,6 +147,51 @@ describe('makeFaultFetch against the emulator (keyless)', () => {
   });
 });
 
+describe('cutAfterTextDeltas (self-improve #3: deterministic mid-text cut)', () => {
+  it('cuts mid-text even when the whole reply arrives as one batched chunk', async () => {
+    // The emulator writes the full SSE body at once — exactly the batching
+    // shape that let raw-event-count cuts silently never fire (dc-03 drift).
+    const fetchWrap = makeFaultFetch((i: number) =>
+      i === 1 ? { cutAfterTextDeltas: 2 } : 'pass',
+    );
+    const { messages, result } = await run(fetchWrap);
+    expect(fetchWrap.ledger).toEqual([{ call: 1, action: 'cut-after-2-text-deltas' }]);
+    expect(result?.is_error).toBe(false);
+    const health = result?.metrics?.transportHealth;
+    expect(
+      (health?.midStreamDrops ?? 0) +
+        (health?.turnsSalvaged ?? 0) +
+        (health?.turnReplays ?? 0) +
+        (health?.emptyStreamRetries ?? 0),
+    ).toBeGreaterThanOrEqual(1);
+    // Recovery may salvage the flowed prefix as the answer (E3) or replay to
+    // a full reply — either way exactly ONE assistant text message survives,
+    // with no duplicated prefix.
+    const texts = messages
+      .filter((m) => m.type === 'assistant')
+      .flatMap((m) =>
+        (m as { message: { content: Array<{ type: string; text?: string }> } }).message.content
+          .filter((b) => b.type === 'text')
+          .map((b) => b.text ?? ''),
+      )
+      .filter((t) => t.length > 0);
+    expect(texts.length).toBe(1);
+    const occurrences = texts[0]!.split('All twenty').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('a reply with fewer text_deltas than the threshold passes through un-cut', async () => {
+    // Guard the other direction: threshold beyond the reply must not corrupt
+    // or truncate a healthy stream.
+    const fetchWrap = makeFaultFetch((i: number) =>
+      i === 1 ? { cutAfterTextDeltas: 99 } : 'pass',
+    );
+    const { result } = await run(fetchWrap);
+    expect(result?.is_error).toBe(false);
+    expect(result?.metrics?.transportHealth?.midStreamDrops ?? 0).toBe(0);
+  });
+});
+
 describe('harness registry governance boundary', () => {
   it('registers a runner for every manual question and only those', () => {
     const doc = JSON.parse(


### PR DESCRIPTION
## 评估对比表（REQ-4.1 首屏）

| question | 三轮历史（漂移实录） | after（分支 run [29192770744](https://github.com/lightproud/brain-in-a-vat/actions/runs/29192770744)） |
|---|---|---|
| dc-03 | **5 → 3 → 1**（故障时注入时不注入） | 注入台账实证 `cut-after-2-text-deltas` **确定性发生**；judge 回包截断无分（见下） |
| dc-05 | 2 → 判卷无效 | 同上：双故障台账俱在；judge 回包截断 |
| 维度均分 | memory 4.86 / disconnect 4.00 / token 4.33（基线） | **4.67 / 4.75 / 4.80** —— REQ-2.2 门禁 **PASS**，零假阳 |
| tok-06（顺带） | 1 → 3 | **4**（构成证据生效，持续爬升） |

**本单把「dc-03 分数漂移」剥成了两层，各归其位**：
1. **注入不确定**（本单修复对象）——已消灭：单测锁定「单个合批大 chunk 也必切」，LIVE 轮注入台账逐条实证故障真的发生；
2. **judge 回包截断**（本轮新剥离出的独立层）——本轮 5/20 判卷无分（mem-03 / dc-03 / tok-01 / tok-02 缺 score、dc-05 JSON 截断），全部被 self-improve #2 的校验闸**诚实拦成 ERROR**、均值与门禁未受污染（这正是 #2 的设计目标在实战兑现）。疑因 judge `max_tokens: 2048` 对证据大的题不够用——已列 **self-improve #4 候选**（判卷输出预算上调；模型与评分提示词两项钉死物不动），按「一 PR 一改动」不并入本单。

## Diff（均评估侧，零发货运行时）

1. `makeFaultFetch` 新增 `{cutAfterTextDeltas: n}`：**累积缓冲字节扫描**，在第 n 个 `text_delta` 事件的终止符后精确切断——无论 delta 怎么合批、chunk 怎么切分（跨界标记照样命中），保证切在正文中段。
2. dc-03（第 2 个 text delta 后切）与 dc-05（混合故障第 1 个后切）换用；harness note 附注入台账自证故障真的发生。dc-02 的**刻意早切**语义不同，保留不动。
3. +2 单测：单个合批大 chunk 场景切流必发生、恢复后恰一条不重复答案；阈值超出回复长度时健康流零损伤通过。

## 环三纪律自查（REQ-3.1）

- 单一问题（切流原语确定性）、一 PR 一改动；judge 输出预算（#4）与引擎截断抢救语义（#5 候选）各自另立
- diff（不含测试）约 90 行；底线层 vitest **1894 绿 + 2 skipped**（+2）、repo pytest **2928 绿**；分支轮底线层 1868/1896 全过
- **合并权在守密人（环四 REQ-4.2）**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV