### PR TITLE
feat(openai-chat): image input hardening + attachment fan-out + PDF file parts + MCP mimeType whitelist (v0.56.0)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,35 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.56.0 — 2026-07-13
+
+**openai-chat image input: hardened translation + tool_result fan-out + PDF
+`file` parts + MCP mimeType whitelist (keeper ruling 2026-07-13).** Four
+related gaps closed in one capability bump. (1) Base64 image blocks already
+translated to `image_url` data URLs but rode through UNVALIDATED — an
+unsupported media_type, empty/line-wrapped base64, or a nested `data:` prefix
+produced a malformed data URL gateways reject opaquely at their
+image-processing stage (`image_moderation_server_error`). The translator now
+enforces the Messages API four-type whitelist (JPEG/PNG/GIF/WebP), normalizes
+media_type case and base64 whitespace, and throws a locatable
+`ConfigurationError` (block path + media_type, never image bytes) for empty /
+double-prefixed / non-base64 data BEFORE any network call. (2) Images / base64
+PDFs inside a tool_result — a screenshot an MCP tool returned, an image file
+Read produced — previously degraded to a text placeholder on openai-chat (the
+`tool` role is text-only): the model never saw them. They now FAN OUT into the
+user message following the tool messages, each labeled with its tool_call_id;
+a malformed tool-OUTPUT attachment degrades to an explicit omission marker
+(never bricks the turn) while user-turn blocks stay fail-fast. (3) Base64 PDF
+`document` blocks translate to the official Chat Completions `file` content
+part (data URL in `file_data`) instead of a placeholder; URL documents keep
+the honest placeholder. (4) The MCP result mapper whitelists image mimeTypes
+against the shared vocabulary (`src/internal/media.ts`) — an off-vocabulary
+type (image/bmp, …) becomes an explicit text marker at the dispatch seam
+instead of 400-ing the whole next request on the Anthropic protocol. One
+byte-free debug summary line per request (protocol, image/file counts, MIME
+types, base64 lengths, outcome). Anthropic-protocol wire shape untouched
+(fixture-locked). Docs: OPENAI-PROTOCOL.md "Image input".
+
 ## 0.55.2 — 2026-07-13
 
 **OpenAI arm: metadata-only stream + `[DONE]` no longer billed as a silent
@@ -45,7 +74,6 @@ mutation-lock suites still pass without re-baselining). +12 test cases
 (transport: role-only, usage-only, empty-first-delta, no-terminator truncation,
 empty-text-finish_reason, tool_call-fragment; translator content tracking x3;
 engine end-to-end error_code x3); docs/OPENAI-PROTOCOL.md updated.
-
 ## 0.55.1 — 2026-07-13
 
 **Degraded empty stream no longer billed as a silent success (BPT "空 stopReason

--- a/projects/silver-core-sdk/docs/OPENAI-PROTOCOL.md
+++ b/projects/silver-core-sdk/docs/OPENAI-PROTOCOL.md
@@ -81,8 +81,8 @@ makes cost metrics and `maxBudgetUsd` enforceable for non-Claude models.
 | Messages API | Chat Completions |
 |---|---|
 | `system` (string or blocks) | one `system` message (blocks joined with `\n`) |
-| user `text` / `image` blocks | `text` / `image_url` content parts (base64 -> data URL) |
-| user `tool_result` blocks | `tool` role messages (emitted first, preserving protocol adjacency); non-text result content degrades to honest text placeholders |
+| user `text` / `image` blocks | `text` / `image_url` content parts (base64 -> data URL; JPEG/PNG/GIF/WebP whitelist + base64 hygiene — see "Image input") |
+| user `tool_result` blocks | `tool` role messages (emitted first, preserving protocol adjacency); images / base64 PDFs inside a result FAN OUT into the user message that follows, each labeled with its tool_call_id (the `tool` role is text-only) — see "Image input" |
 | assistant `text` + `tool_use` | `content` + `tool_calls` (arguments JSON-stringified) |
 | `tools[]` | `tools[]` (`type: 'function'`, `input_schema` -> `parameters`) |
 | `tool_choice` auto/any/tool/none | `'auto'` / `'required'` / `{type:'function',...}` / `'none'`; `disable_parallel_tool_use` -> `parallel_tool_calls: false` |
@@ -131,6 +131,72 @@ with the error type **normalized to Messages API vocabulary** by status
 (`401 -> authentication_error`, `429 -> rate_limit_error`, ...) so engine-side
 handling is provider-agnostic.
 
+## Image input
+
+The engine speaks Messages API image blocks end to end; this transport
+translates them at the wire boundary (v0.55.2 hardening — previously a bad
+image rode through unvalidated and failed opaquely at the gateway's
+image-processing stage, e.g. `image_moderation_server_error`).
+
+**Supported input** (user-turn content blocks):
+
+```ts
+// base64 (JPEG / PNG / GIF / WebP)
+{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: '<raw base64>' } }
+// URL (http(s) or a ready-made data: URL) — passed through verbatim
+{ type: 'image', source: { type: 'url', url: 'https://…' } }
+```
+
+**Conversion rule** (base64 → data URL):
+
+```
+{ type: 'image', source: { type: 'base64', media_type: M, data: D } }
+  ->  { type: 'image_url', image_url: { url: `data:${M};base64,${D}` } }
+```
+
+- `media_type` is trimmed/lowercased and must be one of `image/jpeg`,
+  `image/png`, `image/gif`, `image/webp` — anything else throws a
+  `ConfigurationError` naming the offending type and its block path
+  (`messages[i].content[j]`) before any network call.
+- `data` is whitespace-normalized (line-wrapped base64 from file encoders
+  would produce a malformed data URL); empty data, a nested `data:` prefix,
+  or non-base64 characters likewise throw locatable `ConfigurationError`s.
+  Nothing is silently dropped.
+- Text blocks stay `{ type: 'text', text }`; block order within a message is
+  preserved exactly (text/image/text mixes survive as-is). A message whose
+  blocks are all text still collapses to a plain string (gateway-friendliest
+  shape); any image forces the array-of-parts form.
+- Debug logging is byte-free by design: one summary line per request with the
+  protocol, image count, MIME types, base64 character counts, and outcome —
+  never the base64 payload, credentials, or the request body.
+
+**Cross-protocol difference**: on `protocol: 'anthropic'` the same blocks are
+sent to the wire in their original Messages API shape (no `image_url`
+anywhere); the OpenAI translation applies only on `protocol: 'openai-chat'`.
+
+**tool_result attachments (v0.56.0 fan-out)**: the OpenAI `tool` role is
+text-only, so images and base64 PDFs inside a `tool_result` (a screenshot an
+MCP tool returned, an image file `Read` produced) are lifted into the user
+message that follows the tool messages — each preceded by a text label tying
+it back to its tool call (`[image #1 from tool call toolu_x]`), with a
+forward-reference marker left in the tool body. Validation asymmetry, by
+design: a malformed attachment in a tool RESULT degrades to an explicit
+omission marker with the reason (a bad tool output must not brick the turn);
+a malformed image/document in a USER turn throws the locatable
+`ConfigurationError` above (caller-controlled input, fail fast).
+
+**PDF documents (v0.56.0)**: base64 PDF `document` blocks translate to the
+official Chat Completions `file` content part
+(`{ type: 'file', file: { filename, file_data: 'data:application/pdf;base64,…' } }`,
+filename from the block's `title`, default `document.pdf`); text-source
+documents inline their text. Gateways that predate the `file` part will
+reject it server-side — that is their protocol surface, not a silent drop.
+
+**Current limits**: URL-source documents keep an honest text placeholder (no
+Chat Completions equivalent); no size/dimension pre-validation (gateway
+limits still apply); URL image sources are not fetched or validated
+client-side.
+
 ## Honest limits
 
 - **`thinking` config is dropped from the wire** — it has no Chat Completions
@@ -141,8 +207,9 @@ handling is provider-agnostic.
   automatic, not breakpoint-driven. Cached tokens are still accounted
   (`cache_read_input_tokens` from `prompt_tokens_details.cached_tokens`), but
   the `promptCaching` / `cacheTtl` knobs have no wire effect on this protocol.
-- **PDF/document blocks degrade** to a text placeholder (no protocol
-  equivalent); text-source documents inline their text.
+- **URL-source document blocks degrade** to a text placeholder (no protocol
+  equivalent); base64 PDFs ride the official `file` part and text-source
+  documents inline their text (both since v0.56.0 — see "Image input").
 - **`betas` and `apiVersion` are ignored** (Anthropic header concepts).
 - **Cost metrics read 0** for non-Claude models UNLESS you supply
   `provider.pricing` entries — with them, cost metrics and `maxBudgetUsd`

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.55.2",
+  "version": "0.56.0",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/tool-dispatch.ts
+++ b/projects/silver-core-sdk/src/engine/tool-dispatch.ts
@@ -31,6 +31,10 @@ import type {
   ToolDispatchRecord,
   ToolResultPayload,
 } from '../internal/contracts.js';
+import {
+  normalizeImageMediaType,
+  SUPPORTED_IMAGE_MEDIA_TYPES_LIST,
+} from '../internal/media.js';
 
 /** Wrap any abort-shaped error into this SDK's AbortError. */
 function toAbortError(err: unknown): AbortError {
@@ -68,20 +72,37 @@ export type ToolExecOutcome = {
   observability?: SDKMessage[];
 };
 
-/** Map an MCP CallToolResult into a builtin-style tool result payload. */
-function mapMcpResult(res: CallToolResult): ToolResultPayload {
+/** Map an MCP CallToolResult into a builtin-style tool result payload.
+ *  Exported for unit tests (pure function, no I/O). */
+export function mapMcpResult(res: CallToolResult): ToolResultPayload {
   const parts: Array<TextBlockParam | ImageBlockParam> = [];
   for (const part of res.content) {
     switch (part.type) {
       case 'text':
         parts.push({ type: 'text', text: part.text });
         break;
-      case 'image':
-        parts.push({
-          type: 'image',
-          source: { type: 'base64', media_type: part.mimeType, data: part.data },
-        });
+      case 'image': {
+        // Whitelist the mimeType HERE (v0.56.0): an MCP server is free to
+        // label anything (image/bmp, image/tiff, ...), and an off-vocabulary
+        // media_type riding into the next API request 400s the WHOLE turn on
+        // the Anthropic protocol (and is unrepresentable on openai-chat).
+        // Degrade to an explicit text marker instead — never dropped silently.
+        const mediaType = normalizeImageMediaType(part.mimeType);
+        parts.push(
+          mediaType !== undefined
+            ? {
+                type: 'image',
+                source: { type: 'base64', media_type: mediaType, data: part.data },
+              }
+            : {
+                type: 'text',
+                text:
+                  `[image omitted: unsupported media type "${part.mimeType}"; ` +
+                  `supported: ${SUPPORTED_IMAGE_MEDIA_TYPES_LIST}]`,
+              },
+        );
         break;
+      }
       case 'audio':
         parts.push({ type: 'text', text: `[audio ${part.mimeType}]` });
         break;

--- a/projects/silver-core-sdk/src/internal/media.ts
+++ b/projects/silver-core-sdk/src/internal/media.ts
@@ -1,0 +1,28 @@
+/**
+ * Silver Core SDK - shared media-type vocabulary.
+ *
+ * Single source for the image media types the Messages API documents
+ * (and the OpenAI translation's data-URL path accepts). Both the wire
+ * translator (transport/openai.ts) and the MCP result mapper
+ * (engine/tool-dispatch.ts) validate against THIS set, so an image an MCP
+ * server labels with an off-vocabulary mimeType is caught at the dispatch
+ * seam (degraded to an explicit text marker) instead of 400-ing the whole
+ * next API request server-side.
+ */
+
+export const SUPPORTED_IMAGE_MEDIA_TYPES: ReadonlySet<string> = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+
+/** Human-readable list for error/marker messages (stable order). */
+export const SUPPORTED_IMAGE_MEDIA_TYPES_LIST = [...SUPPORTED_IMAGE_MEDIA_TYPES].join(', ');
+
+/** Normalize a raw media type (trim + lowercase); undefined when the result
+ *  is not one of the supported image types. */
+export function normalizeImageMediaType(raw: string): string | undefined {
+  const mediaType = raw.trim().toLowerCase();
+  return SUPPORTED_IMAGE_MEDIA_TYPES.has(mediaType) ? mediaType : undefined;
+}

--- a/projects/silver-core-sdk/src/transport/openai.ts
+++ b/projects/silver-core-sdk/src/transport/openai.ts
@@ -23,8 +23,15 @@
  *  - `cache_control` breakpoints are stripped (OpenAI-side caching is
  *    automatic); cached prompt tokens are read back from
  *    `usage.prompt_tokens_details.cached_tokens`.
- *  - image blocks translate to `image_url` parts; PDF/document blocks have no
- *    Chat Completions equivalent and degrade to an honest text placeholder.
+ *  - image blocks translate to `image_url` parts (base64 -> data URL, with a
+ *    media-type whitelist + base64 hygiene checks so a bad image fails with a
+ *    locatable error HERE instead of an opaque gateway image-processing
+ *    error); base64-PDF document blocks translate to the official `file`
+ *    part (data URL in file_data); URL documents keep an honest placeholder.
+ *  - images/PDFs inside a tool_result are FANNED OUT into the user message
+ *    following the tool messages (the OpenAI `tool` role is text-only), each
+ *    labeled with its tool_call_id; the tool body keeps a forward-reference
+ *    marker.
  *
  * The HTTP retry/backoff/watchdog policy mirrors AnthropicTransport (the
  * resolve* helpers and semaphore are imported from it); the request loop is
@@ -70,6 +77,10 @@ import {
   resolveStreamIdleMs,
   resolveStreamMaxMs,
 } from './anthropic.js';
+import {
+  SUPPORTED_IMAGE_MEDIA_TYPES,
+  SUPPORTED_IMAGE_MEDIA_TYPES_LIST,
+} from '../internal/media.js';
 
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_TIMEOUT_MS = 600_000;
@@ -105,7 +116,9 @@ type TransportConfig = {
 
 type OpenAIContentPart =
   | { type: 'text'; text: string }
-  | { type: 'image_url'; image_url: { url: string } };
+  | { type: 'image_url'; image_url: { url: string } }
+  /** Official Chat Completions PDF-input part (base64 data URL in file_data). */
+  | { type: 'file'; file: { filename: string; file_data: string } };
 
 type OpenAIToolCall = {
   id: string;
@@ -129,33 +142,158 @@ function encodeSystem(system: string | TextBlockParam[] | undefined): string | u
   return text.length > 0 ? text : undefined;
 }
 
-function imagePartUrl(block: ImageBlockParam): string {
-  return block.source.type === 'base64'
-    ? `data:${block.source.media_type};base64,${block.source.data}`
-    : block.source.url;
+/** Per-request attachment-translation stats for the debug channel. Log
+ *  hygiene: carries ONLY MIME types and base64 character counts — never
+ *  image/document bytes, credentials, or any slice of the request body. */
+type ImageStats = { mediaTypes: string[]; dataChars: number[] };
+
+/** RFC 4648 alphabet (padding allowed only at the end). Catches garbage that
+ *  would otherwise ride into the data URL and fail server-side. */
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/** Whitespace-normalize + validate base64 payload for a data URL. Raw
+ *  newlines (line-wrapped file encoders), an accidental nested `data:` prefix
+ *  and off-alphabet bytes are exactly the malformed shapes gateways reject
+ *  opaquely at their media-processing stage (e.g.
+ *  `image_moderation_server_error`) — fail HERE, locatably, instead. All
+ *  error messages are byte-free (never include the payload). */
+function cleanBase64(raw: string, where: string, what: string): string {
+  const data = raw.replace(/\s+/g, '');
+  if (data.length === 0) {
+    throw new ConfigurationError(
+      `openai-chat: empty base64 ${what} data at ${where}; ` +
+        `supply the ${what} bytes or drop the block`,
+    );
+  }
+  if (data.startsWith('data:')) {
+    throw new ConfigurationError(
+      `openai-chat: ${what} data at ${where} already carries a "data:" URL prefix; ` +
+        `pass RAW base64 in source.data (or use source.type 'url' for a full URL)`,
+    );
+  }
+  if (!BASE64_RE.test(data)) {
+    throw new ConfigurationError(
+      `openai-chat: ${what} data at ${where} is not valid base64 (${data.length} chars)`,
+    );
+  }
+  return data;
 }
 
+function imagePartUrl(block: ImageBlockParam, where: string, stats?: ImageStats): string {
+  if (block.source.type !== 'base64') {
+    // http(s) or ready-made data URL: the Chat Completions image_url part
+    // takes it verbatim.
+    stats?.mediaTypes.push('url');
+    stats?.dataChars.push(block.source.url.length);
+    return block.source.url;
+  }
+  const mediaType = block.source.media_type.trim().toLowerCase();
+  if (!SUPPORTED_IMAGE_MEDIA_TYPES.has(mediaType)) {
+    throw new ConfigurationError(
+      `openai-chat: unsupported image media_type "${block.source.media_type}" at ${where}; ` +
+        `supported: ${SUPPORTED_IMAGE_MEDIA_TYPES_LIST}`,
+    );
+  }
+  const data = cleanBase64(block.source.data, where, 'image');
+  stats?.mediaTypes.push(mediaType);
+  stats?.dataChars.push(data.length);
+  return `data:${mediaType};base64,${data}`;
+}
+
+/** Translate a document block into an OpenAI content part. Base64 PDFs map to
+ *  the official Chat Completions `file` part (data URL in `file_data`,
+ *  v0.56.0 — previously an honest text placeholder); text sources inline
+ *  their text; URL sources have no Chat Completions equivalent and keep the
+ *  honest placeholder. */
+function documentPart(
+  block: DocumentBlockParam,
+  where: string,
+  stats?: ImageStats,
+): OpenAIContentPart {
+  if (block.source.type === 'text') return { type: 'text', text: block.source.data };
+  if (block.source.type === 'url') {
+    return {
+      type: 'text',
+      text: `[document "${block.title ?? block.source.url}" omitted: URL documents have no Chat Completions equivalent]`,
+    };
+  }
+  const data = cleanBase64(block.source.data, where, 'document');
+  stats?.mediaTypes.push('application/pdf');
+  stats?.dataChars.push(data.length);
+  return {
+    type: 'file',
+    file: {
+      filename: block.title ?? 'document.pdf',
+      file_data: `data:application/pdf;base64,${data}`,
+    },
+  };
+}
+
+/** An image/document lifted out of a tool_result and carried into the user
+ *  message that follows the tool messages (fan-out, v0.56.0): the OpenAI
+ *  `tool` role is text-only, so without the carry the model NEVER sees a
+ *  screenshot an MCP tool returned or an image file Read produced. The label
+ *  ties the attachment back to its tool call. */
+type CarriedAttachment = { label: string; part: OpenAIContentPart };
+
 /** Flatten a tool_result's content to the string an OpenAI `tool` message
- *  carries. Non-text blocks degrade to honest placeholders (never dropped
- *  silently). An `is_error` tool_result gets a deterministic textual marker:
- *  the OpenAI `tool` role has no is_error field, so without it the model can
- *  no longer tell a failed tool call (a non-zero Bash exit, a builtin error)
- *  from a successful one — it would treat the error text as a normal result. */
-function flattenToolResultContent(block: ToolResultBlockParam): string {
+ *  carries. Images and base64-PDF documents are lifted into `carry` (see
+ *  CarriedAttachment) with a forward-reference marker left in the tool body;
+ *  an attachment that fails validation degrades to an explicit omission
+ *  marker with the reason (never a thrown error — a malformed tool OUTPUT
+ *  must not brick the turn the way a malformed caller INPUT should; user-turn
+ *  blocks stay strict). An `is_error` tool_result gets a deterministic
+ *  textual marker: the OpenAI `tool` role has no is_error field, so without
+ *  it the model can no longer tell a failed tool call (a non-zero Bash exit,
+ *  a builtin error) from a successful one — it would treat the error text as
+ *  a normal result. */
+function flattenToolResultContent(
+  block: ToolResultBlockParam,
+  where: string,
+  carry: CarriedAttachment[],
+  stats?: ImageStats,
+): string {
   const content = block.content;
+  let imageNo = 0;
+  let documentNo = 0;
   const body =
     content === undefined
       ? ''
       : typeof content === 'string'
         ? content
         : content
-            .map((item) =>
-              item.type === 'text'
-                ? item.text
-                : item.type === 'image'
-                  ? '[image content omitted: not representable in an OpenAI tool result]'
-                  : documentFallbackText(item),
-            )
+            .map((item, j) => {
+              if (item.type === 'text') return item.text;
+              if (item.type === 'image') {
+                imageNo += 1;
+                try {
+                  const url = imagePartUrl(item, `${where}.content[${j}]`, stats);
+                  carry.push({
+                    label: `[image #${imageNo} from tool call ${block.tool_use_id}]`,
+                    part: { type: 'image_url', image_url: { url } },
+                  });
+                  return `[image #${imageNo}: attached in the user message after the tool results]`;
+                } catch (err) {
+                  return `[image #${imageNo} omitted: ${errorMessage(err)}]`;
+                }
+              }
+              // document
+              try {
+                const part = documentPart(item, `${where}.content[${j}]`, stats);
+                // documentPart returns text (inline/placeholder) or file only.
+                if (part.type !== 'file') {
+                  return part.type === 'text' ? part.text : '';
+                }
+                documentNo += 1;
+                carry.push({
+                  label: `[document #${documentNo} ("${part.file.filename}") from tool call ${block.tool_use_id}]`,
+                  part,
+                });
+                return `[document #${documentNo} ("${part.file.filename}"): attached in the user message after the tool results]`;
+              } catch (err) {
+                return `[document omitted: ${errorMessage(err)}]`;
+              }
+            })
             .join('\n');
   return block.is_error === true
     ? body.length > 0
@@ -164,17 +302,15 @@ function flattenToolResultContent(block: ToolResultBlockParam): string {
     : body;
 }
 
-function documentFallbackText(block: DocumentBlockParam): string {
-  if (block.source.type === 'text') return block.source.data;
-  const label = block.title ?? (block.source.type === 'url' ? block.source.url : 'PDF');
-  return `[document "${label}" omitted: no Chat Completions equivalent]`;
-}
-
 /** Translate one Anthropic message-param into its OpenAI message(s). A user
  *  turn carrying tool_result blocks fans out into `tool` role messages (which
  *  must directly follow the assistant tool_calls turn), then any remaining
  *  user content. */
-function encodeMessage(msg: APIMessageParam): OpenAIChatMessage[] {
+function encodeMessage(
+  msg: APIMessageParam,
+  where = 'messages[?]',
+  stats?: ImageStats,
+): OpenAIChatMessage[] {
   if (typeof msg.content === 'string') {
     return msg.role === 'user'
       ? [{ role: 'user', content: msg.content }]
@@ -208,31 +344,48 @@ function encodeMessage(msg: APIMessageParam): OpenAIChatMessage[] {
   // remaining text/image parts as one user message.
   const out: OpenAIChatMessage[] = [];
   const parts: OpenAIContentPart[] = [];
-  for (const block of msg.content as ContentBlockParam[]) {
+  const carry: CarriedAttachment[] = [];
+  const blocks = msg.content as ContentBlockParam[];
+  for (let i = 0; i < blocks.length; i += 1) {
+    const block = blocks[i]!;
     switch (block.type) {
       case 'tool_result':
         out.push({
           role: 'tool',
           tool_call_id: block.tool_use_id,
-          content: flattenToolResultContent(block),
+          content: flattenToolResultContent(block, `${where}.content[${i}]`, carry, stats),
         });
         break;
       case 'text':
         parts.push({ type: 'text', text: block.text });
         break;
       case 'image':
-        parts.push({ type: 'image_url', image_url: { url: imagePartUrl(block) } });
+        parts.push({
+          type: 'image_url',
+          image_url: { url: imagePartUrl(block, `${where}.content[${i}]`, stats) },
+        });
         break;
       default:
         if ((block as { type?: string }).type === 'document') {
-          parts.push({
-            type: 'text',
-            text: documentFallbackText(block as unknown as DocumentBlockParam),
-          });
+          parts.push(
+            documentPart(
+              block as unknown as DocumentBlockParam,
+              `${where}.content[${i}]`,
+              stats,
+            ),
+          );
         }
         // tool_use / thinking blocks never appear in user turns.
         break;
     }
+  }
+  // Carried tool_result attachments ride in the user message FOLLOWING the
+  // tool messages (protocol adjacency: tool messages must directly follow the
+  // assistant tool_calls turn). Each is preceded by its text label so the
+  // model can tie it back to the tool call; appended AFTER any genuine user
+  // content so original block order within the turn is preserved.
+  for (const { label, part } of carry) {
+    parts.push({ type: 'text', text: label }, part);
   }
   if (parts.length > 0) {
     const onlyText = parts.every((p) => p.type === 'text');
@@ -270,16 +423,30 @@ function encodeToolChoice(
 
 /**
  * Encode one StreamRequest as a Chat Completions request body. Exported for
- * unit tests (pure function, no I/O).
+ * unit tests (pure function, no I/O; the optional `debug` sink receives one
+ * image-translation summary line — MIME types and base64 lengths only, never
+ * image bytes / credentials / body content).
  */
 export function encodeOpenAIRequest(
   req: Omit<StreamRequest, 'signal' | 'onRetry'>,
   opts: OpenAIProtocolOptions = {},
+  debug?: (m: string) => void,
 ): Record<string, unknown> {
   const messages: OpenAIChatMessage[] = [];
   const system = encodeSystem(req.system);
   if (system !== undefined) messages.push({ role: 'system', content: system });
-  for (const msg of req.messages) messages.push(...encodeMessage(msg));
+  const imageStats: ImageStats = { mediaTypes: [], dataChars: [] };
+  for (let i = 0; i < req.messages.length; i += 1) {
+    messages.push(...encodeMessage(req.messages[i]!, `messages[${i}]`, imageStats));
+  }
+  if (imageStats.mediaTypes.length > 0) {
+    const files = imageStats.mediaTypes.filter((t) => t === 'application/pdf').length;
+    debug?.(
+      `openai transport: protocol=openai-chat images=${imageStats.mediaTypes.length - files} ` +
+        `files=${files} types=[${imageStats.mediaTypes.join(', ')}] ` +
+        `data_chars=[${imageStats.dataChars.join(', ')}] -> image_url/file parts (ok)`,
+    );
+  }
 
   // Server-declared typed entries (no input_schema, e.g. memory_20250818)
   // have no Chat Completions equivalent and are dropped honestly — the query
@@ -755,9 +922,17 @@ export class OpenAIChatTransport implements Transport {
           `or set the model explicitly.`,
       );
     }
-    const bodyJson = JSON.stringify(
-      encodeOpenAIRequest({ ...requestBody, model: mappedModel }, opts),
-    );
+    let bodyJson: string;
+    try {
+      bodyJson = JSON.stringify(
+        encodeOpenAIRequest({ ...requestBody, model: mappedModel }, opts, this.debug),
+      );
+    } catch (err) {
+      // The encode error is already locatable and byte-free (media_type +
+      // block path only); mirror it on the debug channel and surface as-is.
+      this.debug(`openai transport: request encoding failed (${errorMessage(err)})`);
+      throw err;
+    }
     const headers = this.buildHeaders(this.credential);
     const timeoutMs = this.provider.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const maxRetries = resolveMaxRetries(this.provider, this.env);

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.55.2';
+export const SDK_VERSION = '0.56.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/openai-mutation-kills-r2.test.ts
+++ b/projects/silver-core-sdk/tests/openai-mutation-kills-r2.test.ts
@@ -78,7 +78,7 @@ describe('encoder leftovers (round-2 NC)', () => {
     expect(msgs[0]).toEqual({ role: 'assistant', content: 'previous words' });
   });
 
-  it('a document part in PLAIN user content flattens to its text fallback', async () => {
+  it('a base64 PDF in PLAIN user content rides the official file part (v0.56.0)', async () => {
     const body = await bodyOf({
       messages: [
         {
@@ -91,8 +91,11 @@ describe('encoder leftovers (round-2 NC)', () => {
       ] as never,
     });
     const user = (body.messages as Array<{ role: string; content: unknown }>).find((m) => m.role === 'user')!;
-    // all parts are text -> joined string; the title-less PDF gets the 'PDF' label
-    expect(user.content).toBe('see attached\n[document "PDF" omitted: no Chat Completions equivalent]');
+    // a file part forces the array-of-parts form; the title-less PDF gets the default filename
+    expect(user.content).toEqual([
+      { type: 'text', text: 'see attached' },
+      { type: 'file', file: { filename: 'document.pdf', file_data: 'data:application/pdf;base64,aGk=' } },
+    ]);
   });
 });
 

--- a/projects/silver-core-sdk/tests/openai-mutation-kills.test.ts
+++ b/projects/silver-core-sdk/tests/openai-mutation-kills.test.ts
@@ -112,18 +112,18 @@ describe('tool_result flattening (is_error marker + media fallbacks)', () => {
     expect((await toolMessages(undefined))[0]!.content).toBe('');
   });
 
-  it('image blocks inside a tool_result flatten to the omission placeholder', async () => {
+  it('image blocks inside a tool_result leave a forward-reference marker (fan-out, v0.56.0)', async () => {
     const tool = await toolMessages([
       { type: 'text', text: 'before' },
       { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'aGk=' } },
       { type: 'text', text: 'after' },
     ]);
     expect(tool[0]!.content).toBe(
-      'before\n[image content omitted: not representable in an OpenAI tool result]\nafter',
+      'before\n[image #1: attached in the user message after the tool results]\nafter',
     );
   });
 
-  it('document blocks flatten: text source passes its data; url/pdf sources name the label', async () => {
+  it('document blocks flatten: text source inlines; base64 PDFs fan out; url keeps a placeholder', async () => {
     const tool = await toolMessages([
       { type: 'document', title: 'notes', source: { type: 'text', media_type: 'text/plain', data: 'doc body' } },
       { type: 'document', title: 'spec.pdf', source: { type: 'base64', media_type: 'application/pdf', data: 'aGk=' } },
@@ -131,8 +131,12 @@ describe('tool_result flattening (is_error marker + media fallbacks)', () => {
     ]);
     const text = tool[0]!.content as string;
     expect(text).toContain('doc body');
-    expect(text).toContain('[document "spec.pdf" omitted: no Chat Completions equivalent]');
-    expect(text).toContain('[document "https://x.test/a.pdf" omitted: no Chat Completions equivalent]');
+    expect(text).toContain(
+      '[document #1 ("spec.pdf"): attached in the user message after the tool results]',
+    );
+    expect(text).toContain(
+      '[document "https://x.test/a.pdf" omitted: URL documents have no Chat Completions equivalent]',
+    );
   });
 });
 

--- a/projects/silver-core-sdk/tests/tool-dispatch-mcp-images.test.ts
+++ b/projects/silver-core-sdk/tests/tool-dispatch-mcp-images.test.ts
@@ -1,0 +1,64 @@
+/**
+ * MCP result mapping: image mimeType whitelist (v0.56.0). An MCP server is
+ * free to label image content with any mimeType; an off-vocabulary
+ * media_type riding into the next API request 400s the whole turn on the
+ * Anthropic protocol. mapMcpResult degrades those to an explicit text
+ * marker instead — never silently dropped, never a poisoned wire request.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { mapMcpResult } from '../src/engine/tool-dispatch.js';
+import type { CallToolResult } from '../src/types.js';
+
+describe('mapMcpResult image mimeType whitelist', () => {
+  it.each(['image/png', 'image/jpeg', 'image/gif', 'image/webp'])(
+    'passes a supported %s image through as an image block',
+    (mimeType) => {
+      const res: CallToolResult = {
+        content: [{ type: 'image', mimeType, data: 'QUJD' }],
+      };
+      expect(mapMcpResult(res)).toEqual({
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: mimeType, data: 'QUJD' } },
+        ],
+        isError: false,
+      });
+    },
+  );
+
+  it('normalizes mimeType case/whitespace before whitelisting', () => {
+    const res: CallToolResult = {
+      content: [{ type: 'image', mimeType: ' IMAGE/PNG ', data: 'QUJD' }],
+    };
+    expect(mapMcpResult(res)).toEqual({
+      content: [
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJD' } },
+      ],
+      isError: false,
+    });
+  });
+
+  it('degrades an unsupported mimeType to an explicit text marker (no silent drop)', () => {
+    const res: CallToolResult = {
+      content: [
+        { type: 'text', text: 'before' },
+        { type: 'image', mimeType: 'image/bmp', data: 'QUJD' },
+        { type: 'text', text: 'after' },
+      ],
+    };
+    const mapped = mapMcpResult(res);
+    expect(mapped.content).toEqual([
+      { type: 'text', text: 'before' },
+      {
+        type: 'text',
+        text:
+          '[image omitted: unsupported media type "image/bmp"; ' +
+          'supported: image/jpeg, image/png, image/gif, image/webp]',
+      },
+      { type: 'text', text: 'after' },
+    ]);
+    // The marker must not leak the image payload.
+    expect(JSON.stringify(mapped)).not.toContain('QUJD');
+  });
+});

--- a/projects/silver-core-sdk/tests/transport-openai.test.ts
+++ b/projects/silver-core-sdk/tests/transport-openai.test.ts
@@ -178,9 +178,16 @@ describe('encodeOpenAIRequest', () => {
         role: 'tool',
         tool_call_id: 'toolu_2',
         content:
-          'part\n[image content omitted: not representable in an OpenAI tool result]',
+          'part\n[image #1: attached in the user message after the tool results]',
       },
-      { role: 'user', content: 'background note' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'background note' },
+          { type: 'text', text: '[image #1 from tool call toolu_2]' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AA' } },
+        ],
+      },
     ]);
   });
 
@@ -229,6 +236,265 @@ describe('encodeOpenAIRequest', () => {
         ],
       },
     ]);
+  });
+
+  it('keeps a pure-text message free of any image structures', () => {
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'plain' }] }],
+    });
+    expect(body.messages).toEqual([{ role: 'user', content: 'plain' }]);
+    expect(JSON.stringify(body)).not.toContain('image_url');
+  });
+
+  it.each([
+    ['image/jpeg', 'ZmFrZQ=='],
+    ['image/png', 'QUJD'],
+    ['image/gif', 'R0lG'],
+    ['image/webp', 'V0VCUA=='],
+  ])('translates a single %s image to a correctly prefixed data URL', (mediaType, data) => {
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'look' },
+            { type: 'image', source: { type: 'base64', media_type: mediaType, data } },
+          ],
+        },
+      ],
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'look' },
+          { type: 'image_url', image_url: { url: `data:${mediaType};base64,${data}` } },
+        ],
+      },
+    ]);
+    // No Anthropic-shaped image block may survive into the wire body.
+    expect(JSON.stringify(body)).not.toContain('"type":"image"');
+    expect(JSON.stringify(body)).not.toContain('"source"');
+  });
+
+  it('preserves block order for text/image/text mixes and multiple images', () => {
+    const img = (data: string, mediaType = 'image/png') =>
+      ({ type: 'image', source: { type: 'base64', media_type: mediaType, data } }) as const;
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'before' },
+            img('QQ=='),
+            { type: 'text', text: 'between' },
+            img('Qg==', 'image/jpeg'),
+            img('Qw==', 'image/webp'),
+            { type: 'text', text: 'after' },
+          ],
+        },
+      ],
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'before' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,QQ==' } },
+          { type: 'text', text: 'between' },
+          { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,Qg==' } },
+          { type: 'image_url', image_url: { url: 'data:image/webp;base64,Qw==' } },
+          { type: 'text', text: 'after' },
+        ],
+      },
+    ]);
+  });
+
+  it('normalizes media_type case and strips line-wrapped base64 whitespace', () => {
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: { type: 'base64', media_type: ' IMAGE/PNG ', data: 'QUJ\nDRA\r\n==' },
+            },
+          ],
+        },
+      ],
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,QUJDRA==' } },
+        ],
+      },
+    ]);
+  });
+
+  it('passes a url image source through verbatim', () => {
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'url', url: 'https://example.com/a.png' } },
+          ],
+        },
+      ],
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'image_url', image_url: { url: 'https://example.com/a.png' } },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects an unsupported image media_type with a locatable error', () => {
+    const attempt = (): unknown =>
+      encodeOpenAIRequest({
+        model: 'm',
+        max_tokens: 8,
+        messages: [
+          { role: 'user', content: 'first' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'x' },
+              { type: 'image', source: { type: 'base64', media_type: 'image/bmp', data: 'QUJD' } },
+            ],
+          },
+        ],
+      });
+    expect(attempt).toThrow(ConfigurationError);
+    expect(attempt).toThrow(/unsupported image media_type "image\/bmp"/);
+    expect(attempt).toThrow(/messages\[1\]\.content\[1\]/);
+    expect(attempt).toThrow(/image\/jpeg, image\/png, image\/gif, image\/webp/);
+  });
+
+  it('rejects empty base64 image data instead of sending a malformed data URL', () => {
+    const attempt = (): unknown =>
+      encodeOpenAIRequest({
+        model: 'm',
+        max_tokens: 8,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: '  \n ' } },
+            ],
+          },
+        ],
+      });
+    expect(attempt).toThrow(ConfigurationError);
+    expect(attempt).toThrow(/empty base64 image data at messages\[0\]\.content\[0\]/);
+  });
+
+  it('rejects source.data that already carries a data: URL prefix (double-prefix guard)', () => {
+    const attempt = (): unknown =>
+      encodeOpenAIRequest({
+        model: 'm',
+        max_tokens: 8,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: 'data:image/png;base64,QUJD',
+                },
+              },
+            ],
+          },
+        ],
+      });
+    expect(attempt).toThrow(ConfigurationError);
+    expect(attempt).toThrow(/already carries a "data:" URL prefix/);
+  });
+
+  it('rejects non-base64 image data with a byte-free error', () => {
+    const attempt = (): unknown =>
+      encodeOpenAIRequest({
+        model: 'm',
+        max_tokens: 8,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image', source: { type: 'base64', media_type: 'image/gif', data: '@@not-b64@@' } },
+            ],
+          },
+        ],
+      });
+    expect(attempt).toThrow(ConfigurationError);
+    expect(attempt).toThrow(/is not valid base64/);
+    let message = '';
+    try {
+      attempt();
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // Log/error hygiene: the payload itself must never appear.
+    expect(message).not.toContain('@@not-b64@@');
+  });
+
+  it('debug summary logs count/MIME/lengths but never the base64 payload', () => {
+    const lines: string[] = [];
+    encodeOpenAIRequest(
+      {
+        model: 'm',
+        max_tokens: 8,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'two images' },
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJDRA==' } },
+              { type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: 'ZmFrZQ==' } },
+            ],
+          },
+        ],
+      },
+      {},
+      (m) => lines.push(m),
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('protocol=openai-chat');
+    expect(lines[0]).toContain('images=2');
+    expect(lines[0]).toContain('image/png');
+    expect(lines[0]).toContain('image/jpeg');
+    expect(lines[0]).toContain('data_chars=[8, 8]');
+    expect(lines[0]).toContain('(ok)');
+    expect(lines[0]).not.toContain('QUJDRA');
+    expect(lines[0]).not.toContain('ZmFrZQ');
+  });
+
+  it('emits no image debug line for a request without images', () => {
+    const lines: string[] = [];
+    encodeOpenAIRequest(
+      { model: 'm', max_tokens: 8, messages: [{ role: 'user', content: 'hi' }] },
+      {},
+      (m) => lines.push(m),
+    );
+    expect(lines).toHaveLength(0);
   });
 
   it('maps tools and tool_choice variants', () => {
@@ -1434,5 +1700,409 @@ describe('encodeOpenAIRequest tool schema filter', () => {
         function: { name: 'fine', parameters: { type: 'object', properties: {} } },
       },
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end wire fixtures: image structure on the final request body
+// ---------------------------------------------------------------------------
+
+describe('image wire format (transport fixtures)', () => {
+  const IMAGE_MESSAGES: StreamRequest['messages'] = [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'what is this?' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJD' } },
+      ],
+    },
+  ];
+
+  function openaiSse(): Response {
+    const chunks = [
+      {
+        id: 'chatcmpl-1',
+        model: 'gpt-test',
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'a cat' }, finish_reason: null }],
+      },
+      {
+        id: 'chatcmpl-1',
+        model: 'gpt-test',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      },
+    ];
+    const body =
+      chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join('') + 'data: [DONE]\n\n';
+    return new Response(streamFromChunks([body]), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  }
+
+  function anthropicSse(): Response {
+    const events = [
+      { type: 'message_start', message: { id: 'msg_1', type: 'message', role: 'assistant', model: 'claude-test-1', content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 1, output_tokens: 1 } } },
+      { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'a cat' } },
+      { type: 'content_block_stop', index: 0 },
+      { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 2 } },
+      { type: 'message_stop' },
+    ];
+    const body = events
+      .map((e) => `event: ${(e as { type: string }).type}\ndata: ${JSON.stringify(e)}\n\n`)
+      .join('');
+    return new Response(streamFromChunks([body]), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  }
+
+  it('OpenAIChatTransport sends image_url parts (and no Anthropic image block) on the wire', async () => {
+    const injected = vi.fn(async () => openaiSse());
+    const debugLines: string[] = [];
+    const transport = new OpenAIChatTransport({
+      provider: { protocol: 'openai-chat', apiKey: 'k', fetch: injected },
+      env: {},
+      debug: (m) => debugLines.push(m),
+    });
+    const events = await collect(
+      transport.stream({ model: 'gpt-test', max_tokens: 64, messages: IMAGE_MESSAGES }),
+    );
+    expect(events.at(-1)?.type).toBe('message_stop');
+    const wire = JSON.parse(String(injected.mock.calls[0]![1]!.body)) as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+    expect(wire.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is this?' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,QUJD' } },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(wire)).not.toContain('"type":"image"');
+    // Debug hygiene at the transport level: summary present, payload absent.
+    const summary = debugLines.find((l) => l.includes('images='));
+    expect(summary).toContain('images=1');
+    expect(summary).toContain('image/png');
+    expect(debugLines.join('\n')).not.toContain('QUJD');
+  });
+
+  it('AnthropicTransport keeps the original Anthropic image structure untouched', async () => {
+    const injected = vi.fn(async () => anthropicSse());
+    const transport = new AnthropicTransport({
+      provider: { apiKey: 'k', fetch: injected },
+      env: {},
+      debug: noop,
+    });
+    const events = await collect(
+      transport.stream({ model: 'claude-test-1', max_tokens: 64, messages: IMAGE_MESSAGES }),
+    );
+    expect(events.at(-1)?.type).toBe('message_stop');
+    const wire = JSON.parse(String(injected.mock.calls[0]![1]!.body)) as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+    expect(wire.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is this?' },
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJD' } },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(wire)).not.toContain('image_url');
+  });
+
+  it('OpenAIChatTransport surfaces an encode error before any network call', async () => {
+    const injected = vi.fn(async () => openaiSse());
+    const debugLines: string[] = [];
+    const transport = new OpenAIChatTransport({
+      provider: { protocol: 'openai-chat', apiKey: 'k', fetch: injected },
+      env: {},
+      debug: (m) => debugLines.push(m),
+    });
+    const err = await captureError(
+      collect(
+        transport.stream({
+          model: 'gpt-test',
+          max_tokens: 64,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'image', source: { type: 'base64', media_type: 'image/tiff', data: 'QUJD' } },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+    expect(err).toBeInstanceOf(ConfigurationError);
+    expect((err as Error).message).toContain('image/tiff');
+    expect(injected).not.toHaveBeenCalled();
+    expect(debugLines.some((l) => l.includes('request encoding failed'))).toBe(true);
+    expect(debugLines.join('\n')).not.toContain('QUJD');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tool_result attachment fan-out + document -> file parts (v0.56.0)
+// ---------------------------------------------------------------------------
+
+describe('tool_result attachment fan-out', () => {
+  it('carries a tool_result image into a labeled user message when no other user content exists', () => {
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_shot',
+              content: [
+                { type: 'text', text: 'screenshot taken' },
+                { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJD' } },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'toolu_shot',
+        content:
+          'screenshot taken\n[image #1: attached in the user message after the tool results]',
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '[image #1 from tool call toolu_shot]' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,QUJD' } },
+        ],
+      },
+    ]);
+  });
+
+  it('labels attachments from multiple tool_results by their own tool_call_id, in order', () => {
+    const img = (data: string) =>
+      ({ type: 'image', source: { type: 'base64', media_type: 'image/png', data } }) as const;
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 't1', content: [img('QQ==')] },
+            { type: 'tool_result', tool_use_id: 't2', content: [img('Qg=='), img('Qw==')] },
+          ],
+        },
+      ],
+    });
+    const msgs = body.messages as Array<{ role: string; content: unknown }>;
+    expect(msgs.map((m) => m.role)).toEqual(['tool', 'tool', 'user']);
+    expect(msgs[2]!.content).toEqual([
+      { type: 'text', text: '[image #1 from tool call t1]' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,QQ==' } },
+      { type: 'text', text: '[image #1 from tool call t2]' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,Qg==' } },
+      { type: 'text', text: '[image #2 from tool call t2]' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,Qw==' } },
+    ]);
+  });
+
+  it('degrades an invalid tool_result image to an explicit omission marker instead of throwing', () => {
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tbad',
+              content: [
+                { type: 'image', source: { type: 'base64', media_type: 'image/bmp', data: 'QUJD' } },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'tbad',
+        content: expect.stringMatching(
+          /^\[image #1 omitted: .*unsupported image media_type "image\/bmp".*\]$/,
+        ),
+      },
+    ]);
+    // Nothing carried, no image parts anywhere.
+    expect(JSON.stringify(body)).not.toContain('image_url');
+  });
+});
+
+describe('document -> file part translation', () => {
+  it('translates a user-turn base64 PDF into an official file part (title as filename)', () => {
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'read this' },
+            {
+              type: 'document',
+              title: 'report.pdf',
+              source: { type: 'base64', media_type: 'application/pdf', data: 'UERG' },
+            } as never,
+          ],
+        },
+      ],
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'read this' },
+          {
+            type: 'file',
+            file: { filename: 'report.pdf', file_data: 'data:application/pdf;base64,UERG' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('carries a tool_result base64 PDF into the follow-up user message with a default filename', () => {
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tpdf',
+              content: [
+                {
+                  type: 'document',
+                  source: { type: 'base64', media_type: 'application/pdf', data: 'UERG' },
+                } as never,
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'tpdf',
+        content:
+          '[document #1 ("document.pdf"): attached in the user message after the tool results]',
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '[document #1 ("document.pdf") from tool call tpdf]' },
+          {
+            type: 'file',
+            file: { filename: 'document.pdf', file_data: 'data:application/pdf;base64,UERG' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('inlines text-source documents and keeps an honest placeholder for URL documents', () => {
+    const body = encodeOpenAIRequest({
+      model: 'm',
+      max_tokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'document',
+              source: { type: 'text', media_type: 'text/plain', data: 'inline body' },
+            } as never,
+            {
+              type: 'document',
+              source: { type: 'url', url: 'https://example.com/x.pdf' },
+            } as never,
+          ],
+        },
+      ],
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'user',
+        content:
+          'inline body\n[document "https://example.com/x.pdf" omitted: URL documents have no Chat Completions equivalent]',
+      },
+    ]);
+  });
+
+  it('rejects empty base64 document data in a USER turn with a locatable error', () => {
+    const attempt = (): unknown =>
+      encodeOpenAIRequest({
+        model: 'm',
+        max_tokens: 8,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'document',
+                source: { type: 'base64', media_type: 'application/pdf', data: ' ' },
+              } as never,
+            ],
+          },
+        ],
+      });
+    expect(attempt).toThrow(ConfigurationError);
+    expect(attempt).toThrow(/empty base64 document data at messages\[0\]\.content\[0\]/);
+  });
+
+  it('debug summary counts images and files separately, still byte-free', () => {
+    const lines: string[] = [];
+    encodeOpenAIRequest(
+      {
+        model: 'm',
+        max_tokens: 8,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJD' } },
+              {
+                type: 'document',
+                source: { type: 'base64', media_type: 'application/pdf', data: 'UERG' },
+              } as never,
+            ],
+          },
+        ],
+      },
+      {},
+      (m) => lines.push(m),
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('images=1');
+    expect(lines[0]).toContain('files=1');
+    expect(lines[0]).toContain('application/pdf');
+    expect(lines[0]).not.toContain('QUJD');
+    expect(lines[0]).not.toContain('UERG');
   });
 });


### PR DESCRIPTION
Closes the openai-chat image-translation audit's full gap list (keeper ruling 2026-07-13, "123都修复"):

1. **Base64 image validation (original request)** — four-type whitelist (JPEG/PNG/GIF/WebP), media_type/base64 normalization, locatable `ConfigurationError` (block path + media_type, never image bytes) for empty / double-prefixed / non-base64 data BEFORE any network call. Previously a bad image rode through unvalidated and failed opaquely at the gateway (`image_moderation_server_error`).
2. **tool_result attachment fan-out** — images / base64 PDFs inside a tool_result (MCP screenshots, `Read` on image files) now fan out into the user message following the tool messages, labeled with their tool_call_id; the OpenAI `tool` role is text-only, so previously the model never saw them. Malformed tool-OUTPUT attachments degrade to explicit omission markers; user-turn blocks stay fail-fast.
3. **PDF `file` parts** — base64 PDF document blocks ride the official Chat Completions `file` content part (data URL in `file_data`); URL documents keep the honest placeholder.
4. **MCP mimeType whitelist** — the MCP result mapper validates image mimeTypes against the new shared vocabulary (`src/internal/media.ts`); off-vocabulary types (image/bmp, …) become explicit text markers at the dispatch seam instead of 400-ing the whole next request on the Anthropic protocol.

Log hygiene: one byte-free debug summary per request (protocol, image/file counts, MIME types, base64 lengths, outcome) — no base64, keys, or request bodies in logs. Anthropic-protocol wire shape untouched and fixture-locked.

**Verification (run in-conversation)**: vitest 2247 passed / 2 skipped (120 files, includes #683's tests on the merged tree); repo pytest 2955 passed / 4 skipped; `tsc --noEmit` clean; `check-version-bump.mjs` green; `npm pack` → `silver-core-sdk-0.56.0.tgz` (448 files).

Version: 0.55.2 → **0.56.0** (minor, new capability). CHANGELOG folded into a single 0.56.0 entry atop #683's 0.55.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yk8QVwC8TSPY95rdEDsjc

---
_Generated by [Claude Code](https://claude.ai/code/session_014yk8QVwC8TSPY95rdEDsjc)_