### PR TITLE
fix(silver-core-sdk): re-sync reproduced prompts to upstream ccVersion 2.1.205

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,30 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.53.1 — 2026-07-13
+
+**Corpus-sync re-sync to upstream ccVersion 2.1.205.** The weekly
+claude-code-system-prompts refresh advanced the archived upstream prompts
+(2.1.129 → 2.1.205) and drifted two faithfully-reproduced surfaces:
+- **Background-agent state classifier** (`src/generators/prompts.ts`): eight
+  example/schema lines were reworded upstream. Re-synced verbatim — six
+  `detail` example strings (`dedicated column beats a composite index…`,
+  `localhost:4000 restarted on local CCR`, `venn.png + scripts/venn.R`,
+  `~16K/min notif drop confirmed`, `option B: reuses the table…`, `added at
+  the logging call site`), the OUTPUT schema (`<one line, ≤64 chars>`), and
+  the `detail` guidance clause (`…phone lock screen and as the one-line status
+  column in a session list…`). Note: the `generators.test.ts` guard is a
+  first-60-char substring check, so only two of these tripped it; all eight
+  were still drift and are now fixed.
+- **Bash sandbox note** (`src/tools/descriptions.ts`): upstream deleted the
+  standalone `-user-permission-prompt` archive fragment. The SDK keeps the
+  sentence "This will prompt the user for permission" as its own framing (the
+  escape hatch does gate on a prompt here) but reclassified it `faithful:
+  false` / `slug: ''` — never claim verbatim provenance for text upstream
+  dropped. Assembled sandbox-note output is byte-unchanged.
+
+No behavior change beyond the reproduced prompt text. Full vitest green.
+
 ## 0.53.0 — 2026-07-13
 
 **Persist message uuids at write time (keeper ruling 2026-07-13).** The

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.53.0",
+  "version": "0.53.1",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/generators/prompts.ts
+++ b/projects/silver-core-sdk/src/generators/prompts.ts
@@ -203,14 +203,14 @@ EXAMPLES (tail → classification)
 → {"state":"done","detail":"indentation fixed at 4 call sites; swift-format clean","tempo":"idle","output":{"result":"indentation consistent across RepoPicker/EnvironmentPicker/BranchPicker/SessionView"}}
 
 "At 30-40k rows there's no hint that gets you there without a new index — and at that point the column is strictly cheaper than a (session_uuid, source, sequence_num DESC) index."
-→ {"state":"done","detail":"analysis: dedicated column cheaper than composite index at 30-40k rows","tempo":"idle","output":{"result":"recommend dedicated column over composite index"}}
+→ {"state":"done","detail":"dedicated column beats a composite index at 30-40k rows","tempo":"idle","output":{"result":"recommend dedicated column over composite index"}}
   (pure analysis closing, no question, no forward intent — done)
 
 "No response requested."
 → {"state":"done","detail":"completed; no response requested","tempo":"idle","output":{}}
 
 "Both PRs remain bot-clean. Continue your e2e test on the restarted localhost:4000 (now pointed at local CCR)."
-→ {"state":"done","detail":"both PRs bot-clean; localhost:4000 restarted pointing at local CCR","tempo":"idle","output":{}}
+→ {"state":"done","detail":"both PRs bot-clean; localhost:4000 restarted on local CCR","tempo":"idle","output":{}}
   ("Continue your test" is advice TO the user, not the agent's plan → done)
 
 "Both subagents updated to use \`ack_seq\`. They're still running — I'll report PR URLs when each completes."
@@ -221,14 +221,14 @@ EXAMPLES (tail → classification)
 → {"state":"working","detail":"searching internal KB for org ID","tempo":"active","output":{}}
 
 "Wrote the chart to plots/venn.png; script is at scripts/venn.R."
-→ {"state":"done","detail":"venn chart written to plots/venn.png (script: scripts/venn.R)","tempo":"idle","output":{"result":"plots/venn.png + scripts/venn.R"}}
+→ {"state":"done","detail":"venn chart written to plots/venn.png + scripts/venn.R","tempo":"idle","output":{"result":"plots/venn.png + scripts/venn.R"}}
 
 "Fixed the regex; tests pass. If you want, I can also open a follow-up PR to clean up the old helper."
 → {"state":"done","detail":"regex fixed in parser.ts, all tests green","tempo":"idle","output":{"result":"regex fixed, tests pass"}}
   (deliverable shipped; offer is tangential extra → done)
 
 "Throughput drop confirmed — ~16K/min notifications being dropped from pod capacity. Ship the seek + scale. Want me to dig into the upstream volume change too?"
-→ {"state":"done","detail":"confirmed ~16K/min notif drop from pod capacity; recommend seek+scale","tempo":"idle","output":{"result":"~16K/min drop, pod capacity — ship seek+scale"}}
+→ {"state":"done","detail":"~16K/min notif drop confirmed; recommend seek+scale","tempo":"idle","output":{"result":"~16K/min drop, pod capacity — ship seek+scale"}}
   (finding + recommendation delivered; trailing question is optional extra → done)
 
 "Not applied — say the word and I'll update both widgets."
@@ -236,7 +236,7 @@ EXAMPLES (tail → classification)
   ("say the word and I'll" = optional offer → done)
 
 "B is the right call — it lands in the table the chart already reads, and avoids the migration."
-→ {"state":"done","detail":"recommend option B (reuses existing table, avoids migration)","tempo":"idle","output":{"result":"recommendation: option B"}}
+→ {"state":"done","detail":"recommend option B: reuses the table, avoids the migration","tempo":"idle","output":{"result":"recommendation: option B"}}
 
 "PR opened: https://github.com/acme/repo/pull/123\\nresult: fixed auth race in auth.ts, PR #123"
 → {"state":"done","detail":"opened PR #123: fixed auth race","tempo":"idle","output":{"result":"fixed auth race in auth.ts, PR #123"}}
@@ -250,7 +250,7 @@ EXAMPLES (tail → classification)
   (question is about HOW to ship the asked-for work → blocked)
 
 "Added the analytics enum + conditional at the .withScreenAnalyticsLogging call site. Want me to also add the missing screen tag for the empty-state view while I'm here? It's a ~5-line change."
-→ {"state":"done","detail":"analytics enum + conditional added at .withScreenAnalyticsLogging","tempo":"idle","output":{"result":"analytics logging wired at SessionView"}}
+→ {"state":"done","detail":"analytics enum + conditional added at the logging call site","tempo":"idle","output":{"result":"analytics logging wired at SessionView"}}
   (asked-for work delivered; the "while I'm here" extra is tangential → done)
 
 "I can't proceed — the repo requires GITHUB_TOKEN and it's not set."
@@ -286,9 +286,9 @@ CONTRASTIVE PAIRS — same surface shape, different state
   (first: agent owns the next step. second: user owns it)
 
 OUTPUT — respond with ONLY this JSON, no code fences:
-{"state":"<working|blocked|done|failed>","detail":"<one line>","tempo":"<active|idle|blocked>","needs":"<when blocked: the exact ask; omit otherwise>","output":{"result":"<one-sentence deliverable headline, ≤180 chars; omit when working>"}}
+{"state":"<working|blocked|done|failed>","detail":"<one line, ≤64 chars>","tempo":"<active|idle|blocked>","needs":"<when blocked: the exact ask; omit otherwise>","output":{"result":"<one-sentence deliverable headline, ≤180 chars; omit when working>"}}
 
-"detail" is what shows on the user's phone lock screen — write it like a colleague's Slack message: name the concrete thing (file, function, error, number, finding) and what happened to it. "fixed auth race in middleware.ts, tests green" not "completed task"; "waiting on CI for #4821" not "working"; "confirmed 16K/min drop from pod capacity" not "investigated issue".
+"detail" is what shows on the user's phone lock screen and as the one-line status column in a session list — write it like a colleague's Slack message: name the concrete thing (file, function, error, number, finding) and what happened to it. "fixed auth race in middleware.ts, tests green" not "completed task"; "waiting on CI for #4821" not "working"; "confirmed 16K/min drop from pod capacity" not "investigated issue".
 
 "tempo": "active" = computing; "idle" = waiting on external (CI, timer, reviewer); "blocked" = waiting on user.
 

--- a/projects/silver-core-sdk/src/tools/descriptions.ts
+++ b/projects/silver-core-sdk/src/tools/descriptions.ts
@@ -934,9 +934,15 @@ export const BASH_SANDBOX_FRAGMENTS: SandboxNoteFragment[] = [
     text: 'The user explicitly asks you to run a command outside the sandbox.',
   },
   {
+    // ADAPTED (was faithful): upstream ccVersion 2.1.205 removed the archive's
+    // -user-permission-prompt fragment (it deleted the standalone "This will
+    // prompt the user for permission" line). The SDK keeps the sentence as its
+    // own framing because the escape hatch does gate on a permission prompt
+    // here — but it no longer has an upstream source, so it is no longer marked
+    // faithful (red line: never claim verbatim provenance for text upstream dropped).
     id: 'user-permission-prompt',
-    slug: 'tool-description-bash-sandbox-user-permission-prompt',
-    faithful: true,
+    slug: '',
+    faithful: false,
     text: 'This will prompt the user for permission',
   },
   {

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.53.0';
+export const SDK_VERSION = '0.53.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;


### PR DESCRIPTION
## 概述

每周的 `refresh-claude-code-prompts` 自动刷新把上游 Claude Code 提示词档案从 ccVersion **2.1.129 → 2.1.205**，且该刷新提交带 `[skip ci]` 绕过了 corpus-sync 守卫，使 main 的 required-test（全量 vitest）转红。本 PR 把 SDK 侧两处**忠实复现面**逐字对齐回新档案，恢复 main 绿灯。

---

## 变更类型

- [x] Bug 修复（忠实复现漂移修复 / 版本纪律 bump）

---

## 变更明细

**1. 后台 agent 状态分类器**（`src/generators/prompts.ts`）——上游改写了 8 处示例/schema 文本，全部逐字回同步：
- 6 处 `detail` 示例串：`dedicated column beats a composite index…`、`localhost:4000 restarted on local CCR`、`venn.png + scripts/venn.R`、`~16K/min notif drop confirmed`、`option B: reuses the table…`、`added at the logging call site`
- OUTPUT schema：`<one line>` → `<one line, ≤64 chars>`
- `detail` 指引句：补入 `…phone lock screen and as the one-line status column in a session list…`
- 注：`generators.test.ts` 守卫是**前 60 字符子串检查**，8 处里只有 2 处（composite / venn）在前 60 字符内漂移被抓，其余 6 处漂移在 60 字符之后溜过守卫——但**同样是真漂移**，本 PR 一并修正。

**2. Bash sandbox 说明**（`src/tools/descriptions.ts`）——上游 2.1.205 **删除**了 `-user-permission-prompt` 档案 fragment。SDK 保留 "This will prompt the user for permission" 作为自有措辞（此处逃生舱确实经权限提示把关），但把该 fragment 由 `faithful: true` 降级为 `faithful: false` / `slug: ''`——红线：绝不为上游已删除的文本声称逐字出处。装配后的 sandbox 说明输出**逐字节不变**。

小学生比喻：上游教材换了新版，其中几段例句改了措辞、还删掉了一句话；银芯这本"抄录本"得照新版把改动的例句逐字改回来，那句被删的则老实标注"这句是我自己加的、不是照抄的"，不能继续假装是照抄。

---

## 验证清单

- [x] `npx vitest run tests/generators.test.ts tests/sandbox.test.ts` 由红转绿
- [x] 全量 vitest 绿：**115 文件 / 2134 通过 / 2 跳过**
- [x] `tsc -p tsconfig.json` 干净通过
- [x] 版本纪律：改 `src/` → bump **0.53.0 → 0.53.1**（version.ts + package.json + CHANGELOG 三方对齐，`check-version-bump.mjs` 通过）
- [x] 不引入 emoji
- [x] 未改 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 背景 / 关联

- 此漂移由刷新提交 `77d2f08f9`（`[skip ci]` 旁路守卫）引入，是 main required-test 红灯根因。
- 按守密人 2026-07-13 裁定「分开落：sessions 先并，复现同步单开 PR」——因 required-test 跑全量 vitest，corpus-sync 红会挡下**所有**合并（含 sessions PR #666），故本 PR 需**先并**解封。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq)_