### PR TITLE
ci(silver-core-sdk): sessions ratchet ignoreStatic + de-noised re-baseline 67.66

### DIFF
--- a/.github/workflows/sdk-mutation-ratchet.yml
+++ b/.github/workflows/sdk-mutation-ratchet.yml
@@ -68,10 +68,20 @@ jobs:
             if (!t) { console.error('unknown target ${{ matrix.target }} in mutation-ratchet.json'); process.exit(2); }
             console.log(t.mutate);
           ")
+          # Per-target ignoreStatic: some targets (e.g. sessions) carry heavy
+          # module-load static mutants that inject load-variance noise into the
+          # score. Their baseline is measured WITH --ignoreStatic, so the weekly
+          # round must match. Emitted as the flag string (empty when unset).
+          IGNORE_STATIC=$(node -e "
+            const b = require('./mutation-ratchet.json');
+            const t = (b.targets ?? []).find((t) => t.name === '${{ matrix.target }}');
+            console.log(t && t.ignoreStatic ? '--ignoreStatic' : '');
+          ")
           echo "mutate=$PATTERN" >> "$GITHUB_OUTPUT"
+          echo "ignore_static=$IGNORE_STATIC" >> "$GITHUB_OUTPUT"
       - name: Stryker round (${{ matrix.target }})
         working-directory: projects/silver-core-sdk
-        run: npx stryker run --mutate "${{ steps.pattern.outputs.mutate }}"
+        run: npx stryker run --mutate "${{ steps.pattern.outputs.mutate }}" ${{ steps.pattern.outputs.ignore_static }}
       - name: Ratchet check
         working-directory: projects/silver-core-sdk
         run: node scripts/check-mutation-ratchet.mjs --name "${{ matrix.target }}"

--- a/projects/silver-core-sdk/mutation-ratchet.json
+++ b/projects/silver-core-sdk/mutation-ratchet.json
@@ -26,7 +26,8 @@
     {
       "name": "sessions",
       "mutate": "src/sessions/**/*.ts",
-      "floor": 71.24
+      "floor": 71.24,
+      "ignoreStatic": true
     }
   ]
 }

--- a/projects/silver-core-sdk/mutation-ratchet.json
+++ b/projects/silver-core-sdk/mutation-ratchet.json
@@ -4,7 +4,8 @@
     "score": "Stryker mutation score = (killed + timeout) / (killed + timeout + survived + noCoverage) * 100; compile/runtime-error mutants excluded",
     "tolerance_pp": 0.75,
     "history": {
-      "2026-07-13": "seeded from the overnight quality campaign: permissions round 2 (92.87), openai dedicated rounds 1-6 (85.55); transport-anthropic seeded at 77.42 (measurement round, pre-kill-batch); transport-anthropic raised 77.42 -> 82.97 (kill batch 2, 14 tests); sessions seeded at 68.16 (baseline round); sessions raised 68.16 -> 71.24 (kill batch 1, 19 tests: tool-claims + store-adapter read fallbacks)"
+      "2026-07-13": "seeded from the overnight quality campaign: permissions round 2 (92.87), openai dedicated rounds 1-6 (85.55); transport-anthropic seeded at 77.42 (measurement round, pre-kill-batch); transport-anthropic raised 77.42 -> 82.97 (kill batch 2, 14 tests); sessions seeded at 68.16 (baseline round); sessions raised 68.16 -> 71.24 (kill batch 1, 19 tests: tool-claims + store-adapter read fallbacks)",
+      "2026-07-13 sessions re-baseline (keeper ruling, option A)": "sessions gains ignoreStatic:true and its floor moves 71.24 -> 67.66 (de-noised re-measure, 14m47s vs ~40min noisy). NOT a quality regression: the old score counted 444 store.ts static mutants (module-load code) that any test kills by merely importing the module -- free points that inflated the package score AND injected load-variance noise across rounds. 67.66 is the honest behavioural-mutant score (post kill-batch-2: checkpoints 72.89, file-store 72.55, tool-claims 73.33, store.ts 61.43 = next dig target). Floor decrease sanctioned by the keeper ruling; from here only-up applies on the de-noised basis."
     }
   },
   "targets": [
@@ -26,7 +27,7 @@
     {
       "name": "sessions",
       "mutate": "src/sessions/**/*.ts",
-      "floor": 71.24,
+      "floor": 67.66,
       "ignoreStatic": true
     }
   ]


### PR DESCRIPTION
## 概述

守密人 2026-07-13 裁定「待裁 1 → A：加 ignoreStatic + 重基线」的落地。sessions 变异门禁基线 71.24 含静态变异噪音——store.ts 的 444 个静态变异（模块加载期代码，占该轮 26% 变异、耗 98% 时间）既注入跨轮载入方差，又是"白送分"（任何测试一 import 模块就顺手击杀），虚高整包分数。本 PR 使 sessions 专场剔除静态变异、按去噪实测重定基线。

---

## 变更类型

- [x] 其他：CI 变异门禁配置 + 基线记账（非 shipped-src）

---

## 变更明细

- **`mutation-ratchet.json`**：sessions target 加 `ignoreStatic: true`；floor **71.24 → 67.66**（去噪实测：killed 1131 + timeout 7 / survived 477 / no-coverage 67；14 分 47 秒完赛 vs 含噪轮约 40 分钟）。floor 下调经守密人裁定授权，已入 `_meta.history` 记账；自此在去噪基准上恢复只升不降
- **`.github/workflows/sdk-mutation-ratchet.yml`**：Resolve 步骤增发 `ignore_static` 输出（从注册表读 per-target 旗标），Stryker 步骤按 target 追加 `--ignoreStatic`——**仅 sessions 生效**，permissions / openai / anthropic 三基线的测量基准不受连累
- 去噪后 per-file 真实面貌：checkpoints 72.89 / tool-claims 73.33 / file-store 72.55 / persistence 71.54 / store-adapter 69.96 / session-functions 69.34 / **store.ts 61.43（下一个专场靶点）**

> 小学生比喻：旧分数里混着一批"翻开课本就自动得分"的送分题，还拖慢了整场考试（98% 时间耗在它们身上）；这次把送分题划掉重新算分——分数从 71.24 降到 67.66 不是退步，是把虚的水分挤掉，及格线定在真实水平上，以后每提一分都是真本事。

---

## 验证清单

- [x] `node scripts/check-mutation-ratchet.mjs --name sessions` 对新鲜去噪报告 **OK**（67.66 vs floor 67.66）
- [x] `mutation-ratchet.json` JSON 合法性校验通过
- [x] 非 shipped-src（CI 配置 + 基线注册表）→ 无需版本 bump
- [x] 不引入 emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9xNTLroecEogSzJs8QXTq)_