### PR TITLE
feat(openai-chat): protocol-aware default maxOutputTokens 8192 → 128000 (v0.57.0)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,25 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.57.0 — 2026-07-14
+
+**openai-chat default maxOutputTokens 8192 -> 128000 (BPT ruling 2026-07-14).**
+The global 8192 default rode onto every OpenAI-compatible request as
+`max_tokens: 8192`, starving agentic turns on large-output gateway models. The
+default is now PROTOCOL-AWARE: 128000 on `openai-chat`, 8192 unchanged on
+`anthropic` (that API 400s a max_tokens above the model's output ceiling —
+e.g. claude-sonnet-4-5 caps at 64000 — and no per-model output table is
+bundled, so a blanket 128000 would have killed default Claude sessions on
+turn 1). `provider.maxOutputTokens` overrides either default, both directions.
+Boundary behavior locked by tests (`tests/max-output-tokens-default.test.ts`):
+128000 is sendable (incl. via `maxTokensParam` rename); a gateway whose model
+caps lower rejects with a clear surfaced `APIStatusError` (HTTP 400,
+`invalid_request_error`, the server's own message preserved verbatim, exactly
+one POST — 400 is never retried). Cross-protocol subagent caveat documented in
+OPENAI-PROTOCOL.md. Removed a dead duplicate `DEFAULT_MAX_OUTPUT_TOKENS` in
+query.ts. BPT: passing an explicit 128000 keeps working and is now redundant
+on openai-chat.
+
 ## 0.56.0 — 2026-07-13
 
 **openai-chat image input: hardened translation + tool_result fan-out + PDF

--- a/projects/silver-core-sdk/README.md
+++ b/projects/silver-core-sdk/README.md
@@ -124,7 +124,7 @@ const q = query({
       baseUrl: 'https://my-gateway.example.com',
       maxRetries: 4,
       timeoutMs: 600_000,
-      maxOutputTokens: 8192,
+      maxOutputTokens: 8192,           // default: 8192 (anthropic) / 128000 (openai-chat)
       defaultHeaders: { 'x-team': 'bpt' },
     },
   },

--- a/projects/silver-core-sdk/docs/OPENAI-PROTOCOL.md
+++ b/projects/silver-core-sdk/docs/OPENAI-PROTOCOL.md
@@ -76,6 +76,19 @@ Related (on `provider`, not protocol-specific): **`provider.pricing`** — USD-p
 entries keyed by model-id prefix, merged over the static Claude table. Setting it
 makes cost metrics and `maxBudgetUsd` enforceable for non-Claude models.
 
+**`provider.maxOutputTokens`** — per-request output cap (`max_tokens`, or the
+configured `maxTokensParam`). The default is protocol-aware since v0.57.0:
+**128000 on `openai-chat`** (the previous global 8192 starved agentic turns on
+large-output gateway models), 8192 on `anthropic` (that API 400s a cap above
+the model's ceiling and no per-model table is bundled). A gateway/model whose
+ceiling is below the cap rejects the request with a clear `APIStatusError`
+(HTTP 400, the server's own message preserved, not retried) — set the value
+explicitly to match your endpoint. Cross-protocol caveat: a transport-switched
+subagent (`resolveSubagentTransport`) inherits the parent's resolved cap, so an
+openai-chat parent on the 128000 default routing a child to an Anthropic-route
+Claude model will get that clear 400 — pass an explicit `maxOutputTokens`
+when mixing protocols.
+
 ## Translation map
 
 | Messages API | Chat Completions |

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/config-builder.ts
+++ b/projects/silver-core-sdk/src/engine/config-builder.ts
@@ -33,7 +33,17 @@ import {
   normalizeOutputFormat,
 } from './structured-output.js';
 
-const DEFAULT_MAX_OUTPUT_TOKENS = 8192;
+/** Default per-request output-token cap, BY WIRE PROTOCOL (BPT ruling
+ *  2026-07-14). The Anthropic default stays conservative: that API 400s a
+ *  max_tokens above the model's output ceiling (e.g. claude-sonnet-4-5 caps
+ *  at 64000) and no public per-model output table is bundled, so 8192 keeps
+ *  default sessions safe. The openai-chat default is 128000: agentic turns
+ *  on large-output gateway models were starved at 8192, and a gateway/model
+ *  with a lower ceiling rejects with a clear surfaced APIStatusError (see
+ *  the transport-openai boundary tests) rather than failing silently.
+ *  `provider.maxOutputTokens` overrides either default. */
+const DEFAULT_MAX_OUTPUT_TOKENS_ANTHROPIC = 8192;
+const DEFAULT_MAX_OUTPUT_TOKENS_OPENAI_CHAT = 128_000;
 
 export type BuiltEngineConfig = {
   /** Mutable engine config shared across turns (setModel etc. mutate it live). */
@@ -215,7 +225,11 @@ export function buildEngineConfig(args: {
   const engineConfig: EngineConfig = {
     model: initialModel,
     fallbackModel: options.fallbackModel,
-    maxOutputTokens: options.provider?.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+    maxOutputTokens:
+      options.provider?.maxOutputTokens ??
+      (options.provider?.protocol === 'openai-chat'
+        ? DEFAULT_MAX_OUTPUT_TOKENS_OPENAI_CHAT
+        : DEFAULT_MAX_OUTPUT_TOKENS_ANTHROPIC),
     systemPrompt: systemPromptStable,
     // Volatile (cwd) tail rides after the cache breakpoint; absent -> the
     // stable prompt is sent as a single string (e.g. a user-string prompt).

--- a/projects/silver-core-sdk/src/query.ts
+++ b/projects/silver-core-sdk/src/query.ts
@@ -100,7 +100,6 @@ import { createAgentTool } from './subagents/agent-tool.js';
 import { loadProjectMcpServers } from './mcp/project-config.js';
 
 const DEFAULT_MODEL = 'claude-sonnet-4-5';
-const DEFAULT_MAX_OUTPUT_TOKENS = 8192;
 /** S3 tool-call record: cap on the persisted input JSON (the full input lives
  *  in the assistant message's tool_use block with the same tool_use_id). */
 const TOOL_RECORD_INPUT_MAX_CHARS = 2048;

--- a/projects/silver-core-sdk/src/types.ts
+++ b/projects/silver-core-sdk/src/types.ts
@@ -61,7 +61,8 @@ export type ModelUsage = {
   /**
    * Max output tokens in force for requests to this model (REQUIRED on the
    * official surface). This engine reports the ACTUAL per-request `max_tokens`
-   * cap it sends (provider.maxOutputTokens ?? 8192) — an honest runtime value,
+   * cap it sends (provider.maxOutputTokens, defaulting by protocol: 8192 on
+   * 'anthropic', 128000 on 'openai-chat') — an honest runtime value,
    * NOT the model's theoretical output ceiling (no public per-model
    * max-output table is bundled). Optional during the transition (same
    * subagent-ledger caveat as contextWindow).
@@ -1099,6 +1100,18 @@ export type ProviderConfig = {
    * source); no credential rides the probe.
    */
   preconnect?: boolean;
+  /**
+   * Per-request output-token cap (`max_tokens` / the configured
+   * maxTokensParam on the wire). Default is protocol-aware: 8192 on
+   * 'anthropic' (that API 400s a cap above the model's output ceiling and no
+   * per-model table is bundled), 128000 on 'openai-chat' (BPT ruling
+   * 2026-07-14 — agentic turns on large-output gateway models were starved
+   * at 8192). A model/gateway whose ceiling is lower rejects the request
+   * with a clear surfaced APIStatusError; set this explicitly to match your
+   * endpoint. Note: compaction budgets derive from `contextWindow -
+   * maxOutputTokens`, so a cap at/above the model's context window disables
+   * compaction (logged, not silent).
+   */
   maxOutputTokens?: number;
   /** Automatic prompt caching via cache_control breakpoints; default true. */
   promptCaching?: boolean;

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.56.0';
+export const SDK_VERSION = '0.57.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/max-output-tokens-default.test.ts
+++ b/projects/silver-core-sdk/tests/max-output-tokens-default.test.ts
@@ -1,0 +1,150 @@
+/**
+ * maxOutputTokens: protocol-aware default + boundary behavior (BPT ruling
+ * 2026-07-14). The openai-chat default rises 8192 -> 128000 (agentic turns on
+ * large-output gateway models were starved); the anthropic default stays 8192
+ * (that API 400s a cap above the model's output ceiling and no per-model
+ * table is bundled). provider.maxOutputTokens overrides either default.
+ * Boundary: 128000 is sendable on the wire; a gateway whose model caps lower
+ * rejects with a CLEAR surfaced APIStatusError (server message preserved,
+ * no retry on 400).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildEngineConfig } from '../src/engine/config-builder.js';
+import { OpenAIChatTransport } from '../src/transport/openai.js';
+import { APIStatusError } from '../src/errors.js';
+import type { Options } from '../src/types.js';
+
+const noop = (): void => {};
+
+function engineConfigOf(options: Options) {
+  return buildEngineConfig({
+    options,
+    cwd: '/tmp/proj',
+    initialModel: 'claude-sonnet-4-5',
+    builtinToolNames: ['Read', 'Grep'],
+    debug: noop,
+  }).engineConfig;
+}
+
+describe('maxOutputTokens protocol-aware default', () => {
+  it('defaults to 8192 with no provider config (anthropic path unchanged)', () => {
+    expect(engineConfigOf({}).maxOutputTokens).toBe(8192);
+  });
+
+  it("defaults to 8192 on protocol 'anthropic'", () => {
+    expect(
+      engineConfigOf({ provider: { protocol: 'anthropic' } }).maxOutputTokens,
+    ).toBe(8192);
+  });
+
+  it("defaults to 128000 on protocol 'openai-chat'", () => {
+    expect(
+      engineConfigOf({ provider: { protocol: 'openai-chat' } }).maxOutputTokens,
+    ).toBe(128_000);
+  });
+
+  it('provider.maxOutputTokens overrides the openai-chat default', () => {
+    expect(
+      engineConfigOf({
+        provider: { protocol: 'openai-chat', maxOutputTokens: 4096 },
+      }).maxOutputTokens,
+    ).toBe(4096);
+  });
+
+  it('provider.maxOutputTokens overrides the anthropic default too (either direction)', () => {
+    expect(
+      engineConfigOf({
+        provider: { protocol: 'anthropic', maxOutputTokens: 128_000 },
+      }).maxOutputTokens,
+    ).toBe(128_000);
+  });
+});
+
+describe('maxOutputTokens wire boundary (openai-chat)', () => {
+  it('sends max_tokens: 128000 on the wire (and renames via maxTokensParam)', async () => {
+    const chunks = [
+      {
+        id: 'c1',
+        model: 'big-model',
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'ok' }, finish_reason: null }],
+      },
+      {
+        id: 'c1',
+        model: 'big-model',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      },
+    ];
+    const sse =
+      chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join('') + 'data: [DONE]\n\n';
+    const injected = vi.fn(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'content-type': 'text/event-stream' } }),
+    );
+    const transport = new OpenAIChatTransport({
+      provider: {
+        protocol: 'openai-chat',
+        apiKey: 'k',
+        fetch: injected,
+        openai: { maxTokensParam: 'max_completion_tokens' },
+      },
+      env: {},
+      debug: noop,
+    });
+    for await (const _ of transport.stream({
+      model: 'big-model',
+      max_tokens: 128_000,
+      messages: [{ role: 'user', content: 'hi' }],
+    })) {
+      // drain
+    }
+    const body = JSON.parse(String(injected.mock.calls[0]![1]!.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(body.max_completion_tokens).toBe(128_000);
+    expect(body).not.toHaveProperty('max_tokens');
+  });
+
+  it('surfaces a gateway over-limit rejection as a clear, non-retried APIStatusError', async () => {
+    const gatewayMessage =
+      'max_tokens is too large: 128000. This model supports at most 16384 completion tokens.';
+    const injected = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { message: gatewayMessage, type: 'invalid_request_error', code: null },
+          }),
+          { status: 400, headers: { 'content-type': 'application/json' } },
+        ),
+    );
+    const transport = new OpenAIChatTransport({
+      provider: { protocol: 'openai-chat', apiKey: 'k', fetch: injected },
+      env: {},
+      debug: noop,
+    });
+    let caught: unknown;
+    try {
+      for await (const _ of transport.stream({
+        model: 'small-model',
+        max_tokens: 128_000,
+        messages: [{ role: 'user', content: 'hi' }],
+      })) {
+        // drain
+      }
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(APIStatusError);
+    const err = caught as APIStatusError;
+    expect(err.status).toBe(400);
+    expect(err.errorType).toBe('invalid_request_error');
+    // The gateway's own explanation must reach the caller verbatim — this is
+    // the "clear error above the model/gateway ceiling" contract.
+    expect(err.message).toContain('supports at most 16384');
+    // 400 is not retryable: exactly one POST.
+    expect(injected).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
BPT ruling 2026-07-14: `DEFAULT_MAX_OUTPUT_TOKENS = 8192` rode onto every OpenAI-compatible request as `max_tokens: 8192`, starving agentic turns on large-output gateway models.

**Change** — the default is now protocol-aware:
- `openai-chat`: **128000**
- `anthropic`: 8192 unchanged (the Anthropic API 400s a `max_tokens` above the model's output ceiling — claude-sonnet-4-5 caps at 64000 — and no per-model output table is bundled, so a blanket 128000 would kill default Claude sessions on turn 1)
- `provider.maxOutputTokens` overrides either default, both directions (request-level override preserved)

**Boundary tests** (`tests/max-output-tokens-default.test.ts`, 7 cases): default derivation per protocol + override precedence; 128000 sendable on the wire (incl. `maxTokensParam` rename); a gateway whose model caps lower surfaces a clear `APIStatusError` (HTTP 400, `invalid_request_error`, server message verbatim, exactly one POST — 400 never retried).

Also: removed the dead duplicate `DEFAULT_MAX_OUTPUT_TOKENS` in query.ts; documented the cross-protocol subagent caveat (OPENAI-PROTOCOL.md) — pass explicit `maxOutputTokens` when mixing protocols.

**Verification (in-conversation)**: vitest 2254 passed / 2 skipped; repo pytest 2955 passed / 4 skipped; `tsc --noEmit` clean; version guard green; `npm pack` → `silver-core-sdk-0.57.0.tgz` (448 files).

Version 0.56.0 → **0.57.0** (minor). BPT's explicit 128000 keeps working and becomes redundant on openai-chat once pinned to this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yk8QVwC8TSPY95rdEDsjc

---
_Generated by [Claude Code](https://claude.ai/code/session_014yk8QVwC8TSPY95rdEDsjc)_