### PR TITLE
test(silver-core-sdk): transport 变异歼灭批一——韧性臂 25 击杀

### DIFF
--- a/projects/silver-core-sdk/tests/transport-anthropic-mutation-kills.test.ts
+++ b/projects/silver-core-sdk/tests/transport-anthropic-mutation-kills.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Mutation-kill tests: AnthropicTransport survivors (transport round 1).
+ * Focus: the resilience arms the campaign prioritizes - Retry-After
+ * HTTP-date parsing (was NO COVERAGE on this arm; the 0.48.3 tests
+ * exercised the numeric form), the no-body response guard, retryable
+ * status classification, credential-resolution messaging, and mid-stream
+ * error-frame payload fallbacks.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AnthropicTransport } from '../src/transport/anthropic.js';
+import { APIConnectionError, APIStatusError, ConfigurationError } from '../src/errors.js';
+import type { RetryInfo, StreamRequest } from '../src/internal/contracts.js';
+import type { ProviderConfig, RawMessageStreamEvent } from '../src/types.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// --- helpers (mirroring tests/transport.test.ts) ------------------------------
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(c) {
+      for (const ch of chunks) c.enqueue(enc.encode(ch));
+      c.close();
+    },
+  });
+}
+function sseBody(frames: Array<{ event: string; data: unknown }>): string {
+  return frames.map((f) => `event: ${f.event}\ndata: ${JSON.stringify(f.data)}\n\n`).join('');
+}
+function sseResponse(text: string, headers: Record<string, string> = {}): Response {
+  return new Response(streamFromChunks([text]), {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream', ...headers },
+  });
+}
+function okSse(): string {
+  return sseBody([
+    { event: 'ping', data: { type: 'ping' } },
+    { event: 'message_stop', data: { type: 'message_stop' } },
+  ]);
+}
+const OK_EVENTS: RawMessageStreamEvent[] = [{ type: 'ping' }, { type: 'message_stop' }];
+
+function stubFetch(factories: Array<() => Response | Promise<Response>>) {
+  let i = 0;
+  const fn = vi.fn((_url: string | URL, _init?: RequestInit): Promise<Response> => {
+    const factory = factories[i];
+    i += 1;
+    if (!factory) return Promise.reject(new Error('stubFetch: unexpected extra fetch call'));
+    return Promise.resolve().then(factory);
+  });
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+function makeTransport(cfg: { provider?: ProviderConfig; env?: Record<string, string | undefined> } = {}) {
+  return new AnthropicTransport({
+    provider: cfg.provider,
+    env: { BPT_HTTP_CLIENT: 'fetch', ...cfg.env },
+    debug: () => undefined,
+  });
+}
+function baseReq(extra: Partial<StreamRequest> = {}): StreamRequest {
+  return { model: 'claude-test-1', max_tokens: 64, messages: [{ role: 'user', content: 'hi' }], ...extra };
+}
+async function collect<T>(gen: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const e of gen) out.push(e);
+  return out;
+}
+async function captureError(p: Promise<unknown>): Promise<unknown> {
+  try {
+    await p;
+    return undefined;
+  } catch (err) {
+    return err;
+  }
+}
+function rateLimited(headers: Record<string, string>): Response {
+  return new Response(
+    JSON.stringify({ type: 'error', error: { type: 'rate_limit_error', message: 'slow down' } }),
+    { status: 429, headers },
+  );
+}
+
+// --- Retry-After HTTP-date arm (was NO COVERAGE) --------------------------------
+
+describe('Retry-After HTTP-date parsing (anthropic.ts:790-794)', () => {
+  it('a PAST http-date means retry immediately (retryAfterMs 0 on the RetryInfo, fast wall clock)', async () => {
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    const fetchMock = stubFetch([() => rateLimited({ 'retry-after': past }), () => sseResponse(okSse())]);
+    const retries: RetryInfo[] = [];
+    const started = Date.now();
+    const events = await collect(
+      makeTransport({ provider: { apiKey: 'k' } }).stream(
+        baseReq({ onRetry: (i) => retries.push(i) }),
+      ),
+    );
+    expect(events).toEqual(OK_EVENTS);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(retries[0]).toMatchObject({ kind: 'http_status', retryAfterMs: 0 });
+    expect(Date.now() - started).toBeLessThan(450);
+  });
+
+  it('a FUTURE http-date is honored as delta-from-now (not clamped to the 60s exponential cap)', async () => {
+    const future = new Date(Date.now() + 90_000).toUTCString();
+    stubFetch([() => rateLimited({ 'retry-after': future })]);
+    const ac = new AbortController();
+    const retries: RetryInfo[] = [];
+    const err = await captureError(
+      collect(
+        makeTransport({ provider: { apiKey: 'k' } }).stream(
+          baseReq({
+            signal: ac.signal,
+            onRetry: (i) => {
+              retries.push(i);
+              ac.abort(); // never actually wait the 90s
+            },
+          }),
+        ),
+      ),
+    );
+    expect((err as Error).name).toBe('AbortError');
+    expect(retries).toHaveLength(1);
+    const ms = retries[0]!.retryAfterMs!;
+    expect(ms).toBeGreaterThan(60_000); // beyond the exponential cap - honored, not clamped down
+    expect(ms).toBeLessThanOrEqual(120_000); // bounded by the Retry-After ceiling
+  });
+
+  it('a pathological far-future http-date is bounded by the 120s ceiling', async () => {
+    const far = new Date(Date.now() + 3_600_000).toUTCString();
+    stubFetch([() => rateLimited({ 'retry-after': far })]);
+    const ac = new AbortController();
+    const retries: RetryInfo[] = [];
+    await captureError(
+      collect(
+        makeTransport({ provider: { apiKey: 'k' } }).stream(
+          baseReq({
+            signal: ac.signal,
+            onRetry: (i) => {
+              retries.push(i);
+              ac.abort();
+            },
+          }),
+        ),
+      ),
+    );
+    expect(retries[0]!.retryAfterMs).toBe(120_000);
+  });
+
+  it('an unparsable Retry-After falls back to exponential backoff (no retryAfterMs on the info)', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    stubFetch([() => rateLimited({ 'retry-after': 'soonish' }), () => sseResponse(okSse())]);
+    const retries: RetryInfo[] = [];
+    const events = await collect(
+      makeTransport({ provider: { apiKey: 'k' } }).stream(
+        baseReq({ onRetry: (i) => retries.push(i) }),
+      ),
+    );
+    expect(events).toEqual(OK_EVENTS);
+    expect(retries[0]!.retryAfterMs).toBeUndefined();
+  });
+});
+
+// --- retryable-status classification (anthropic.ts:485) --------------------------
+
+describe('retryable status classification', () => {
+  it('500 and 408 are retried; 404 is terminal on the first call', async () => {
+    const err500 = () =>
+      new Response(JSON.stringify({ type: 'error', error: { type: 'api_error', message: 'boom' } }), {
+        status: 500,
+        headers: { 'retry-after': '0' },
+      });
+    const fetch1 = stubFetch([err500, () => sseResponse(okSse())]);
+    const t1 = makeTransport({ provider: { apiKey: 'k' } });
+    expect(await collect(t1.stream(baseReq()))).toEqual(OK_EVENTS);
+    expect(fetch1).toHaveBeenCalledTimes(2);
+    vi.unstubAllGlobals();
+
+    const err408 = () =>
+      new Response(JSON.stringify({ type: 'error', error: { type: 'timeout_error', message: 'slow' } }), {
+        status: 408,
+        headers: { 'retry-after': '0' },
+      });
+    const fetch2 = stubFetch([err408, () => sseResponse(okSse())]);
+    const t2 = makeTransport({ provider: { apiKey: 'k' } });
+    expect(await collect(t2.stream(baseReq()))).toEqual(OK_EVENTS);
+    expect(fetch2).toHaveBeenCalledTimes(2);
+    vi.unstubAllGlobals();
+
+    const err404 = () =>
+      new Response(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: 'nope' } }), {
+        status: 404,
+      });
+    const fetch3 = stubFetch([err404]);
+    const t3 = makeTransport({ provider: { apiKey: 'k' } });
+    const err = await captureError(collect(t3.stream(baseReq())));
+    expect(err).toBeInstanceOf(APIStatusError);
+    expect((err as APIStatusError).status).toBe(404);
+    expect(fetch3).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- response-body guard + error-frame payload fallbacks ---------------------------
+
+describe('response and error-frame edge guards', () => {
+  it('an HTTP 200 with a NULL body raises the dedicated no-body connection error', async () => {
+    stubFetch([() => new Response(null, { status: 200 })]);
+    const t = makeTransport({ provider: { apiKey: 'k', maxRetries: 0 } });
+    const err = await captureError(collect(t.stream(baseReq())));
+    expect(err).toBeInstanceOf(APIConnectionError);
+    expect((err as Error).message).toContain('Messages API response has no body');
+  });
+
+  it('a mid-stream error frame WITHOUT an error member falls back to api_error with the raw data', async () => {
+    const body = `event: error\ndata: {"weird":1}\n\n`;
+    stubFetch([() => sseResponse(body)]);
+    const t = makeTransport({ provider: { apiKey: 'k', maxRetries: 0 } });
+    const err = await captureError(collect(t.stream(baseReq())));
+    expect(err).toBeInstanceOf(APIStatusError);
+    expect((err as APIStatusError).errorType).toBe('api_error');
+    expect((err as Error).message).toContain('weird');
+  });
+
+  it('a mid-stream error frame with a NON-STRING error.type normalizes to api_error', async () => {
+    const body = `event: error\ndata: {"type":"error","error":{"type":123,"message":"odd"}}\n\n`;
+    stubFetch([() => sseResponse(body)]);
+    const t = makeTransport({ provider: { apiKey: 'k', maxRetries: 0 } });
+    const err = await captureError(collect(t.stream(baseReq())));
+    expect(err).toBeInstanceOf(APIStatusError);
+    expect((err as APIStatusError).errorType).toBe('api_error');
+    expect((err as Error).message).toBe('odd');
+  });
+});
+
+// --- credential-resolution message (anthropic.ts:158-160) ---------------------------
+
+describe('credential resolution', () => {
+  it('a credential-less transport names every credential source in its error', async () => {
+    let thrown: unknown;
+    try {
+      const t = makeTransport({ provider: {}, env: { BPT_HTTP_CLIENT: 'fetch' } });
+      await collect(t.stream(baseReq()));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ConfigurationError);
+    const msg = (thrown as Error).message;
+    expect(msg).toContain('No Anthropic credential found');
+    expect(msg).toContain('options.provider.apiKey');
+    expect(msg).toContain('ANTHROPIC_API_KEY');
+    expect(msg).toContain('ANTHROPIC_AUTH_TOKEN');
+  });
+});

--- a/projects/silver-core-sdk/tests/transport-mutation-kills.test.ts
+++ b/projects/silver-core-sdk/tests/transport-mutation-kills.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Mutation-kill tests: transport module (overnight quality campaign,
+ * transport round 1 scored 67.77% - 445 survived + 137 no-coverage).
+ * This file takes the resilience-critical small files first: the SSE
+ * parser's deterministic field edges + abort paths, the stall watchdog's
+ * whole lifecycle, and node-http's header normalization / null-body
+ * statuses / resolution seams / preconnect probe. The big remaining
+ * clusters (openai.ts translator, anthropic.ts long tail) are ledgered in
+ * the campaign report rather than force-killed tonight.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import http from 'node:http';
+import { parseSSE, type SSEFrame } from '../src/transport/sse.js';
+import {
+  DEFAULT_ASYNC_AGENT_STALL_TIMEOUT_MS,
+  StallWatchdog,
+  resolveStallTimeoutMs,
+} from '../src/transport/stall-watchdog.js';
+import {
+  createNodeFetch,
+  firePreconnect,
+  resolveHttpClient,
+  resolvePreconnect,
+} from '../src/transport/node-http.js';
+
+// ---------------------------------------------------------------------------
+// SSE parser: deterministic field-grammar edges + abort paths
+// ---------------------------------------------------------------------------
+
+function streamOf(chunks: Array<Uint8Array | string>): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(c) {
+      for (const ch of chunks) c.enqueue(typeof ch === 'string' ? enc.encode(ch) : ch);
+      c.close();
+    },
+  });
+}
+async function parseAll(chunks: Array<Uint8Array | string>, signal?: AbortSignal): Promise<SSEFrame[]> {
+  const out: SSEFrame[] = [];
+  for await (const f of parseSSE(streamOf(chunks), signal)) out.push(f);
+  return out;
+}
+
+describe('SSE field-grammar edges (sse.ts survivors)', () => {
+  it("a bare 'data' line (no colon) carries an empty value", async () => {
+    expect(await parseAll(['data\n\n'])).toEqual([{ data: '' }]);
+  });
+
+  it("'data:x' (no space after colon) keeps the full value - only ONE leading space is stripped", async () => {
+    expect(await parseAll(['data:x\n\n'])).toEqual([{ data: 'x' }]);
+    expect(await parseAll(['data:  two\n\n'])).toEqual([{ data: ' two' }]);
+  });
+
+  it("a bare 'event' line names an empty event; the frame still dispatches on its data", async () => {
+    expect(await parseAll(['event\ndata: d\n\n'])).toEqual([{ event: '', data: 'd' }]);
+  });
+
+  it('frame state fully resets between frames (event name does not bleed forward)', async () => {
+    expect(
+      await parseAll(['event: a\ndata: 1\n\ndata: 2\n\n']),
+    ).toEqual([{ event: 'a', data: '1' }, { data: '2' }]);
+  });
+
+  it('re-drained buffers never re-emit already-consumed lines (multi-chunk duplication guard)', async () => {
+    // Three chunks, each ending mid-way: any buffer mis-trim would duplicate
+    // 'data: 1' into the second frame or emit extra frames.
+    const frames = await parseAll(['data: 1\n', '\ndata: 2', '\n\n']);
+    expect(frames).toEqual([{ data: '1' }, { data: '2' }]);
+  });
+
+  it('a pre-aborted signal rejects with AbortError before reading anything', async () => {
+    const c = new AbortController();
+    c.abort();
+    await expect(parseAll(['data: x\n\n'], c.signal)).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('aborting between chunks rejects with AbortError and stops yielding', async () => {
+    const c = new AbortController();
+    const enc = new TextEncoder();
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(ctrl) {
+        pulls += 1;
+        if (pulls === 1) {
+          ctrl.enqueue(enc.encode('data: first\n\n'));
+        } else {
+          c.abort(); // abort while the parser awaits the next read
+          // never enqueue again; cancel() from the parser ends the read
+        }
+      },
+    });
+    const seen: SSEFrame[] = [];
+    await expect(
+      (async () => {
+        for await (const f of parseSSE(body, c.signal)) seen.push(f);
+      })(),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(seen).toEqual([{ data: 'first' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stall watchdog: env resolution + full lifecycle
+// ---------------------------------------------------------------------------
+
+describe('stall watchdog (stall-watchdog.ts survivors)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('env resolution: integer wins, 0 disables, junk/blank/negative fall back to default', () => {
+    expect(resolveStallTimeoutMs({ CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS: '5000' })).toBe(5000);
+    expect(resolveStallTimeoutMs({ CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS: '0' })).toBe(0);
+    expect(resolveStallTimeoutMs({})).toBe(DEFAULT_ASYNC_AGENT_STALL_TIMEOUT_MS);
+    expect(resolveStallTimeoutMs({ CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS: '' })).toBe(
+      DEFAULT_ASYNC_AGENT_STALL_TIMEOUT_MS,
+    );
+    expect(resolveStallTimeoutMs({ CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS: '   ' })).toBe(
+      DEFAULT_ASYNC_AGENT_STALL_TIMEOUT_MS,
+    );
+    expect(resolveStallTimeoutMs({ CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS: 'ten' })).toBe(
+      DEFAULT_ASYNC_AGENT_STALL_TIMEOUT_MS,
+    );
+    expect(resolveStallTimeoutMs({ CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS: '-1' })).toBe(
+      DEFAULT_ASYNC_AGENT_STALL_TIMEOUT_MS,
+    );
+    expect(resolveStallTimeoutMs({ CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS: '1.5' })).toBe(
+      DEFAULT_ASYNC_AGENT_STALL_TIMEOUT_MS,
+    );
+  });
+
+  it('fires exactly once after silence; touch() resets the clock', () => {
+    vi.useFakeTimers();
+    let stalls = 0;
+    const dog = new StallWatchdog({ timeoutMs: 1000, onStall: () => (stalls += 1) });
+    vi.advanceTimersByTime(900);
+    dog.touch(); // reset at t=900
+    vi.advanceTimersByTime(900);
+    expect(stalls).toBe(0); // 900 into the SECOND window - a non-reset would have fired at t=1000
+    vi.advanceTimersByTime(200);
+    expect(stalls).toBe(1);
+    expect(dog.stalled).toBe(true);
+    // once fired, more time and more touches change nothing
+    dog.touch();
+    vi.advanceTimersByTime(5000);
+    expect(stalls).toBe(1);
+  });
+
+  it('dispose() cancels the pending fire and stays safe to repeat; touch() after dispose is inert', () => {
+    vi.useFakeTimers();
+    let stalls = 0;
+    const dog = new StallWatchdog({ timeoutMs: 1000, onStall: () => (stalls += 1) });
+    dog.dispose();
+    dog.dispose();
+    dog.touch(); // must NOT re-arm a disposed watchdog
+    vi.advanceTimersByTime(10_000);
+    expect(stalls).toBe(0);
+    expect(dog.stalled).toBe(false);
+  });
+
+  it('timeoutMs 0 constructs a disabled watchdog that never fires', () => {
+    vi.useFakeTimers();
+    let stalls = 0;
+    const dog = new StallWatchdog({ timeoutMs: 0, onStall: () => (stalls += 1) });
+    dog.touch();
+    vi.advanceTimersByTime(DEFAULT_ASYNC_AGENT_STALL_TIMEOUT_MS * 2);
+    expect(stalls).toBe(0);
+    expect(dog.stalled).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// node-http: header normalization, null-body statuses, resolution, preconnect
+// ---------------------------------------------------------------------------
+
+type Echo = { headers: http.IncomingHttpHeaders; method: string };
+
+let server: http.Server | undefined;
+let baseUrl = '';
+
+function startEcho(status = 200): Promise<void> {
+  server = http.createServer((req, res) => {
+    const payload = JSON.stringify({ headers: req.headers, method: req.method });
+    res.writeHead(status, { 'content-type': 'application/json', 'x-echo': 'yes' });
+    if (status === 204 || status === 304) return res.end();
+    res.end(payload);
+  });
+  return new Promise((r) =>
+    server!.listen(0, '127.0.0.1', () => {
+      const addr = server!.address();
+      baseUrl = `http://127.0.0.1:${typeof addr === 'object' && addr ? addr.port : 0}`;
+      r();
+    }),
+  );
+}
+
+afterEach(async () => {
+  if (server) await new Promise<void>((r) => server!.close(() => r()));
+  server = undefined;
+});
+
+describe('node-http fetch adapter (node-http.ts survivors)', () => {
+  it('normalizes Headers-instance, tuple-array, and record inits - keys lowercased on the wire', async () => {
+    await startEcho();
+    const fetchFn = createNodeFetch();
+
+    const viaRecord = await fetchFn(baseUrl, { headers: { 'X-Alpha': 'a' } });
+    const r1 = (await viaRecord.json()) as Echo;
+    expect(r1.headers['x-alpha']).toBe('a');
+
+    const viaArray = await fetchFn(baseUrl, { headers: [['X-Beta', 'b']] });
+    const r2 = (await viaArray.json()) as Echo;
+    expect(r2.headers['x-beta']).toBe('b');
+
+    const h = new Headers();
+    h.set('X-Gamma', 'c');
+    const viaHeaders = await fetchFn(baseUrl, { headers: h });
+    const r3 = (await viaHeaders.json()) as Echo;
+    expect(r3.headers['x-gamma']).toBe('c');
+  });
+
+  it('a 204 response carries a NULL body (null-body status handling)', async () => {
+    await startEcho(204);
+    const fetchFn = createNodeFetch();
+    const res = await fetchFn(baseUrl);
+    expect(res.status).toBe(204);
+    expect(res.body).toBeNull();
+    // a normal 200 keeps a readable body
+    await new Promise<void>((r) => server!.close(() => r()));
+    server = undefined;
+    await startEcho(200);
+    const ok = await fetchFn(baseUrl);
+    expect(ok.status).toBe(200);
+    expect(ok.body).not.toBeNull();
+  });
+
+  it('resolveHttpClient precedence: provider > env > node default (junk ignored)', () => {
+    expect(resolveHttpClient({}, {})).toBe('node');
+    expect(resolveHttpClient({ httpClient: 'fetch' }, {})).toBe('fetch');
+    expect(resolveHttpClient({ httpClient: 'node' }, { BPT_HTTP_CLIENT: 'fetch' })).toBe('node');
+    expect(resolveHttpClient({}, { BPT_HTTP_CLIENT: 'fetch' })).toBe('fetch');
+    expect(resolveHttpClient({}, { BPT_HTTP_CLIENT: 'node' })).toBe('node');
+    expect(resolveHttpClient({}, { BPT_HTTP_CLIENT: 'weird' })).toBe('node');
+    expect(resolveHttpClient({}, { BPT_HTTP_CLIENT: '' })).toBe('node');
+  });
+
+  it('resolvePreconnect precedence: explicit provider beats env; env needs exactly "1"', () => {
+    expect(resolvePreconnect({}, {})).toBe(false);
+    expect(resolvePreconnect({ preconnect: true }, {})).toBe(true);
+    expect(resolvePreconnect({ preconnect: false }, { BPT_PRECONNECT: '1' })).toBe(false);
+    expect(resolvePreconnect({}, { BPT_PRECONNECT: '1' })).toBe(true);
+    expect(resolvePreconnect({}, { BPT_PRECONNECT: 'yes' })).toBe(false);
+  });
+
+  it('firePreconnect: a completed probe debug-logs the status; a dead endpoint logs failed-and-ignored', async () => {
+    await startEcho();
+    const lines: string[] = [];
+    firePreconnect((u, i) => createNodeFetch()(u, i), baseUrl, (m) => lines.push(m));
+    await vi.waitFor(() => {
+      expect(lines.join('\n')).toContain('preconnect completed (HTTP 200)');
+    });
+
+    const lines2: string[] = [];
+    firePreconnect(
+      (u, i) => createNodeFetch()(u, i),
+      'http://127.0.0.1:1/unreachable',
+      (m) => lines2.push(m),
+    );
+    await vi.waitFor(() => {
+      expect(lines2.join('\n')).toContain('preconnect failed (ignored)');
+    });
+  });
+});


### PR DESCRIPTION
## 概述

通宵质量攻坚批三：transport 首轮 1,813 变异体、总分 67.77%（1,224 杀含超时 / 445 存活 / 137 无覆盖 / 7 错误）。本批按韧性优先歼灭：SSE 字段文法边角与中止路径、stall 看门狗全生命周期、node-http 头规整/空体状态/解析优先级/预连探针、AnthropicTransport 的 **Retry-After HTTP-date 臂**（本臂此前整段无覆盖——0.48.3 的测试只打到数字形式）+ 可重试状态分类 + 200 空体守卫 + 流中错误帧兜底 + 凭据错误全源命名。+25 测，纯测试免 bump。openai 翻译器 360 存活长尾按停机纪律落盲区台账，不硬啃。

小学生比喻：给「断线保命装置」的每个零件单独做了压力试验——尤其发现「服务器用日期格式说'等到几点'」那条线路以前根本没通过电。

## 变更类型
- [x] 其他：SDK 测试补强（全量 **2003 绿 + 2 skipped，104 files**）

## 来源声明
- [x] 本仓库自产测试代码。

## 安全声明（强制）
- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

## 验证清单
- [x] SDK vitest 全量 2003 passed + 2 skipped；不引入 emoji；不动主控台档案

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq)_