### PR TITLE
test(silver-core-sdk): deepen corpus-sync guard to full-string match

### DIFF
--- a/projects/silver-core-sdk/tests/generators.test.ts
+++ b/projects/silver-core-sdk/tests/generators.test.ts
@@ -445,7 +445,12 @@ describe('generator prompt provenance (corpus-sync guard, Track B parity)', () =
         .map(norm)
         // skip short/boilerplate lines and the interpolation placeholder line
         .filter((s) => s.length >= 40 && !s.includes('{description}'))
-        .filter((s) => !body.includes(s.slice(0, 60)));
+        // FULL-string check (deepened 2026-07-13, keeper ruling): each reproduced
+        // sentence must be verbatim in the archive end-to-end, not just its first
+        // 60 chars. The old slice(0, 60) let deep drift through — the 2.1.205
+        // refresh reworded 8 classifier lines and this guard caught only the 2
+        // whose divergence fell inside the first 60 chars.
+        .filter((s) => !body.includes(s));
       expect(drifted, `not found in archive:\n${drifted.join('\n')}`).toEqual([]);
     });
   }


### PR DESCRIPTION
## 概述

守密人 2026-07-13 裁定「待裁 2 → A：加深守卫为全串比对」的落地。`generators.test.ts` 的忠实复现守卫原为**前 60 字符浅检**（`body.includes(s.slice(0, 60))`）——上游 2.1.205 刷新改写了 8 处 classifier 示例行，此浅检只抓到 2 处（漂移落在前 60 字符内），放走 6 处深处漂移（靠人工比对档案 diff 才发现，已在 #667 逐字回同步）。本 PR 把守卫加深为全串命中（`body.includes(s)`），根治漏检。

---

## 变更类型

- [x] Bug 修复（测试守卫加固，非 shipped-src）

---

## 变更明细

- `tests/generators.test.ts`：每个复现句须**整段逐字**命中档案，而非只比头 60 字符
- **当下零红**——7 个复现面（COMMAND_PREFIX / BACKGROUND_STATE / SESSION_TITLE / TITLE_AND_BRANCH / SESSION_NAME / AWAY_SUMMARY / MEMORY_FILES）在 #667 后全部端到端逐字匹配；本 PR 只是把"未来的深处漂移会红"这道门焊死
- sandbox 守卫无需改（已是全串 `body.includes(norm(f.text))`）
- 附带印证：加深后跑绿 = #667 的 corpus-sync 修复无深处残留漂移

> 小学生比喻：原来的抄写检查只核对每句头 60 个字，后半段抄错发现不了；这次改成整句逐字核对，抄错哪儿都逃不掉。现在抄本本身是对的，所以检查全绿——只是把"以后抄错必被抓"这道关补严了。

---

## 验证清单

- [x] `npx vitest run tests/generators.test.ts` 绿（67 tests）
- [x] 全量 vitest 绿：115 文件 / 2134 通过 / 2 跳过
- [x] 纯测试改动，无 `src/` / runtime 依赖变更 → 无需版本 bump
- [x] 不引入 emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq)_