### PR TITLE
fix(sdk): run batched foreground Agent calls concurrently (0.53.8)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,27 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.53.8 — 2026-07-13
+
+**Foreground Agent batch serialization fix (child-agent serialization report,
+2026-07-13).** Independent foreground `Agent` calls issued in one assistant
+batch ran strictly one-after-another (three 5s timer children showed zero
+overlap, ~12s start-to-start gaps), while `run_in_background: true` overlapped
+fine — the engine's concurrent tool grouping admitted only read-only tools,
+and Agent is `readOnly: false`, so every foreground spawn fell into the
+sequential branch. Root cause was the loop's grouping predicate, not the
+transport (the request semaphore defaults to unlimited) and not the subagent
+runtime (no global lock). Fix: a new `BuiltinTool.parallelSafe` flag — set on
+Agent, whose children each run their own isolated loop — widens ONLY the
+engine's parallel grouping (`isParallelSafeTool` = readOnly OR parallelSafe);
+permission semantics (plan-mode allow, default-mode auto-approve) still key
+off `readOnly` untouched. Batched foreground agents now start together under
+one `Promise.all`, results stay in tool_use order, and mutating tools keep
+the strict sequential contract. +5 tests (engine grouping 3: Agent×2 overlap /
+mixed Read+Agent group / non-parallelSafe still serial; runtime concurrent
+spawn overlap 1; Agent tool metadata 1). Docs: SUBAGENTS.md + CONCURRENCY.md
+now state the foreground-batch concurrency contract.
+
 ## 0.53.7 — 2026-07-13
 
 **Second multi-subsystem audit batch: 5 verified fixes across subagents, MCP

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -67,6 +67,16 @@ src/
 
 ## 当前状态
 
+**v0.53.8（2026-07-13）：前台子代理批量调用串行化修复（子代理串行化报告）**——同一 assistant
+批次内多个互不依赖的前台 `Agent` 调用被逐个 await（三个 5 秒计时子代理零重叠、启动间隔约 12 秒），
+后台模式却正常并发。根因唯一：`engine/loop.ts` 并发分组谓词只收「只读工具」，Agent `readOnly: false`
+落入串行支路；传输层信号量默认无限额、runtime 无全局锁，均排除。修复：契约新增
+`BuiltinTool.parallelSafe`（Agent 置真——每个子代理跑自己的隔离环，批内互不共享可变态），
+调度器暴露 `isParallelSafeTool`（= readOnly 或 parallelSafe）供分组用；权限门的 readOnly 判定
+（plan 放行 / default 自动批准）不放宽。前台批次现与只读组同样走 `Promise.all` 并发启动，
+tool_result 保持 tool_use 顺序，可变工具维持严格串行契约。+5 测试（引擎分组 3 + runtime 并发
+spawn 1 + 工具元数据 1）；SUBAGENTS.md / CONCURRENCY.md 补记前台批次并发契约。
+
 **v0.53.2（2026-07-13）：工具 Schema 边界校验（BPT P0，PR #665）**——azure/*（OpenAI 兼容）网关
 对缺失/非法 `input_schema` 的 tools[] 条目拒绝整个请求（`tools.N.custom.input_schema: Field required`），
 对话在生成前即死。三层修复：① `engine/loop.ts` 组装层——内置/MCP 非对象 inputSchema（缺失/null/

--- a/projects/silver-core-sdk/docs/CONCURRENCY.md
+++ b/projects/silver-core-sdk/docs/CONCURRENCY.md
@@ -1,9 +1,11 @@
 # Running conversations concurrently
 
 The SDK supports true parallelism at three levels: **many conversations** over
-one `SessionManager`, **read-only tools within a turn** (grouped `Promise.all`,
-writes stay serial), and **background subagents**. This doc is about the first
-level and the two knobs that make a large fan-out safe.
+one `SessionManager`, **parallel-safe tools within a turn** (grouped
+`Promise.all`: read-only tools plus foreground `Agent` calls, which are
+`parallelSafe` because each child runs its own isolated loop; writes stay
+serial), and **background subagents**. This doc is about the first level and
+the two knobs that make a large fan-out safe.
 
 ## The footgun: pull-driven iteration
 

--- a/projects/silver-core-sdk/docs/SUBAGENTS.md
+++ b/projects/silver-core-sdk/docs/SUBAGENTS.md
@@ -92,6 +92,12 @@ Pick the mode by the shape of the work — this mirrors how Claude Code delegate
 | Long-running work; don't block the main turn | **background** (depth-0 only) | `run_in_background: true`; the result arrives on a later turn |
 | Several agents that MUTATE files in parallel without clobbering each other | **worktree** | `isolation: 'worktree'` — each gets a temporary git worktree, auto-removed if left unchanged |
 
+Foreground `Agent` calls batched in one assistant turn run **concurrently**:
+the tool is `parallelSafe` (each child runs its own isolated loop), so the
+engine groups the batch under one `Promise.all` like read-only tools instead
+of awaiting one child at a time. Background exists to not block the *turn* —
+it is not a prerequisite for parallelism within the batch.
+
 Delegation discipline (reproduced from the official main-loop prompt — have your
 host follow it):
 

--- a/projects/silver-core-sdk/package-lock.json
+++ b/projects/silver-core-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.53.5",
+  "version": "0.53.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silver-core-sdk",
-      "version": "0.53.5",
+      "version": "0.53.8",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.53.7",
+  "version": "0.53.8",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -835,7 +835,7 @@ export async function* runAgentLoop(
   // 2026-07-10 F5): hooks -> gate -> execute -> hooks, plus read-only
   // classification. Touches no streaming state — a per-run factory bound to
   // this loop's deps/hook fields/metrics recorder.
-  const { isReadOnlyTool, executeToolUse } = createToolDispatcher({
+  const { isParallelSafeTool, executeToolUse } = createToolDispatcher({
     deps,
     sessionId: config.sessionId,
     baseHookFields,
@@ -1244,14 +1244,16 @@ export async function* runAgentLoop(
         let batchStop: ToolExecOutcome['stop'];
         let batchDefer: ToolExecOutcome['defer'];
         // Execute in content order, but run a maximal run of >= 2 consecutive
-        // read-only tools CONCURRENTLY (they have no side effects and are
-        // order-independent). Non-read-only and lone read-only tools run
-        // sequentially, exactly as before. Results stay in tool_use order (the
-        // API pairs by id; history keeps them ordered). A stop/defer from any
-        // executed tool suppresses all LATER tools with a "Not executed"
-        // placeholder. "Read-only" covers builtins (readOnly flag) and MCP
-        // tools whose server annotation sets readOnlyHint (isReadOnlyTool).
-        const isReadOnly = (b: ToolUseBlock): boolean => isReadOnlyTool(b.name);
+        // parallel-safe tools CONCURRENTLY (order-independent within a batch).
+        // Other tools and lone parallel-safe tools run sequentially, exactly
+        // as before. Results stay in tool_use order (the API pairs by id;
+        // history keeps them ordered). A stop/defer from any executed tool
+        // suppresses all LATER tools with a "Not executed" placeholder.
+        // "Parallel-safe" covers read-only builtins (readOnly flag), MCP tools
+        // whose server annotation sets readOnlyHint, and builtins explicitly
+        // marked parallelSafe (Agent — batched foreground subagents must
+        // overlap, not serialize; each child runs in its own isolated loop).
+        const isParallelSafe = (b: ToolUseBlock): boolean => isParallelSafeTool(b.name);
         let ti = 0;
         while (ti < toolUses.length) {
           if (batchStop !== undefined || batchDefer !== undefined) {
@@ -1267,16 +1269,18 @@ export async function* runAgentLoop(
             continue;
           }
           let groupEnd = ti;
-          while (groupEnd < toolUses.length && isReadOnly(toolUses[groupEnd]!)) groupEnd += 1;
+          while (groupEnd < toolUses.length && isParallelSafe(toolUses[groupEnd]!)) groupEnd += 1;
           const outcomes: ToolExecOutcome[] =
             groupEnd - ti >= 2
               ? await Promise.all(toolUses.slice(ti, groupEnd).map((b) => executeToolUse(b)))
               : [await executeToolUse(toolUses[ti]!)];
           // Process outcomes in tool_use order. Once one stops/defers the run,
           // OVERRIDE the rest of this concurrent group with the skip marker so
-          // the observable contract matches sequential execution: the group
-          // already ran, but its members are read-only, so that was
-          // side-effect-free. Later GROUPS are skipped by the outer guard.
+          // the observable contract matches sequential execution. For read-only
+          // members that is side-effect-free; a parallelSafe member (Agent) DID
+          // run its child to completion — only its RESULT is masked, a
+          // documented trade-off of batching agents with an interrupting call.
+          // Later GROUPS are skipped by the outer guard.
           let stoppedInGroup = false;
           for (let g = 0; g < outcomes.length; g += 1) {
             if (stoppedInGroup) {

--- a/projects/silver-core-sdk/src/engine/tool-dispatch.ts
+++ b/projects/silver-core-sdk/src/engine/tool-dispatch.ts
@@ -165,6 +165,7 @@ function summarizeResultContent(
 
 export function createToolDispatcher(cfg: ToolDispatcherConfig): {
   isReadOnlyTool: (name: string) => boolean;
+  isParallelSafeTool: (name: string) => boolean;
   executeToolUse: (block: ToolUseBlock) => Promise<ToolExecOutcome>;
 } {
   const { deps, sessionId, baseHookFields, signal, recordTool, onToolRecord } = cfg;
@@ -179,6 +180,13 @@ export function createToolDispatcher(cfg: ToolDispatcherConfig): {
       .allTools()
       .some((t) => t.qualifiedName === name && t.annotations?.readOnlyHint === true);
   };
+
+  /** A tool may join a concurrent batch group if it is read-only OR a builtin
+   * explicitly marked parallelSafe (Agent: children run in isolated contexts,
+   * so batched foreground spawns must overlap, not serialize). Grouping only —
+   * the permission gate's readOnly flag is NOT widened by this. */
+  const isParallelSafeTool = (name: string): boolean =>
+    isReadOnlyTool(name) || deps.builtinTools.get(name)?.parallelSafe === true;
 
   /** S3 wrapper: time the whole dispatch and emit one structured record per
    *  block, including error/deny/stop outcomes. An abort still records (with
@@ -435,5 +443,5 @@ export function createToolDispatcher(cfg: ToolDispatcherConfig): {
     return { result, stop };
   }
 
-  return { isReadOnlyTool, executeToolUse };
+  return { isReadOnlyTool, isParallelSafeTool, executeToolUse };
 }

--- a/projects/silver-core-sdk/src/internal/contracts.ts
+++ b/projects/silver-core-sdk/src/internal/contracts.ts
@@ -268,6 +268,14 @@ export interface BuiltinTool {
   readOnly: boolean;
   /** Mutates files; auto-approved under acceptEdits. */
   isFileEdit?: boolean;
+  /**
+   * Safe to run concurrently with the other tools of the same assistant
+   * batch even though it is NOT readOnly — its side effects are contained in
+   * an independent context (e.g. Agent: each subagent runs its own isolated
+   * loop). Feeds ONLY the engine's parallel grouping; permission semantics
+   * (plan-mode allow, default-mode auto-approve) still key off readOnly.
+   */
+  parallelSafe?: boolean;
   execute(
     input: Record<string, unknown>,
     ctx: ToolContext,

--- a/projects/silver-core-sdk/src/subagents/agent-tool.ts
+++ b/projects/silver-core-sdk/src/subagents/agent-tool.ts
@@ -48,6 +48,11 @@ export function createAgentTool(agentNames: string[]): BuiltinTool {
       'cache, more privileged) rather than a fresh isolated one.',
     readOnly: false,
     isFileEdit: false,
+    // Foreground Agent calls batched in one assistant turn must run
+    // concurrently (official parity: "send them in a single message with
+    // multiple tool uses so they run concurrently"). Each child runs in its
+    // own isolated loop/session, so batch-mates share no mutable state here.
+    parallelSafe: true,
     inputSchema: {
       type: 'object',
       properties: {

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.53.7';
+export const SDK_VERSION = '0.53.8';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/engine.test.ts
+++ b/projects/silver-core-sdk/tests/engine.test.ts
@@ -1574,6 +1574,104 @@ describe('runAgentLoop', () => {
     expect(toolResults.map((r) => r.tool_use_id)).toEqual(['toolu_a', 'toolu_b']);
   });
 
+  // ----- child-agent serialization fix: parallelSafe joins the concurrent
+  // group (foreground Agent batches must overlap, not serialize) -----
+
+  /** Start/end probe: under concurrent execution every member STARTS before
+   *  any member ENDS; sequential execution interleaves start/end/start/end. */
+  function timingProbe(
+    name: string,
+    order: string[],
+    opts: { readOnly: boolean; parallelSafe?: boolean } = { readOnly: false },
+  ): BuiltinTool {
+    return {
+      name,
+      description: `${name} timing probe`,
+      inputSchema: { type: 'object', properties: { file_path: { type: 'string' } } },
+      readOnly: opts.readOnly,
+      ...(opts.parallelSafe !== undefined ? { parallelSafe: opts.parallelSafe } : {}),
+      async execute(input) {
+        const p = (input as { file_path: string }).file_path;
+        order.push(`start:${p}`);
+        await new Promise((r) => setTimeout(r, 10));
+        order.push(`end:${p}`);
+        return { content: `${name} ${p}` };
+      },
+    };
+  }
+
+  function twoToolBatch(nameA: string, nameB: string): RawMessageStreamEvent[] {
+    return [
+      messageStart(),
+      { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'toolu_a', name: nameA, input: {} } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"file_path":"/a"}' } },
+      { type: 'content_block_stop', index: 0 },
+      { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'toolu_b', name: nameB, input: {} } },
+      { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{"file_path":"/b"}' } },
+      { type: 'content_block_stop', index: 1 },
+      { type: 'message_delta', delta: { stop_reason: 'tool_use', stop_sequence: null }, usage: { output_tokens: 5 } },
+      { type: 'message_stop' },
+    ];
+  }
+
+  it('runs consecutive parallelSafe tools (foreground Agent batch) concurrently, results in order', async () => {
+    const transport = new MockTransport([twoToolBatch('Agent', 'Agent'), textReplyEvents('done')]);
+    const order: string[] = [];
+    const deps = makeDeps(transport, {
+      builtinTools: new Map<string, BuiltinTool>([
+        ['Agent', timingProbe('Agent', order, { readOnly: false, parallelSafe: true })],
+      ]),
+    });
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+
+    await collect(runAgentLoop(history, deps, makeConfig()));
+
+    // Both agents START before either ENDS: the execution windows overlap
+    // (the reported bug had them strictly serial: start/end/start/end).
+    expect(order).toHaveLength(4);
+    expect(order.slice(0, 2).every((s) => s.startsWith('start:'))).toBe(true);
+    expect(order.slice(2).every((s) => s.startsWith('end:'))).toBe(true);
+
+    // tool_results stay in tool_use order (API pairs by id).
+    const userTurn = history.find((m) => m.role === 'user' && Array.isArray(m.content));
+    const toolResults = userTurn!.content as ToolResultBlockParam[];
+    expect(toolResults.map((r) => r.tool_use_id)).toEqual(['toolu_a', 'toolu_b']);
+  });
+
+  it('groups a read-only tool and a parallelSafe tool into one concurrent group', async () => {
+    const transport = new MockTransport([twoToolBatch('Read', 'Agent'), textReplyEvents('done')]);
+    const order: string[] = [];
+    const deps = makeDeps(transport, {
+      builtinTools: new Map<string, BuiltinTool>([
+        ['Read', timingProbe('Read', order, { readOnly: true })],
+        ['Agent', timingProbe('Agent', order, { readOnly: false, parallelSafe: true })],
+      ]),
+    });
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+
+    await collect(runAgentLoop(history, deps, makeConfig()));
+
+    expect(order).toHaveLength(4);
+    expect(order.slice(0, 2).every((s) => s.startsWith('start:'))).toBe(true);
+    expect(order.slice(2).every((s) => s.startsWith('end:'))).toBe(true);
+  });
+
+  it('still serializes consecutive tools that are neither readOnly nor parallelSafe', async () => {
+    const transport = new MockTransport([twoToolBatch('Write', 'Write'), textReplyEvents('done')]);
+    const order: string[] = [];
+    const deps = makeDeps(transport, {
+      builtinTools: new Map<string, BuiltinTool>([
+        ['Write', timingProbe('Write', order, { readOnly: false })],
+      ]),
+    });
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+
+    await collect(runAgentLoop(history, deps, makeConfig()));
+
+    // Mutating tools keep the strict sequential contract.
+    expect(order).toEqual(['start:/a', 'end:/a', 'start:/b', 'end:/b']);
+  });
+
   // ----- finding #5: fallback retry folds the failed attempt's usage -----
 
   it('folds the failed attempt usage into totals before a fallback retry (#5)', async () => {

--- a/projects/silver-core-sdk/tests/subagents.test.ts
+++ b/projects/silver-core-sdk/tests/subagents.test.ts
@@ -40,11 +40,13 @@ import type {
   SessionStore,
   SpawnSubagentParams,
   StoredSession,
+  StreamRequest,
   ToolContext,
   Transport,
 } from '../src/internal/contracts.js';
 import type {
   AgentDefinition,
+  ApiKeySource,
   APIMessageParam,
   CallToolResult,
   HookInput,
@@ -328,6 +330,10 @@ describe('createAgentTool', () => {
     expect(tool.name).toBe('Agent');
     expect(tool.readOnly).toBe(false);
     expect(tool.isFileEdit).toBe(false);
+    // Batched foreground Agent calls join the engine's concurrent tool group
+    // (child-agent serialization fix): each child runs in its own isolated
+    // loop, so parallel batch-mates must overlap instead of serializing.
+    expect(tool.parallelSafe).toBe(true);
     // Official required set: subagent_type is optional (defaults to
     // general-purpose in execute()).
     expect(tool.inputSchema.required).toEqual(['description', 'prompt']);
@@ -592,6 +598,44 @@ describe('subagent runtime — foreground', () => {
     const second = h.runtime.drainUsageLedger();
     expect(second.usage.input_tokens).toBe(0);
     expect(second.cost).toBe(0);
+  });
+
+  it('two concurrent foreground spawns overlap (no runtime-level serialization)', async () => {
+    // Guards the runtime half of the child-agent serialization fix: the
+    // engine may await a batch of Agent execute()s via Promise.all, so the
+    // runtime must not hold a global lock that would re-serialize them.
+    const order: string[] = [];
+    class SlowTransport implements Transport {
+      readonly requests: StreamRequest[] = [];
+      apiKeySource(): ApiKeySource {
+        return 'user';
+      }
+      async *stream(req: StreamRequest): AsyncGenerator<RawMessageStreamEvent, void> {
+        this.requests.push(req);
+        const label = lastUserContent(req.messages).includes('alpha') ? 'alpha' : 'beta';
+        order.push(`start:${label}`);
+        await new Promise((r) => setTimeout(r, 10));
+        order.push(`end:${label}`);
+        for (const ev of textReplyEvents(`${label} done`, { model: 'claude-sonnet-4-5' })) {
+          yield ev;
+        }
+      }
+    }
+    const h = makeRuntime({ scripts: [], transport: new SlowTransport() });
+    const spawn = h.runtime.makeSpawnFn(0);
+    const [a, b] = await Promise.all([
+      spawn(baseParams({ prompt: 'alpha task' })),
+      spawn(baseParams({ prompt: 'beta task' })),
+    ]);
+
+    expect(a.isError).toBe(false);
+    expect(b.isError).toBe(false);
+    expect(a.content).toContain('alpha done');
+    expect(b.content).toContain('beta done');
+    // Both children START before either ENDS: execution windows overlap.
+    expect(order).toHaveLength(4);
+    expect(order.slice(0, 2).every((s) => s.startsWith('start:'))).toBe(true);
+    expect(order.slice(2).every((s) => s.startsWith('end:'))).toBe(true);
   });
 
   it('restricts the child tool set via agentDef.tools (Bash absent)', async () => {


### PR DESCRIPTION
## 概述

修复子代理串行化报告所述缺陷：同一 assistant 批次内多个互不依赖的前台 `Agent` 调用被逐个 await（三个 5 秒计时子代理零重叠、启动间隔约 12 秒），后台模式却正常并发。根因定位为 `engine/loop.ts` 并发分组谓词只收「只读工具」（Agent `readOnly: false` 落入串行支路）；传输层信号量（默认无限额）与 subagent runtime（无全局锁）均排除。版本 0.53.7 → 0.53.8。

修复：契约新增 `BuiltinTool.parallelSafe`（Agent 置真——每个子代理跑自己的隔离环），调度器暴露 `isParallelSafeTool`（= readOnly 或 parallelSafe）供引擎分组；权限门的 readOnly 判定（plan 放行 / default 自动批准）不放宽。前台 Agent 批次现走 `Promise.all` 并发启动，tool_result 保持 tool_use 顺序，可变工具维持严格串行契约。

---

## 变更类型

- [x] Bug 修复
- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [x] 文档完善（子项目 CONTEXT.md + docs/SUBAGENTS.md + docs/CONCURRENCY.md）
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [ ] 其他

---

## 来源声明

- [x] 本 PR 为 silver-core-sdk 工程代码变更，不涉及游戏数据；净室纪律不变（零专有代码引入）。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献仅为银芯自有工程产物代码**，不含内部美术资产、解包原始文件或未公开剧情。
- [x] **同意按 [MIT License](../LICENSE) 提交贡献。**

---

## 验证清单

- [x] SDK 全量 vitest：2178 passed / 3 skipped（含新增 5 项回归测试）
- [x] 仓库级 pytest：2915 passed / 12 skipped
- [x] `npm run typecheck` 通过；版本三方对账守卫（CHANGELOG / package.json / version.ts）绿
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案

---

## 关联 Issue

- Refs：子代理前台批量调用串行化问题报告（会话内派发，无 Issue 号）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPvUuruj8HWtmWUWPY6MJU

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPvUuruj8HWtmWUWPY6MJU)_