### PR TITLE
test(silver-core-sdk): sessions 变异歼灭批二（checkpoints+file-store 逐档抬升）+ 穿越测试隔离加固

### DIFF
--- a/projects/silver-core-sdk/tests/sessions-mutation-kills-r2.test.ts
+++ b/projects/silver-core-sdk/tests/sessions-mutation-kills-r2.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Mutation-kill tests: sessions module, batch 2 (keeper "1 继续推进 sessions").
+ * Attacks the two remaining weak files from the batch-1 report:
+ *  - checkpoints.ts (60.84%): FileCheckpointStore record/rewind/seq —
+ *    first-touch-per-turn wins, seq monotonicity + reconstruction across
+ *    rebind, rewind first-wins plan (modified->restore, created->delete),
+ *    dryRun purity, unknown-checkpoint soft-fail vs unbound throw, unsafe-id
+ *    refusal.
+ *  - file-store.ts (67.73%): encodeKeyComponent/decodeKeyComponent byte
+ *    round-trip incl. the UPPERCASE-hex + empty-marker + dot escapes, tilde
+ *    expansion, and the torn-tail (endsWithoutNewline) heal on first append.
+ *
+ * Overfitting guard (not killed): debug strings, ENOENT-detail plumbing,
+ * mkdir recursive flags whose effect JSON-round-trips identically.
+ */
+// @ts-nocheck
+
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { FileCheckpointStore, makeCheckpointRecorder } from '../src/sessions/checkpoints.js';
+import {
+  FileSessionStore,
+  encodeKeyComponent,
+  decodeKeyComponent,
+} from '../src/sessions/file-store.js';
+import { ConfigurationError } from '../src/errors.js';
+import type { SessionKey, SessionStoreEntry } from '../src/types.js';
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'sess-kills2-'));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// checkpoints.ts
+// ---------------------------------------------------------------------------
+
+function makeCp(): FileCheckpointStore {
+  return new FileCheckpointStore({ sessionDir: dir });
+}
+
+describe('FileCheckpointStore: record semantics', () => {
+  it('first touch of a path per turn wins; repeats are ignored (earliest pre-image restored)', async () => {
+    const cp = makeCp();
+    cp.bind('sess-1');
+    cp.beginTurn('turn-A');
+    const target = join(dir, 'work', 'f.txt');
+    await mkdir(join(dir, 'work'), { recursive: true });
+    await writeFile(target, 'ORIGINAL', 'utf8');
+
+    cp.record(target, 'ORIGINAL'); // first pre-image
+    cp.record(target, 'LATER'); // ignored (same turn, same path)
+    await writeFile(target, 'MUTATED', 'utf8');
+
+    const res = await cp.rewind('turn-A');
+    expect(res.canRewind).toBe(true);
+    expect(res.restoredFiles).toEqual([target]);
+    expect(await readFile(target, 'utf8')).toBe('ORIGINAL'); // not LATER
+  });
+
+  it('a created file (null pre-image) is DELETED on rewind; a modified file is RESTORED', async () => {
+    const cp = makeCp();
+    cp.bind('sess-2');
+    cp.beginTurn('turn-B');
+    const modified = join(dir, 'mod.txt');
+    const created = join(dir, 'new.txt');
+    await writeFile(modified, 'OLD', 'utf8');
+    cp.record(modified, 'OLD');
+    cp.record(created, null); // created this turn
+    await writeFile(modified, 'NEW', 'utf8');
+    await writeFile(created, 'CREATED', 'utf8');
+
+    const res = await cp.rewind('turn-B');
+    expect(res.restoredFiles).toEqual([modified]);
+    expect(res.deletedFiles).toEqual([created]);
+    expect(await readFile(modified, 'utf8')).toBe('OLD');
+    expect(existsSync(created)).toBe(false);
+  });
+
+  it('dryRun computes the plan WITHOUT touching disk', async () => {
+    const cp = makeCp();
+    cp.bind('sess-3');
+    cp.beginTurn('turn-C');
+    const f = join(dir, 'd.txt');
+    await writeFile(f, 'A', 'utf8');
+    cp.record(f, 'A');
+    await writeFile(f, 'B', 'utf8');
+
+    const res = await cp.rewind('turn-C', { dryRun: true });
+    expect(res.canRewind).toBe(true);
+    expect(res.restoredFiles).toEqual([f]);
+    expect(res.dryRun).toBe(true);
+    expect(await readFile(f, 'utf8')).toBe('B'); // untouched
+  });
+
+  it('an unknown checkpoint soft-fails (canRewind:false); an UNBOUND store throws', async () => {
+    const cp = makeCp();
+    cp.bind('sess-4');
+    cp.beginTurn('turn-D');
+    const res = await cp.rewind('no-such-turn');
+    expect(res.canRewind).toBe(false);
+    expect(res.error).toContain('No file checkpoint found');
+    expect(res.restoredFiles).toEqual([]);
+
+    const unbound = makeCp(); // never bound
+    await expect(unbound.rewind('x')).rejects.toBeInstanceOf(ConfigurationError);
+  });
+
+  it('an unsafe session id refuses to bind (record becomes a no-op, rewind throws)', async () => {
+    const cp = makeCp();
+    cp.bind('../evil');
+    // Not bound -> record is a silent no-op, no dir created.
+    cp.beginTurn('t');
+    cp.record(join(dir, 'x.txt'), 'p');
+    expect(existsSync(join(dir, 'checkpoints', '..', 'evil'))).toBe(false);
+    await expect(cp.rewind('t')).rejects.toBeInstanceOf(ConfigurationError);
+  });
+
+  it('seq is monotonic within a bind and RECONSTRUCTS across a fresh bind (max+1)', async () => {
+    const cp = makeCp();
+    cp.bind('sess-seq');
+    cp.beginTurn('t1');
+    cp.record(join(dir, 'a'), 'a');
+    cp.record(join(dir, 'b'), 'b'); // distinct paths -> two records
+    const idxPath = join(dir, 'checkpoints', 'sess-seq', 'index.jsonl');
+    const seqs1 = readFileSync(idxPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((l) => (JSON.parse(l) as { seq: number }).seq);
+    expect(seqs1).toEqual([0, 1]);
+
+    // Fresh store instance rebinding the SAME session must continue at max+1.
+    const cp2 = makeCp();
+    cp2.bind('sess-seq');
+    cp2.beginTurn('t2');
+    cp2.record(join(dir, 'c'), 'c');
+    const seqs2 = readFileSync(idxPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((l) => (JSON.parse(l) as { seq: number }).seq);
+    expect(seqs2).toEqual([0, 1, 2]); // reconstructed to 2, not reset to 0
+  });
+
+  it('makeCheckpointRecorder forwards to store.record', async () => {
+    const cp = makeCp();
+    cp.bind('sess-rec');
+    cp.beginTurn('t');
+    const rec = makeCheckpointRecorder(cp);
+    const f = join(dir, 'r.txt');
+    await writeFile(f, 'ORIG', 'utf8');
+    rec(f, 'ORIG');
+    await writeFile(f, 'CHG', 'utf8');
+    const res = await cp.rewind('t');
+    expect(res.restoredFiles).toEqual([f]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// file-store.ts
+// ---------------------------------------------------------------------------
+
+describe('encodeKeyComponent: byte-precise escaping', () => {
+  it('safe bytes pass through; non-safe bytes become UPPERCASE %XX', () => {
+    expect(encodeKeyComponent('Aa0._-')).toBe('Aa0._-'); // all safe
+    // space (0x20) -> %20; '/' (0x2F) -> %2F; UPPERCASE hex is load-bearing
+    expect(encodeKeyComponent('a b')).toBe('a%20b');
+    expect(encodeKeyComponent('a/b')).toBe('a%2Fb');
+    // a byte whose hex has a letter: 0xC3 0xA9 = é -> uppercase, zero-padded
+    expect(encodeKeyComponent('é')).toBe('%C3%A9');
+  });
+
+  it('the empty string maps to the bare "%" marker, distinct from a literal "%"', () => {
+    expect(encodeKeyComponent('')).toBe('%');
+    expect(encodeKeyComponent('%')).toBe('%25'); // literal % never collides with the empty marker
+    expect(decodeKeyComponent('%')).toBe('');
+    expect(decodeKeyComponent('%25')).toBe('%');
+  });
+
+  it('"." and ".." escape to reserved forms (never a real dot filename)', () => {
+    expect(encodeKeyComponent('.')).toBe('%2E');
+    expect(encodeKeyComponent('..')).toBe('%2E%2E');
+    expect(decodeKeyComponent('%2E')).toBe('.');
+    expect(decodeKeyComponent('%2E%2E')).toBe('..');
+  });
+
+  it('round-trips arbitrary content and never yields a separator or traversal name', () => {
+    for (const raw of ['../../etc', 'a b%c\\d', '中文/键', 'plain_1.2', '', '.', '..']) {
+      const enc = encodeKeyComponent(raw);
+      expect(decodeKeyComponent(enc)).toBe(raw);
+      expect(enc).not.toMatch(/[/\\]/);
+      expect(enc).not.toBe('.');
+      expect(enc).not.toBe('..');
+    }
+  });
+
+  it('decode leaves a lone "%" without two hex digits as a literal char (no crash)', () => {
+    // trailing '%' with no hex, and '%zz' non-hex both pass through literally
+    expect(decodeKeyComponent('ab%')).toBe('ab%');
+    expect(decodeKeyComponent('a%zzb')).toBe('a%zzb');
+  });
+});
+
+describe('FileSessionStore: torn-tail heal + layout', () => {
+  const PK = 'projX';
+  const key = (sessionId: string, subpath = ''): SessionKey => ({ projectKey: PK, sessionId, subpath });
+  const entry = (uuid: string): SessionStoreEntry =>
+    ({ type: 'user', uuid, message: { role: 'user', content: 'hi' } }) as SessionStoreEntry;
+
+  it('the FIRST append heals a crash-torn tail (no trailing newline) by prefixing one', async () => {
+    const store = new FileSessionStore(dir);
+    // Plant a torn main.jsonl (a record with NO trailing newline).
+    const base = join(dir, encodeKeyComponent(PK), encodeKeyComponent('s-torn'));
+    await mkdir(base, { recursive: true });
+    const main = join(base, 'main.jsonl');
+    await writeFile(main, JSON.stringify({ type: 'user', uuid: 'pre', message: { role: 'user', content: 'x' } }), 'utf8');
+
+    await store.append(key('s-torn'), [entry('post')]);
+    const text = await readFile(main, 'utf8');
+    const lines = text.split('\n').filter((l) => l.trim().length > 0);
+    // Two well-formed lines: the healed pre-existing one + the new one.
+    expect(lines).toHaveLength(2);
+    for (const l of lines) expect(() => JSON.parse(l)).not.toThrow();
+    const loaded = await store.load(key('s-torn'));
+    expect(loaded).toHaveLength(2);
+  });
+
+  it('a clean newline-terminated tail is NOT double-prefixed on append', async () => {
+    const store = new FileSessionStore(dir);
+    await store.append(key('s-clean'), [entry('a')]);
+    await store.append(key('s-clean'), [entry('b')]);
+    const base = join(dir, encodeKeyComponent(PK), encodeKeyComponent('s-clean'));
+    const text = await readFile(join(base, 'main.jsonl'), 'utf8');
+    expect(text).not.toContain('\n\n'); // no blank line injected
+    expect((await store.load(key('s-clean')))).toHaveLength(2);
+  });
+
+  it('subpath entries land under sub/ with an encoded filename; main stays at main.jsonl', async () => {
+    const store = new FileSessionStore(dir);
+    await store.append(key('s'), [entry('m')]);
+    await store.append(key('s', 'agent/child'), [entry('c')]);
+    const base = join(dir, encodeKeyComponent(PK), encodeKeyComponent('s'));
+    expect(existsSync(join(base, 'main.jsonl'))).toBe(true);
+    expect(existsSync(join(base, 'sub', `${encodeKeyComponent('agent/child')}.jsonl`))).toBe(true);
+    expect(await store.load(key('s', 'agent/child'))).toHaveLength(1);
+  });
+
+  it('load of a never-written key returns null (ENOENT swallowed, not thrown)', async () => {
+    const store = new FileSessionStore(dir);
+    expect(await store.load(key('ghost'))).toBeNull();
+  });
+});
+
+describe('FileSessionStore: tilde expansion', () => {
+  it("a leading '~/' expands to the home directory", async () => {
+    // Use a unique subdir under home so we can clean it deterministically.
+    const rel = `.bpt-test-${process.pid}-${Date.now() % 100000}`;
+    const store = new FileSessionStore(`~/${rel}`);
+    const k: SessionKey = { projectKey: 'p', sessionId: 's', subpath: '' };
+    try {
+      await store.append(k, [{ type: 'user', message: { role: 'user', content: 'hi' } } as SessionStoreEntry]);
+      expect(existsSync(join(homedir(), rel))).toBe(true);
+    } finally {
+      await rm(join(homedir(), rel), { recursive: true, force: true });
+    }
+  });
+});

--- a/projects/silver-core-sdk/tests/sessions-mutation-kills-r2.test.ts
+++ b/projects/silver-core-sdk/tests/sessions-mutation-kills-r2.test.ts
@@ -19,7 +19,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtemp, rm, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
-import { tmpdir, homedir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { FileCheckpointStore, makeCheckpointRecorder } from '../src/sessions/checkpoints.js';
 import {
@@ -257,17 +257,11 @@ describe('FileSessionStore: torn-tail heal + layout', () => {
   });
 });
 
-describe('FileSessionStore: tilde expansion', () => {
-  it("a leading '~/' expands to the home directory", async () => {
-    // Use a unique subdir under home so we can clean it deterministically.
-    const rel = `.bpt-test-${process.pid}-${Date.now() % 100000}`;
-    const store = new FileSessionStore(`~/${rel}`);
-    const k: SessionKey = { projectKey: 'p', sessionId: 's', subpath: '' };
-    try {
-      await store.append(k, [{ type: 'user', message: { role: 'user', content: 'hi' } } as SessionStoreEntry]);
-      expect(existsSync(join(homedir(), rel))).toBe(true);
-    } finally {
-      await rm(join(homedir(), rel), { recursive: true, force: true });
-    }
-  });
-});
+// NOTE: a tilde-expansion test was deliberately REMOVED (2026-07-13). Driving
+// expandTilde('~/…') through a real FileSessionStore.append writes to disk, so
+// a mutation run that disables the tilde branch creates a LITERAL `~/` dir in
+// the repo (and the passing path writes under the real homedir) — the same
+// side-effecting pollution class as the /tmp/evil.jsonl traversal case. The
+// expandTilde branch's low kill value does not justify a filesystem-side-effect
+// test; it is left as an accepted survivor per the overfitting/side-effect
+// guard (100%-question analysis).

--- a/projects/silver-core-sdk/tests/sessions-store.test.ts
+++ b/projects/silver-core-sdk/tests/sessions-store.test.ts
@@ -3,9 +3,11 @@
  * (findings #10/#40) and load()'s tool_use/tool_result pairing repair
  * (finding #37).
  */
+// @ts-nocheck
+
 
 import { appendFileSync, existsSync, readFileSync } from 'node:fs';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -21,13 +23,25 @@ import { renameSession, tagSession } from '../src/sessions/session-functions.js'
 import type { APIMessageParam } from '../src/types.js';
 
 let dir: string;
+let dirRoot: string;
 
 beforeEach(async () => {
-  dir = await mkdtemp(join(tmpdir(), 'bpt-store-'));
+  // `dir` is a NESTED subdir of the mkdtemp root, so the path-traversal
+  // test's `../evil.jsonl` escape target lands back INSIDE the isolated root
+  // (removed by afterEach), not in the shared system tmpdir. Without the
+  // nesting, a mutation run that disables the traversal guard writes
+  // /tmp/evil.jsonl and poisons every later run and parallel worker — a real
+  // pollution source that hit 2026-07-13. All `join(dir, …)` assertions are
+  // unchanged: `dir` is still the store's sessionDir.
+  dirRoot = await mkdtemp(join(tmpdir(), 'bpt-store-'));
+  dir = join(dirRoot, 'nest');
+  await mkdir(dir, { recursive: true });
 });
 
 afterEach(async () => {
-  await rm(dir, { recursive: true, force: true });
+  // Remove the whole isolated root, so any guard-escape file the traversal
+  // test provoked (dir/../evil.jsonl == dirRoot/evil.jsonl) goes with it.
+  await rm(dirRoot, { recursive: true, force: true });
 });
 
 function makeStore(): { store: JsonlSessionStore; warnings: string[] } {


### PR DESCRIPTION
## 概述

守密人「1 继续推进 sessions」+「2 也可以推进」执行:sessions 两最弱档 16 击杀,**逐档真实抬升**——checkpoints.ts **60.84→72.89%**(+12pp)、file-store.ts **67.73→74.09%**(+6pp);并落实穿越测试隔离加固(余项 2)。隔离全绿(3 档 55 测)。

小学生比喻:把「文件回滚」与「会话文件名编码」两块的警报网各补密一档。

### 逐档歼灭
- **checkpoints.ts**:首触优先/回滚计划(改档还原·新档删除)/dryRun 纯净/未知检查点软失败 vs 未绑定抛错/不安全 id 拒绑/seq 跨重绑重建/recorder 转发。
- **file-store.ts**:字节级 encode/decode 往返(大写 hex·空串「%」标记 vs 字面「%25」·点转义)/断尾自愈首次 append/sub 布局/ENOENT→null。

### 穿越测试加固(余项 2,守密人批准)
`dir` 改为 mkdtemp 根下**嵌套子目录**,守卫禁用变异体的逃逸落点回到隔离根内(afterEach 清)、不再逃到系统 `/tmp`——根治今日发现的 `/tmp/evil.jsonl` 污染源;所有 `join(dir,…)` 断言不变。连带移除一个有文件系统副作用的 tilde 测试(同类污染,击杀价值低,按防过拟合弃)。

---

## 守密人侧两项显著待裁(呈复核)

**① 既有 main 红(非本 PR 引入)**:今晨自动任务 `refresh-claude-code-prompts`(commit 77d2f08f9,ccVersion 2.1.129→2.1.205)带 `[skip ci]` 绕过 corpus-sync 守卫,SDK 忠实复现片段不再逐字匹配归档,两守卫(generators/sandbox)在 main 上就红。守密人 2026-07-13 裁定「分开落」:sessions 先并,复现层追同步单开 PR(本 PR 后即办)。仓根 pytest 2915 绿不受影响。

**② sessions 棋轮地板噪声发现**:重负载重测 sessions 聚合分 **67.98%**(低于 #664 设的 71.24 地板),元凶是 **444 个静态变异体(占 26%、吃 98% 时间)**——模块加载期代码每个重跑全套,超时判定随机器负载漂移,把 store.ts 单档从 71.86 压到 61.74(我未碰 store.ts 测试)。即 71.24 地板是噪声乐观值、GitHub 周检 runner 会照样假红。**本 PR 不动地板(降地板须守密人裁定)**;建议:启用 `ignoreStatic` 消除噪声源并重定四靶基线(静态变异体多属模块常量、等价率高)。棋轮周检为非阻塞(scheduled/manual),假红不拦 PR,有缓冲。

## 变更类型
- [x] 其他:SDK 测试补强(+16 击杀 + 穿越加固,隔离 55 测全绿)

## 来源声明
- [x] 本仓库自产测试代码与实测数据。

## 安全声明(强制)
- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

## 验证清单
- [x] 我的 3 个 sessions 测试文件隔离全绿(55 测);仓根 pytest **2915 passed + 12 skipped**
- [x] 不引入 emoji;不动主控台档案
- [ ] SDK 全量 vitest 现有 2 个 corpus-sync 守卫红为**既有 main 问题**(见①,非本 diff),复现层追同步单开 PR 处理

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq)_