### PR TITLE
fix(silver-core-sdk): second audit batch — 5 verified fixes (v0.53.7)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,50 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.53.7 — 2026-07-13
+
+**Second multi-subsystem audit batch: 5 verified fixes across subagents, MCP
+tools, and sessions (BPT stability, 2026-07-13).** A three-cluster audit
+(subagents/task runtime, sessions/accumulator, workflow/misc tools) surfaced
+five more concrete defects, each with a regression test. Ranked:
+
+- **Background SendMessage continuations had no stall watchdog (subagents).**
+  The initial background launch wraps the child in a `StallWatchdog` that aborts
+  a silent stream; `runContinuation` (the SendMessage follow-up path) constructed
+  none, so a continuation whose stream went silent never aborted — `turn` never
+  settled, the background delivery promise never pushed its `<task-notification>`,
+  and a coordinator waiting on the reply hung until whole-query teardown. Fix:
+  wire the same watchdog into the continuation, AND return a stalled continuation
+  as an error RESULT (not a thrown abort) so the delivery path surfaces a FAILED
+  note to the coordinator instead of swallowing it in its `.catch`.
+- **Foreground child result discarded if the SubagentStop hook aborted
+  (subagents).** The foreground path awaited `fireSubagentStop(…, params.signal)`
+  bare; an outer abort landing during that await made the hook throw and rejected
+  spawn(), discarding the child's already-computed answer. The background path
+  already fired the stop hook with a fresh signal and a `.catch`; the foreground
+  path now mirrors it (the child has finished — the hook is a notification, not a
+  gate on returning the result).
+- **`readCappedBody` off-by-one flagged an exactly-cap body as truncated
+  (webfetch).** The streaming path used `value.byteLength >= remaining`, so a
+  body exactly `MAX_BODY_BYTES` long (or a chunk landing right on the boundary)
+  was marked overflow though nothing was dropped — appending a misleading
+  `[truncated]`. The non-stream fallback correctly used `> cap`. Fix: `>` in the
+  streaming path too; an exactly-cap chunk is taken whole and the next read()'s
+  `done` distinguishes "exactly cap" from "more follows".
+- **`auditToolClaims` reused a stateful RegExp across texts (sessions).** A
+  consumer-supplied detector whose `claimPattern` carries the `g`/`y` flag is
+  stateful; exec() advanced `lastIndex`, so matching resumed mid-string on the
+  next assistant text and a genuinely-unbacked claim was silently missed. Fix:
+  reset `lastIndex` before each exec.
+- **`list()`/`getSessionInfo` dropped a meta_update gitBranch (sessions).**
+  `load()` honored an updated `gitBranch` on a `meta_update` record; the
+  `loadInfo()` scan behind `list()`/`listSessions()` read only `customTitle`/`tag`,
+  so the two read paths reported different branches for the same session. Fix:
+  read `gitBranch` in `loadInfo` too.
+
++4 regression tests (the foreground stop-hook fix mirrors the already-tested
+background path). Full suite 2175 passing + 2 skipped; typecheck + build clean.
+
 ## 0.53.6 — 2026-07-13
 
 **Multi-subsystem audit batch: 5 verified fixes across MCP, hooks, permissions,

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.53.6",
+  "version": "0.53.7",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/sessions/store.ts
+++ b/projects/silver-core-sdk/src/sessions/store.ts
@@ -535,6 +535,11 @@ export class JsonlSessionStore implements SessionStore {
           if (typeof entry.customTitle === 'string') customTitle = entry.customTitle;
           if (typeof entry.tag === 'string') tag = entry.tag;
           else if (entry.tag === null) tag = undefined;
+          // Mirror load(): a meta_update may carry an updated gitBranch (a
+          // documented meta_update field). Omitting it here made list()/
+          // getSessionInfo report a stale branch while load() reported the new
+          // one for the same session.
+          if (typeof entry.gitBranch === 'string') gitBranch = entry.gitBranch;
         } else if (entry.type === 'pending_turn' && typeof entry.uuid === 'string') {
           openPending.set(
             entry.uuid,

--- a/projects/silver-core-sdk/src/sessions/tool-claims.ts
+++ b/projects/silver-core-sdk/src/sessions/tool-claims.ts
@@ -114,6 +114,12 @@ export function auditToolClaims(args: AuditToolClaimsArgs): ToolClaimFinding[] {
     if (backed) continue;
     for (const [i, entry] of args.assistantTexts.entries()) {
       const text = typeof entry === 'string' ? entry : entry.text;
+      // Reset before each exec: a consumer-supplied detector whose claimPattern
+      // carries the `g`/`y` flag is STATEFUL — exec() advances lastIndex, so
+      // without this reset matching resumes mid-string on the next text and a
+      // genuinely-unbacked claim is silently missed (the one failure this audit
+      // must minimize). Harmless for the default non-global detectors.
+      detector.claimPattern.lastIndex = 0;
       const match = detector.claimPattern.exec(text);
       if (match === null) continue;
       const lineStart = text.lastIndexOf('\n', match.index) + 1;

--- a/projects/silver-core-sdk/src/subagents/runtime.ts
+++ b/projects/silver-core-sdk/src/subagents/runtime.ts
@@ -1337,7 +1337,16 @@ export function createSubagentRuntime(
       }
       record.status = result.isError ? 'failed' : 'completed';
       emitTaskFinished(agentId, result);
-      await fireSubagentStop(agentId, resolved.type, params.signal);
+      // Fire the stop hook with a FRESH signal and swallow its errors, mirroring
+      // the background path: the child has already finished (result + usage are
+      // computed), so an outer abort landing during the stop-hook await must not
+      // reject spawn() and DISCARD the completed answer. The hook is a
+      // notification here, not a gate on returning the result.
+      await fireSubagentStop(
+        agentId,
+        resolved.type,
+        new AbortController().signal,
+      ).catch(() => undefined);
       return {
         content: `${result.text}\n\nagentId: ${agentId}`,
         isError: result.isError,
@@ -1361,6 +1370,7 @@ export function createSubagentRuntime(
     if (record.controller.signal.aborted) {
       record.controller = new AbortController();
     }
+    const contController = record.controller;
     record.status = 'running';
     record.history.push({ role: 'user', content: params.message });
     // Fresh signal composition: the spawn-time ToolContext signal belonged to
@@ -1370,12 +1380,21 @@ export function createSubagentRuntime(
     const contSignal = AbortSignal.any([
       outerSignal,
       params.signal,
-      record.controller.signal,
+      contController.signal,
     ]);
     const contDeps: EngineDeps = {
       ...record.deps,
       toolContext: { ...record.deps.toolContext, signal: contSignal },
     };
+    // Stall watchdog for the continuation too (twin of the initial background
+    // launch). Without it a SendMessage continuation whose stream goes silent
+    // never aborts, so `turn` never settles, the background delivery promise
+    // never pushes its <task-notification>, and a coordinator waiting on the
+    // reply hangs until whole-query teardown. touch() rides every stream event.
+    const stallWatchdog = new StallWatchdog({
+      timeoutMs: resolveStallTimeoutMs(env),
+      onStall: () => contController.abort(),
+    });
     try {
       const result = await runChildToCompletion(
         record.history,
@@ -1383,13 +1402,31 @@ export function createSubagentRuntime(
         record.config,
         agentId,
         record.sidechain,
+        stallWatchdog,
       );
       record.status = result.isError ? 'failed' : 'completed';
       emitTaskFinished(agentId, result);
       return result;
     } catch (err) {
       if (record.status === 'running') record.status = 'failed';
+      // A stall-watchdog abort has NO cancellation site (unlike stopTask/close,
+      // whose notes are emitted at the kill site). Surface it as an error RESULT
+      // rather than throwing: for a BACKGROUND continuation the delivery promise
+      // only pushes a <task-notification> on the .then (success/error result),
+      // so a thrown abort is swallowed by its .catch and the coordinator polling
+      // completedBuffer never learns the continuation died. Returning an error
+      // result routes through the .then and surfaces a FAILED note — mirroring
+      // the initial background run's stallWatchdog.stalled handling.
+      if (stallWatchdog.stalled) {
+        const message =
+          `stalled: no stream event for ${resolveStallTimeoutMs(env)}ms; ` +
+          `aborted by the stall watchdog`;
+        emitTaskFinished(agentId, { text: message, isError: true });
+        return { text: message, isError: true, usage: { totalTokens: 0, toolUses: 0, durationMs: 0 } };
+      }
       throw err;
+    } finally {
+      stallWatchdog.dispose();
     }
   }
 

--- a/projects/silver-core-sdk/src/tools/webfetch.ts
+++ b/projects/silver-core-sdk/src/tools/webfetch.ts
@@ -211,7 +211,7 @@ function htmlToText(html: string): string {
  * `cap` bytes have accumulated. `overflow` is true when the source exceeded the
  * cap (so the caller can mark the output truncated).
  */
-async function readCappedBody(
+export async function readCappedBody(
   response: Response,
   cap: number,
 ): Promise<{ buf: Buffer; overflow: boolean }> {
@@ -231,7 +231,13 @@ async function readCappedBody(
       if (done) break;
       if (!value || value.byteLength === 0) continue;
       const remaining = cap - total;
-      if (value.byteLength >= remaining) {
+      // Strictly GREATER than remaining = genuine overflow (this chunk carries
+      // more than fits). A chunk that EXACTLY fills the cap is not overflow —
+      // take it whole and let the next read()'s `done` distinguish "body is
+      // exactly `cap` bytes" (no overflow) from "more follows" (overflow on the
+      // next iteration, where remaining is 0). Mirrors the non-stream fallback's
+      // `full.length > cap`; `>=` here falsely flagged an exactly-cap body.
+      if (value.byteLength > remaining) {
         if (remaining > 0) chunks.push(Buffer.from(value.subarray(0, remaining)));
         overflow = true;
         break;

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.53.6';
+export const SDK_VERSION = '0.53.7';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/sendmessage.test.ts
+++ b/projects/silver-core-sdk/tests/sendmessage.test.ts
@@ -44,6 +44,32 @@ import type {
   RawMessageStreamEvent,
 } from '../src/types.js';
 import { MockTransport, textReplyEvents } from './helpers/mock-transport.js';
+import { AbortError } from '../src/errors.js';
+
+/** Completes the initial run (stream call 0), then stalls every later stream
+ *  (the SendMessage continuation): one event to touch the watchdog, then silent
+ *  until the signal aborts. */
+class StallOnContinuationTransport extends MockTransport {
+  private n = 0;
+  override async *stream(
+    req: StreamRequest,
+  ): AsyncGenerator<RawMessageStreamEvent, void> {
+    const idx = this.n++;
+    if (idx === 0) {
+      yield* super.stream(req);
+      return;
+    }
+    yield textReplyEvents('x')[0]!; // one event, then go silent
+    await new Promise<void>((_, reject) => {
+      const sig = req.signal;
+      if (sig?.aborted) {
+        reject(new AbortError());
+        return;
+      }
+      sig?.addEventListener('abort', () => reject(new AbortError()), { once: true });
+    });
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Fakes / builders (same shapes as tests/subagents.test.ts)
@@ -126,6 +152,7 @@ function makeRuntime(cfg: {
   baseBuiltins?: Map<string, BuiltinTool>;
   store?: SessionStore;
   persist?: boolean;
+  env?: Record<string, string | undefined>;
 }) {
   const engineConfig = makeConfig();
   const opts: SubagentRuntimeOptions = {
@@ -139,7 +166,7 @@ function makeRuntime(cfg: {
     store: cfg.store,
     persist: cfg.persist,
     cwd: '/tmp/sendmsg-test',
-    env: {},
+    env: cfg.env ?? {},
     additionalDirectories: [],
     outerSignal: new AbortController().signal,
     sessionId: () => engineConfig.sessionId,
@@ -395,6 +422,36 @@ describe('SubagentRuntime.sendMessage — background flow', () => {
     const spawned = await runtime.makeSpawnFn(0)(baseParams());
     expect(runtime.stopAgent(spawned.agentId)).toContain('already completed');
     expect(runtime.stopAgent('nope')).toBeUndefined();
+  });
+
+  it('a STALLED background continuation surfaces a FAILED note (coordinator not left waiting)', async () => {
+    // The initial run completes; the SendMessage continuation stalls. Without a
+    // continuation stall watchdog the reply promise never settles and the
+    // coordinator (polling drainCompletedResults) waits forever. The watchdog
+    // must abort the stalled continuation AND surface a FAILED task-notification.
+    const transport = new StallOnContinuationTransport([textReplyEvents('bg done')]);
+    const runtime = makeRuntime({
+      transport,
+      env: { CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS: '20' }, // trip fast
+    });
+    const spawned = await runtime.makeSpawnFn(0)(
+      baseParams({ runInBackground: true, description: 'bg worker' }),
+    );
+    await runtime.settleAll();
+    runtime.drainCompletedResults(); // clear the initial completion note
+
+    const ack = await runtime.sendMessage({
+      to: spawned.agentId,
+      message: 'one more thing',
+      signal: new AbortController().signal,
+    });
+    expect(ack.isError).toBe(false); // background ack is immediate
+    await runtime.settleAll();
+    const notes = runtime.drainCompletedResults();
+    expect(notes).toHaveLength(1);
+    expect(notes[0]!.text.toLowerCase()).toContain('failed');
+    expect(notes[0]!.text.toLowerCase()).toContain('stalled');
+    expect(notes[0]!.text).toContain(spawned.agentId);
   });
 });
 

--- a/projects/silver-core-sdk/tests/sessions-store.test.ts
+++ b/projects/silver-core-sdk/tests/sessions-store.test.ts
@@ -385,6 +385,25 @@ describe('rename/tag round trip via meta_update (T1-6)', () => {
     expect(info?.summary).toBe('first prompt line');
   });
 
+  it('a meta_update gitBranch is honored by BOTH load() and getSessionInfo()', async () => {
+    // Seed with an initial branch, then append a meta_update switching it.
+    const file = join(dir, `${SID}.jsonl`);
+    appendFileSync(
+      file,
+      `${JSON.stringify({ type: 'meta', sessionId: SID, createdAt: 1, cwd: '/w', firstPrompt: 'p', gitBranch: 'main' })}\n` +
+        `${JSON.stringify({ type: 'user', message: { role: 'user', content: 'p' } })}\n` +
+        `${JSON.stringify({ type: 'meta_update', uuid: 'mu-1', gitBranch: 'release' })}\n`,
+      'utf8',
+    );
+    const { store } = makeStore();
+    const loaded = await store.load(SID);
+    const info = await getSessionInfo(SID, { sessionDir: dir });
+    // Both read paths must agree — loadInfo() previously ignored the update and
+    // reported the stale 'main' while load() reported 'release'.
+    expect(loaded?.gitBranch).toBe('release');
+    expect(info?.gitBranch).toBe('release');
+  });
+
   it('listSessions carries customTitle/tag through', async () => {
     seed();
     await renameSession(SID, 'Listed title', { sessionDir: dir });

--- a/projects/silver-core-sdk/tests/tool-call-log.test.ts
+++ b/projects/silver-core-sdk/tests/tool-call-log.test.ts
@@ -232,6 +232,23 @@ describe('S4 tool-claim verification', () => {
     expect(readOnly).toHaveLength(1);
   });
 
+  it('a consumer detector with a `g`-flag claimPattern flags EVERY unbacked text', () => {
+    // A global/sticky RegExp is STATEFUL: exec() advances lastIndex, so without a
+    // per-text reset the second text resumes mid-string and its genuine claim is
+    // missed. Two texts, both unbacked -> both must be flagged (indices 0 and 1).
+    const detector = {
+      id: 'wrote-file-claim',
+      claimPattern: /wrote .* to disk/g, // note the `g` flag
+      backedBy: () => false,
+    };
+    const findings = auditToolClaims({
+      assistantTexts: ['I wrote config to disk.', 'Then I wrote data to disk.'],
+      toolCalls: [],
+      detectors: [detector],
+    });
+    expect(findings.map((f) => f.messageIndex)).toEqual([0, 1]);
+  });
+
   it('exposes the detector building blocks for consumer-defined detectors', () => {
     expect(DEFAULT_TOOL_CLAIM_DETECTORS).toContain(MEMORY_WRITE_CLAIM_DETECTOR);
     expect(MEMORY_WRITE_CLAIM_DETECTOR.id).toBe('memory-write-claim');

--- a/projects/silver-core-sdk/tests/tools-v2.test.ts
+++ b/projects/silver-core-sdk/tests/tools-v2.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
 import { lookup } from 'node:dns/promises';
 
-import { webFetchTool } from '../src/tools/webfetch.js';
+import { webFetchTool, readCappedBody } from '../src/tools/webfetch.js';
 import { webSearchTool } from '../src/tools/websearch.js';
 import { askUserQuestionTool } from '../src/tools/askuserquestion.js';
 import { todoWriteTool } from '../src/tools/todo.js';
@@ -302,9 +302,42 @@ describe('webFetchTool', () => {
     const r = await webFetchTool.execute({ url: 'https://example.com', prompt: 'x' }, ctx);
     expect(r.isError).toBeUndefined();
     expect(String(r.content)).toContain('[truncated]');
-    // The reader is cancelled at the cap; before the fix arrayBuffer() drained
-    // all 20MB into memory.
-    expect(pulled).toBeLessThanOrEqual(5 * 1024 * 1024 + chunk);
+    // The reader is cancelled shortly past the cap; before the fix arrayBuffer()
+    // drained all 20MB into memory. The bound allows a couple of extra chunks:
+    // the correct overflow check reads one chunk to fill the cap and one more to
+    // confirm overflow, plus the stream's 1-chunk prefetch — still O(cap), not 20MB.
+    expect(pulled).toBeLessThanOrEqual(5 * 1024 * 1024 + 3 * chunk);
+  });
+
+  it('readCappedBody: body EXACTLY at the cap is not overflow; one more byte is', async () => {
+    const cap = 1024;
+    const makeStream = (total: number, chunkSize: number): ReadableStream<Uint8Array> => {
+      let sent = 0;
+      return new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (sent >= total) {
+            controller.close();
+            return;
+          }
+          const n = Math.min(chunkSize, total - sent);
+          controller.enqueue(new Uint8Array(n).fill(97));
+          sent += n;
+        },
+      });
+    };
+    // Exactly cap bytes, delivered as a chunk that lands right on the boundary:
+    // the whole body arrived, so overflow must be false (was true under `>=`).
+    const exact = await readCappedBody(new Response(makeStream(cap, 256)), cap);
+    expect(exact.overflow).toBe(false);
+    expect(exact.buf.length).toBe(cap);
+    // One byte over the cap is genuine overflow, capped to `cap` bytes.
+    const over = await readCappedBody(new Response(makeStream(cap + 1, 256)), cap);
+    expect(over.overflow).toBe(true);
+    expect(over.buf.length).toBe(cap);
+    // A single chunk that exactly equals the cap: also not overflow.
+    const oneShot = await readCappedBody(new Response(makeStream(cap, cap)), cap);
+    expect(oneShot.overflow).toBe(false);
+    expect(oneShot.buf.length).toBe(cap);
   });
 
   // -- finding 8: IPv6-literal hostnames (URL keeps the brackets) -------------


### PR DESCRIPTION
## 概述

silver-core-sdk 第二轮多子系统缺陷排查：三区并行审计（subagents/task 运行时、sessions/accumulator、workflow/misc tools），坐实并修复 5 处真缺陷，各带回归测试。v0.53.6 → v0.53.7。

---

## 变更类型

- [x] Bug 修复

---

## 修复清单（读码 + 执行双重坐实）

- **subagents：后台 SendMessage 续跑缺失 stall 看门狗** — 初次后台启动装了看门狗，`runContinuation` 没装，续跑停流永不中止 → `turn` 永不落定 → 协调者永久等待。修：续跑装同款看门狗，且 stall 时返回**错误结果**而非抛出，让 delivery 路径推 FAILED 通知而非在 `.catch` 吞掉。
- **subagents：前台 SubagentStop 中止吞结果** — 前台裸 `await fireSubagentStop(…, params.signal)`，外部中止落在此刻使钩子抛错、reject spawn，丢弃已完成答案。修：镜像后台路径，用 fresh signal + `.catch`（子任务已完成，钩子是通知而非返回结果的闸门）。
- **webfetch：`readCappedBody` off-by-one 误标截断** — 流式路径 `>= remaining` 把「恰好等于上限」当溢出、误加 `[truncated]`（非流式回退用 `> cap` 正确）。修：改 `>`，恰好填满的块整取、靠下一次 read 的 done 区分。
- **sessions：`auditToolClaims` 复用有状态正则** — 消费方 `g`/`y` flag 的 detector，`exec` 推进 `lastIndex`，跨文本从半截续读、漏标真正无据的声明。修：每次 exec 前归零 lastIndex。
- **sessions：`list()`/`getSessionInfo` 漏读 meta_update gitBranch** — `load()` 认更新后的分支，`loadInfo()` 只读 customTitle/tag，两读路径对同一会话报不同分支。修：loadInfo 也读 gitBranch。

---

## 安全声明

- [x] 本变更不含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据；仅改动 silver-core-sdk 工程代码与测试。
- [x] 不涉及游戏图片 / 内部美术 / 解包原始文件。
- [x] 同意按 MIT License 提交。

---

## 验证清单

- [x] 全量单测对话内跑通：`npm test`（SDK vitest）**2175 通过 / 2 跳过**（本轮基线 2171）
- [x] `npm run typecheck` + `npm run build` 干净
- [x] 版本守卫绿（package.json / `src/version.ts` / CHANGELOG 三处同步至 0.53.7）
- [x] +4 回归测试（前台 stop-hook 修复镜像已测的后台路径）；每个新测经强断言绑定
- [x] 不引入 emoji
- [x] 未动 `memory/decisions.md` / `memory/lessons-learned.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCzMMTCNDQRzpg8DwESsAS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCzMMTCNDQRzpg8DwESsAS)_