### PR TITLE
fix(silver-core-sdk): close out 3 deferred stability items — T2 retry budget + killAgent race (v0.53.5)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,37 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.53.5 — 2026-07-13
+
+**Conversation-stability follow-up: the three deferred light items from 0.53.4
+(BPT stability, 2026-07-13).** Keeper asked the remaining trio be closed out.
+
+- **T2 — retry-budget amplification (both transports).** The empty-stream
+  re-issue counter was INDEPENDENT of `requestWithRetries`' own attempt counter,
+  each bounded by `maxRetries` — so a gateway alternating errors and empty-200s
+  under fan-out throttle could burn ~`maxRetries²` POSTs on an already-struggling
+  endpoint. Fix: one `{ used }` budget threaded through BOTH the request-phase
+  retries and the empty-stream re-issues, capping the total extra POSTs at
+  `maxRetries` (so `maxRetries+1` attempts overall). Anthropic + OpenAI arms.
+- **killAgent status race (subagent runtime).** `stopTask`/`killAgent` racing a
+  child's completion could emit a `stopped` notification contradicting a
+  `completed` one and flip `record.status` between the two. Fix: killAgent no
+  longer clobbers a record that already reached a terminal status (the
+  completed→kill direction), and the completion body only reports completion
+  while the record is still `running` (the kill→completed direction) — mirroring
+  the catch arm's existing guard. Both directions now resolve to one consistent
+  terminal signal.
+- **T3 — pre-message_start ping "leak" — assessed WAI, left unchanged.** A ping
+  keep-alive is yielded to the consumer as it arrives BY DESIGN: live ping
+  delivery is load-bearing (the idle-watchdog / hard-cap / progress paths and
+  their tests depend on the consumer seeing keep-alives in real time). The
+  theoretical leak of a discarded empty-retry attempt's pings is harmless (pings
+  carry no content; the accumulator ignores them), so buffering them — which
+  would degrade live delivery — is not worth it. Documented in-code.
+
++2 regression tests (`tests/conversation-stability-followups.test.ts`, T2 bound).
+Full suite 2160 passing + 2 skipped; typecheck + build clean.
+
 ## 0.53.4 — 2026-07-13
 
 **Conversation-stability audit batch: 13 verified fixes across compaction,

--- a/projects/silver-core-sdk/package-lock.json
+++ b/projects/silver-core-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.53.4",
+  "version": "0.53.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silver-core-sdk",
-      "version": "0.53.4",
+      "version": "0.53.5",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.53.4",
+  "version": "0.53.5",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/subagents/runtime.ts
+++ b/projects/silver-core-sdk/src/subagents/runtime.ts
@@ -1199,32 +1199,40 @@ export function createSubagentRuntime(
               sidechainInfo,
               stallWatchdog,
             );
-            record.status = result.isError ? 'failed' : 'completed';
-            completedBuffer.push({
-              type: 'text',
-              text: formatTaskNotification({
-                agentId,
+            // Finding (killAgent race) — only report completion if the task is
+            // still RUNNING. If stopTask()/killAgent raced in first (status now
+            // 'killed'), respect that terminal decision: do NOT overwrite the
+            // status back to completed nor emit a 'completed' notification that
+            // contradicts the 'stopped' one the kill site already sent. Mirrors
+            // the catch arm's existing `status === 'running'` guard.
+            if (record.status === 'running') {
+              record.status = result.isError ? 'failed' : 'completed';
+              completedBuffer.push({
+                type: 'text',
+                text: formatTaskNotification({
+                  agentId,
+                  status: result.isError ? 'failed' : 'completed',
+                  summary: `Agent "${taskDescription}" ${
+                    result.isError
+                      ? `failed: ${resultPreview(result.text)}`
+                      : 'completed'
+                  }`,
+                  result: result.text,
+                  usage: result.usage,
+                }),
+              });
+              emitTaskFinished(agentId, result);
+              emitTask({
+                type: 'system',
+                subtype: 'task_notification',
+                task_id: agentId,
+                ...(params.toolUseId !== '' ? { tool_use_id: params.toolUseId } : {}),
                 status: result.isError ? 'failed' : 'completed',
-                summary: `Agent "${taskDescription}" ${
-                  result.isError
-                    ? `failed: ${resultPreview(result.text)}`
-                    : 'completed'
-                }`,
-                result: result.text,
-                usage: result.usage,
-              }),
-            });
-            emitTaskFinished(agentId, result);
-            emitTask({
-              type: 'system',
-              subtype: 'task_notification',
-              task_id: agentId,
-              ...(params.toolUseId !== '' ? { tool_use_id: params.toolUseId } : {}),
-              status: result.isError ? 'failed' : 'completed',
-              // No task output files in this engine (official field, required).
-              output_file: '',
-              summary: `background subagent '${resolved.type}' ${result.isError ? 'failed' : 'completed'}`,
-            });
+                // No task output files in this engine (official field, required).
+                output_file: '',
+                summary: `background subagent '${resolved.type}' ${result.isError ? 'failed' : 'completed'}`,
+              });
+            }
           } catch (err) {
             if (record.status === 'running') record.status = 'failed';
             debug(
@@ -1392,7 +1400,14 @@ export function createSubagentRuntime(
     const task = backgroundTasks.get(taskId);
     const record = childRegistry.get(taskId);
     if (task === undefined && record === undefined) return { outcome: 'unknown' };
-    if (task === undefined && record !== undefined && record.status !== 'running') {
+    // Finding (killAgent race) — if the record already reached a TERMINAL status
+    // (the child finished, or a prior kill landed), do not abort/clobber it or
+    // emit a contradictory 'stopped' notification. This covers the completed→
+    // kill direction (the child's completion continuation ran first); the
+    // completion body covers the kill→completed direction. Clean up any stale
+    // task entry either way.
+    if (record !== undefined && record.status !== 'running') {
+      backgroundTasks.delete(taskId);
       return { outcome: 'not_running', status: record.status };
     }
     (task?.controller ?? record?.controller)?.abort();

--- a/projects/silver-core-sdk/src/transport/anthropic.ts
+++ b/projects/silver-core-sdk/src/transport/anthropic.ts
@@ -210,6 +210,13 @@ export class AnthropicTransport implements Transport {
     // stream and letting the engine fall through to accumulator.finalize()'s
     // raw `Protocol error: finalize before message_start`.
     let emptyStreamRetries = 0;
+    // Finding T2 — ONE retry budget shared by the request-phase retries AND the
+    // empty-stream re-issues. Previously each empty-stream re-issue called
+    // requestWithRetries afresh with the FULL maxRetries, so a gateway that
+    // alternates errors and empty-200s could burn ~maxRetries² POSTs on an
+    // already-struggling endpoint. Threading one `{ used }` counter caps the
+    // total extra POSTs at maxRetries (so maxRetries+1 attempts overall).
+    const retryBudget = { used: 0 };
     for (;;) {
       // ---- request phase: retries allowed ---------------------------------
       const { response, signal, timeoutSignal, detachRequestTimeout, releaseSignals } =
@@ -219,6 +226,7 @@ export class AnthropicTransport implements Transport {
           callerSignal,
           timeoutMs,
           maxRetries,
+          retryBudget,
           onRetry,
         );
 
@@ -357,6 +365,13 @@ export class AnthropicTransport implements Transport {
             const sr = (parsed as { delta?: { stop_reason?: unknown } }).delta?.stop_reason;
             if (sr !== null && sr !== undefined) sawStopReason = true;
           }
+          // T3 (NOT changed — WAI): a ping keep-alive is yielded to the consumer
+          // as it arrives, deliberately. Live ping delivery is load-bearing (the
+          // idle-watchdog / hard-cap / progress paths and their tests rely on the
+          // consumer seeing keep-alives in real time). The theoretical "a
+          // discarded empty-retry attempt's pings reach the consumer" leak is
+          // harmless (pings carry no content; the accumulator ignores them), so
+          // it is not worth buffering pings and degrading live delivery.
           yield parsed as RawMessageStreamEvent;
           // The Messages API streams exactly one message; message_stop is its
           // terminal event. Stop consuming here - official-client lifecycle -
@@ -397,16 +412,17 @@ export class AnthropicTransport implements Transport {
       // Any caller abort observed here wins over the retry.
       if (!sawMessageStart) {
         if (callerSignal?.aborted) throw new AbortError();
-        if (emptyStreamRetries < maxRetries) {
+        if (retryBudget.used < maxRetries) {
+          retryBudget.used += 1;
           emptyStreamRetries += 1;
           this.debug(
             `transport: empty stream (HTTP 200, no message_start); ` +
-              `retry ${emptyStreamRetries}/${maxRetries}`,
+              `retry ${retryBudget.used}/${maxRetries}`,
           );
           // Surface it like a network-level retry (no HTTP status) so the loop
           // emits an api_retry observability message, same as a dropped socket.
-          onRetry?.({ attempt: emptyStreamRetries, maxRetries, kind: 'empty_stream' });
-          await this.backoff(emptyStreamRetries, undefined, callerSignal);
+          onRetry?.({ attempt: retryBudget.used, maxRetries, kind: 'empty_stream' });
+          await this.backoff(retryBudget.used, undefined, callerSignal);
           continue;
         }
         throw new APIConnectionError(
@@ -454,6 +470,10 @@ export class AnthropicTransport implements Transport {
     callerSignal: AbortSignal | undefined,
     timeoutMs: number,
     maxRetries: number,
+    // Finding T2 — shared retry budget (see streamRequest). Both request-phase
+    // retries here and empty-stream re-issues in the caller draw from it, so the
+    // total is bounded by maxRetries rather than maxRetries per re-issue.
+    retryBudget: { used: number },
     onRetry?: (info: RetryInfo) => void,
   ): Promise<{
     response: Response;
@@ -467,7 +487,6 @@ export class AnthropicTransport implements Transport {
      *  a long-lived caller signal does not accumulate one listener per turn. */
     releaseSignals: () => void;
   }> {
-    let attempt = 0;
     for (;;) {
       if (callerSignal?.aborted) throw new AbortError();
       // Fresh timeout per attempt, propagated into a DEDICATED per-attempt
@@ -495,7 +514,7 @@ export class AnthropicTransport implements Transport {
       let response: Response;
       try {
         this.debug(
-          `transport: POST ${this.endpoint} (attempt ${attempt + 1}/${maxRetries + 1})`,
+          `transport: POST ${this.endpoint} (attempt ${retryBudget.used + 1}/${maxRetries + 1})`,
         );
         response = await (this.fetchFn ?? fetch)(this.endpoint, {
           method: 'POST',
@@ -507,13 +526,13 @@ export class AnthropicTransport implements Transport {
         releaseSignals();
         if (callerSignal?.aborted) throw new AbortError();
         // Connection failure or per-attempt timeout: retryable.
-        if (attempt < maxRetries) {
-          attempt += 1;
+        if (retryBudget.used < maxRetries) {
+          retryBudget.used += 1;
           this.debug(
-            `transport: network error (${errorMessage(err)}); retry ${attempt}/${maxRetries}`,
+            `transport: network error (${errorMessage(err)}); retry ${retryBudget.used}/${maxRetries}`,
           );
-          onRetry?.({ attempt, maxRetries, kind: 'network' });
-          await this.backoff(attempt, undefined, callerSignal);
+          onRetry?.({ attempt: retryBudget.used, maxRetries, kind: 'network' });
+          await this.backoff(retryBudget.used, undefined, callerSignal);
           continue;
         }
         throw new APIConnectionError(
@@ -531,21 +550,21 @@ export class AnthropicTransport implements Transport {
       const info = await readErrorInfo(response);
       const retryable =
         response.status === 408 || response.status === 429 || response.status >= 500;
-      if (retryable && attempt < maxRetries) {
-        attempt += 1;
+      if (retryable && retryBudget.used < maxRetries) {
+        retryBudget.used += 1;
         const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
         this.debug(
-          `transport: HTTP ${response.status} (${info.type}); retry ${attempt}/${maxRetries}`,
+          `transport: HTTP ${response.status} (${info.type}); retry ${retryBudget.used}/${maxRetries}`,
         );
         onRetry?.({
-          attempt,
+          attempt: retryBudget.used,
           maxRetries,
           status: response.status,
           errorType: info.type,
           kind: 'http_status',
           ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
         });
-        await this.backoff(attempt, retryAfterMs, callerSignal);
+        await this.backoff(retryBudget.used, retryAfterMs, callerSignal);
         continue;
       }
       throw new APIStatusError(response.status, info.type, info.message, requestId);

--- a/projects/silver-core-sdk/src/transport/openai.ts
+++ b/projects/silver-core-sdk/src/transport/openai.ts
@@ -748,6 +748,10 @@ export class OpenAIChatTransport implements Transport {
     // ERROR mid-stream (parseSSE throws) still routes through the catch below
     // and is NEVER retried, empty or not.
     let emptyStreamRetries = 0;
+    // Finding T2 — one retry budget shared by request-phase retries AND
+    // empty-stream re-issues (see the Anthropic arm), so the total is bounded by
+    // maxRetries rather than maxRetries per re-issue on a struggling gateway.
+    const retryBudget = { used: 0 };
     for (;;) {
       // ---- request phase: retries allowed ---------------------------------
       const { response, signal, timeoutSignal, detachRequestTimeout, releaseSignals } =
@@ -757,6 +761,7 @@ export class OpenAIChatTransport implements Transport {
           callerSignal,
           timeoutMs,
           maxRetries,
+          retryBudget,
           onRetry,
         );
 
@@ -889,16 +894,17 @@ export class OpenAIChatTransport implements Transport {
       // caller abort observed here wins.
       if (chunkCount === 0) {
         if (callerSignal?.aborted) throw new AbortError();
-        if (emptyStreamRetries < maxRetries) {
+        if (retryBudget.used < maxRetries) {
+          retryBudget.used += 1;
           emptyStreamRetries += 1;
           this.debug(
             `openai transport: empty stream (HTTP 200, zero SSE chunks); ` +
-              `retry ${emptyStreamRetries}/${maxRetries}`,
+              `retry ${retryBudget.used}/${maxRetries}`,
           );
           // Surface it like a network-level retry (no HTTP status) so the loop
           // emits an api_retry observability message, same as a dropped socket.
-          onRetry?.({ attempt: emptyStreamRetries, maxRetries, kind: 'empty_stream' });
-          await this.backoff(emptyStreamRetries, undefined, callerSignal);
+          onRetry?.({ attempt: retryBudget.used, maxRetries, kind: 'empty_stream' });
+          await this.backoff(retryBudget.used, undefined, callerSignal);
           continue;
         }
         throw new APIConnectionError(
@@ -932,6 +938,8 @@ export class OpenAIChatTransport implements Transport {
     callerSignal: AbortSignal | undefined,
     timeoutMs: number,
     maxRetries: number,
+    // Finding T2 — shared retry budget (see streamRequest / the Anthropic arm).
+    retryBudget: { used: number },
     onRetry?: (info: RetryInfo) => void,
   ): Promise<{
     response: Response;
@@ -945,7 +953,6 @@ export class OpenAIChatTransport implements Transport {
      *  a long-lived caller signal does not accumulate one listener per turn. */
     releaseSignals: () => void;
   }> {
-    let attempt = 0;
     for (;;) {
       if (callerSignal?.aborted) throw new AbortError();
       // Fresh timeout per attempt, propagated into a DEDICATED per-attempt
@@ -973,7 +980,7 @@ export class OpenAIChatTransport implements Transport {
       let response: Response;
       try {
         this.debug(
-          `openai transport: POST ${this.endpoint} (attempt ${attempt + 1}/${maxRetries + 1})`,
+          `openai transport: POST ${this.endpoint} (attempt ${retryBudget.used + 1}/${maxRetries + 1})`,
         );
         response = await (this.fetchFn ?? fetch)(this.endpoint, {
           method: 'POST',
@@ -985,13 +992,13 @@ export class OpenAIChatTransport implements Transport {
         releaseSignals();
         if (callerSignal?.aborted) throw new AbortError();
         // Connection failure or per-attempt timeout: retryable.
-        if (attempt < maxRetries) {
-          attempt += 1;
+        if (retryBudget.used < maxRetries) {
+          retryBudget.used += 1;
           this.debug(
-            `openai transport: network error (${errorMessage(err)}); retry ${attempt}/${maxRetries}`,
+            `openai transport: network error (${errorMessage(err)}); retry ${retryBudget.used}/${maxRetries}`,
           );
-          onRetry?.({ attempt, maxRetries, kind: 'network' });
-          await this.backoff(attempt, undefined, callerSignal);
+          onRetry?.({ attempt: retryBudget.used, maxRetries, kind: 'network' });
+          await this.backoff(retryBudget.used, undefined, callerSignal);
           continue;
         }
         throw new APIConnectionError(
@@ -1009,21 +1016,21 @@ export class OpenAIChatTransport implements Transport {
       const info = await readOpenAIErrorInfo(response);
       const retryable =
         response.status === 408 || response.status === 429 || response.status >= 500;
-      if (retryable && attempt < maxRetries) {
-        attempt += 1;
+      if (retryable && retryBudget.used < maxRetries) {
+        retryBudget.used += 1;
         const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
         this.debug(
-          `openai transport: HTTP ${response.status} (${info.type}); retry ${attempt}/${maxRetries}`,
+          `openai transport: HTTP ${response.status} (${info.type}); retry ${retryBudget.used}/${maxRetries}`,
         );
         onRetry?.({
-          attempt,
+          attempt: retryBudget.used,
           maxRetries,
           status: response.status,
           errorType: info.type,
           kind: 'http_status',
           ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
         });
-        await this.backoff(attempt, retryAfterMs, callerSignal);
+        await this.backoff(retryBudget.used, retryAfterMs, callerSignal);
         continue;
       }
       throw new APIStatusError(response.status, info.type, info.message, requestId);

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.53.4';
+export const SDK_VERSION = '0.53.5';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/conversation-stability-followups.test.ts
+++ b/projects/silver-core-sdk/tests/conversation-stability-followups.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Follow-up stability fixes (2026-07-13, keeper "3 条极轻项也一起修复").
+ *   T2 shared retry budget: empty-stream re-issues + request-phase retries draw
+ *      from ONE budget, so a gateway that alternates errors and empty-200s can
+ *      no longer amplify to ~maxRetries² POSTs.
+ * (T3 was assessed WAI and left unchanged — pings are yielded live by design;
+ *  the killAgent status-race guard is covered by the subagent suite + the
+ *  status-guard reasoning.)
+ */
+// @ts-nocheck
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AnthropicTransport } from '../src/transport/anthropic.js';
+import { APIStatusError } from '../src/errors.js';
+
+afterEach(() => vi.unstubAllGlobals());
+
+function emptySse(): Response {
+  // HTTP 200 with a body that carries no message_start (empty non-start).
+  return new Response('event: ping\ndata: {"type":"ping"}\n\n', {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+function retryable429(): Response {
+  return new Response('rate limited', { status: 429 });
+}
+async function drain(gen: AsyncIterable<unknown>): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _ of gen) { /* consume */ }
+}
+const baseReq = { model: 'claude-test', max_tokens: 8, messages: [{ role: 'user', content: 'q' }] };
+
+describe('T2 — shared retry budget bounds total POSTs', () => {
+  it('alternating 429/empty-200 stays within maxRetries+1 total POSTs', async () => {
+    const maxRetries = 1;
+    let calls = 0;
+    // Alternate: 429, empty, 429, empty, … A pre-fix run would let each
+    // empty-stream re-issue spend a FRESH maxRetries on the 429s (≈4 POSTs for
+    // maxRetries=1); the shared budget caps it at maxRetries+1 = 2.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1;
+        return calls % 2 === 1 ? retryable429() : emptySse();
+      }),
+    );
+    const t = new AnthropicTransport({
+      provider: { apiKey: 'k', maxRetries },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: () => undefined,
+    });
+    let err: unknown;
+    try {
+      await drain(t.stream(baseReq));
+    } catch (e) {
+      err = e;
+    }
+    // Terminal outcome is a surfaced error (the budget ran out), and the total
+    // POST count never exceeded the single shared budget.
+    expect(err).toBeDefined();
+    expect(calls).toBeLessThanOrEqual(maxRetries + 1);
+  }, 15_000);
+
+  it('a persistent empty stream still exhausts into exactly maxRetries+1 POSTs', async () => {
+    const maxRetries = 2;
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1;
+        return emptySse();
+      }),
+    );
+    const t = new AnthropicTransport({
+      provider: { apiKey: 'k', maxRetries },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: () => undefined,
+    });
+    await expect(drain(t.stream(baseReq))).rejects.toBeInstanceOf(Error);
+    // Initial POST + maxRetries empty-stream re-issues, no more.
+    expect(calls).toBe(maxRetries + 1);
+  }, 15_000);
+});


### PR DESCRIPTION
## 概述

v0.53.4 稳定性批的 3 条极轻项收口（守密人「也一起修复」）。2 条修复 + 1 条判定 WAI。

---

## 变更类型

- [x] Bug 修复

- **T2 共享重试预算（双臂）**：空流重试计数原与 `requestWithRetries` 内层 attempt 计数**相互独立**，各受 `maxRetries` 约束 → 网关在错误与空-200 间交替时可放大到 ~`maxRetries²` 次 POST。改为一个 `{ used }` 预算贯穿内外两层，总量收敛到 `maxRetries+1`。Anthropic + OpenAI 双臂。
- **killAgent 状态竞态（子代理运行时）**：stopTask 撞上子任务完成可发出互相矛盾的 stopped/completed 信号并回刷 `record.status`。killAgent 不再覆盖已终态记录；完成体仅在 `running` 时报完成。双向收敛到单一一致终态。
- **T3 预启动 ping「泄漏」——判定 WAI，不改**：ping 保活按设计即时 yield 给消费者，实时投递是 idle-watchdog / 硬帽 / 进度路径的承载契约（5 测试为证）；被丢弃重试尝试的 ping 泄漏无害（无内容、accumulator 忽略），缓冲反而降级实时投递。已在代码内注明。

---

## 安全声明（强制）

- [x] 不含内网 / 黑池 / 未发布数据；纯 SDK 工程代码。
- [x] 不上传内部资产。
- [x] 同意按 MIT License 提交。

§1.1-HC 黑池防火墙无涉。

---

## 验证清单

- [x] 全量单测 **2160 通过** + 2 skipped（+2 新回归 `tests/conversation-stability-followups.test.ts` 证 T2 上界）
- [x] `npm run typecheck` 干净；`npm run build` 通过
- [x] 版本纪律：0.53.4 → 0.53.5（patch），三源对齐，版本守卫绿
- [x] 不引入 emoji

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJSS3y9TNeJXjem6RPM33h)_