### PR TITLE
test(silver-core-sdk): keyless dc-05 mixed-fault dual-bucket ledger assertion

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -225,6 +225,15 @@
   credit balance is too low」。+4 测试（`tests/eval-scoring.test.ts`，**1905 全绿 + 2 skipped**）。
   仅改 scripts/ + tests/（非 shipped `src/**`），版本升号守卫豁免、无需升版。**判卷侧证分待守密人为
   API 账户充值后重跑**（dc-03 续写旗分数复核 + mem-03/dc-05 深挖一单 judgeDiag 收集均阻塞于此）。
+- **无钥替代：dc-05 双桶台账确定性断言（2026-07-12，充值阻塞下的免费推进）**：守密人 API 暂无法充值，
+  遂把被判卷阻塞的机械内核转成无钥断言（`tests/eval-harness-faults.test.ts` 本地 SSE 模拟器驱真引擎，
+  零 API 零成本）。**结论**：① **dc-03 续写旗机械核早已无钥覆盖**（`engine.test.ts:2279`
+  断言 `salvageMode:'continue'`→`turnsSalvaged:0,turnReplays:1`），不真阻塞；② **dc-05「只记一个桶」被
+  证伪**——新增混合故障断言（网络错 POST#1 + 流中切断 POST#2 同处一轮）实测 `networkRetries≥1` **且**
+  drop/recovery 桶 `≥1` **同时成立**，引擎台账双桶各记一笔、并未漏记；judge 那句 2 分说的是喂它的证据只
+  浮现一个桶（呈现/rubric 层面），**非引擎缺陷**。价值 = 免费永久 CI 双桶回归锁 + 无需判卷即判明 dc-05
+  工程无罪。**判卷侧真剩项**（确须付费判卷、无钥不可复现）：mem-03/dc-05 judge 结构化输出偶发失败的
+  深挖，属判卷官模型行为、待充值后收 judgeDiag。**1906 全绿 + 2 skipped**（+1 混合故障断言）、仅改 tests/。
 - **首份全量 LIVE 评估基线（2026-07-12，run [29178972282](https://github.com/lightproud/brain-in-a-vat/actions/runs/29178972282)，v0.51.1）**：
   20 题全执行（8 题 Phase 2 harness 首次真跑真判），**19 判卷成功 / 1 judge 解析错误（tok-02，偶发）**；
   维度均分 memory_recall **4.86** / disconnect_recovery **4.00** / token_efficiency **4.33**，

--- a/projects/silver-core-sdk/tests/eval-harness-faults.test.ts
+++ b/projects/silver-core-sdk/tests/eval-harness-faults.test.ts
@@ -84,7 +84,11 @@ function startServer(): Promise<void> {
   );
 }
 
-async function run(fetchWrap: typeof fetch, extraProvider: Record<string, unknown> = {}) {
+async function run(
+  fetchWrap: typeof fetch,
+  extraProvider: Record<string, unknown> = {},
+  extraOptions: Record<string, unknown> = {},
+) {
   const messages: SDKMessage[] = [];
   let result: SDKResultMessage | null = null;
   const q = query({
@@ -94,6 +98,7 @@ async function run(fetchWrap: typeof fetch, extraProvider: Record<string, unknow
       cwd: sandbox,
       sessionDir: path.join(sandbox, '.sessions'),
       sandbox: false,
+      ...extraOptions,
     },
   });
   for await (const msg of q) {
@@ -189,6 +194,41 @@ describe('cutAfterTextDeltas (self-improve #3: deterministic mid-text cut)', () 
     const { result } = await run(fetchWrap);
     expect(result?.is_error).toBe(false);
     expect(result?.metrics?.transportHealth?.midStreamDrops ?? 0).toBe(0);
+  });
+});
+
+describe('dc-05 mixed-fault ledger attribution (keyless, judge-independent)', () => {
+  // The 2026-07-12 baseline round scored dc-05 a 2 with the judge note
+  // "transportHealth only records to one event bucket" in a mixed fault. That
+  // claim is mechanical, not subjective — it needs no paid judge, only a
+  // deterministic assertion that DIFFERENT fault kinds land in DIFFERENT
+  // buckets simultaneously. Same shape as the dc-05 harness (a request-phase
+  // network error on one POST + a mid-stream cut on a later POST), all within
+  // one recovered run. Either the ledger double-counts correctly (proving the
+  // judge's note was about presentation, not the ledger) or this test catches
+  // a real under-count — both outcomes are informative, at zero API cost.
+  it('a network error AND a mid-stream cut each increment their own bucket', async () => {
+    const fetchWrap = makeFaultFetch((i: number) => {
+      if (i === 1) return 'fail'; // request-phase network error  -> networkRetries
+      if (i === 2) return { cutAfterTextDeltas: 2 }; // mid-stream cut -> drop/recovery
+      return 'pass';
+    });
+    const { result } = await run(fetchWrap);
+    expect(result?.is_error).toBe(false);
+    const health = result?.metrics?.transportHealth;
+    // Bucket A — the request-phase fault.
+    expect(health?.networkRetries ?? 0).toBeGreaterThanOrEqual(1);
+    // Bucket B — the mid-stream cut (salvaged or replayed, but recorded).
+    const dropBucket =
+      (health?.midStreamDrops ?? 0) +
+      (health?.turnsSalvaged ?? 0) +
+      (health?.turnReplays ?? 0) +
+      (health?.emptyStreamRetries ?? 0);
+    expect(dropBucket).toBeGreaterThanOrEqual(1);
+    // The point of the test: BOTH kinds recorded, not collapsed into one.
+    expect((health?.networkRetries ?? 0) > 0 && dropBucket > 0).toBe(true);
+    // The injection ledger proves both faults actually fired (not a no-op run).
+    expect(fetchWrap.ledger.length).toBeGreaterThanOrEqual(2);
   });
 });
 


### PR DESCRIPTION
## 定性

守密人 API 账户暂无法充值（虚拟卡 3DS 验证阻塞），付费判卷这条路走不通。本 PR 是**充值阻塞下的免费替代方案**：把被判卷阻塞的评估发现里**机械可判定的内核**，转成确定性无钥断言——用现成的本地 SSE 模拟器驱真引擎，**零 API、零成本**，且结论比 judge 的 1-5 模糊分更硬。

## 结论（两项被阻塞发现的工程真相）

| 发现 | 是否真阻塞判卷 | 无钥结论 |
|------|--------------|---------|
| **dc-03 续写旗** | 否 | 机械核**早已无钥覆盖**（`engine.test.ts` 断言 `salvageMode:'continue'` → `turnsSalvaged:0, turnReplays:1`），从来没真被卡住 |
| **dc-05「只记一个桶」** | 否（judge 那句是呈现层，非引擎缺陷） | 新增混合故障断言实测**双桶各记一笔、并未漏记** |

## 新增断言

一轮内注入两种故障：请求相网络错（POST #1）+ 流中切断（POST #2），运行恢复成功。断言：

- `networkRetries ≥ 1`（桶 A：网络错）**且**
- drop/recovery 桶（`midStreamDrops + turnsSalvaged + turnReplays + emptyStreamRetries`）`≥ 1`（桶 B：流中切断）
- **两者同时成立** → 引擎台账把不同故障记进各自的桶，没有塌成一个。

基线轮 judge 给 dc-05 打 2 分、附注「transportHealth 只记到一个事件桶」——本断言**证伪了这句对引擎的指控**：漏的是喂给判卷官的证据里只浮现了一个桶（呈现/rubric 层面），引擎台账本身是对的。

小学生比喻：judge 尝一口说「这锅菜好像只放了一样料」；掀开锅盖数一眼——两样料都在，只是端上桌那盘没摆出来。锅（引擎）没问题，是摆盘（证据）漏了。

## 真正剩下的判卷依赖项（无钥不可复现，须充值）

mem-03/dc-05 的 judge 结构化输出**偶发失败**——这是判卷官模型自身的行为，模拟器复现不了，待守密人为 API 充值后收 `judgeDiag` 深挖。

## 验证

- **1906 全绿 + 2 skipped**（+1 混合故障断言），tsc/build 历史绿；
- 仅改 `tests/`（扩 `run()` 助手签名支持顶层 options + 一条新断言），非 shipped `src/**`，版本升号守卫豁免。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3YTqk7L6ejjzmVGiHscyV)_