### PR TITLE
fix(sdk/openai): reject metadata-only stream + [DONE] as empty_message

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,36 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.55.2 — 2026-07-13
+
+**OpenAI arm: metadata-only stream + `[DONE]` no longer billed as a silent
+success (BPT idealab "turn stop / hasAssistantMessage:false", 2026-07-13).**
+0.55.1 fixed the Anthropic arm's degraded-200 shape and asserted the OpenAI arm
+"already self-heals its analog" — true only for the ZERO-chunk case (the
+empty-stream retry). The metadata-then-`[DONE]` case was still mis-routed: an
+HTTP 200 that streamed only role-only / usage-only chunks (so `chunkCount > 0`)
+and then closed with a bare `data: [DONE]`, carrying NO `delta.content`, NO
+`reasoning_content`, NO `tool_calls` and NO `finish_reason`, satisfied the old
+`chunkCount > 0 && (doneSeen || sawFinishReason())` success gate and was
+finalized as an empty assistant with `stop_reason: null` — the exact idealab
+"turn stop, hasAssistantMessage:false, lastAssistantMessage:''" log shape.
+Fix: the translator now tracks VALID assistant content (`sawContent()`)
+separately from the raw chunk count — flipped only by a non-empty text /
+reasoning delta or a tool_call fragment bearing an id/name/arguments — and
+`finish_reason` counts only when a non-empty string. The transport now
+completes only on an explicit `finish_reason` (protocol semantics preserved,
+incl. an empty-text `finish_reason:'stop'`) OR a `[DONE]` paired with valid
+content; a `[DONE]` with neither throws a diagnosable `empty_message`
+`APIConnectionError` (not `turnReplaySafe`/`midStreamTruncation`, so NOT
+retried — a started stream is not replay-safe), which the engine surfaces as
+`error_during_execution` (error_code `empty_message`). Preserved unchanged:
+zero-chunk `empty_stream` retry, partial-content-without-terminator truncation
+salvage, and the honest empty-text-with-`finish_reason` path (all existing
+mutation-lock suites still pass without re-baselining). +12 test cases
+(transport: role-only, usage-only, empty-first-delta, no-terminator truncation,
+empty-text-finish_reason, tool_call-fragment; translator content tracking x3;
+engine end-to-end error_code x3); docs/OPENAI-PROTOCOL.md updated.
+
 ## 0.55.1 — 2026-07-13
 
 **Degraded empty stream no longer billed as a silent success (BPT "空 stopReason

--- a/projects/silver-core-sdk/docs/OPENAI-PROTOCOL.md
+++ b/projects/silver-core-sdk/docs/OPENAI-PROTOCOL.md
@@ -104,6 +104,28 @@ concurrency semaphore all mirror the Anthropic transport; the same
 `ProviderConfig` knobs (`maxRetries`, `timeoutMs`, `streamIdleTimeoutMs`,
 `maxConcurrentRequests`) apply. A mid-stream drop *after* chunks (a truncated
 turn) is never retried — it degrades gracefully via the engine's E3 salvage.
+
+Stream completion is decided from three independent facts, **not** the raw
+chunk count: whether a `[DONE]` terminator arrived, whether an explicit
+non-empty `finish_reason` arrived, and whether any **valid assistant content**
+arrived. Valid content means at least one of: a non-empty `delta.content`, a
+non-empty `delta.reasoning_content` / `delta.reasoning`, or a `tool_calls`
+fragment carrying an id / function name / arguments. A stream is finalized only
+when it saw an explicit `finish_reason` (protocol semantics preserved — an
+empty-text `finish_reason:'stop'` is a legitimate completed message) **or** a
+`[DONE]` paired with valid content. The degenerate **"empty finish"** — an
+HTTP 200 that streams only role-only / usage-only metadata chunks (`chunkCount
+> 0`) then closes with a bare `[DONE]`, carrying no content, no reasoning, no
+`tool_calls` and no `finish_reason` (the idealab-gateway "turn stop /
+hasAssistantMessage:false" shape) — is **never** finalized as an empty
+`stop_reason: null` success. Because a *started* stream is not replay-safe it
+is not retried either; it throws a diagnosable `APIConnectionError` code
+`empty_message` (not flagged `turnReplaySafe` / `midStreamTruncation`), which
+the engine surfaces as an `error_during_execution` result with
+`error_code: 'empty_message'`. This is the OpenAI twin of the Anthropic arm's
+degraded-`message_stop` guard (0.55.1); the zero-chunk case still self-heals
+via the `empty_stream` retry above.
+
 Non-2xx errors surface as `APIStatusError`
 with the error type **normalized to Messages API vocabulary** by status
 (`401 -> authentication_error`, `429 -> rate_limit_error`, ...) so engine-side

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/transport/openai.ts
+++ b/projects/silver-core-sdk/src/transport/openai.ts
@@ -414,6 +414,17 @@ export class OpenAIStreamTranslator {
   private usage: NonNullable<OpenAIChunk['usage']> | null = null;
   private done = false;
   /**
+   * Whether any delta carried VALID assistant content — as opposed to the
+   * role-only / usage-only metadata chunks a gateway may stream before it
+   * closes with a bare [DONE]. Tracked SEPARATELY from the transport's raw
+   * chunk count: `chunkCount > 0` proves a frame arrived, not that the model
+   * produced anything. Flips true on a non-empty text/reasoning delta or a
+   * tool_call fragment bearing an id/name/arguments (see feed()). Used by the
+   * transport to reject the "empty finish" shape (metadata + [DONE], no
+   * content, no finish_reason) instead of fabricating an empty success.
+   */
+  private contentSeen = false;
+  /**
    * Per-tool-call buffered state so a fragmented gateway does not lose the id
    * or the name. Some OpenAI-compatible gateways stream the id in a LATER chunk
    * than the one that opens the tool call, or split `function.name` across
@@ -438,6 +449,15 @@ export class OpenAIStreamTranslator {
    *  end-of-message marker; used by the transport's truncation heuristic). */
   sawFinishReason(): boolean {
     return this.finishReason !== null;
+  }
+
+  /** True once any delta carried VALID assistant content — non-empty text,
+   *  non-empty reasoning, or a tool_call fragment carrying an id/name/arguments.
+   *  Role-only and usage-only metadata chunks do NOT flip this, so it separates
+   *  a real (if short) message from the "empty finish" shape the transport must
+   *  reject as an `empty_message` failure. */
+  sawContent(): boolean {
+    return this.contentSeen;
   }
 
   /** True once the first chunk arrived (message_start was emitted). */
@@ -466,7 +486,10 @@ export class OpenAIStreamTranslator {
     if (chunk.usage !== undefined && chunk.usage !== null) this.usage = chunk.usage;
     const choice = chunk.choices?.[0];
     if (choice === undefined) return events;
-    if (choice.finish_reason !== undefined && choice.finish_reason !== null) {
+    // Only a non-empty finish_reason string counts as an explicit terminal
+    // marker: the requirement's "empty finish" shape may carry finish_reason:''
+    // (or null), which must NOT be read as a real end-of-message.
+    if (typeof choice.finish_reason === 'string' && choice.finish_reason.length > 0) {
       this.finishReason = choice.finish_reason;
     }
     const delta = choice.delta;
@@ -474,6 +497,7 @@ export class OpenAIStreamTranslator {
 
     const reasoning = delta.reasoning_content ?? delta.reasoning;
     if (typeof reasoning === 'string' && reasoning.length > 0) {
+      this.contentSeen = true;
       const index = this.openBlock(events, 'reasoning', {
         type: 'thinking',
         thinking: '',
@@ -486,6 +510,7 @@ export class OpenAIStreamTranslator {
       });
     }
     if (typeof delta.content === 'string' && delta.content.length > 0) {
+      this.contentSeen = true;
       const index = this.openBlock(events, 'text', { type: 'text', text: '' });
       events.push({
         type: 'content_block_delta',
@@ -494,6 +519,17 @@ export class OpenAIStreamTranslator {
       });
     }
     for (const tc of delta.tool_calls ?? []) {
+      // A tool_call fragment is VALID assistant content the moment it carries
+      // an id, a function name, or argument bytes — even before the block can
+      // be emitted (a fragmented-id gateway holds the block open). An empty
+      // `{index:0}` placeholder alone does not count.
+      if (
+        (typeof tc.id === 'string' && tc.id.length > 0) ||
+        (typeof tc.function?.name === 'string' && tc.function.name.length > 0) ||
+        (typeof tc.function?.arguments === 'string' && tc.function.arguments.length > 0)
+      ) {
+        this.contentSeen = true;
+      }
       // Key by index when present (the normal case); fall back to id, then a
       // last-resort constant. Keying an index-less call by its id keeps two
       // distinct id-bearing calls from colliding on `tool:0`.
@@ -871,21 +907,55 @@ export class OpenAIChatTransport implements Transport {
         releaseSignals();
       }
 
-      // The stream ended without throwing. A [DONE] terminator or any
-      // finish_reason means the message reached its end-of-message marker:
-      // synthesize the terminal message_delta/message_stop and finish. Guard on
-      // chunkCount > 0: a stream that delivered ZERO content chunks but a bare
-      // `[DONE]` (an overloaded gateway that accepts the request then closes it
-      // with only the terminator) is NOT a completed message — translator
-      // never started, so finish() would throw a raw, non-replay-safe error
-      // and the engine's turn-replay could not catch it. Fall through to the
-      // empty-stream retry below instead, so this zero-consumption shape
-      // self-heals exactly like the Anthropic arm's (a finish_reason chunk
-      // always increments chunkCount first, so sawFinishReason implies > 0).
-      if (chunkCount > 0 && (doneSeen || translator.sawFinishReason())) {
+      // The stream ended without throwing. Decide the outcome from THREE
+      // independent facts, not the raw chunk count alone: whether a terminator
+      // arrived (doneSeen), whether an explicit finish_reason arrived
+      // (sawFinishReason), and whether any VALID assistant content arrived
+      // (sawContent). `chunkCount > 0` only proves a frame was delivered — a
+      // gateway can stream role-only / usage-only metadata then close with a
+      // bare [DONE], which is NOT a completed message. (BPT 2026-07-13: idealab
+      // "turn stop / hasAssistantMessage:false" — an empty message billed as a
+      // null-stop_reason success.)
+      const sawContent = translator.sawContent();
+      const sawFinish = translator.sawFinishReason();
+
+      // Completed message, case 1: an explicit finish_reason is BOTH a
+      // terminator and — per the Chat Completions protocol — a real
+      // end-of-message, even when the text is empty (finish_reason:'stop' with
+      // no content is a legitimate, if unusual, response). Keep its protocol
+      // semantics; a finish_reason chunk always incremented chunkCount first.
+      if (chunkCount > 0 && sawFinish) {
         yield* translator.finish();
         this.debug(`openai transport: stream completed after ${chunkCount} chunk(s)`);
         return;
+      }
+      // Completed message, case 2: a [DONE] terminator paired with valid
+      // assistant content (text / reasoning / tool_calls) is the normal
+      // completion path.
+      if (chunkCount > 0 && doneSeen && sawContent) {
+        yield* translator.finish();
+        this.debug(`openai transport: stream completed after ${chunkCount} chunk(s)`);
+        return;
+      }
+      // The "empty finish": a [DONE] arrived (chunkCount > 0, so metadata frames
+      // WERE delivered — role-only / usage-only), but with NO valid assistant
+      // content AND NO finish_reason. This is exactly the shape that produced
+      // the idealab empty turns. It is NOT a completed message: never fabricate
+      // a stop_reason:null / subtype:'success' / empty assistant message from
+      // it. A started (chunkCount > 0) stream is not replay-safe, so it is NOT
+      // retried; surface a diagnosable, non-replay-safe `empty_message`
+      // APIConnectionError (no turnReplaySafe / midStreamTruncation flags) so
+      // the engine reports error_during_execution with error_code
+      // 'empty_message'. Twin of AnthropicTransport's message_stop guard.
+      if (chunkCount > 0 && doneSeen && !sawContent) {
+        if (callerSignal?.aborted) throw new AbortError();
+        throw new APIConnectionError(
+          `OpenAI Chat Completions stream received [DONE] after ${chunkCount} chunk(s) ` +
+            `with no valid assistant content and no finish_reason; treating as a failed ` +
+            `turn (empty message)`,
+          undefined,
+          'empty_message',
+        );
       }
 
       // No end-of-message marker (or a bare [DONE] with no chunks). ZERO chunks

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.55.1';
+export const SDK_VERSION = '0.55.2';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/query.test.ts
+++ b/projects/silver-core-sdk/tests/query.test.ts
@@ -695,6 +695,94 @@ describe('query() e2e - degraded empty stream (BPT "空 stopReason 轮次")', ()
   });
 });
 
+describe('query() e2e - OpenAI arm degraded empty stream (idealab "turn stop")', () => {
+  // The OpenAI twin: an HTTP 200 that streams only role-only / usage-only
+  // metadata chunks then closes with a bare `data: [DONE]` — no content, no
+  // finish_reason — must reach the main loop as an error_during_execution
+  // result with error_code 'empty_message', NEVER a silent empty success.
+  const openaiEnc = new TextEncoder();
+  function openaiSSEFetch(payloads: Array<Record<string, unknown> | '[DONE]'>): {
+    fn: ReturnType<typeof vi.fn>;
+  } {
+    const body = payloads
+      .map((p) => `data: ${p === '[DONE]' ? '[DONE]' : JSON.stringify(p)}\n\n`)
+      .join('');
+    const fn = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(openaiEnc.encode(body));
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'text/event-stream' } },
+        ),
+    );
+    return { fn };
+  }
+
+  function openaiOptions(): Options {
+    return baseOptions({
+      provider: { apiKey: 'test-key', promptCaching: false, protocol: 'openai-chat' },
+      model: 'gpt-4o',
+    });
+  }
+
+  it('role-only chunk + [DONE] surfaces error_during_execution (empty_message), not a silent success', async () => {
+    const { fn } = openaiSSEFetch([
+      { id: 'chatcmpl-x', model: 'gpt-4o', choices: [{ delta: { role: 'assistant' } }] },
+      '[DONE]',
+    ]);
+    vi.stubGlobal('fetch', fn);
+    const messages = await collect(query({ prompt: 'hi', options: openaiOptions() }));
+
+    const result = lastResult(messages);
+    expect(result.subtype).toBe('error_during_execution');
+    expect(result.is_error).toBe(true);
+    if (result.subtype !== 'success') {
+      expect(result.error_code).toBe('empty_message');
+    }
+    const assistants = messages.filter((m) => m.type === 'assistant');
+    expect(assistants).toHaveLength(0);
+    expect(resultsOf(messages).some((r) => r.subtype === 'success')).toBe(false);
+    // A started stream is not replay-safe: exactly one request, no retry.
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('usage-only chunk + [DONE] surfaces error_during_execution (empty_message)', async () => {
+    const { fn } = openaiSSEFetch([
+      { choices: [], usage: { prompt_tokens: 9, completion_tokens: 0 } },
+      '[DONE]',
+    ]);
+    vi.stubGlobal('fetch', fn);
+    const messages = await collect(query({ prompt: 'hi', options: openaiOptions() }));
+
+    const result = lastResult(messages);
+    expect(result.subtype).toBe('error_during_execution');
+    if (result.subtype !== 'success') {
+      expect(result.error_code).toBe('empty_message');
+    }
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a real text stream on the same OpenAI arm still succeeds (no false positive)', async () => {
+    const { fn } = openaiSSEFetch([
+      { id: 'chatcmpl-ok', model: 'gpt-4o', choices: [{ delta: { role: 'assistant', content: 'hello' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+      { choices: [], usage: { prompt_tokens: 3, completion_tokens: 1 } },
+      '[DONE]',
+    ]);
+    vi.stubGlobal('fetch', fn);
+    const messages = await collect(query({ prompt: 'hi', options: openaiOptions() }));
+
+    const result = lastResult(messages);
+    expect(result.subtype).toBe('success');
+    const assistants = messages.filter((m) => m.type === 'assistant');
+    expect(assistants).toHaveLength(1);
+  });
+});
+
 describe('query() e2e - persistence and resume', () => {
   async function runOnce(prompt: string, reply: string): Promise<SDKMessage[]> {
     stubFetch(makeSSEFetch([textReplyEvents(reply)]));

--- a/projects/silver-core-sdk/tests/transport-openai.test.ts
+++ b/projects/silver-core-sdk/tests/transport-openai.test.ts
@@ -1104,6 +1104,207 @@ describe('OpenAIChatTransport empty-stream retry (idealab throttle self-heal)', 
   });
 });
 
+describe('OpenAIChatTransport empty-message guard (idealab "turn stop / hasAssistantMessage:false")', () => {
+  // A stream that DELIVERS chunks (so it is NOT the zero-chunk empty_stream
+  // case) but only role-only / usage-only metadata, then closes with a bare
+  // `[DONE]`: no content, no reasoning, no tool_calls, no finish_reason. The
+  // old `chunkCount > 0 && doneSeen` success gate finalized this as an empty
+  // stop_reason:null message; it must now throw a diagnosable empty_message.
+  function metaOnlyDone(payloads: Array<Record<string, unknown> | '[DONE]'>): Response {
+    return new Response(streamFromChunks([sseBody(payloads)]), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  }
+
+  it('role-only chunk + [DONE] (no content, no finish_reason) throws empty_message, never a success', async () => {
+    const fetchMock = vi.fn(async () =>
+      metaOnlyDone([
+        { id: 'chatcmpl-x', model: 'gpt-4o', choices: [{ delta: { role: 'assistant' } }] },
+        '[DONE]',
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({
+      provider: { apiKey: 'k', maxRetries: 2 },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: noop,
+    });
+    const err = (await captureError(collect(transport.stream(REQ)))) as APIConnectionError;
+    expect(err).toBeInstanceOf(APIConnectionError);
+    expect(err.code).toBe('empty_message');
+    expect(err.message).toContain('OpenAI');
+    expect(err.message).toContain('[DONE]');
+    expect(err.message).toMatch(/no valid assistant content/i);
+    expect(err.message).toMatch(/no finish_reason/i);
+    // A started stream is NOT replay-safe: it is thrown, not retried.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Must NOT carry the replay/salvage flags (would let the engine mask it).
+    expect(err.turnReplaySafe).not.toBe(true);
+    expect(err.midStreamTruncation).not.toBe(true);
+  });
+
+  it('usage-only chunk + [DONE] (no content, no finish_reason) throws empty_message', async () => {
+    const fetchMock = vi.fn(async () =>
+      metaOnlyDone([
+        { choices: [], usage: { prompt_tokens: 12, completion_tokens: 0 } },
+        '[DONE]',
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({
+      provider: { apiKey: 'k', maxRetries: 2 },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: noop,
+    });
+    const err = (await captureError(collect(transport.stream(REQ)))) as APIConnectionError;
+    expect(err).toBeInstanceOf(APIConnectionError);
+    expect(err.code).toBe('empty_message');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('empty first delta then real text + finish_reason still completes normally', async () => {
+    const fetchMock = vi.fn(async () =>
+      okStream([
+        { id: 'chatcmpl-y', model: 'gpt-4o', choices: [{ delta: { role: 'assistant', content: '' } }] },
+        { choices: [{ delta: { content: 'hello' } }] },
+        { choices: [{ delta: {}, finish_reason: 'stop' }] },
+        { choices: [], usage: { prompt_tokens: 3, completion_tokens: 1 } },
+        '[DONE]',
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({
+      provider: { apiKey: 'k' },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: noop,
+    });
+    const events = await collect(transport.stream(REQ));
+    expect(events.at(-1)?.type).toBe('message_stop');
+    const acc = new MessageAccumulator();
+    for (const ev of events) acc.feed(ev);
+    const msg = acc.finalize();
+    expect(msg.content).toEqual([{ type: 'text', text: 'hello' }]);
+    expect(msg.stop_reason).toBe('end_turn');
+  });
+
+  it('text but no [DONE]/finish_reason stays a truncated turn, NOT empty_message', async () => {
+    // Content arrived but the connection dropped before any terminator: this is
+    // a mid-stream truncation (salvageable), which must not be reclassified as
+    // the empty-finish shape.
+    const fetchMock = vi.fn(async () =>
+      okStream([
+        { id: 'chatcmpl-z', model: 'gpt-4o', choices: [{ delta: { role: 'assistant', content: 'partial' } }] },
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({
+      provider: { apiKey: 'k' },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: noop,
+    });
+    const err = (await captureError(collect(transport.stream(REQ)))) as APIConnectionError;
+    expect(err).toBeInstanceOf(APIConnectionError);
+    expect(err.code).not.toBe('empty_message');
+    expect(err.midStreamTruncation).toBe(true);
+    expect(err.message).toMatch(/truncated turn/i);
+  });
+
+  it('explicit finish_reason:stop with EMPTY text completes per protocol (not empty_message)', async () => {
+    // A legitimate — if unusual — completed message: the model finished with no
+    // text. finish_reason is the authoritative terminal marker, so this keeps
+    // its protocol semantics and must NOT be reclassified as an empty finish.
+    const fetchMock = vi.fn(async () =>
+      okStream([
+        { id: 'chatcmpl-e', model: 'gpt-4o', choices: [{ delta: { role: 'assistant' } }] },
+        { choices: [{ delta: {}, finish_reason: 'stop' }] },
+        { choices: [], usage: { prompt_tokens: 4, completion_tokens: 0 } },
+        '[DONE]',
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({
+      provider: { apiKey: 'k' },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: noop,
+    });
+    const events = await collect(transport.stream(REQ));
+    expect(events.at(-1)?.type).toBe('message_stop');
+    const acc = new MessageAccumulator();
+    for (const ev of events) acc.feed(ev);
+    const msg = acc.finalize();
+    expect(msg.content).toEqual([]);
+    expect(msg.stop_reason).toBe('end_turn');
+  });
+
+  it('tool_call fragment + [DONE] (no text, no finish_reason) is valid content, completes normally', async () => {
+    // A tool_call bearing an id/name IS assistant content even without a
+    // finish_reason: [DONE] + valid content is the normal completion path.
+    const fetchMock = vi.fn(async () =>
+      okStream([
+        {
+          id: 'chatcmpl-t',
+          model: 'gpt-4o',
+          choices: [
+            {
+              delta: {
+                role: 'assistant',
+                tool_calls: [
+                  { index: 0, id: 'call_1', type: 'function', function: { name: 'Read', arguments: '{}' } },
+                ],
+              },
+            },
+          ],
+        },
+        '[DONE]',
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const transport = new OpenAIChatTransport({
+      provider: { apiKey: 'k' },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: noop,
+    });
+    const events = await collect(transport.stream(REQ));
+    expect(events.at(-1)?.type).toBe('message_stop');
+    const acc = new MessageAccumulator();
+    for (const ev of events) acc.feed(ev);
+    const msg = acc.finalize();
+    expect(msg.content.some((b) => b.type === 'tool_use')).toBe(true);
+  });
+});
+
+describe('OpenAIStreamTranslator content tracking', () => {
+  it('sawContent() stays false for role-only and usage-only chunks', () => {
+    const t = new OpenAIStreamTranslator('gpt-4o');
+    t.feed({ id: 'c', choices: [{ delta: { role: 'assistant' } }] });
+    t.feed({ choices: [], usage: { prompt_tokens: 5 } });
+    expect(t.sawContent()).toBe(false);
+    expect(t.sawFinishReason()).toBe(false);
+  });
+
+  it('sawContent() flips on non-empty text / reasoning / tool_call fragments', () => {
+    const text = new OpenAIStreamTranslator('gpt-4o');
+    text.feed({ choices: [{ delta: { content: 'x' } }] });
+    expect(text.sawContent()).toBe(true);
+
+    const reason = new OpenAIStreamTranslator('gpt-4o');
+    reason.feed({ choices: [{ delta: { reasoning_content: 'thinking' } }] });
+    expect(reason.sawContent()).toBe(true);
+
+    const tool = new OpenAIStreamTranslator('gpt-4o');
+    tool.feed({ choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"a":1}' } }] } }] });
+    expect(tool.sawContent()).toBe(true);
+  });
+
+  it('empty content string does not flip sawContent(); an empty finish_reason is not a terminal marker', () => {
+    const t = new OpenAIStreamTranslator('gpt-4o');
+    t.feed({ choices: [{ delta: { content: '' }, finish_reason: '' }] });
+    expect(t.sawContent()).toBe(false);
+    expect(t.sawFinishReason()).toBe(false);
+  });
+});
+
 describe('OpenAIChatTransport gateway knobs (audit P1-4)', () => {
   it('applies provider.openai.modelMap at the wire boundary', async () => {
     const fetchMock = vi.fn(async () => okStream(TEXT_CHUNKS));


### PR DESCRIPTION
## 概述

修复 silver-core-sdk 的 OpenAI transport 将「空流退化响应」误报为成功的可靠性漏洞。BPT 对接 idealab 网关时，HTTP 200 + 仅 role/usage 元信息分块 + 裸 `[DONE]`（无内容、无 finish_reason）被旧逻辑当作正常收尾，合成空 assistant（`stop_reason: null`），刷出大量 `turn stop / hasAssistantMessage:false`。本 PR 补齐 0.55.1 已在 Anthropic 臂做过的同款守卫的 OpenAI 孪生。

---

## 变更类型

- [x] Bug 修复
- [x] 文档完善（`docs/OPENAI-PROTOCOL.md` + `CHANGELOG.md`）

---

## 来源声明

- [x] 不涉及游戏数据补全 / 翻译；纯 SDK 工程修正，无外部数据引用。

---

## 安全声明（强制）

- [x] 本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。
- [x] 不上传内部美术资产 / 解包原始文件 / 未公开草稿。
- [x] 同意按 MIT License 提交贡献。

---

## 验证清单

- [x] typecheck 通过（`npm run typecheck`）
- [x] 全量 `vitest run`：2215 通过 / 3 跳过 / 0 失败；突变锁套件全部原样通过、无需重基线
- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

### 核心变更

- 翻译器新增 `sawContent()`，把「收到 SSE 分块」与「收到有效 assistant 内容」分开统计（有效 = 非空 content / 非空 reasoning / 带 id·name·arguments 的 tool_call 片段）；`finish_reason` 收紧为非空字符串才算终止标记。
- 收尾判定改为：明确 `finish_reason`（含空文本 stop）→ 成功；`[DONE]` + 有效内容 → 成功；`[DONE]` 但两者皆无 → 抛 `APIConnectionError(code:'empty_message')`，不带 replay 标志（不重放），引擎终局报 `error_during_execution` + `error_code === 'empty_message'`。
- 保留：零分块 `empty_stream` 重试、有内容无收尾 truncated 打捞、明确 finish_reason 空文本按协议成功。
- bump 0.55.1 → 0.55.2；+12 测试用例（含实际模拟 SSE 序列的回归测试）。

---

## 关联 Issue

- Refs: BPT idealab "空 stopReason 轮次"（守密人 2026-07-13）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDT6NQaNeP3cyod3CHHm2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDT6NQaNeP3cyod3CHHm2E)_