### PR TITLE
self-improve #6 (loop 3): trim oversized strings in judge evidence

### DIFF
--- a/projects/silver-core-sdk/scripts/eval-scoring.mjs
+++ b/projects/silver-core-sdk/scripts/eval-scoring.mjs
@@ -31,6 +31,28 @@ export function isValidVerdict(graded) {
 }
 
 /**
+ * Deep-trim judge evidence (self-improve #6): dc-05's verdict came back
+ * scoreless TWICE even at the 4096 output budget — its two-phase transcript
+ * evidence is enormous (seeded fixtures + full message contents), and an
+ * over-stuffed judge input degrades output reliability and burns budget.
+ * Any string longer than `cap` chars anywhere in the evidence tree is cut
+ * with an explicit marker; structure, keys and short values (metrics,
+ * ledgers, notes) pass through untouched, so rubric-relevant signals stay.
+ */
+export function trimEvidence(value, cap = 3000) {
+  if (typeof value === 'string') {
+    return value.length > cap
+      ? `${value.slice(0, cap)}…[trimmed ${value.length - cap} chars]`
+      : value;
+  }
+  if (Array.isArray(value)) return value.map((v) => trimEvidence(v, cap));
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, trimEvidence(v, cap)]));
+  }
+  return value;
+}
+
+/**
  * Per-dimension means over SCORED results with valid scores. Invalid scores
  * never reach this point when the runner enforces isValidVerdict, but the
  * filter here is deliberate defense in depth — one bad record must never

--- a/projects/silver-core-sdk/scripts/run-evals.mjs
+++ b/projects/silver-core-sdk/scripts/run-evals.mjs
@@ -34,7 +34,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { dumpMemory, getHarnessRunner, seedWorkspace } from './eval-harnesses.mjs';
-import { computeDimensionMeans, isValidVerdict, parseJudgeMessage } from './eval-scoring.mjs';
+import { computeDimensionMeans, isValidVerdict, parseJudgeMessage, trimEvidence } from './eval-scoring.mjs';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const JUDGE_MODEL = 'claude-sonnet-5'; // PINNED — keeper ruling 2026-07-11.
@@ -275,7 +275,7 @@ async function runBehavior() {
       try {
         const out = await runner({ sdk });
         ws = out.ws;
-        toJudge.push({ question, base, evidence: out.evidence });
+        toJudge.push({ question, base, evidence: trimEvidence(out.evidence) });
       } catch (err) {
         results.push({ ...base, outcome: 'ERROR', note: String(err).slice(0, 500) });
       } finally {
@@ -308,7 +308,7 @@ async function runBehavior() {
         });
       }
       evidence.memoryDump = dumpMemory(ws);
-      toJudge.push({ question, base, evidence });
+      toJudge.push({ question, base, evidence: trimEvidence(evidence) });
     } catch (err) {
       results.push({ ...base, outcome: 'ERROR', note: String(err).slice(0, 500) });
     } finally {

--- a/projects/silver-core-sdk/tests/eval-scoring.test.ts
+++ b/projects/silver-core-sdk/tests/eval-scoring.test.ts
@@ -8,7 +8,12 @@
 import { describe, expect, it } from 'vitest';
 
 // eslint-disable-next-line import/no-relative-packages -- eval-side tooling under test
-import { computeDimensionMeans, isValidVerdict, parseJudgeMessage } from '../scripts/eval-scoring.mjs';
+import {
+  computeDimensionMeans,
+  isValidVerdict,
+  parseJudgeMessage,
+  trimEvidence,
+} from '../scripts/eval-scoring.mjs';
 
 describe('isValidVerdict', () => {
   it('accepts integer scores 1..5 only', () => {
@@ -49,6 +54,27 @@ describe('parseJudgeMessage', () => {
     expect(() =>
       parseJudgeMessage({ content: [{ type: 'text', text: '{"score":4,"verd' }], usage: {} }),
     ).toThrow();
+  });
+});
+
+describe('trimEvidence (self-improve #6)', () => {
+  it('cuts oversized strings anywhere in the tree with an explicit marker', () => {
+    const big = 'x'.repeat(5000);
+    const out = trimEvidence({
+      phases: [{ transcript: [{ message: { content: [{ type: 'text', text: big }] } }] }],
+      harnessNotes: 'short note',
+      metrics: { turnReplays: 1 },
+    });
+    const text = out.phases[0].transcript[0].message.content[0].text;
+    expect(text.length).toBeLessThan(3100);
+    expect(text).toContain('…[trimmed 2000 chars]');
+    expect(out.harnessNotes).toBe('short note');
+    expect(out.metrics.turnReplays).toBe(1);
+  });
+
+  it('leaves structure, numbers, booleans and nulls untouched', () => {
+    const evidence = { a: [1, true, null, 'ok'], b: { c: 'fine' } };
+    expect(trimEvidence(evidence)).toEqual(evidence);
   });
 });
 


### PR DESCRIPTION
## 评估对比表（REQ-4.1 首屏）

| 指标 | #4 轮（run 29193453561） | 本轮（run [29194232519](https://github.com/lightproud/brain-in-a-vat/actions/runs/29194232519)，含 #5+#6） |
|---|---|---|
| 判卷成功率 | 19/20 | 18/20（mem-03 / dc-05 重试后仍无分——已定性为**顽固无分对子**，3 轮共 5 次，非尺寸问题，转观察项） |
| 门禁 | PASS | **PASS**：memory_recall **5.00**（+0.14）/ token_efficiency 4.57（+0.24）/ disconnect_recovery 3.80（-0.20） |
| 整流水线 | unit 红（flake） | **9 作业全绿**（#5 的追加序列化令 unit flake 消失） |
| mem-01 | 2 | **5**（零代码改动回升——实证 judge 方差论） |

`trimEvidence`（[eval-scoring.mjs](https://github.com/lightproud/brain-in-a-vat/blob/main/projects/silver-core-sdk/scripts/eval-scoring.mjs)）：证据树内超 3000 字符的字符串带标记截断，结构 / 指标 / 台账原样保留；两处收集点接线；+2 测试。判卷输入瘦身同时降 judge 成本。

**本 PR 为自改循环末单**——合并后循环按停机准则收官（详见收官总结）。合并按守密人「循环自改、合并自断」授权执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV)_