### PR TITLE
fix(silver-core-sdk): classify judge HTTP errors — no doomed retry on terminal request failures (self-improve #7)

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -212,6 +212,19 @@
   顽固无分对子转观察（3 轮 5 次 judge 结构化输出失败）；③ judge 方差（mem-01 零改动 2→5 实证）
   与 estBytes 等收益递减项不再专门烧轮。判卷侧当日约 $15（$30/月帽内）。裁定全文
   `memory/decisions.md` 同日「自改循环授权 + 首轮循环收官」条。
+- **self-improve #7：判卷 HTTP 错误分类（2026-07-12，判卷无关硬化，收官后补一单）**：
+  收官后点火的确诊轮（run [29196113106](https://github.com/lightproud/brain-in-a-vat/actions/runs/29196113106)）
+  20 题全 judge HTTP 400——完整报文是 **`invalid_request_error: Your credit balance is too low`**
+  （API 账户余额耗尽，非代码缺陷，与 2026-07-07 v0.14.0 余额耗尽轮同类「无效不可采信」）。
+  基础设施**正确降级**（20 题全记 ERROR、维度均值空、REQ-2.2 只发 advisory 警告不误报假回归——
+  self-improve #2 均值防毒化在判卷全线中断下按设计工作的铁证）。但暴露两个判卷无关缺陷：① 账单/鉴权
+  类 400 被当瞬时错误盲目重试一次（注定失败、白烧已耗尽余额）；② 报告 90 字备注格被 JSON 信封前缀
+  `…"message":"` 占满，真因得钻原始 CI 日志才见。**修复**：`classifyJudgeError()`（`scripts/eval-scoring.mjs`
+  纯函数）按状态码 + 报文分诊——billing/auth/permission/其他 4xx 为终态 `retryable:false`（judge() 不再
+  空重试），429/5xx/529 仍为瞬时可重试；备注前置 `[kind]` + API 原文，截断格也读得出「billing: Your
+  credit balance is too low」。+4 测试（`tests/eval-scoring.test.ts`，**1905 全绿 + 2 skipped**）。
+  仅改 scripts/ + tests/（非 shipped `src/**`），版本升号守卫豁免、无需升版。**判卷侧证分待守密人为
+  API 账户充值后重跑**（dc-03 续写旗分数复核 + mem-03/dc-05 深挖一单 judgeDiag 收集均阻塞于此）。
 - **首份全量 LIVE 评估基线（2026-07-12，run [29178972282](https://github.com/lightproud/brain-in-a-vat/actions/runs/29178972282)，v0.51.1）**：
   20 题全执行（8 题 Phase 2 harness 首次真跑真判），**19 判卷成功 / 1 judge 解析错误（tok-02，偶发）**；
   维度均分 memory_recall **4.86** / disconnect_recovery **4.00** / token_efficiency **4.33**，

--- a/projects/silver-core-sdk/scripts/eval-scoring.mjs
+++ b/projects/silver-core-sdk/scripts/eval-scoring.mjs
@@ -41,6 +41,69 @@ export function diagnoseJudgeMessage(body) {
   };
 }
 
+/**
+ * Classify a non-2xx judge HTTP response (self-improve #7). The 2026-07-12
+ * confirm round returned twenty identical HTTP 400s whose body was
+ * "Your credit balance is too low" — a billing outage, not a code fault.
+ * Two things went wrong in how the runner handled it: (1) judge() retried
+ * each one once, a guaranteed-doomed second call that burned the last of a
+ * depleted balance; (2) the report's 90-char note cell showed only the JSON
+ * envelope prefix (…{"type":"error","error":{"type":"invalid_request_error",
+ * "message":"), so the real cause was invisible without digging into raw CI
+ * logs. This classifier fixes both: `retryable` tells judge() not to re-fire
+ * terminal request errors, and `note` front-loads a human `kind` + the API's
+ * own message text so the truncated table cell is legible.
+ *
+ * Terminal (retryable:false): billing, auth, permission, and any other 4xx —
+ * an identical re-POST cannot change the verdict. Transient (retryable:true):
+ * 408/425/429 and 5xx/529 — backoff may help.
+ */
+export function classifyJudgeError(status, bodyText) {
+  let apiType;
+  let apiMessage;
+  try {
+    const parsed = JSON.parse(bodyText);
+    apiType = parsed?.error?.type ?? undefined;
+    apiMessage = parsed?.error?.message ?? undefined;
+  } catch {
+    // Non-JSON body (gateway HTML, empty) — keep the raw head as the message.
+  }
+  const msg = String(apiMessage ?? bodyText ?? '').trim();
+  const lower = msg.toLowerCase();
+  let kind;
+  let retryable;
+  if (status === 429 || status === 408 || status === 425) {
+    kind = 'rate_limit';
+    retryable = true;
+  } else if (status >= 500) {
+    kind = 'server';
+    retryable = true;
+  } else if (status === 401) {
+    kind = 'auth';
+    retryable = false;
+  } else if (status === 403) {
+    kind = 'permission';
+    retryable = false;
+  } else if (status === 400 && (lower.includes('credit balance') || lower.includes('billing'))) {
+    kind = 'billing';
+    retryable = false;
+  } else if (status === 400) {
+    kind = 'invalid_request';
+    retryable = false;
+  } else {
+    // Any other non-2xx (odd 4xx / 3xx): do not retry an identical re-POST.
+    kind = apiType ?? 'http';
+    retryable = false;
+  }
+  return {
+    status,
+    kind,
+    retryable,
+    apiType: apiType ?? null,
+    note: `judge HTTP ${status} [${kind}]: ${msg.slice(0, 160)}`,
+  };
+}
+
 /** A verdict counts only with an integer score in 1..5. */
 export function isValidVerdict(graded) {
   return (

--- a/projects/silver-core-sdk/scripts/run-evals.mjs
+++ b/projects/silver-core-sdk/scripts/run-evals.mjs
@@ -35,6 +35,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { dumpMemory, getHarnessRunner, seedWorkspace } from './eval-harnesses.mjs';
 import {
+  classifyJudgeError,
   computeDimensionMeans,
   diagnoseJudgeMessage,
   isValidVerdict,
@@ -173,7 +174,16 @@ async function judgeOnce(question, evidence, judgePrompt) {
     headers: API_HEADERS(),
     body: JSON.stringify(judgeParams(question, evidence, judgePrompt)),
   });
-  if (!res.ok) throw new Error(`judge HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  if (!res.ok) {
+    // Classify (self-improve #7): terminal request errors (billing/auth/
+    // malformed) carry retryable:false so judge() skips a doomed re-POST, and
+    // the note front-loads the API's own message for the 90-char report cell.
+    const cls = classifyJudgeError(res.status, await res.text());
+    const err = new Error(cls.note);
+    err.retryable = cls.retryable;
+    err.judgeErrorKind = cls.kind;
+    throw err;
+  }
   const body = await res.json();
   const verdict = parseJudgeMessage(body);
   // 深挖一单 (keeper 2026-07-12): when the verdict has no valid score, carry
@@ -192,6 +202,11 @@ async function judge(question, evidence, judgePrompt) {
     first = await judgeOnce(question, evidence, judgePrompt);
     if (isValidVerdict(first)) return first;
   } catch (err) {
+    // Terminal request errors (billing/auth/malformed, retryable:false) can't
+    // be fixed by an identical re-POST — surface immediately instead of
+    // burning a doomed retry (self-improve #7). Transient throws (network /
+    // 5xx / 429, retryable undefined or true) still get their one retry.
+    if (err.retryable === false) throw err;
     console.log(`judge retry for ${question.id}: first attempt threw (${String(err).slice(0, 120)})`);
     return judgeOnce(question, evidence, judgePrompt);
   }

--- a/projects/silver-core-sdk/tests/eval-scoring.test.ts
+++ b/projects/silver-core-sdk/tests/eval-scoring.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest';
 
 // eslint-disable-next-line import/no-relative-packages -- eval-side tooling under test
 import {
+  classifyJudgeError,
   computeDimensionMeans,
   diagnoseJudgeMessage,
   isValidVerdict,
@@ -86,6 +87,48 @@ describe('diagnoseJudgeMessage (深挖一单 probe)', () => {
     expect(diag.text_len).toBe('{"verdict":"unsure"}'.length);
     expect(diag.text_head).toContain('unsure');
     expect(diag.block_types).toEqual(['text']);
+  });
+});
+
+describe('classifyJudgeError (self-improve #7)', () => {
+  const billingBody = JSON.stringify({
+    type: 'error',
+    error: { type: 'invalid_request_error', message: 'Your credit balance is too low to access the API.' },
+  });
+
+  it('a billing 400 is terminal and legible in a 90-char cell (the 2026-07-12 confirm round)', () => {
+    const cls = classifyJudgeError(400, billingBody);
+    expect(cls.kind).toBe('billing');
+    expect(cls.retryable).toBe(false);
+    // The note front-loads kind + API message so `Error: <note>`.slice(0,90)
+    // still shows the cause, not the JSON envelope prefix.
+    expect(cls.note).toBe('judge HTTP 400 [billing]: Your credit balance is too low to access the API.');
+    expect(`Error: ${cls.note}`.slice(0, 90)).toContain('credit balance');
+  });
+
+  it('auth/permission/other-400 are terminal (no doomed retry)', () => {
+    expect(classifyJudgeError(401, '{}')).toMatchObject({ kind: 'auth', retryable: false });
+    expect(classifyJudgeError(403, '{}')).toMatchObject({ kind: 'permission', retryable: false });
+    expect(
+      classifyJudgeError(
+        400,
+        JSON.stringify({ error: { type: 'invalid_request_error', message: 'max_tokens: bad' } }),
+      ),
+    ).toMatchObject({ kind: 'invalid_request', retryable: false });
+  });
+
+  it('rate-limit and server errors stay transient (retry may help)', () => {
+    expect(classifyJudgeError(429, '{}')).toMatchObject({ kind: 'rate_limit', retryable: true });
+    expect(classifyJudgeError(408, '{}')).toMatchObject({ kind: 'rate_limit', retryable: true });
+    expect(classifyJudgeError(500, '{}')).toMatchObject({ kind: 'server', retryable: true });
+    expect(classifyJudgeError(529, '{}')).toMatchObject({ kind: 'server', retryable: true });
+  });
+
+  it('a non-JSON body (gateway HTML) keeps its raw head as the message', () => {
+    const cls = classifyJudgeError(502, '<html>Bad Gateway</html>');
+    expect(cls.kind).toBe('server');
+    expect(cls.retryable).toBe(true);
+    expect(cls.note).toContain('Bad Gateway');
   });
 });
 


### PR DESCRIPTION
## 定性

SCS-REQ-002 自我改进闭环收官后补的一项**判卷无关硬化**。收官后点火的确诊轮（run [29196113106](https://github.com/lightproud/brain-in-a-vat/actions/runs/29196113106)）20 题全 judge HTTP 400，完整报文是 `invalid_request_error: Your credit balance is too low`——**API 账户余额耗尽，非代码缺陷**（与 2026-07-07 v0.14.0 余额耗尽轮同类「无效不可采信」）。基础设施正确降级（20 题全 ERROR、维度均值空、REQ-2.2 只发 advisory 警告不误报假回归——self-improve #2 均值防毒化在判卷全线中断下按设计工作的铁证）。但这次调查暴露了两个判卷无关缺陷。

## 缺陷与修复

| # | 缺陷 | 比喻 |
|---|------|------|
| 1 | 账单/鉴权类 400 被当瞬时错误盲目重试一次（注定失败、白烧已耗尽余额） | 明知钱包空了还硬刷第二次卡，只是又被拒一次 |
| 2 | 报告 90 字备注格被 JSON 信封前缀 `…"message":"` 占满，真因得钻原始 CI 日志才见 | 快递单只印了「寄件人：」三个字，收件人名字被截在框外 |

`classifyJudgeError()`（`scripts/eval-scoring.mjs` 纯函数）按状态码 + 报文分诊：

- **终态 `retryable:false`**：billing / auth / permission / 其他 4xx——`judge()` 不再空重试；
- **瞬时 `retryable:true`**：408 / 425 / 429 / 5xx / 529——退避可能有救；
- 备注前置 `[kind]` + API 原文，截断格也读得出「billing: Your credit balance is too low」。

## 验证

- `scripts/run-evals.mjs` 接线：`judgeOnce` 抛分类错误、`judge` 对终态错误立即上抛不重试；
- +4 回归测试（`tests/eval-scoring.test.ts`），**1905 全绿 + 2 skipped**，tsc/build exit 0；
- 仅改 `scripts/` + `tests/`（非 shipped `src/**`），版本升号守卫豁免、无需升版。

## 判卷侧余项（阻塞于 API 充值）

dc-03 续写旗分数复核 + mem-03/dc-05 深挖一单 judgeDiag 收集——均需守密人为 API 账户充值后重跑 LIVE 轮方能推进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV)_