### PR TITLE
fix(silver-core-sdk): multi-subsystem audit batch — 5 verified fixes (v0.53.6)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,57 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.53.6 — 2026-07-13
+
+**Multi-subsystem audit batch: 5 verified fixes across MCP, hooks, permissions,
+grep, and the engine (BPT stability, 2026-07-13).** A four-cluster audit
+(permissions/hooks, file/shell tools, engine/transport, MCP/sessions/subagents)
+surfaced (and this release fixes) five concrete defects, each with a regression
+test. Ranked:
+
+- **ReDoS guard was bypassable by a nested group (hooks matcher).** The
+  catastrophic-backtracking detector used `[^()]` around the inner quantifier,
+  so it only recognized a nested quantifier when the quantified group held no
+  further parens — `((a+))+$` and `(a(b+))+$` evaded it, reached
+  `new RegExp().test()`, and froze the event loop synchronously (confirmed: a
+  33-char value ran past a 5s timeout). Fix: replaced the flat regex with a
+  paren-stack star-height walk that flags any repetition-bearing group that is
+  itself quantified, at any nesting depth; safe linear patterns
+  (`(foo|bar)+`, `Edit.*`, `^mcp__`) keep working.
+- **auto-mode classifier `deny` was bypassed by an ask route (permissions
+  gate).** The auto classifier lived inside the `!routeToPrompt` mode switch, so
+  any active ask route (hook `ask`, session ask rule, requiresUserInteraction,
+  sandboxEscape) skipped it and routed a classifier-DENY call to `canUseTool` —
+  which could ALLOW it, inverting the module's own documented deny > ask
+  invariant. Fix: the classifier `deny` verdict is now evaluated as its own
+  guard, regardless of the ask route (a hook `allow` still outranks it); the
+  `allow`/`prompt` verdicts stay behind the ask route so it still prompts.
+  Bites consumers who inject a custom classifier.
+- **stdio elicitation reply could leak an unhandled rejection (MCP).** The
+  server-initiated `elicitation/create` reply chain had only two `.then/.catch`
+  links; when the connection was closing, the fallback decline `write()` threw
+  again with no terminal catch → unhandled rejection → process crash under a
+  strict policy. The HTTP arm already had the terminal `.catch` (finding 15);
+  it was missed on the stdio arm. Fix: mirror the terminal `.catch`.
+- **`grep` multiline + `-o` reported "No matches found" for a matching file.**
+  In only-matching mode the substring extraction ran the regex per-line, so a
+  `multiline` pattern whose match spans a newline extracted nothing and
+  fell through to the empty-result guard — a false negative, while
+  `files_with_matches`/`count` correctly reported the match. Fix: multiline `-o`
+  scans the reconstructed whole content and emits each match with its starting
+  line number (ripgrep -oU semantics).
+- **`grep -o` emitted spurious empty output lines for a zero-length pattern.**
+  A pattern that can match the empty string (e.g. `x*`) pushed a blank entry at
+  every offset. Fix: skip zero-length matches (ripgrep omits them).
+- **thinking `budget_tokens` could be emitted below the API's 1024 floor
+  (engine).** For pre-adaptive models the code guarded only the upper bound
+  (`< max_tokens`), so a positive-but-sub-1024 budget (e.g.
+  `maxThinkingTokens: 500`) passed straight through and 400'd the turn — then
+  every turn. Fix: clamp up to the 1024 floor; when `max_tokens` cannot fit the
+  floor, disable thinking rather than emit a guaranteed-400 request.
+
++11 regression tests. Full suite 2171 passing + 2 skipped; typecheck + build clean.
+
 ## 0.53.5 — 2026-07-13
 
 **Conversation-stability follow-up: the three deferred light items from 0.53.4

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.53.5",
+  "version": "0.53.6",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -72,6 +72,9 @@ import {
 } from './thinking-provenance.js';
 
 const DEFAULT_THINKING_BUDGET = 10_000;
+/** Messages API floor for an enabled thinking budget (pre-adaptive wire form):
+ *  `thinking.budget_tokens` must be >= 1024 or the request 400s. */
+const MIN_THINKING_BUDGET = 1_024;
 
 /** Resilience P0-1: per-turn budget for replay-safe turn replays. Bounded and
  *  small on purpose — replays fight transient link faults (a cut socket, a
@@ -571,15 +574,35 @@ export async function* runAgentLoop(
       return { type: 'adaptive', ...(display !== undefined ? { display } : {}) };
     }
     // Pre-adaptive model: enabled + clamped budget. The Messages API requires
-    // budget_tokens < max_tokens or it 400s; the default budget (10000) exceeds
-    // the default max_tokens (8192), so clamp below max_tokens and warn.
+    // 1024 <= budget_tokens < max_tokens or it 400s; the default budget (10000)
+    // exceeds the default max_tokens (8192), so clamp below max_tokens and warn.
     const ceiling = config.maxOutputTokens - 1;
-    const budget_tokens = requested > ceiling ? ceiling : requested;
+    // If max_tokens leaves no room for even the 1024 floor, thinking cannot be
+    // validly enabled — emitting budget_tokens < 1024 (or >= max_tokens) 400s
+    // the turn, and then every turn (config is re-read each turn). Disable it.
+    if (ceiling < MIN_THINKING_BUDGET) {
+      deps.debug(
+        `engine: thinking disabled: max_tokens ${config.maxOutputTokens} leaves ` +
+          `no room for the API's ${MIN_THINKING_BUDGET}-token budget floor`,
+      );
+      return undefined;
+    }
+    let budget_tokens = requested > ceiling ? ceiling : requested;
     if (budget_tokens < requested) {
       deps.debug(
         `engine: thinking budget_tokens ${requested} >= max_tokens ` +
           `${config.maxOutputTokens}; clamped to ${budget_tokens} to satisfy the API`,
       );
+    }
+    // Lower-bound clamp: a positive-but-sub-1024 budget (e.g. maxThinkingTokens:
+    // 500) previously passed straight through and 400'd the request. Raise it to
+    // the floor, which fits since ceiling >= MIN_THINKING_BUDGET here.
+    if (budget_tokens < MIN_THINKING_BUDGET) {
+      deps.debug(
+        `engine: thinking budget_tokens ${budget_tokens} below the API's ` +
+          `${MIN_THINKING_BUDGET}-token floor; raised to ${MIN_THINKING_BUDGET}`,
+      );
+      budget_tokens = MIN_THINKING_BUDGET;
     }
     return {
       type: 'enabled',

--- a/projects/silver-core-sdk/src/hooks/matcher.ts
+++ b/projects/silver-core-sdk/src/hooks/matcher.ts
@@ -36,8 +36,59 @@ const MAX_VALUE_LENGTH = 1024;
  * backtracking signature: `(a+)+`, `(a*)+`, `(a+)*`, `(.*x)+`, `(a+){2,}`, ...
  * Intentionally conservative: safe linear patterns like `(foo|bar)+`, `Edit.*`
  * or `^mcp__` do not match and keep working.
+ *
+ * A single flat regex CANNOT do this correctly: the old detector
+ * `/\([^()]*[*+][^()]*\)\s*[*+{]/` used `[^()]*` around the inner quantifier,
+ * so it only saw a nested quantifier when the quantified group held NO further
+ * parens — `((a+))+` and `(a(b+))+` slipped through and still froze the event
+ * loop. We instead walk the pattern with a paren stack, tracking (at every
+ * nesting depth) whether the group body contains a repetition, and flag the
+ * moment a repetition-bearing group is itself quantified.
  */
-const NESTED_QUANTIFIER_RE = /\([^()]*[*+][^()]*\)\s*[*+{]/;
+function hasNestedQuantifier(pattern: string): boolean {
+  const isRepeatQuant = (c: string | undefined): boolean =>
+    c === '*' || c === '+' || c === '{';
+  // Per open group: does its body (at ANY depth) contain a repetition quantifier?
+  const bodyHasRepeat: boolean[] = [];
+  const markAllOpenGroups = (): void => {
+    for (let k = 0; k < bodyHasRepeat.length; k += 1) bodyHasRepeat[k] = true;
+  };
+  for (let i = 0; i < pattern.length; i += 1) {
+    const ch = pattern[i];
+    if (ch === '\\') {
+      i += 1; // escaped metachar is a literal atom; skip it
+      continue;
+    }
+    if (ch === '[') {
+      // character class: consume to the closing ']' so parens/quantifier chars
+      // inside it are treated as literals, not structure.
+      i += 1;
+      while (i < pattern.length && pattern[i] !== ']') {
+        if (pattern[i] === '\\') i += 1;
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === '(') {
+      bodyHasRepeat.push(false);
+      continue;
+    }
+    if (ch === ')') {
+      const closedBodyRepeat = bodyHasRepeat.pop() ?? false;
+      // Look past optional whitespace for a quantifier applied to THIS group.
+      let j = i + 1;
+      while (j < pattern.length && /\s/.test(pattern[j] ?? '')) j += 1;
+      const outerQuantified = isRepeatQuant(pattern[j]);
+      // A repetition-bearing group that is itself repeated = star height >= 2.
+      if (outerQuantified && closedBodyRepeat) return true;
+      // A quantified group counts as a repetition within its parent's body.
+      if (outerQuantified) markAllOpenGroups();
+      continue;
+    }
+    if (isRepeatQuant(ch)) markAllOpenGroups(); // in-body repetition at this depth
+  }
+  return false;
+}
 
 export function matcherMatches(
   matcher: string | undefined,
@@ -64,7 +115,7 @@ export function matcherMatches(
     );
     return false;
   }
-  if (NESTED_QUANTIFIER_RE.test(matcher)) {
+  if (hasNestedQuantifier(matcher)) {
     debug?.(
       `hooks matcher: pattern "${matcher}" has a nested quantifier ` +
         `(catastrophic-backtracking risk); treated as no-match`,

--- a/projects/silver-core-sdk/src/mcp/stdio.ts
+++ b/projects/silver-core-sdk/src/mcp/stdio.ts
@@ -295,7 +295,18 @@ export class StdioMcpConnection {
         const replyId = msg.id as JsonRpcId;
         void resolveElicitation(msg.params, this.elicitation, this.lifeController.signal)
           .then((result) => this.write({ jsonrpc: '2.0', id: replyId, result }))
-          .catch(() => this.write({ jsonrpc: '2.0', id: replyId, result: { action: 'decline' } }));
+          .catch(() => this.write({ jsonrpc: '2.0', id: replyId, result: { action: 'decline' } }))
+          // The fallback decline write can ITSELF throw (e.g. the connection is
+          // already closing -> write() throws McpError). Without this terminal
+          // catch that second rejection is unhandled and can crash the process
+          // under a strict unhandledRejection policy. Mirrors http.ts.
+          .catch((err: unknown) => {
+            this.debug(
+              `[mcp:${this.label}] elicitation reply failed: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+          });
         return;
       }
       // Other server-initiated requests: this client implements no server-

--- a/projects/silver-core-sdk/src/permissions/gate.ts
+++ b/projects/silver-core-sdk/src/permissions/gate.ts
@@ -206,6 +206,27 @@ export class DefaultPermissionGate implements PermissionGate {
       return { decision: 'allow', updatedInput: effectiveInput };
     }
 
+    // ----- STEP 4a: auto-classifier DENY (applies even on an ask route) -------
+    // The auto classifier's `deny` is a hard deny that must survive an active
+    // ask route, exactly as the module invariant states ("an ask route can never
+    // widen permissions"). Evaluating it inside the `!routeToPrompt` switch below
+    // meant any ask route (hook 'ask', a session ask rule, requiresUserInteraction,
+    // sandboxEscape) skipped the classifier entirely and routed a classifier-DENY
+    // call to canUseTool — which could ALLOW it, inverting deny > ask. So the deny
+    // verdict is checked here, regardless of routeToPrompt. A hook 'allow' (the
+    // deliberate escape hatch resolved just above) still outranks it. The 'allow'
+    // / 'prompt' verdicts stay in the mode step so an ask route still prompts.
+    if (this.mode === 'auto' && !hookAllow) {
+      const cls = this.classifier(toolName, input, { readOnly, isFileEdit });
+      if (cls === 'deny') {
+        return this.deny(toolName, toolUseID, input, 'auto classifier');
+      }
+      if (!routeToPrompt) {
+        if (cls === 'allow') return { decision: 'allow', updatedInput: input };
+        routeToPrompt = true; // 'prompt'
+      }
+    }
+
     // ----- STEP 4: permission mode (only when no hook-allow / ask route) ------
     if (!hookAllow && !routeToPrompt) {
       switch (this.mode) {
@@ -219,15 +240,10 @@ export class DefaultPermissionGate implements PermissionGate {
           // v0.2: plan ROUTES writes to canUseTool (never a hard deny).
           routeToPrompt = true;
           break;
-        case 'auto': {
-          const cls = this.classifier(toolName, input, { readOnly, isFileEdit });
-          if (cls === 'allow') return { decision: 'allow', updatedInput: input };
-          if (cls === 'deny') {
-            return this.deny(toolName, toolUseID, input, 'auto classifier');
-          }
-          routeToPrompt = true; // 'prompt'
+        case 'auto':
+          // Resolved in step 4a above (deny already returned; allow/prompt
+          // handled there). Nothing left to decide here.
           break;
-        }
         case 'default':
         case 'dontAsk':
           if (readOnly) return { decision: 'allow', updatedInput: input };

--- a/projects/silver-core-sdk/src/tools/grep.ts
+++ b/projects/silver-core-sdk/src/tools/grep.ts
@@ -438,16 +438,39 @@ export const grepTool: BuiltinTool = {
       if (onlyMatching) {
         // Print each matched substring on its own line; context is ignored.
         const re = new RegExp(pattern, flags.includes('g') ? flags : `${flags}g`);
+        if (multiline) {
+          // A multiline pattern's match can SPAN newlines, so a per-line exec
+          // would extract nothing and report "No matches found" for a file the
+          // scanner already flagged as matching. Scan the reconstructed whole
+          // content instead and emit each match with its STARTING line number
+          // (ripgrep -oU semantics).
+          const text = scan.lines.join('\n');
+          const offsets = lineStartOffsets(text);
+          let m: RegExpExecArray | null;
+          while ((m = re.exec(text)) !== null) {
+            if (m[0].length === 0) {
+              re.lastIndex++; // zero-length match: advance, emit nothing
+              continue;
+            }
+            if (out.length >= collectCap) break;
+            const lineNo = showLineNumbers ? `${lineIndexAt(offsets, m.index) + 1}:` : '';
+            out.push(`${file}:${lineNo}${clipLine(m[0])}`);
+          }
+          continue;
+        }
         for (const i of scan.matches) {
           if (out.length >= collectCap) break;
           const line = scan.lines[i] ?? '';
           re.lastIndex = 0;
           let m: RegExpExecArray | null;
           while ((m = re.exec(line)) !== null) {
+            if (m[0].length === 0) {
+              re.lastIndex++; // zero-length match: advance without emitting a
+              continue; //       spurious empty line (ripgrep omits empty matches)
+            }
             if (out.length >= collectCap) break;
             const lineNo = showLineNumbers ? `${i + 1}:` : '';
             out.push(`${file}:${lineNo}${clipLine(m[0])}`);
-            if (m[0].length === 0) re.lastIndex++; // avoid zero-length loop
           }
         }
         continue;

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.53.5';
+export const SDK_VERSION = '0.53.6';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/engine.test.ts
+++ b/projects/silver-core-sdk/tests/engine.test.ts
@@ -1192,6 +1192,53 @@ describe('runAgentLoop', () => {
     });
   });
 
+  it('raises a sub-1024 thinking budget to the 1024 API floor (pre-adaptive)', async () => {
+    const transport = new MockTransport([textReplyEvents('ok')]);
+    const deps = makeDeps(transport);
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+
+    await collect(
+      runAgentLoop(
+        history,
+        deps,
+        // 500 is positive (not "off") but below the API's 1024 floor: previously
+        // sent verbatim -> 400 "budget_tokens must be >= 1024" -> every turn dies.
+        makeConfig({
+          model: 'claude-haiku-4-5',
+          maxOutputTokens: 8192,
+          thinking: { type: 'enabled', budget_tokens: 500 },
+        }),
+      ),
+    );
+
+    expect(transport.requests[0]!.thinking).toEqual({
+      type: 'enabled',
+      budget_tokens: 1024,
+    });
+  });
+
+  it('disables thinking when max_tokens cannot fit the 1024 floor (pre-adaptive)', async () => {
+    const transport = new MockTransport([textReplyEvents('ok')]);
+    const deps = makeDeps(transport);
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+
+    await collect(
+      runAgentLoop(
+        history,
+        deps,
+        // max_tokens 900 => ceiling 899 < 1024: no valid budget exists, so emit
+        // NO thinking param rather than a guaranteed-400 request.
+        makeConfig({
+          model: 'claude-haiku-4-5',
+          maxOutputTokens: 900,
+          thinking: { type: 'enabled', budget_tokens: 2000 },
+        }),
+      ),
+    );
+
+    expect(transport.requests[0]!.thinking).toBeUndefined();
+  });
+
   it('a resolved thinking budget of 0 sends NO thinking param (E1 live-disable guard)', async () => {
     // thinking {type:'enabled'} with maxThinkingTokens 0 is what a live
     // setMaxThinkingTokens(0) produces under the preset default (which injects

--- a/projects/silver-core-sdk/tests/grep-opt.test.ts
+++ b/projects/silver-core-sdk/tests/grep-opt.test.ts
@@ -132,3 +132,50 @@ describe('OPT: unchanged basics still hold', () => {
     ).rejects.toBeInstanceOf(AbortError);
   });
 });
+
+describe('OPT: -o (only-matching) content mode', () => {
+  async function fileWith(body: string): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'grep-o-'));
+    sandboxes.push(dir);
+    await writeFile(path.join(dir, 'm.txt'), body);
+    return dir;
+  }
+
+  it('multiline + -o extracts a match spanning newlines (was: "No matches found")', async () => {
+    const dir = await fileWith('alpha\nbeta\ngamma\n');
+    const res = await grepTool.execute(
+      { pattern: 'alpha.beta', path: dir, output_mode: 'content', multiline: true, '-o': true },
+      makeCtx(dir),
+    );
+    const c = contentOf(res);
+    expect(c).not.toBe('No matches found');
+    // starting line number (1) + the whole spanning match
+    expect(c).toContain('m.txt:1:alpha\nbeta');
+  });
+
+  it('-o omits empty matches for a zero-length-capable pattern (no blank spam)', async () => {
+    const dir = await fileWith('abc\n');
+    const c = contentOf(
+      await grepTool.execute(
+        { pattern: 'x*', path: dir, output_mode: 'content', '-o': true },
+        makeCtx(dir),
+      ),
+    );
+    // 'x*' matches empty at every offset; ripgrep emits nothing, so the file is
+    // reported as not matching rather than four blank `m.txt:1:` lines.
+    expect(c).toBe('No matches found');
+  });
+
+  it('-o still extracts ordinary single-line matches', async () => {
+    const dir = await fileWith('foo bar foo baz\n');
+    const c = contentOf(
+      await grepTool.execute(
+        { pattern: 'foo', path: dir, output_mode: 'content', '-o': true },
+        makeCtx(dir),
+      ),
+    );
+    const lines = c.split('\n');
+    expect(lines).toHaveLength(2); // two 'foo' occurrences, each on its own line
+    expect(lines.every((l) => l.endsWith('m.txt:1:foo'))).toBe(true);
+  });
+});

--- a/projects/silver-core-sdk/tests/mcp.test.ts
+++ b/projects/silver-core-sdk/tests/mcp.test.ts
@@ -19,13 +19,14 @@ import { z } from 'zod';
 
 import { createSdkMcpServer, SdkMcpConnection, tool } from '../src/mcp/sdk-server.js';
 import { HttpMcpConnection } from '../src/mcp/http.js';
-import { parseResourcesList, parseResourceContents } from '../src/mcp/stdio.js';
+import { parseResourcesList, parseResourceContents, StdioMcpConnection } from '../src/mcp/stdio.js';
 import { DefaultMcpRegistry } from '../src/mcp/registry.js';
-import type { CallToolResult, SdkMcpToolDefinition } from '../src/types.js';
+import type { CallToolResult, ElicitationHandler, SdkMcpToolDefinition } from '../src/types.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ECHO_FIXTURE = path.join(HERE, 'fixtures', 'mcp-echo-server.mjs');
 const HTTP_FIXTURE = path.join(HERE, 'fixtures', 'mcp-http-server.mjs');
+const ELICIT_FIXTURE = path.join(HERE, 'fixtures', 'mcp-elicit-server.mjs');
 
 /** Fresh non-aborted signal for registry calls. */
 function liveSignal(): AbortSignal {
@@ -489,6 +490,52 @@ describe('StdioMcpConnection via DefaultMcpRegistry (echo fixture)', () => {
     expect(await waitForPidExit(pid)).toBe(true);
     expect(reg.statuses()[0]?.status).toBe('pending');
     expect(reg.allTools()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stdio elicitation reply teardown: the fallback decline write must not leak
+// an unhandled rejection when the connection is closing (twin of the HTTP
+// "finding 15" guard in tools-v2.test.ts; the terminal .catch was applied to
+// http.ts but originally missed on stdio.ts).
+// ---------------------------------------------------------------------------
+
+describe('StdioMcpConnection elicitation reply teardown', () => {
+  it('does not emit an unhandled rejection when both reply writes fail on a closing connection', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+
+    let conn: StdioMcpConnection | undefined;
+    // Closing the connection while resolving the elicitation makes BOTH the
+    // result write AND the fallback decline write throw McpError (not open).
+    const handler: ElicitationHandler = async () => {
+      await conn?.close();
+      return { action: 'accept', content: { name: 'x' } };
+    };
+
+    try {
+      conn = new StdioMcpConnection(
+        { type: 'stdio', command: process.execPath, args: [ELICIT_FIXTURE] },
+        { name: 'elicit', elicitation: handler },
+      );
+      await conn.connect();
+      try {
+        await conn.callTool('ask', {});
+      } catch {
+        // callTool rejects once close() fails all pending; not the point.
+      }
+      // Give the detached decline-write time to throw and surface (if unhandled).
+      for (let i = 0; i < 6; i++) {
+        await new Promise((r) => setTimeout(r, 10));
+      }
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      await conn?.close().catch(() => {});
+    }
   });
 });
 

--- a/projects/silver-core-sdk/tests/permissions-gate-fixes.test.ts
+++ b/projects/silver-core-sdk/tests/permissions-gate-fixes.test.ts
@@ -701,3 +701,61 @@ describe('sandbox escape is gated as its own ask (never piggybacks a command app
     expect(spy).not.toHaveBeenCalled(); // allowed by rule, no prompt
   });
 });
+
+// ---------------------------------------------------------------------------
+// auto-classifier DENY must survive an active ask route (deny > ask). An ask
+// route (hook 'ask' / session ask rule) previously skipped the mode switch that
+// held the classifier, routing a classifier-DENY call to canUseTool — which
+// could ALLOW it, inverting the documented deny > ask precedence.
+// ---------------------------------------------------------------------------
+
+describe('auto mode: classifier deny is not bypassed by an ask route', () => {
+  const denyAll: ToolClassifier = () => 'deny';
+  const allowingCanUse: CanUseTool = async () => ({ behavior: 'allow' }) as PermissionResult;
+
+  it('hook ask + classifier deny => deny (not allow via canUseTool)', async () => {
+    const spy = vi.fn(allowingCanUse);
+    const gate = makeGate({ mode: 'auto', classifier: denyAll, canUseTool: spy });
+    const res = await gate.check(
+      'Bash',
+      { command: 'rm -rf /' },
+      checkOpts({ hook: { decision: 'ask' } }),
+    );
+    expect(res.decision).toBe('deny');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('session ask rule + classifier deny => deny (not allow via canUseTool)', async () => {
+    const spy = vi.fn(allowingCanUse);
+    const gate = makeGate({ mode: 'auto', classifier: denyAll, canUseTool: spy });
+    gate.applyUpdates([
+      { type: 'addRules', behavior: 'ask', rules: [{ toolName: 'Bash' }], destination: 'session' },
+    ]);
+    const res = await gate.check('Bash', { command: 'rm -rf /' }, checkOpts());
+    expect(res.decision).toBe('deny');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('hook ask + classifier ALLOW still prompts (ask route is not widened away)', async () => {
+    const allowAll: ToolClassifier = () => 'allow';
+    const spy = vi.fn(allowingCanUse);
+    const gate = makeGate({ mode: 'auto', classifier: allowAll, canUseTool: spy });
+    const res = await gate.check(
+      'Bash',
+      { command: 'ls' },
+      checkOpts({ hook: { decision: 'ask' } }),
+    );
+    // classifier 'allow' must NOT short-circuit past the ask route: canUseTool
+    // decides, and here it allows — but it WAS consulted (the prompt happened).
+    expect(res.decision).toBe('allow');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifier deny with NO ask route still denies (regression control)', async () => {
+    const spy = vi.fn(allowingCanUse);
+    const gate = makeGate({ mode: 'auto', classifier: denyAll, canUseTool: spy });
+    const res = await gate.check('Bash', { command: 'rm -rf /' }, checkOpts());
+    expect(res.decision).toBe('deny');
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/projects/silver-core-sdk/tests/permissions-hooks.test.ts
+++ b/projects/silver-core-sdk/tests/permissions-hooks.test.ts
@@ -839,6 +839,18 @@ describe('matcherMatches', () => {
     expect(matcherMatches('(a+){2,}', value)).toBe(false);
   });
 
+  // The original flat-regex detector used [^()] around the inner quantifier, so
+  // a quantified group wrapping ANOTHER group evaded it and still froze the
+  // event loop. These deeper-nested shapes must also be flagged, fast.
+  it('flags DEEPLY nested quantifier shapes and returns quickly', () => {
+    const evil = 'a'.repeat(40) + 'b';
+    for (const pat of ['((a+))+$', '(a(b+))+$', '((a|b)+)+$', '(x(y+)z)*$']) {
+      const started = Date.now();
+      expect(matcherMatches(pat, evil)).toBe(false);
+      expect(Date.now() - started).toBeLessThan(100);
+    }
+  });
+
   it('caps an over-long regex input value as no-match (#24)', () => {
     expect(matcherMatches('x.*', 'x'.repeat(5000))).toBe(false);
   });


### PR DESCRIPTION
## 概述

silver-core-sdk 多子系统缺陷排查批次：四区并行审计（permissions/hooks、file/shell tools、engine/transport、MCP/sessions/subagents）+ 手检未派发模块，坐实并修复 5 处（6 条）真缺陷，各带回归测试。v0.53.5 → v0.53.6。

---

## 变更类型

- [x] Bug 修复

---

## 修复清单（读码 + 执行双重坐实）

- **hooks ReDoS 守卫被嵌套括号绕过** — `hooks/matcher.ts`：扁平正则检测器用 `[^()]` 包住内层量词，`((a+))+$` / `(a(b+))+$` 绕过后触发灾难性回溯冻结事件循环（33 字符实测跑过 5 秒）。改为括号栈星高扫描，安全线性模式（`(foo|bar)+` / `Edit.*` / `^mcp__`）照常工作。
- **auto 模式分类器 deny 被 ask 路由吞掉** — `permissions/gate.ts`：分类器位于 `!routeToPrompt` 的 mode switch 内，任何 ask 路由（hook ask / session ask 规则 / requiresUserInteraction / sandboxEscape）跳过它并把 classifier-DENY 的调用路由给 canUseTool，后者可放行 → deny>ask 倒置。deny 裁决改为独立守卫、不受 ask 路由影响（hook allow 仍高于它）。
- **stdio elicitation 回复泄漏 unhandled rejection** — `mcp/stdio.ts`：连接关闭时兜底 decline 的 `write()` 二次抛出且无终结 catch → 严格策略下崩进程。HTTP 臂已有终结 `.catch`（finding 15），stdio 臂遗漏；补齐。
- **grep `multiline`+`-o` 谎报 No matches found** — `tools/grep.ts`：只匹配模式逐行 exec，跨行匹配抽不出内容而回落空结果守卫（假阴性）。多行 `-o` 改为扫全文并按起始行号输出（ripgrep -oU 语义）。
- **grep `-o` 空匹配刷空行** — `tools/grep.ts`：可空模式（`x*`）每个偏移都推一条空行。改为跳过零长匹配（ripgrep 也省略）。
- **thinking budget_tokens 可低于 1024 下限** — `engine/loop.ts`：pre-adaptive 模型只钳上界，正的但 <1024 的预算直通 → 每轮 400。改为钳到 1024 下限；max_tokens 容不下下限时禁用 thinking。

---

## 安全声明

- [x] 本变更不含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据；仅改动 silver-core-sdk 工程代码与测试。
- [x] 不涉及游戏图片 / 内部美术 / 解包原始文件。
- [x] 同意按 MIT License 提交。

---

## 验证清单

- [x] 全量单测对话内跑通：`pytest tests/`（Python 侧）+ `npm test`（SDK vitest）**2171 通过 / 2 跳过**（修前 2160）
- [x] `npm run typecheck` + `npm run build` 干净
- [x] 版本守卫绿（package.json / `src/version.ts` / CHANGELOG 三处同步至 0.53.6）
- [x] +11 回归测试；每个修复经「回退即变红、恢复即变绿」或强断言绑定核实
- [x] 不引入 emoji
- [x] 未动 `memory/decisions.md` / `memory/lessons-learned.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCzMMTCNDQRzpg8DwESsAS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCzMMTCNDQRzpg8DwESsAS)_