### PR TITLE
fix(silver-core-sdk): free-socket idle TTL kills keep-alive zombie sockets (v0.53.3, BPT stability)

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -199,6 +199,21 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.53.3（2026-07-13，BPT 稳定性《keep-alive 空闲 socket TTL》）**：修复黑池升 pin 后
+  「回合卡住无输出、并发对话越多越易发」——0.45.0 默认 node HTTP 客户端把池化 socket 握到
+  「服务端来关」为止，但 azure/* 等网关中间设备**静默丢弃**空闲连接（不发 FIN/RST），池内积累
+  僵尸 socket；写上去的请求要等满请求阶段超时（默认 600 秒），重试还可能摸到下一条僵尸；
+  0.45 之前 undici 约 4 秒回收空闲连接、掩盖了整类问题。修复：空闲 socket 55 秒 TTL 主动销毁
+  （`FREE_SOCKET_TTL_MS`，压在常见 60 秒中间设备空闲底线之下；计时器 unref、复用即清零重计），
+  过期只花一次 TCP+TLS 重握手（约 100–300 毫秒，TLS 会话恢复不受影响）；Agent 显式钉
+  `scheduling:'lifo'`。逃生口不变（`provider.httpClient:'fetch'` / `BPT_HTTP_CLIENT=fetch`）。
+  +2 测试，全量 **2145 绿 + 3 skipped**（多出的 1 个 skip 为 `replay-backoff-process-exit`
+  在云容器的环境性跳过，非本改动引起）；tarball `silver-core-sdk-0.53.3.tgz`（809,430 B，
+  sha1 `d5dc13c03a7b43daaa21d72285faebce8cb9150e`）已干净目录装机 + 导入冒烟。
+  **消费侧速判三则**（黑池工具快照对不上源码登记 ≠ 版本不同步）：`memory` 工具仅在传
+  `options.memory` 时才广告（`query.ts`）、`ToolSearch` 仅在 `toolSearch:true` 或工具总数
+  >50 自动激活时出现（`toolsearch.ts` `shouldActivate`）、`SendMessage` 自 0.42.0 起默认在列
+  ——宿主权限表须显式登记（迁移文档 §1.5 已预警）。
 - **v0.53.2（2026-07-13，BPT P0《工具 Schema 边界校验与协议安全》，PR #665）**：修复 azure/*（OpenAI
   Chat Completions 兼容）网关整请求被拒（`tools.N.custom.input_schema: Field required`——单个缺失/非法
   `input_schema` 的工具条目令整段对话无法开始）。三层收口：① 组装层（`engine/loop.ts`）内置/MCP

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,30 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.53.3 — 2026-07-13
+
+**Free-socket idle TTL: keep-alive pool no longer accumulates zombie
+sockets (BPT stability, 2026-07-13).** Symptom: turns hang with NO output
+— worst with several concurrent conversations — on gateway deployments
+(azure/* and friends). Root cause: the default node HTTP client (0.45.0)
+held pooled sockets "until the SERVER closes it", but middleboxes
+(Azure LB, ALB, nginx, corporate proxies) drop idle flows SILENTLY — no
+FIN/RST — so the pool filled with sockets that look alive to node.
+A request written onto one stalls for the full request-phase timeout
+(default 600s), and each retry can pick the NEXT zombie; concurrency
+multiplies exposure (more sockets idling between turns). The pre-0.45
+undici client recycled pooled connections after ~4s idle, which had
+masked the entire class. Fix: a free socket is destroyed after 55s of
+pool idleness (`FREE_SOCKET_TTL_MS`, under the common 60s middlebox idle
+floor; timer unref'd, cleared + re-armed on reuse) — an expired socket
+costs one fresh TCP+TLS handshake (~100-300ms, TLS session resumption
+intact), never a 600s stall. Agents also pin `scheduling: 'lifo'`
+(node's default, now explicit: most-recently-used socket first minimizes
+zombie-pick odds inside the TTL window). `createNodeFetch()` accepts
+`{ freeSocketTtlMs }` for tests/tuning. Consumer escape hatches
+unchanged (`provider.httpClient: 'fetch'` / `BPT_HTTP_CLIENT=fetch`).
++2 tests (TTL destroy + reuse re-arm).
+
 ## 0.53.2 — 2026-07-13
 
 **Tool schema boundary validation (BPT P0, 2026-07-13).** Symptom: on

--- a/projects/silver-core-sdk/docs/PERFORMANCE.md
+++ b/projects/silver-core-sdk/docs/PERFORMANCE.md
@@ -36,7 +36,13 @@ adapter (`src/transport/node-http.ts`) with long keep-alive agents:
 - Node's global fetch (undici) drops pooled connections after **~4s idle**,
   so any turn whose tool run exceeds that re-paid a TCP+TLS handshake
   (typically 100-300ms) — every turn. The adapter's agents hold the socket
-  until the server closes it.
+  across those gaps, bounded by a **55s free-socket TTL** (v0.53.3,
+  `FREE_SOCKET_TTL_MS`): middleboxes (Azure LB, ALB, nginx, corporate
+  proxies) drop idle flows silently — no FIN/RST — and an unbounded pool
+  accumulated zombie sockets that stalled the next request for the full
+  request-phase timeout (worst under concurrent conversations, each
+  parking sockets between turns). 55s sits under the common 60s middlebox
+  idle floor; an expired socket costs one fresh handshake, never a stall.
 - Measured head-to-head (same TLS server): adapter reused ONE connection
   across 21 requests where undici recycled mid-run; kept the socket across a
   5.2s idle gap; resumed TLS sessions after a forced close

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.53.2",
+  "version": "0.53.3",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/transport/node-http.ts
+++ b/projects/silver-core-sdk/src/transport/node-http.ts
@@ -39,6 +39,18 @@
  * PROCESS-EXIT SAFETY: pooled keep-alive sockets are unref()'d while idle and
  * ref()'d again on reuse, so a warm pool never keeps a finished process
  * alive (the classic node Agent keep-alive hang).
+ *
+ * BOUNDED IDLE LIFETIME (v0.53.3, BPT stability): a free socket is destroyed
+ * after FREE_SOCKET_TTL_MS of pool idleness instead of being held "until the
+ * server closes it". Middleboxes (Azure LB, ALB, nginx, corporate proxies)
+ * drop idle flows SILENTLY — no FIN/RST ever arrives — so an unbounded pool
+ * accumulates zombie sockets that look alive to node; a request written onto
+ * one hangs for the full request-phase timeout (default 600s), and a retry
+ * can pick the NEXT zombie. Concurrent conversations multiply the exposure
+ * (more sockets idling between turns). The TTL (55s) sits under the common
+ * 60s middlebox idle floor while still covering the multi-second tool-run
+ * gaps this adapter exists for; an expired socket just costs one fresh
+ * TCP+TLS handshake (~100-300ms, TLS session resumption still applies).
  */
 
 import http from 'node:http';
@@ -50,20 +62,49 @@ import type { ProviderConfig } from '../types.js';
 /** The provider.fetch seam shape (kept structurally identical to types.ts). */
 export type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
-/** Idle keep-alive sockets must not hold the event loop open. */
-function unrefOnFree<T extends http.Agent | https.Agent>(agent: T): T {
+/**
+ * Default free-socket TTL: just under the common 60s middlebox idle floor
+ * (ALB 60s, nginx keepalive_timeout 75s, Azure LB 240s), far above the ~4s
+ * undici recycle whose handshake re-pay this adapter was built to avoid.
+ */
+export const FREE_SOCKET_TTL_MS = 55_000;
+
+/**
+ * Idle keep-alive sockets must not hold the event loop open (unref while
+ * pooled, ref on reuse) and must not outlive silent middlebox idle drops
+ * (destroy after ttlMs of pool idleness; the TTL timer is itself unref'd).
+ */
+function manageFreeSockets<T extends http.Agent | https.Agent>(agent: T, ttlMs: number): T {
   const anyAgent = agent as unknown as {
     keepSocketAlive(socket: import('node:net').Socket): boolean;
     reuseSocket(socket: import('node:net').Socket, req: http.ClientRequest): void;
+  };
+  const ttlTimers = new WeakMap<import('node:net').Socket, ReturnType<typeof setTimeout>>();
+  const clearTtl = (socket: import('node:net').Socket): void => {
+    const timer = ttlTimers.get(socket);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      ttlTimers.delete(socket);
+    }
   };
   const origKeep = anyAgent.keepSocketAlive.bind(anyAgent);
   const origReuse = anyAgent.reuseSocket.bind(anyAgent);
   anyAgent.keepSocketAlive = (socket) => {
     const keep = origKeep(socket);
-    if (keep) socket.unref();
+    if (keep) {
+      socket.unref();
+      clearTtl(socket); // re-arm, never stack
+      const timer = setTimeout(() => {
+        ttlTimers.delete(socket);
+        socket.destroy();
+      }, ttlMs);
+      timer.unref();
+      ttlTimers.set(socket, timer);
+    }
     return keep;
   };
   anyAgent.reuseSocket = (socket, req) => {
+    clearTtl(socket);
     socket.ref();
     origReuse(socket, req);
   };
@@ -115,11 +156,16 @@ export type NodeFetch = FetchLike & {
   readonly agents: { http: http.Agent; https: https.Agent };
 };
 
-export function createNodeFetch(): NodeFetch {
-  const httpsAgent = unrefOnFree(
-    new https.Agent({ keepAlive: true, maxCachedSessions: 100 }),
+export function createNodeFetch(opts: { freeSocketTtlMs?: number } = {}): NodeFetch {
+  const ttlMs = opts.freeSocketTtlMs ?? FREE_SOCKET_TTL_MS;
+  const httpsAgent = manageFreeSockets(
+    new https.Agent({ keepAlive: true, maxCachedSessions: 100, scheduling: 'lifo' }),
+    ttlMs,
   );
-  const httpAgent = unrefOnFree(new http.Agent({ keepAlive: true }));
+  const httpAgent = manageFreeSockets(
+    new http.Agent({ keepAlive: true, scheduling: 'lifo' }),
+    ttlMs,
+  );
 
   const nodeFetch = function nodeFetch(input: string | URL, init: RequestInit = {}): Promise<Response> {
     return new Promise<Response>((resolve, reject) => {

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.53.2';
+export const SDK_VERSION = '0.53.3';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/transport-node-http.test.ts
+++ b/projects/silver-core-sdk/tests/transport-node-http.test.ts
@@ -108,6 +108,58 @@ describe('node-http adapter (unit)', () => {
     }
   });
 
+  it('destroys a free socket after the idle TTL (silent middlebox drops must not leave zombies)', async () => {
+    let connections = 0;
+    const server = createServer((req, res) => {
+      res.writeHead(200);
+      res.end('ok');
+    });
+    server.on('connection', () => { connections += 1; });
+    const base = await listen(server);
+    const nodeFetch = createNodeFetch({ freeSocketTtlMs: 60 });
+    try {
+      await (await nodeFetch(base, {})).text();
+      await new Promise((r) => setTimeout(r, 20));
+      expect((Object.values(nodeFetch.agents.http.freeSockets).flat() as Socket[]).length).toBe(1);
+
+      // Past the TTL the pooled socket is proactively destroyed...
+      await new Promise((r) => setTimeout(r, 120));
+      expect((Object.values(nodeFetch.agents.http.freeSockets).flat() as Socket[]).length).toBe(0);
+
+      // ...and the next request simply opens a fresh connection.
+      await (await nodeFetch(base, {})).text();
+      expect(connections).toBe(2);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('reuse within the TTL re-arms the timer instead of killing an active line', async () => {
+    let connections = 0;
+    const server = createServer((req, res) => {
+      res.writeHead(200);
+      res.end('ok');
+    });
+    server.on('connection', () => { connections += 1; });
+    const base = await listen(server);
+    const nodeFetch = createNodeFetch({ freeSocketTtlMs: 150 });
+    try {
+      await (await nodeFetch(base, {})).text();
+      await new Promise((r) => setTimeout(r, 80)); // inside the TTL window
+      await (await nodeFetch(base, {})).text(); // reuse: same socket, timer cleared + re-armed
+      expect(connections).toBe(1);
+
+      // The clock restarts from the SECOND release: still alive 80ms later...
+      await new Promise((r) => setTimeout(r, 80));
+      expect((Object.values(nodeFetch.agents.http.freeSockets).flat() as Socket[]).length).toBe(1);
+      // ...and gone once the re-armed TTL lapses.
+      await new Promise((r) => setTimeout(r, 120));
+      expect((Object.values(nodeFetch.agents.http.freeSockets).flat() as Socket[]).length).toBe(0);
+    } finally {
+      await close(server);
+    }
+  });
+
   it('propagates AbortSignal: pre-flight abort rejects, mid-stream abort errors the body', async () => {
     let res: import('node:http').ServerResponse | undefined;
     const server = createServer((req, r) => {


### PR DESCRIPTION
## What

Fixes the "turns hang with NO output, worst with several concurrent conversations" instability BPT hit after the 0.37.1 → 0.53.x pin upgrade.

## Root cause

The default node HTTP client (0.45.0) held pooled keep-alive sockets "until the SERVER closes it". Gateway middleboxes (Azure LB, ALB, nginx, corporate proxies) drop idle flows **silently** — no FIN/RST ever arrives — so the pool accumulated zombie sockets that look alive to node. A request written onto one stalls for the full request-phase timeout (default 600s), and each retry can pick the NEXT zombie. Concurrency multiplies exposure: more conversations park more sockets between turns, and one idle window turns the whole pool into zombies. The pre-0.45 undici client recycled pooled connections after ~4s idle, which had masked the entire class.

## Fix

- `src/transport/node-http.ts`: free sockets are destroyed after **55s** of pool idleness (`FREE_SOCKET_TTL_MS`, under the common 60s middlebox idle floor; timer unref'd so it never holds the event loop, cleared + re-armed on reuse). An expired socket costs one fresh TCP+TLS handshake (~100–300ms, TLS session resumption intact), never a 600s stall.
- Agents pin `scheduling: 'lifo'` explicitly (most-recently-used socket first minimizes zombie-pick odds inside the TTL window).
- `createNodeFetch()` accepts `{ freeSocketTtlMs }` for tests/tuning. Consumer escape hatches unchanged (`provider.httpClient: 'fetch'` / `BPT_HTTP_CLIENT=fetch`).
- Version 0.53.2 → 0.53.3, CHANGELOG + docs/PERFORMANCE.md + memory/project-status.md ledger updated.

## Verification

- +2 tests (TTL destroy after idle; reuse re-arms the timer): vitest full suite **2145 passed + 3 skipped** (the extra skip is `replay-backoff-process-exit.test.ts`'s environment-conditional skip in the cloud container, present with and without this change).
- Repo pytest full suite **2951 passed + 4 skipped**.
- Tarball `silver-core-sdk-0.53.3.tgz` (809,430 B, sha1 `d5dc13c03a7b43daaa21d72285faebce8cb9150e`): clean-directory install + import smoke green, `FREE_SOCKET_TTL_MS` confirmed in the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wXA3Uc3adJW1ZWv2CjYEb

---
_Generated by [Claude Code](https://claude.ai/code/session_013wXA3Uc3adJW1ZWv2CjYEb)_