### PR TITLE
fix(silver-core-sdk): serialize run-log appends — ledger order is arrival order (v0.51.2)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,17 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.51.2 — 2026-07-12
+
+**Fix: run-log appends are serialized (ledger order = arrival order) +
+`RunLogSink.flush()`.** Two fire-and-forget `appendFile` calls could land
+out of arrival order — surfaced as a CI flake in the sink's own ordering
+test, and a consumer reading `runlog-*.jsonl` as a timeline would see the
+same inversion. Appends now ride one promise chain (each link swallows its
+own failure, so a bad append never wedges the chain; still fire-and-forget
+for the run). `flush()` resolves once everything observed so far is
+appended — tests and shutdown paths await durability instead of sleeping.
+
 ## 0.51.1 — 2026-07-12
 
 **Fix: replay-backoff timer no longer unref'd — headless consumers survive

--- a/projects/silver-core-sdk/package-lock.json
+++ b/projects/silver-core-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silver-core-sdk",
-      "version": "0.51.1",
+      "version": "0.51.2",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/reporting/run-log.ts
+++ b/projects/silver-core-sdk/src/reporting/run-log.ts
@@ -64,6 +64,10 @@ export type RunLogRecord = {
 export type RunLogSink = {
   /** Observe one consumer-facing message; mirrors result messages. */
   observe(msg: SDKMessage): void;
+  /** Resolves once every record observed SO FAR has been appended (or its
+   *  append failed and was swallowed). Lets tests and shutdown paths await
+   *  durability instead of sleeping. */
+  flush(): Promise<void>;
 };
 
 /** UTC day file name for a timestamp. */
@@ -132,6 +136,14 @@ export function createRunLogSink(args: {
     dirReady ??= mkdir(runLog.dir, { recursive: true }).then(() => undefined);
     return dirReady;
   };
+  // Appends are SERIALIZED on one promise chain: two concurrent fire-and-
+  // forget appendFile calls can land out of arrival order (surfaced as a CI
+  // flake in the sink's own ordering test, 2026-07-12 — and a consumer
+  // reading the ledger as a timeline would see the same inversion). Each
+  // link swallows its own failure so one bad append never wedges the chain;
+  // still fire-and-forget from the caller's view (observability never breaks
+  // the run).
+  let tail: Promise<void> = Promise.resolve();
   return {
     observe(msg: SDKMessage): void {
       if (msg.type !== 'result') return;
@@ -140,9 +152,13 @@ export function createRunLogSink(args: {
         ...(runLog.scenario !== undefined ? { scenario: runLog.scenario } : {}),
       });
       const line = `${JSON.stringify(record)}\n`;
-      void ensureDir()
+      tail = tail
+        .then(() => ensureDir())
         .then(() => appendFile(join(runLog.dir, runLogFileName(new Date())), line, 'utf8'))
         .catch((err) => debug(`runLog: append failed (ignored): ${String(err)}`));
+    },
+    flush(): Promise<void> {
+      return tail;
     },
   };
 }

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.51.1';
+export const SDK_VERSION = '0.51.2';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/runtime-report.test.ts
+++ b/projects/silver-core-sdk/tests/runtime-report.test.ts
@@ -136,11 +136,15 @@ describe('createRunLogSink', () => {
     sink.observe({ type: 'system', subtype: 'init' } as never);
     sink.observe(resultFixture() as never);
     sink.observe(resultFixture({ session_id: 'sess-9' } as never) as never);
-    await new Promise((r) => setTimeout(r, 50));
+    // flush() (v0.51.2) resolves once all observed records are appended —
+    // appends are serialized, so line order IS arrival order (the old 50ms
+    // sleep raced two independent append chains and flaked in CI).
+    await sink.flush();
     const lines = (await readFile(join(logDir, runLogFileName(new Date())), 'utf8'))
       .trim()
       .split('\n');
     expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).session_id).toBe('sess-1');
     expect(JSON.parse(lines[1]!).session_id).toBe('sess-9');
   });
 });


### PR DESCRIPTION
self-improve #5（发货侧真缺陷，确定性证据）。两次 fire-and-forget `appendFile` 可乱序落盘：CI unit 作业已实际红过一次（run [29193453561](https://github.com/lightproud/brain-in-a-vat/actions/runs/29193453561)，`sess-9` 抢在 `sess-1` 前），且任何把 `runlog-*.jsonl` 当时间线读的消费方会看到同样的倒置。修法：追加串到单一 promise 链（逐环自吞错、坏追加不卡链、对运行仍是 fire-and-forget）+ `RunLogSink.flush()`（等待落盘的诚实原语，测试弃用 50ms 睡眠、并新增对两行顺序的完整断言）。

vitest 1894 绿 + 2 skipped、repo pytest 2956 绿、tsc + build exit 0、版本三方对账 0.51.2。确定性修复不烧 LIVE 轮。合并按守密人「循环自改、合并自断」授权执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV)_