### PR TITLE
self-improve #4 (loop 3): judge output budget 2048 → 4096 + one retry on invalid verdicts

### DIFF
--- a/projects/silver-core-sdk/scripts/run-evals.mjs
+++ b/projects/silver-core-sdk/scripts/run-evals.mjs
@@ -118,7 +118,11 @@ function judgeParams(question, evidence, judgePrompt) {
     .replace('{{EVIDENCE_JSON}}', JSON.stringify(evidence, null, 2));
   return {
     model: JUDGE_MODEL,
-    max_tokens: 2048,
+    // 4096 since self-improve #4: at 2048 evidence-heavy questions hit the
+    // cap mid-JSON (5/20 scoreless verdicts in the 2026-07-12 branch round —
+    // truncated rubric_findings evidence strings). Output budget is runner
+    // plumbing; the PINNED judge model + prompt are untouched.
+    max_tokens: 4096,
     messages: [{ role: 'user', content: prompt }],
     output_config: {
       format: {
@@ -157,7 +161,7 @@ const API_HEADERS = () => ({
 });
 
 /** Grade one question with the pinned judge (inline lane). */
-async function judge(question, evidence, judgePrompt) {
+async function judgeOnce(question, evidence, judgePrompt) {
   const res = await fetch(API_URL, {
     method: 'POST',
     headers: API_HEADERS(),
@@ -165,6 +169,24 @@ async function judge(question, evidence, judgePrompt) {
   });
   if (!res.ok) throw new Error(`judge HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
   return parseJudgeMessage(await res.json());
+}
+
+/** Judge with ONE retry on an invalid/unparseable verdict (self-improve #4):
+ *  scoreless or truncated judge replies are transient — a single fresh call
+ *  usually yields a valid verdict; a second failure surfaces as ERROR. */
+async function judge(question, evidence, judgePrompt) {
+  let first;
+  try {
+    first = await judgeOnce(question, evidence, judgePrompt);
+    if (isValidVerdict(first)) return first;
+  } catch (err) {
+    console.log(`judge retry for ${question.id}: first attempt threw (${String(err).slice(0, 120)})`);
+    return judgeOnce(question, evidence, judgePrompt);
+  }
+  console.log(
+    `judge retry for ${question.id}: first verdict invalid (score=${JSON.stringify(first.score)})`,
+  );
+  return judgeOnce(question, evidence, judgePrompt);
 }
 
 /** Grade every pending question in ONE Message Batch (50% nightly lane).
@@ -298,14 +320,22 @@ async function runBehavior() {
   if (judgeBatches && toJudge.length > 0) {
     try {
       const graded = await judgeViaBatches(toJudge, judgePrompt);
-      for (const { question, base } of toJudge) {
-        const g = graded.get(question.id);
-        if (g === undefined || g.error !== undefined) {
-          results.push({ ...base, outcome: 'ERROR', note: g?.error ?? 'missing batch result' });
+      for (const { question, base, evidence } of toJudge) {
+        let g = graded.get(question.id);
+        // A verdict without a valid 1-5 score is NOT a score (self-improve
+        // #2). Batch-lane misses fall back to ONE inline retry (self-improve
+        // #4) before surfacing as ERROR.
+        if (g === undefined || g.error !== undefined || !isValidVerdict(g)) {
+          try {
+            console.log(`judge retry (inline) for ${question.id}: batch verdict missing/invalid`);
+            g = await judgeOnce(question, evidence, judgePrompt);
+          } catch (err) {
+            g = { error: String(err).slice(0, 300) };
+          }
+        }
+        if (g.error !== undefined) {
+          results.push({ ...base, outcome: 'ERROR', note: g.error });
         } else if (!isValidVerdict(g)) {
-          // A verdict without a valid 1-5 score is NOT a score (self-improve
-          // #2: an undefined score fed the dimension mean and nulled it,
-          // firing false REQ-2.2 regressions).
           results.push({
             ...base,
             outcome: 'ERROR',


### PR DESCRIPTION
## 评估对比表（REQ-4.1 首屏）

| 指标 | before（run 29192770744） | after（run [29193453561](https://github.com/lightproud/brain-in-a-vat/actions/runs/29193453561)） |
|---|---|---|
| 判卷成功率 | 15/20 | **19/20**（重试日志实证：mem-03 首判无分 → 重试得 4；dc-05 重试仍无分为唯一残留） |
| 门禁 | PASS | **PASS**（-0.43 / -0.40 / +0.24，均在 0.5 阈内） |
| dc-03 | ERROR（judge 层） | **首份稳定判决 1 分**——注入确定化后引擎语义暴露：截断抢救以半截话作最终答案（E3 官方对齐语义）vs rubric 期待续写补全，题面级冲突移交守密人 |

修法：judge 输出预算 2048→4096 + 无效判卷重试一次（行内 + Batches 回落）。钉死的评分模型与提示词零字节不动。unit 作业红为与本单无关的既有 flake（runlog fire-and-forget 追加乱序，本地 1894 绿、CI 时序偶发）——self-improve #5 即修。

合并按守密人 2026-07-12「循环自改、合并自断」授权执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV