### PR TITLE
ci(silver-core-sdk): 变异分棋轮门禁——只升不降的逐模块地板（余项 1）

### DIFF
--- a/.github/workflows/sdk-mutation-ratchet.yml
+++ b/.github/workflows/sdk-mutation-ratchet.yml
@@ -1,0 +1,84 @@
+name: SDK Mutation Ratchet (weekly)
+
+# Test-QUALITY ratchet for silver-core-sdk (keeper order 2026-07-13): the
+# 2026-07-13 quality campaign pushed per-module mutation scores up
+# (permissions 92.87%, transport/openai 85.55%); this workflow re-measures
+# each ratcheted target weekly and REDS when a score falls below its
+# committed floor (mutation-ratchet.json) - i.e. new code brought mutants
+# the suite does not kill. Floors only rise (bump after a measured
+# improvement); lowering one requires a keeper ruling. Complements the
+# python-side mutation-test.yml (mutmut, scripts/) and the SDK unit suite:
+# line coverage proves a line ran, the ratchet proves the assertions BITE.
+#
+# Deliberately scheduled + manual, NOT a per-PR required check: a full
+# per-target Stryker round costs ~7-12 minutes.
+#
+# Matrix names must match mutation-ratchet.json target names - the guard
+# script REDS loudly on drift (unknown name), so adding a target means
+# editing both files in one PR.
+
+on:
+  schedule:
+    - cron: '43 5 * * 1' # Mondays 05:43 UTC (13:43 北京)
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Single ratchet target name to run (empty = full matrix)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [permissions, transport-openai, transport-anthropic]
+    steps:
+      - name: Skip when a single target was requested and this is not it
+        if: github.event.inputs.target != '' && github.event.inputs.target != matrix.target
+        run: echo "skipping ${{ matrix.target }}" && exit 0
+      - uses: actions/checkout@v7
+        with:
+          # SPARSE: the SDK suite does not need the 2.4G archive layers
+          # (same exclusions as silver-core-sdk.yml; corpus-sync tests skip
+          # gracefully without the Reference snapshot).
+          sparse-checkout: |
+            /*
+            !/Public-Info-Pool/Record/
+            !/Public-Info-Pool/Reference/
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        working-directory: projects/silver-core-sdk
+        run: npm ci
+      - name: Resolve mutate pattern from the baseline
+        id: pattern
+        working-directory: projects/silver-core-sdk
+        run: |
+          PATTERN=$(node -e "
+            const b = require('./mutation-ratchet.json');
+            const t = (b.targets ?? []).find((t) => t.name === '${{ matrix.target }}');
+            if (!t) { console.error('unknown target ${{ matrix.target }} in mutation-ratchet.json'); process.exit(2); }
+            console.log(t.mutate);
+          ")
+          echo "mutate=$PATTERN" >> "$GITHUB_OUTPUT"
+      - name: Stryker round (${{ matrix.target }})
+        working-directory: projects/silver-core-sdk
+        run: npx stryker run --mutate "${{ steps.pattern.outputs.mutate }}"
+      - name: Ratchet check
+        working-directory: projects/silver-core-sdk
+        run: node scripts/check-mutation-ratchet.mjs --name "${{ matrix.target }}"
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report-${{ matrix.target }}
+          path: projects/silver-core-sdk/reports/mutation/mutation.json
+          retention-days: 30

--- a/projects/silver-core-sdk/mutation-ratchet.json
+++ b/projects/silver-core-sdk/mutation-ratchet.json
@@ -1,0 +1,27 @@
+{
+  "_meta": {
+    "what": "Mutation-score ratchet baselines (keeper order 2026-07-13: lock the campaign gains as only-up floors). One entry per mutate target; the scheduled sdk-mutation-ratchet workflow re-measures each and REDS below floor. Raising a floor is the only sanctioned edit after a measured improvement; floors never go down without a keeper ruling.",
+    "score": "Stryker mutation score = (killed + timeout) / (killed + timeout + survived + noCoverage) * 100; compile/runtime-error mutants excluded",
+    "tolerance_pp": 0.75,
+    "history": {
+      "2026-07-13": "seeded from the overnight quality campaign: permissions round 2 (92.87), openai dedicated rounds 1-6 (85.55); transport-anthropic seeded at 77.42 (measurement round, pre-kill-batch)"
+    }
+  },
+  "targets": [
+    {
+      "name": "permissions",
+      "mutate": "src/permissions/**/*.ts",
+      "floor": 92.87
+    },
+    {
+      "name": "transport-openai",
+      "mutate": "src/transport/openai.ts",
+      "floor": 85.55
+    },
+    {
+      "name": "transport-anthropic",
+      "mutate": "src/transport/anthropic.ts",
+      "floor": 77.42
+    }
+  ]
+}

--- a/projects/silver-core-sdk/scripts/check-mutation-ratchet.mjs
+++ b/projects/silver-core-sdk/scripts/check-mutation-ratchet.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Mutation-score ratchet guard (keeper order 2026-07-13).
+ *
+ * Compares a fresh Stryker JSON report against the committed floor for one
+ * ratchet target (mutation-ratchet.json). The floor only ever RISES: a run
+ * below floor - tolerance fails (test quality regressed - new code brought
+ * blind spots the suite does not pin); a run meaningfully above the floor
+ * prints a notice suggesting the baseline bump.
+ *
+ * Usage (after `npx stryker run --mutate <target.mutate>`):
+ *   node scripts/check-mutation-ratchet.mjs --name transport-openai \
+ *     [--report reports/mutation/mutation.json] [--baseline mutation-ratchet.json]
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(HERE, '..');
+
+const arg = (name, dflt) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : dflt;
+};
+const NAME = arg('name', '');
+const REPORT = path.resolve(ROOT, arg('report', 'reports/mutation/mutation.json'));
+const BASELINE = path.resolve(ROOT, arg('baseline', 'mutation-ratchet.json'));
+
+if (!NAME) {
+  console.error('ratchet: pass --name <target name from mutation-ratchet.json>');
+  process.exit(2);
+}
+const baseline = JSON.parse(fs.readFileSync(BASELINE, 'utf8'));
+const target = (baseline.targets ?? []).find((t) => t.name === NAME);
+if (!target) {
+  console.error(
+    `ratchet: unknown target "${NAME}" - the workflow matrix and mutation-ratchet.json drifted apart. ` +
+      `Known: ${(baseline.targets ?? []).map((t) => t.name).join(', ')}`,
+  );
+  process.exit(2);
+}
+if (!fs.existsSync(REPORT)) {
+  console.error(`ratchet: report not found at ${REPORT} - did the stryker run complete?`);
+  process.exit(2);
+}
+
+const report = JSON.parse(fs.readFileSync(REPORT, 'utf8'));
+let killed = 0;
+let timeout = 0;
+let survived = 0;
+let noCoverage = 0;
+let errors = 0;
+for (const file of Object.values(report.files ?? {})) {
+  for (const m of file.mutants ?? []) {
+    if (m.status === 'Killed') killed += 1;
+    else if (m.status === 'Timeout') timeout += 1;
+    else if (m.status === 'Survived') survived += 1;
+    else if (m.status === 'NoCoverage') noCoverage += 1;
+    else errors += 1;
+  }
+}
+const valid = killed + timeout + survived + noCoverage;
+if (valid === 0) {
+  console.error('ratchet: report contains zero valid mutants - wrong --mutate target?');
+  process.exit(2);
+}
+const score = ((killed + timeout) / valid) * 100;
+const tolerance = Number(baseline._meta?.tolerance_pp ?? 0.75);
+const floorWithGrace = target.floor - tolerance;
+
+console.log(
+  `ratchet[${NAME}]: score ${score.toFixed(2)}% ` +
+    `(killed ${killed} + timeout ${timeout} / survived ${survived} / no-coverage ${noCoverage} / errors ${errors}) ` +
+    `vs floor ${target.floor}% (tolerance ${tolerance}pp)`,
+);
+
+if (score < floorWithGrace) {
+  console.error(
+    `ratchet[${NAME}] FAILED: ${score.toFixed(2)}% < floor ${target.floor}% - ${tolerance}pp. ` +
+      'Test quality regressed on this module: recent changes introduced mutants the suite does not kill. ' +
+      'Fix by adding kill tests (see the campaign report for the playbook), NOT by lowering the floor - ' +
+      'floors only move down by keeper ruling.',
+  );
+  process.exit(1);
+}
+if (score >= target.floor + 1) {
+  console.log(
+    `::notice::ratchet[${NAME}]: measured ${score.toFixed(2)}% is >=1pp above the floor ${target.floor}% - ` +
+      'raise the floor in mutation-ratchet.json to lock the gain (only-up discipline).',
+  );
+}
+console.log(`ratchet[${NAME}] OK.`);


### PR DESCRIPTION
## 概述

守密人「1 3 推进」之余项 1 执行：把质量攻坚战果锁进**只升不降的棋轮**——基线 `mutation-ratchet.json`（permissions **92.87** / transport-openai **85.55** / transport-anthropic **77.42** 三靶起步，0.75pp 抖动容差，降地板须守密人裁定的纪律入 _meta）+ 守卫脚本（低于地板−容差即红并指路「补击杀测试、绝不降地板」；升 ≥1pp 出提杆提示；矩阵与基线漂移响亮红）+ 周检工作流（每周一 05:43 UTC + 手动 dispatch，逐靶矩阵并行，报告 artifact 存 30 天；刻意不做 per-PR required——单靶一轮 7-26 分钟）。三靶已各对真实报告自验通过。纯 CI/工装，免 bump。

小学生比喻：登山扣好的安全绳只许往上挪扣点——手一滑最多回到上一个扣点，不会摔回山脚。

## 变更类型
- [x] 其他：CI 门禁基建（+3 档案 205 行）

## 来源声明
- [x] 本仓库自产工装；地板数字来自本会话实测轮。

## 安全声明（强制）
- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

## 验证清单
- [x] 守卫脚本三靶自验（85.55/92.87/77.42 精确对账 OK + 漂移名 exit 2）；仓根 pytest **2915 passed + 12 skipped**
- [x] 不引入 emoji；不动主控台档案

## 关联 Issue
- Refs: 战报余项 1（守密人「1 3 推进」口谕）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq)_