### PR TITLE
feat(sdk): unified upstream-error normalization — no bare 500s穿透 to host (v0.57.1)

### DIFF
--- a/projects/silver-core-sdk/.gitignore
+++ b/projects/silver-core-sdk/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 dist/
+# npm pack tarballs are build artifacts shipped to 黑池 (BPT pins them); never
+# commit them — an 865 KB blob would trip the pre-push fat-pack firewall.
+*.tgz
 *.tsbuildinfo
 .vitest-cache/
 conformance-l1.json

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,53 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.57.1 — 2026-07-14
+
+**Unified upstream-error normalization: no more bare 500s穿透ing to the host
+(BPT P1, keeper ruling 2026-07-14).** BPT saw a raw
+`{ error: { message: "Internal server error", code: null, status: 500 } }`
+object reach the host un-classified — it bypassed the retry / error chain, so
+the user got an opaque 500 with no way to tell provider, retryability, or
+request id. Root cause: the Anthropic arm's SSE error detector only recognized
+the native `type: 'error'` frame, so a gateway that wrapped the failure as a
+bare top-level `{ error: {...} }` / `{ message, status }` data frame (no
+`event: error` name, no `type` discriminator) was neither caught as an error
+nor a valid stream event — it穿透ed. New unified layer
+(`src/error-normalize.ts`):
+
+- **`NormalizedProviderError`** — one STABLE shape every upstream failure maps
+  to: `name`, `message` (readable, never `[object Object]`), `status`, `code`,
+  `provider`, `model`, `requestId`, `retryable`, `retryAfterMs`, `phase`,
+  `rawType`. `normalizeProviderError()` maps an `APIStatusError`,
+  `APIConnectionError`, a bare gateway error object, a plain `Error`, or an
+  opaque value; `normalizeRetry()` builds one for a retry-in-progress.
+- **Detection widened** — both transports now recognize the wrapped
+  `{ error: {...} }` and bare `{ message, status }` shapes (`looksLikeErrorObject`
+  cannot swallow a real stream event: those always carry a known `type`).
+- **Richer extraction** — `APIStatusError` gained `providerErrorCode` +
+  `retryAfterMs`; transports lift `code` / `status` / `request_id` from the body
+  (accepting `request_id` / `requestId` / `x-request-id` / `X-Request-Id`
+  spellings, header preferred), for the Anthropic Messages API, the
+  OpenAI-compatible Chat Completions protocol, SSE in-stream error frames, and
+  non-streaming HTTP paths alike.
+- **Retry policy** (status-based, so it never string-matches "quota"/
+  "allocation" to force a non-retry): 408/429 and every 5xx retryable; other
+  4xx (400/401/403/404/…) not. `APIConnectionError` honors the existing
+  replay-safe contract (a started stream is not blind-retried).
+- **Host surfaces** — the `error_during_execution` result, the `api_retry`
+  message (now also carrying `retryable` / `retry_remaining` / `retry_reason`),
+  and the `rate_limit_event` all carry `providerError`. A 500 with no assistant
+  content is surfaced as an error, never a silent empty success.
+- **Redaction (硬约束)** — the normalized message is bounded (2 KB) and scrubs
+  API keys / Bearer tokens / Authorization; the raw error object is never
+  attached.
+
+Additive-only (drop-in surface gains fields, never changes existing ones).
+New tests: 24 normalizer unit + 11 transport/end-to-end integration; the two
+mandated integration shapes (JSON `{error:{…,request_id:"test-500"}}` and
+`text/plain` 500) both assert the host gets `status: 500` / readable message /
+`retryable: true` / `requestId` / an explicit error event.
+
 ## 0.57.0 — 2026-07-14
 
 **openai-chat default maxOutputTokens 8192 -> 128000 (BPT ruling 2026-07-14).**

--- a/projects/silver-core-sdk/docs/ARCHITECTURE.md
+++ b/projects/silver-core-sdk/docs/ARCHITECTURE.md
@@ -18,8 +18,9 @@ genuinely internal or leaked material is used.
 1. **Language**: TypeScript strict, ESM (`module: NodeNext`). Relative imports
    MUST use the `.js` suffix (`import { x } from '../types.js'`).
 2. **Imports**: a module may import from `src/types.ts`, `src/errors.ts`,
-   `src/version.ts`, anything under `src/internal/` (the shared kernel),
-   Node builtins (`node:` prefix), `zod`, `fast-glob`, and files it owns.
+   `src/version.ts`, `src/error-normalize.ts`, anything under `src/internal/`
+   (the shared kernel), Node builtins (`node:` prefix), `zod`, `fast-glob`, and
+   files it owns.
    Cross-module imports beyond that are allowed ONLY along the directed
    edges in the **Import edges** table below — which
    `tests/import-discipline.test.ts` parses and enforces, the same
@@ -54,7 +55,7 @@ richer internal/ without the map following.)
 | I sandbox | `sandbox/` (backend, bwrap, evidence) | `SandboxBackend`; consumed by tools |
 | J generators | `generators/` (utility LLM runtime + prompts) | single-shot utility calls; consumed by hooks (condition), tips, verifier |
 | K tips + verifier | `tips/`, `verifier/` | context-tip / adversarial-verify features over generators |
-| shared kernel | `internal/` (contracts, model-alias, worktree, setting-sources), `types.ts`, `errors.ts`, `version.ts` | importable by every module |
+| shared kernel | `internal/` (contracts, model-alias, worktree, setting-sources), `types.ts`, `errors.ts`, `version.ts`, `error-normalize.ts` | importable by every module |
 
 ## Import edges
 

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/config-builder.ts
+++ b/projects/silver-core-sdk/src/engine/config-builder.ts
@@ -225,6 +225,9 @@ export function buildEngineConfig(args: {
   const engineConfig: EngineConfig = {
     model: initialModel,
     fallbackModel: options.fallbackModel,
+    // Provider label for normalized errors: map the wire protocol to a stable
+    // backend name a host can branch on ('openai-chat' -> 'openai').
+    providerLabel: options.provider?.protocol === 'openai-chat' ? 'openai' : 'anthropic',
     maxOutputTokens:
       options.provider?.maxOutputTokens ??
       (options.provider?.protocol === 'openai-chat'

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -13,6 +13,11 @@ import {
   errorCodeOf,
   isAbortError,
 } from '../errors.js';
+import {
+  normalizeProviderError,
+  normalizeRetry,
+  type NormalizedProviderError,
+} from '../error-normalize.js';
 import type {
   APIAssistantMessage,
   APIMessageParam,
@@ -368,6 +373,12 @@ export async function* runAgentLoop(
     // CODE rather than by parsing errorMessage. Absent for non-SDK / codeless
     // failures. Additive; does not touch the request wire.
     errorCode?: string,
+    // Unified normalized upstream error (error normalization 2026-07-14): a
+    // stable, host-consumable shape so BPT can read status/code/provider/model/
+    // requestId/retryable without parsing errorMessage or duck-typing the raw
+    // error. Present only when the run ended on an actual provider/transport
+    // failure (the outer catch); absent for max-turns/budget/refusal stops.
+    providerError?: NormalizedProviderError,
   ): SDKResultMessage => ({
     type: 'result',
     subtype,
@@ -378,6 +389,7 @@ export async function* runAgentLoop(
     stop_reason: lastStopReason,
     ...(apiErrorStatus !== undefined ? { api_error_status: apiErrorStatus } : {}),
     ...(errorCode !== undefined ? { error_code: errorCode } : {}),
+    ...(providerError !== undefined ? { providerError } : {}),
     ...resultBase(),
     // Official-surface parallel: the reference SDK reports error text as a
     // string[]. Placed AFTER the resultBase spread so the fatal message wins
@@ -662,6 +674,15 @@ export async function* runAgentLoop(
         transportHealth.httpRetries += 1;
       }
       const base = { uuid: randomUUID(), session_id: config.sessionId };
+      // Unified normalized error for THIS retry (error normalization 2026-07-14):
+      // a retry proves the failure was retryable, so it carries a full
+      // NormalizedProviderError (provider/model/status/code/requestId) on both
+      // the rate_limit_event and api_retry arms — the host reads one shape.
+      const providerError = normalizeRetry(info, {
+        provider: config.providerLabel,
+        model: useModel,
+      });
+      const retryRemaining = Math.max(0, info.maxRetries - info.attempt);
       if (info.status === 429) {
         retryMessages.push({
           type: 'rate_limit_event',
@@ -678,6 +699,7 @@ export async function* runAgentLoop(
           // Deprecated dual-track flat fields, still populated.
           retry_after_ms: info.retryAfterMs ?? 0,
           limit_type: 'api',
+          providerError,
         });
       } else {
         retryMessages.push({
@@ -687,6 +709,19 @@ export async function* runAgentLoop(
           max_retries: info.maxRetries,
           ...(info.status !== undefined ? { status: info.status } : {}),
           ...(info.errorType !== undefined ? { reason: info.errorType } : {}),
+          // Additive unified-error fields (do not break existing consumers).
+          retryable: true,
+          retry_remaining: retryRemaining,
+          retry_reason:
+            info.errorType ??
+            (info.kind === 'empty_stream'
+              ? 'empty_stream'
+              : info.kind === 'network'
+                ? 'network'
+                : info.status !== undefined
+                  ? `http_${info.status}`
+                  : 'retry'),
+          providerError,
         });
       }
     };
@@ -1024,6 +1059,13 @@ export async function* runAgentLoop(
               attempt: replayN,
               max_retries: TURN_REPLAY_LIMIT,
               reason: `turn_replay:${err.code}`,
+              retryable: true,
+              retry_remaining: turnReplaysLeft,
+              retry_reason: `turn_replay:${err.code}`,
+              providerError: normalizeProviderError(err, {
+                provider: config.providerLabel,
+                model,
+              }),
             };
             await replayBackoff(replayN, signal);
             // A mid-run setModel()/latched fallback applies to the replay too.
@@ -1558,10 +1600,25 @@ export async function* runAgentLoop(
     }
   } catch (err) {
     if (isAbortError(err)) throw toAbortError(err);
-    const message = err instanceof Error ? err.message : String(err);
-    deps.debug(`engine: error during execution: ${message}`);
-    const apiStatus = err instanceof APIStatusError ? err.status : undefined;
-    yield errorResult('error_during_execution', message, apiStatus, errorCodeOf(err));
+    // Unified normalization: map ANY thrown upstream failure — an APIStatusError,
+    // an APIConnectionError, or a bare gateway error object that穿透ed
+    // un-classified — into a stable NormalizedProviderError so the host never
+    // receives a raw object or an opaque exception. The readable normalized
+    // message is the surfaced errorMessage (never [object Object]).
+    const providerError = normalizeProviderError(err, {
+      provider: config.providerLabel,
+      model: fallbackModel ?? config.model,
+    });
+    deps.debug(`engine: error during execution: ${providerError.message}`);
+    const apiStatus =
+      err instanceof APIStatusError ? err.status : providerError.status;
+    yield errorResult(
+      'error_during_execution',
+      providerError.message,
+      apiStatus,
+      errorCodeOf(err),
+      providerError,
+    );
     return;
   }
 }

--- a/projects/silver-core-sdk/src/error-normalize.ts
+++ b/projects/silver-core-sdk/src/error-normalize.ts
@@ -1,0 +1,390 @@
+/**
+ * Silver Core SDK — unified upstream-error normalization (BPT P1, keeper ruling
+ * 2026-07-14).
+ *
+ * PROBLEM this closes: a gateway that wraps an upstream failure as a TOP-LEVEL
+ *   { error: { message, code, status } }
+ * (no `type: 'error'` discriminator, no SSE `event: error` name) slipped past
+ * the Anthropic arm's `type === 'error'` error detector — it was neither
+ * recognized as an error NOR a valid stream event, so the raw object穿透ed to
+ * the host, bypassing BPT's retry / error chain. The host saw a bare 500 with
+ * no way to tell provider, retryability, or request id.
+ *
+ * This module is the ONE place that turns ANY upstream failure shape — an
+ * `APIStatusError`, an `APIConnectionError`, a gateway error object, a plain
+ * `Error`, or an opaque value — into a STABLE `NormalizedProviderError` the
+ * host can consume without parsing English or duck-typing raw objects.
+ *
+ * REDACTION (硬约束): the normalized error carries only a de-identified
+ * diagnostic summary — never an API key, Authorization header, request body,
+ * image bytes, or a full response dump. `message` is the upstream error text
+ * (bounded + scrubbed); the raw error object is NOT attached.
+ */
+
+import {
+  APIConnectionError,
+  APIStatusError,
+  AbortError,
+  errorCodeOf,
+} from './errors.js';
+
+/**
+ * The stable, host-consumable shape every upstream failure normalizes to.
+ * Additive surface: fields are only ever appended, never renamed/removed.
+ */
+export interface NormalizedProviderError {
+  /** Error class / family name (e.g. 'APIStatusError', 'APIConnectionError'). */
+  name: string;
+  /** Human-readable text. NEVER `[object Object]` — objects are summarized. */
+  message: string;
+  /** HTTP status extracted from the response or the error object, when known. */
+  status?: number;
+  /** Machine-readable provider error code (e.g. 'rate_limit_error'), when known. */
+  code?: string;
+  /** Provider / protocol label ('anthropic' | 'openai' | ...), when known. */
+  provider?: string;
+  /** Model in play when the failure occurred, when known. */
+  model?: string;
+  /** Upstream request id (body `request_id`/`requestId` or `x-request-id` header). */
+  requestId?: string;
+  /** Whether re-issuing is safe per the default retry policy (see isRetryableHttpStatus). */
+  retryable: boolean;
+  /** Server-requested wait before retrying (Retry-After), when present. */
+  retryAfterMs?: number;
+  /** Where in the request lifecycle the failure surfaced. */
+  phase?: 'request' | 'stream' | 'response' | 'transport';
+  /** The SDK-internal error code / raw type slug, for diagnostics. */
+  rawType?: string;
+}
+
+/** Optional context the caller (engine) can supply to enrich the summary. */
+export interface NormalizeContext {
+  provider?: string;
+  model?: string;
+  /** Extra request-id source (e.g. a response header) when the error omits one. */
+  requestId?: string;
+  phase?: NormalizedProviderError['phase'];
+}
+
+/**
+ * Default HTTP retryability policy (keeper table 2026-07-14):
+ *   - 408 (request timeout) and 429 (rate limit) → retryable
+ *   - any 5xx (500/502/503/504/…) → retryable (treated as a TRANSIENT provider
+ *     fault; the engine's replay-safe rules still gate whether an ALREADY-started
+ *     turn may be replayed — this only says "the status class is retryable")
+ *   - every other 4xx (400/401/403/404/422/…) → NOT retryable
+ * Deliberately status-based: it never string-matches "quota"/"allocation" to
+ * force a non-retry, so a rate-limit (429) stays retryable and is not mistaken
+ * for a terminal key/permission failure.
+ */
+export function isRetryableHttpStatus(status: number): boolean {
+  if (status === 408 || status === 429) return true;
+  return status >= 500 && status < 600;
+}
+
+/** Redact common secret shapes from a diagnostic string (defensive). Upstream
+ *  error messages should not carry credentials, but a gateway that echoes a
+ *  request header could; scrub before the text leaves this layer. */
+function redact(text: string): string {
+  return text
+    // Bearer / Basic auth tokens.
+    .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._\-+/=]+/gi, '$1 [REDACTED]')
+    // Provider API-key shapes (sk-..., sk-ant-..., and generic long key tails).
+    .replace(/\bsk-[A-Za-z0-9_\-]{6,}/g, 'sk-[REDACTED]')
+    // x-api-key: <value> style leaks.
+    .replace(/(x-api-key|api[_-]?key|authorization)(["']?\s*[:=]\s*["']?)[^\s"',}]+/gi,
+      '$1$2[REDACTED]');
+}
+
+/** Bound a message so a giant HTML/JSON error page cannot bloat the surface. */
+function boundMessage(text: string): string {
+  const trimmed = text.trim();
+  const scrubbed = redact(trimmed);
+  return scrubbed.length > 2_000 ? `${scrubbed.slice(0, 2_000)}…` : scrubbed;
+}
+
+/** Pull a numeric HTTP status out of an arbitrary error-ish object. */
+function pickStatus(obj: Record<string, unknown>): number | undefined {
+  const candidates = [obj.status, obj.statusCode, obj.status_code, obj.code];
+  for (const c of candidates) {
+    if (typeof c === 'number' && Number.isFinite(c) && c >= 100 && c < 600) return c;
+  }
+  return undefined;
+}
+
+/** Pull a machine code slug out of an arbitrary error-ish object. A numeric
+ *  `code` (some gateways put the HTTP status there) is NOT a slug. */
+function pickCode(obj: Record<string, unknown>): string | undefined {
+  const raw = obj.code ?? obj.type ?? obj.error_code;
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+/** Request-id under any of the accepted spellings, top-level or nested. */
+function pickRequestId(obj: Record<string, unknown>): string | undefined {
+  const keys = ['request_id', 'requestId', 'x-request-id', 'X-Request-Id'];
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
+}
+
+/**
+ * Extract the salient fields from a gateway/provider ERROR OBJECT — either the
+ * wrapped `{ error: { message, code, status, request_id } }` form or the bare
+ * top-level `{ message, status, code, request_id }` form. Returns null when the
+ * value is not a recognizable error object.
+ */
+export function extractProviderErrorObject(value: unknown): {
+  message: string;
+  status?: number;
+  code?: string;
+  requestId?: string;
+} | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const top = value as Record<string, unknown>;
+  // Prefer the nested `error` envelope when present.
+  const nested =
+    typeof top.error === 'object' && top.error !== null
+      ? (top.error as Record<string, unknown>)
+      : undefined;
+
+  const messageSrc = nested?.message ?? top.message;
+  // A bare object with neither a message nor an error envelope is not one of the
+  // error shapes we own — let the caller fall back to its own handling.
+  if (nested === undefined && typeof messageSrc !== 'string') return null;
+
+  const message =
+    typeof messageSrc === 'string'
+      ? messageSrc
+      : nested !== undefined
+        ? // Nested error object with a non-string message: stringify the error
+          // envelope (bounded + secret-scrubbed by boundMessage below), matching
+          // the historical extractErrorPayload behavior.
+          JSON.stringify(nested)
+        : JSON.stringify(top);
+
+  const status = (nested && pickStatus(nested)) ?? pickStatus(top);
+  const code = (nested && pickCode(nested)) ?? pickCode(top);
+  const requestId = (nested && pickRequestId(nested)) ?? pickRequestId(top);
+
+  const out: {
+    message: string;
+    status?: number;
+    code?: string;
+    requestId?: string;
+  } = { message: boundMessage(message) };
+  if (status !== undefined) out.status = status;
+  if (code !== undefined) out.code = code;
+  if (requestId !== undefined) out.requestId = requestId;
+  return out;
+}
+
+/** A compact, de-identified one-liner for an object that has no usable message
+ *  — reports only its shape (top-level keys), never its values. */
+function summarizeObject(obj: Record<string, unknown>): string {
+  const keys = Object.keys(obj).slice(0, 12).join(', ');
+  return `provider error object {${keys}}`;
+}
+
+/** True when `value` is a raw error object shape (used at detection sites to
+ *  recognize a gateway error that carries no `type: 'error'` discriminator and
+ *  no SSE `event: error` name). */
+export function looksLikeErrorObject(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  // Nested { error: {...} } envelope.
+  if (typeof obj.error === 'object' && obj.error !== null) return true;
+  // Bare { message, status } with no stream-event `type` (real stream events
+  // ALWAYS carry a known `type` discriminator, so this cannot swallow one).
+  return (
+    obj.type === undefined &&
+    typeof obj.message === 'string' &&
+    typeof pickStatus(obj) === 'number'
+  );
+}
+
+/** Retryability for an APIConnectionError, honoring the existing replay-safe
+ *  contract (a turn that already started streaming is NOT freely replayable). */
+function connectionRetryable(err: APIConnectionError): boolean {
+  if (err.turnReplaySafe === true) return true;
+  if (err.midStreamTruncation === true) return false;
+  switch (err.code) {
+    case 'api_connection_failed':
+    case 'stream_idle_timeout':
+    case 'empty_stream':
+      return true;
+    // A started stream that produced nothing usable, a corrupt frame, or a
+    // hard-cap cut is NOT safe to blind-retry here.
+    case 'sse_malformed_frame':
+    case 'empty_message':
+    case 'stream_max_duration':
+      return false;
+    default:
+      return true;
+  }
+}
+
+function connectionPhase(err: APIConnectionError): NormalizedProviderError['phase'] {
+  // A truncation / mid-stream drop happened DURING streaming regardless of the
+  // class-default code; only a pre-stream connect failure is 'transport'.
+  if (err.midStreamTruncation === true) return 'stream';
+  return err.code === 'api_connection_failed' ? 'transport' : 'stream';
+}
+
+/**
+ * Normalize ANY thrown upstream failure into a `NormalizedProviderError`.
+ * Never throws; always returns a fully-formed object with a readable message.
+ */
+export function normalizeProviderError(
+  err: unknown,
+  ctx: NormalizeContext = {},
+): NormalizedProviderError {
+  const base = (over: Partial<NormalizedProviderError>): NormalizedProviderError => {
+    const out: NormalizedProviderError = {
+      name: over.name ?? 'ProviderError',
+      message: over.message ?? 'Unknown provider error',
+      retryable: over.retryable ?? false,
+    };
+    const status = over.status ?? undefined;
+    const code = over.code ?? undefined;
+    const requestId = over.requestId ?? ctx.requestId;
+    const provider = over.provider ?? ctx.provider;
+    const model = over.model ?? ctx.model;
+    const retryAfterMs = over.retryAfterMs;
+    const phase = over.phase ?? ctx.phase;
+    const rawType = over.rawType;
+    if (status !== undefined) out.status = status;
+    if (code !== undefined) out.code = code;
+    if (provider !== undefined) out.provider = provider;
+    if (model !== undefined) out.model = model;
+    if (requestId !== undefined) out.requestId = requestId;
+    if (retryAfterMs !== undefined) out.retryAfterMs = retryAfterMs;
+    if (phase !== undefined) out.phase = phase;
+    if (rawType !== undefined) out.rawType = rawType;
+    return out;
+  };
+
+  // 1) Non-2xx / in-stream provider status error — the richest source.
+  if (err instanceof APIStatusError) {
+    return base({
+      name: err.name,
+      message: boundMessage(err.message),
+      status: err.status,
+      // Prefer the body's own code slug (E6c providerErrorCode) over the
+      // Anthropic-vocabulary errorType the transport normalized to.
+      code: err.providerErrorCode ?? err.errorType,
+      requestId: err.requestId,
+      retryable: isRetryableHttpStatus(err.status),
+      retryAfterMs: err.retryAfterMs,
+      phase: 'response',
+      rawType: err.errorType,
+    });
+  }
+
+  // 2) Transport / stream connection failure.
+  if (err instanceof APIConnectionError) {
+    return base({
+      name: err.name,
+      message: boundMessage(err.message),
+      code: err.code,
+      retryable: connectionRetryable(err),
+      phase: connectionPhase(err),
+      rawType: err.code,
+    });
+  }
+
+  // 3) Abort — a caller cancellation, not an upstream fault; never retryable.
+  if (err instanceof AbortError || (err instanceof Error && err.name === 'AbortError')) {
+    return base({
+      name: 'AbortError',
+      message: boundMessage(err instanceof Error ? err.message : 'The operation was aborted'),
+      retryable: false,
+      phase: 'request',
+      rawType: 'aborted',
+    });
+  }
+
+  // 4) A raw gateway error object that reached us un-classified (the穿透 case).
+  const obj = extractProviderErrorObject(err);
+  if (obj !== null) {
+    const status = obj.status;
+    return base({
+      name: 'ProviderError',
+      message: obj.message,
+      status,
+      code: obj.code,
+      requestId: obj.requestId,
+      retryable: status !== undefined ? isRetryableHttpStatus(status) : false,
+      phase: 'response',
+      rawType: 'provider_error_object',
+    });
+  }
+
+  // 5) A plain Error with no upstream shape.
+  if (err instanceof Error) {
+    return base({
+      name: err.name || 'Error',
+      message: boundMessage(err.message || String(err)),
+      retryable: false,
+      rawType: errorCodeOf(err),
+    });
+  }
+
+  // 6) Anything else (string / number / null) — summarized, never bare-cast.
+  return base({
+    name: 'ProviderError',
+    message: boundMessage(typeof err === 'string' ? err : summarizeObject(Object(err))),
+    retryable: false,
+  });
+}
+
+/** Source fields carried on a retry observation, mirrored from the transport's
+ *  `RetryInfo` so a retry event can carry a full `NormalizedProviderError`. */
+export interface RetryLike {
+  status?: number;
+  code?: string;
+  message?: string;
+  requestId?: string;
+  retryAfterMs?: number;
+  kind?: 'network' | 'http_status' | 'empty_stream';
+}
+
+/**
+ * Build a `NormalizedProviderError` for a RETRY that is about to happen (the
+ * transport signaled it via onRetry, before the next attempt). The retry itself
+ * proves the failure was retryable, so `retryable` is true here regardless of
+ * status class.
+ */
+export function normalizeRetry(
+  info: RetryLike,
+  ctx: NormalizeContext = {},
+): NormalizedProviderError {
+  const name =
+    info.kind === 'network'
+      ? 'APIConnectionError'
+      : info.kind === 'empty_stream'
+        ? 'APIConnectionError'
+        : 'APIStatusError';
+  const out: NormalizedProviderError = {
+    name,
+    message:
+      info.message !== undefined && info.message.length > 0
+        ? boundMessage(info.message)
+        : info.status !== undefined
+          ? `HTTP ${info.status} (retrying)`
+          : info.kind === 'empty_stream'
+            ? 'Empty stream (retrying)'
+            : 'Connection failure (retrying)',
+    retryable: true,
+    phase: info.kind === 'http_status' ? 'response' : 'transport',
+  };
+  if (info.status !== undefined) out.status = info.status;
+  if (info.code !== undefined) out.code = info.code;
+  if (info.retryAfterMs !== undefined) out.retryAfterMs = info.retryAfterMs;
+  const requestId = info.requestId ?? ctx.requestId;
+  if (requestId !== undefined) out.requestId = requestId;
+  if (ctx.provider !== undefined) out.provider = ctx.provider;
+  if (ctx.model !== undefined) out.model = ctx.model;
+  return out;
+}

--- a/projects/silver-core-sdk/src/errors.ts
+++ b/projects/silver-core-sdk/src/errors.ts
@@ -113,18 +113,41 @@ export class APIConnectionError extends Error {
   }
 }
 
-/** Non-2xx response from the Messages API. */
+/** Non-2xx response from the Messages API (or an in-stream error frame). */
 export class APIStatusError extends Error {
   override name = 'APIStatusError';
   readonly code: ErrorCode = 'api_status_error';
+  /**
+   * The provider/gateway's OWN machine code slug when the error body carried
+   * one — e.g. a gateway `{ error: { code: 'model_overloaded' } }`. Distinct
+   * from `errorType` (the Anthropic-vocabulary type the transport normalizes
+   * to) and from `code` (this SDK's stable ErrorCode). Append-only field; the
+   * error-normalization layer prefers it over `errorType` when present.
+   */
+  readonly providerErrorCode?: string;
+  /**
+   * Milliseconds the server asked us to wait before retrying (parsed
+   * Retry-After), carried onto the terminal error so the normalized error can
+   * surface `retryAfterMs` even after the transport's retry budget is spent.
+   */
+  readonly retryAfterMs?: number;
   constructor(
     readonly status: number,
     readonly errorType: string,
     message: string,
-    readonly requestId?: string,
+    requestId?: string,
+    extra?: { providerErrorCode?: string; retryAfterMs?: number },
   ) {
     super(message);
+    this.requestId = requestId;
+    if (extra?.providerErrorCode !== undefined) {
+      this.providerErrorCode = extra.providerErrorCode;
+    }
+    if (extra?.retryAfterMs !== undefined) this.retryAfterMs = extra.retryAfterMs;
   }
+
+  /** Upstream request id (body `request_id`/`requestId` or `x-request-id` header). */
+  readonly requestId?: string;
 }
 
 /** Feature accepted for type compatibility but not implemented in this version. */

--- a/projects/silver-core-sdk/src/index.ts
+++ b/projects/silver-core-sdk/src/index.ts
@@ -247,6 +247,18 @@ export {
   isAbortError,
 } from './errors.js';
 export type { ErrorCode, McpErrorCode, McpPhase, McpTransportKind } from './errors.js';
+export {
+  normalizeProviderError,
+  normalizeRetry,
+  isRetryableHttpStatus,
+  extractProviderErrorObject,
+  looksLikeErrorObject,
+} from './error-normalize.js';
+export type {
+  NormalizedProviderError,
+  NormalizeContext,
+  RetryLike,
+} from './error-normalize.js';
 export type * from './types.js';
 // Official tool input/output schema types (ToolInputSchemas / ToolOutputSchemas
 // and their members) — the drop-in consumer surface for typed tool interactions.

--- a/projects/silver-core-sdk/src/internal/contracts.ts
+++ b/projects/silver-core-sdk/src/internal/contracts.ts
@@ -54,6 +54,13 @@ export type RetryInfo = {
   /** Disconnect-taxonomy class of this retry (resilience P0-2): what kind of
    *  failure triggered it, so the loop can count retries by cause. */
   kind?: 'network' | 'http_status' | 'empty_stream';
+  /** Redacted upstream error message, when the body carried one (error
+   *  normalization 2026-07-14) — lets a retry event carry a readable cause. */
+  message?: string;
+  /** Upstream request id (body or header), when known. */
+  requestId?: string;
+  /** Provider/gateway machine code slug from the error body, when present. */
+  code?: string;
 };
 
 export type StreamRequest = {
@@ -537,6 +544,10 @@ export type SystemComposition = {
 export type EngineConfig = {
   model: string;
   fallbackModel?: string;
+  /** Provider/protocol label ('anthropic' | 'openai') carried onto normalized
+   *  provider errors so a host knows WHICH backend failed (error normalization
+   *  2026-07-14). Derived from provider.protocol; defaults to 'anthropic'. */
+  providerLabel?: string;
   maxOutputTokens: number;
   /** Stable system-prompt prefix (cache-worthy; byte-identical across runs). */
   systemPrompt: string;

--- a/projects/silver-core-sdk/src/transport/anthropic.ts
+++ b/projects/silver-core-sdk/src/transport/anthropic.ts
@@ -14,6 +14,10 @@ import {
   ConfigurationError,
   isAbortError,
 } from '../errors.js';
+import {
+  extractProviderErrorObject,
+  looksLikeErrorObject,
+} from '../error-normalize.js';
 import type {
   APIMessageParam,
   ApiKeySource,
@@ -340,11 +344,15 @@ export class AnthropicTransport implements Transport {
               type: 'api_error',
               message: frame.data,
             };
+            // An in-stream error frame carries no HTTP status (the response was
+            // 200). Prefer a `status` the gateway put IN the body (the wrapped
+            // { error: { status } } shape), else derive one from the error type.
             throw new APIStatusError(
-              statusForErrorType(info.type),
+              info.status ?? statusForErrorType(info.type),
               info.type,
               info.message,
-              requestId,
+              info.requestId ?? requestId,
+              info.code !== undefined ? { providerErrorCode: info.code } : undefined,
             );
           }
           eventCount += 1;
@@ -566,7 +574,12 @@ export class AnthropicTransport implements Transport {
           this.debug(
             `transport: network error (${errorMessage(err)}); retry ${retryBudget.used}/${maxRetries}`,
           );
-          onRetry?.({ attempt: retryBudget.used, maxRetries, kind: 'network' });
+          onRetry?.({
+            attempt: retryBudget.used,
+            maxRetries,
+            kind: 'network',
+            message: errorMessage(err),
+          });
           await this.backoff(retryBudget.used, undefined, callerSignal);
           continue;
         }
@@ -581,13 +594,17 @@ export class AnthropicTransport implements Transport {
       }
       releaseSignals();
 
-      const requestId = response.headers.get('request-id') ?? undefined;
+      // Request id: prefer the response header, fall back to a request_id the
+      // gateway put in the error body.
+      const requestId =
+        response.headers.get('request-id') ?? undefined;
       const info = await readErrorInfo(response);
+      const resolvedRequestId = requestId ?? info.requestId;
+      const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
       const retryable =
         response.status === 408 || response.status === 429 || response.status >= 500;
       if (retryable && retryBudget.used < maxRetries) {
         retryBudget.used += 1;
-        const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
         this.debug(
           `transport: HTTP ${response.status} (${info.type}); retry ${retryBudget.used}/${maxRetries}`,
         );
@@ -597,12 +614,24 @@ export class AnthropicTransport implements Transport {
           status: response.status,
           errorType: info.type,
           kind: 'http_status',
+          message: info.message,
+          ...(resolvedRequestId !== undefined ? { requestId: resolvedRequestId } : {}),
+          ...(info.code !== undefined ? { code: info.code } : {}),
           ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
         });
         await this.backoff(retryBudget.used, retryAfterMs, callerSignal);
         continue;
       }
-      throw new APIStatusError(response.status, info.type, info.message, requestId);
+      throw new APIStatusError(
+        response.status,
+        info.type,
+        info.message,
+        resolvedRequestId,
+        {
+          ...(info.code !== undefined ? { providerErrorCode: info.code } : {}),
+          ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+        },
+      );
     }
   }
 
@@ -844,26 +873,62 @@ function resolveCredential(
   return null;
 }
 
+/** True for an SSE frame payload that is actually an ERROR — the native
+ *  `{ type: 'error' }` frame OR a gateway that wrapped an upstream failure as a
+ *  bare `{ error: {...} }` / `{ message, status }` object with no `type:'error'`
+ *  discriminator (the穿透 case this normalization work closes). A real stream
+ *  event always carries a known `type`, so `looksLikeErrorObject` cannot swallow
+ *  one (it requires either a nested `error` object or a `type`-less body). */
 function isErrorPayload(parsed: unknown): boolean {
-  return (
+  if (
     typeof parsed === 'object' &&
     parsed !== null &&
     (parsed as { type?: unknown }).type === 'error'
-  );
+  ) {
+    return true;
+  }
+  return looksLikeErrorObject(parsed);
 }
 
-/** Extract `{ error: { type, message } }` from an API error payload. */
-function extractErrorPayload(
-  parsed: unknown,
-): { type: string; message: string } | null {
+/** Diagnostic fields lifted from an API error payload. `status`/`code`/
+ *  `requestId` are present only when the body carried them. */
+type ErrorPayloadInfo = {
+  type: string;
+  message: string;
+  status?: number;
+  code?: string;
+  requestId?: string;
+};
+
+/** Extract `{ error: { type, message, code, status, request_id } }` (or the bare
+ *  top-level `{ message, status, code, request_id }`) from an API error payload. */
+function extractErrorPayload(parsed: unknown): ErrorPayloadInfo | null {
   if (typeof parsed !== 'object' || parsed === null) return null;
-  const error = (parsed as { error?: unknown }).error;
-  if (typeof error !== 'object' || error === null) return null;
-  const type = (error as { type?: unknown }).type;
-  const message = (error as { message?: unknown }).message;
+  const top = parsed as Record<string, unknown>;
+  const error =
+    typeof top.error === 'object' && top.error !== null
+      ? (top.error as Record<string, unknown>)
+      : undefined;
+  // The `type` slug (Anthropic vocabulary) lives on the error envelope when
+  // present, else on the top-level object.
+  const typeSrc = error?.type ?? top.type;
+  const type =
+    typeof typeSrc === 'string' && typeSrc !== 'error' ? typeSrc : 'api_error';
+  // Delegate message/status/code/request_id extraction to the shared, redacting
+  // normalizer helper so both arms agree on the field spellings.
+  const obj = extractProviderErrorObject(parsed);
+  if (obj === null) {
+    // Neither a nested error nor a usable message: keep the old behavior of
+    // stringifying the error envelope (bounded by the normalizer elsewhere).
+    if (error === undefined) return null;
+    return { type, message: JSON.stringify(error) };
+  }
   return {
-    type: typeof type === 'string' ? type : 'api_error',
-    message: typeof message === 'string' ? message : JSON.stringify(error),
+    type,
+    message: obj.message,
+    ...(obj.status !== undefined ? { status: obj.status } : {}),
+    ...(obj.code !== undefined ? { code: obj.code } : {}),
+    ...(obj.requestId !== undefined ? { requestId: obj.requestId } : {}),
   };
 }
 
@@ -871,10 +936,10 @@ function statusForErrorType(errorType: string): number {
   return ERROR_TYPE_STATUS[errorType] ?? 500;
 }
 
-/** Read and classify a non-2xx response body (best effort, never throws). */
-async function readErrorInfo(
-  response: Response,
-): Promise<{ type: string; message: string }> {
+/** Read and classify a non-2xx response body (best effort, never throws). A
+ *  non-JSON body (e.g. a plain-text "Internal server error" 500 page) yields a
+ *  readable message rather than an opaque object. */
+async function readErrorInfo(response: Response): Promise<ErrorPayloadInfo> {
   let text = '';
   try {
     text = await response.text();

--- a/projects/silver-core-sdk/src/transport/openai.ts
+++ b/projects/silver-core-sdk/src/transport/openai.ts
@@ -46,6 +46,7 @@ import {
   ConfigurationError,
   isAbortError,
 } from '../errors.js';
+import { extractProviderErrorObject } from '../error-normalize.js';
 import type {
   APIMessageParam,
   APIToolDefinition,
@@ -1054,11 +1055,13 @@ export class OpenAIChatTransport implements Transport {
             // a mid-stream rate-limit / quota / auth error must classify as
             // 429 / 401 etc. so the engine's fallback + the caller see the right
             // class (the Anthropic arm likewise maps its in-stream error type).
+            // A `status` the gateway put in the body wins over the derived one.
             throw new APIStatusError(
-              statusForOpenAIErrorType(info.type),
+              info.status ?? statusForOpenAIErrorType(info.type),
               info.type,
               info.message,
-              requestId,
+              info.requestId ?? requestId,
+              info.code !== undefined ? { providerErrorCode: info.code } : undefined,
             );
           }
           chunkCount += 1;
@@ -1242,7 +1245,12 @@ export class OpenAIChatTransport implements Transport {
           this.debug(
             `openai transport: network error (${errorMessage(err)}); retry ${retryBudget.used}/${maxRetries}`,
           );
-          onRetry?.({ attempt: retryBudget.used, maxRetries, kind: 'network' });
+          onRetry?.({
+            attempt: retryBudget.used,
+            maxRetries,
+            kind: 'network',
+            message: errorMessage(err),
+          });
           await this.backoff(retryBudget.used, undefined, callerSignal);
           continue;
         }
@@ -1259,11 +1267,12 @@ export class OpenAIChatTransport implements Transport {
 
       const requestId = response.headers.get('x-request-id') ?? response.headers.get('request-id') ?? undefined;
       const info = await readOpenAIErrorInfo(response);
+      const resolvedRequestId = requestId ?? info.requestId;
+      const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
       const retryable =
         response.status === 408 || response.status === 429 || response.status >= 500;
       if (retryable && retryBudget.used < maxRetries) {
         retryBudget.used += 1;
-        const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
         this.debug(
           `openai transport: HTTP ${response.status} (${info.type}); retry ${retryBudget.used}/${maxRetries}`,
         );
@@ -1273,12 +1282,24 @@ export class OpenAIChatTransport implements Transport {
           status: response.status,
           errorType: info.type,
           kind: 'http_status',
+          message: info.message,
+          ...(resolvedRequestId !== undefined ? { requestId: resolvedRequestId } : {}),
+          ...(info.code !== undefined ? { code: info.code } : {}),
           ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
         });
         await this.backoff(retryBudget.used, retryAfterMs, callerSignal);
         continue;
       }
-      throw new APIStatusError(response.status, info.type, info.message, requestId);
+      throw new APIStatusError(
+        response.status,
+        info.type,
+        info.message,
+        resolvedRequestId,
+        {
+          ...(info.code !== undefined ? { providerErrorCode: info.code } : {}),
+          ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+        },
+      );
     }
   }
 
@@ -1366,23 +1387,51 @@ function statusForOpenAIErrorType(type: string): number {
   }
 }
 
-function extractOpenAIError(error: unknown): { type: string; message: string } {
+/** Diagnostic fields lifted from an OpenAI-protocol error payload. */
+type OpenAIErrorInfo = {
+  type: string;
+  message: string;
+  code?: string;
+  status?: number;
+  requestId?: string;
+};
+
+function extractOpenAIError(error: unknown): OpenAIErrorInfo {
   if (typeof error === 'object' && error !== null) {
-    const type = (error as { type?: unknown }).type;
-    const message = (error as { message?: unknown }).message;
-    return {
+    const e = error as Record<string, unknown>;
+    const type = e.type;
+    const message = e.message;
+    // Meta (status/code/request_id) is lifted via the shared extractor by
+    // wrapping the error object in an `error` envelope; the MESSAGE keeps the
+    // historical semantics (string message, else JSON.stringify) so existing
+    // consumers and mutation-kill tests see the exact same text.
+    const meta = extractProviderErrorObject({ error: e });
+    const out: OpenAIErrorInfo = {
       type: typeof type === 'string' ? type : 'api_error',
       message: typeof message === 'string' ? message : JSON.stringify(error),
     };
+    if (meta?.code !== undefined) out.code = meta.code;
+    if (meta?.status !== undefined) out.status = meta.status;
+    if (meta?.requestId !== undefined) out.requestId = meta.requestId;
+    return out;
   }
   return { type: 'api_error', message: String(error) };
 }
 
+/** Additive meta fields (code/status/requestId) of an OpenAIErrorInfo, spread
+ *  into a returned info without touching type/message. */
+function meta(info: OpenAIErrorInfo): Partial<OpenAIErrorInfo> {
+  return {
+    ...(info.code !== undefined ? { code: info.code } : {}),
+    ...(info.status !== undefined ? { status: info.status } : {}),
+    ...(info.requestId !== undefined ? { requestId: info.requestId } : {}),
+  };
+}
+
 /** Read a non-2xx body; normalize the error type to Anthropic vocabulary by
- *  status (engine-side handling switches on those), keep the server message. */
-async function readOpenAIErrorInfo(
-  response: Response,
-): Promise<{ type: string; message: string }> {
+ *  status (engine-side handling switches on those), keep the server message.
+ *  A non-JSON body (a plain-text 5xx page) yields a readable message. */
+async function readOpenAIErrorInfo(response: Response): Promise<OpenAIErrorInfo> {
   const normalizedType =
     STATUS_ERROR_TYPE[response.status] ??
     (response.status >= 500 ? 'api_error' : 'invalid_request_error');
@@ -1396,7 +1445,21 @@ async function readOpenAIErrorInfo(
     try {
       const parsed = JSON.parse(text) as { error?: unknown };
       if (parsed.error !== undefined && parsed.error !== null) {
-        return { type: normalizedType, message: extractOpenAIError(parsed.error).message };
+        // Keep the historical message derivation (incl. a STRING error member
+        // -> String(error)); meta (status/code/request_id) is additive.
+        const info = extractOpenAIError(parsed.error);
+        return { type: normalizedType, message: info.message, ...meta(info) };
+      }
+      // A bare top-level { message, status } (no error envelope).
+      const bare = extractProviderErrorObject(parsed);
+      if (bare !== null) {
+        return {
+          type: normalizedType,
+          message: bare.message,
+          ...(bare.code !== undefined ? { code: bare.code } : {}),
+          ...(bare.status !== undefined ? { status: bare.status } : {}),
+          ...(bare.requestId !== undefined ? { requestId: bare.requestId } : {}),
+        };
       }
     } catch {
       // Not JSON; use raw text below.

--- a/projects/silver-core-sdk/src/types.ts
+++ b/projects/silver-core-sdk/src/types.ts
@@ -13,6 +13,12 @@
 
 import type { Readable, Writable } from 'node:stream';
 
+import type { NormalizedProviderError } from './error-normalize.js';
+
+/** Re-export so consumers can `import type { NormalizedProviderError }` from the
+ *  package root alongside the rest of the SDK message surface. */
+export type { NormalizedProviderError } from './error-normalize.js';
+
 // ---------------------------------------------------------------------------
 // Anthropic Messages API wire types (minimal independent subset)
 // ---------------------------------------------------------------------------
@@ -2210,6 +2216,15 @@ export type SDKResultMessage =
        * Absent for codeless failures and on non-error results.
        */
       error_code?: string;
+      /**
+       * Unified normalized upstream error (error normalization 2026-07-14).
+       * Present when the run ended on an actual provider/transport failure
+       * (`error_during_execution`); carries status / code / provider / model /
+       * requestId / retryable in a STABLE shape so a host never has to parse
+       * errorMessage or duck-type a raw gateway object. Absent for
+       * max-turns / budget / refusal / structured-retry stops.
+       */
+      providerError?: NormalizedProviderError;
       /** Time to first token (ms); only present when a token actually arrived. */
       ttft_ms?: number;
       ttft_stream_ms?: number;
@@ -2533,6 +2548,10 @@ export type SDKRateLimitEvent = {
   limit_type?: 'api' | 'token' | 'requests';
   /** @deprecated Pre-alignment flat field; never populated. */
   requests_remaining?: number;
+  /** Unified normalized upstream error for this 429 (error normalization
+   *  2026-07-14): stable status/code/provider/model/requestId/retryAfterMs the
+   *  host can consume without parsing. Additive. */
+  providerError?: NormalizedProviderError;
 };
 
 /** @deprecated Use the official export name SDKRateLimitEvent (v0.7 spelling
@@ -2540,7 +2559,8 @@ export type SDKRateLimitEvent = {
 export type SDKRateLimitEventMessage = SDKRateLimitEvent;
 
 /** An API call is being retried. EMITTED (v0.3) via the transport's onRetry
- *  observer on each non-429 (5xx/network) retry. */
+ *  observer on each non-429 (5xx/network) retry, and by the engine's bounded
+ *  turn-replay. */
 export type SDKAPIRetryMessage = {
   type: 'api_retry';
   uuid: string;
@@ -2549,6 +2569,19 @@ export type SDKAPIRetryMessage = {
   max_retries: number;
   status?: number;
   reason?: string;
+  /** Whether the failure being retried is retryable (always true on an emitted
+   *  api_retry — a retry is in progress). Additive (error normalization
+   *  2026-07-14). */
+  retryable?: boolean;
+  /** Retries left in this budget after the current one. Additive. */
+  retry_remaining?: number;
+  /** Short machine reason for the retry (error type / kind / http_<status> /
+   *  turn_replay:<code>). Additive. */
+  retry_reason?: string;
+  /** Unified normalized upstream error for this retry: stable status / code /
+   *  provider / model / requestId the host can consume without parsing.
+   *  Additive. */
+  providerError?: NormalizedProviderError;
 };
 
 /** @deprecated Use the official export name SDKAPIRetryMessage (v0.7

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.57.0';
+export const SDK_VERSION = '0.57.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/error-normalization-integration.test.ts
+++ b/projects/silver-core-sdk/tests/error-normalization-integration.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Integration tests for unified upstream-error normalization (BPT P1, keeper
+ * ruling 2026-07-14). Drives the REAL transports over a scripted fetch and the
+ * REAL runAgentLoop, asserting the host receives a stable NormalizedProviderError
+ * (status / retryable / requestId / readable message) instead of a raw object
+ * or a silent empty success.
+ *
+ * Response shapes exercised (both mandated by the acceptance criteria):
+ *   - HTTP 500 application/json  {"error":{"message":...,"code":null,"status":500,"request_id":"test-500"}}
+ *   - HTTP 500 text/plain        Internal server error
+ *   - HTTP 200 SSE carrying a bare {error:{...}} data frame (the穿透 case)
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AnthropicTransport } from '../src/transport/anthropic.js';
+import { OpenAIChatTransport } from '../src/transport/openai.js';
+import { APIStatusError } from '../src/errors.js';
+import { runAgentLoop } from '../src/engine/loop.js';
+import type { StreamRequest, Transport, EngineConfig, EngineDeps } from '../src/internal/contracts.js';
+import type { SDKMessage, SDKResultMessage } from '../src/types.js';
+import { FakeMcp, FakeGate, FakeHookRunner } from './helpers/engine-fakes.js';
+
+// ---------------------------------------------------------------------------
+// Fetch stubs
+// ---------------------------------------------------------------------------
+
+/** A non-streaming error Response (status + body + optional headers). */
+function errorResponse(
+  status: number,
+  body: string,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(body, { status, statusText: `HTTP ${status}`, headers });
+}
+
+/** A 200 Response whose SSE body is the exact `frames` string. */
+function sseResponse(frames: string): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(frames));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+const JSON_500 =
+  '{"error":{"message":"Internal server error","code":null,"status":500,"request_id":"test-500"}}';
+
+// ---------------------------------------------------------------------------
+// Transport-level extraction
+// ---------------------------------------------------------------------------
+
+describe('AnthropicTransport error extraction', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function drain(t: Transport): Promise<void> {
+    for await (const _ of t.stream({
+      model: 'claude-x',
+      max_tokens: 16,
+      messages: [{ role: 'user', content: 'hi' }],
+    } as StreamRequest)) {
+      // no-op
+    }
+  }
+
+  function transport(): AnthropicTransport {
+    return new AnthropicTransport({
+      provider: { apiKey: 'k', maxRetries: 0 },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: () => {},
+    });
+  }
+
+  it('HTTP 500 JSON { error: { message, status, request_id } } -> APIStatusError(500) with body request_id', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => errorResponse(500, JSON_500)));
+    const err = await drain(transport()).then(
+      () => null,
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(APIStatusError);
+    expect((err as APIStatusError).status).toBe(500);
+    expect((err as APIStatusError).message).toBe('Internal server error');
+    expect((err as APIStatusError).requestId).toBe('test-500');
+  });
+
+  it('non-JSON text/plain HTTP 500 -> a readable message (never [object Object])', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(500, 'Internal server error', { 'content-type': 'text/plain' })),
+    );
+    const err = (await drain(transport()).catch((e) => e)) as APIStatusError;
+    expect(err).toBeInstanceOf(APIStatusError);
+    expect(err.status).toBe(500);
+    expect(err.message).toBe('Internal server error');
+    expect(err.message).not.toContain('[object Object]');
+  });
+
+  it('prefers the x-request-id header over the body when present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(500, JSON_500, { 'request-id': 'hdr-500' })),
+    );
+    const err = (await drain(transport()).catch((e) => e)) as APIStatusError;
+    expect(err.requestId).toBe('hdr-500');
+  });
+
+  it('the穿透 case: a bare {error:{...}} SSE data frame (no type:error) is caught as an error', async () => {
+    // HTTP 200 whose SSE body carries a gateway error object with NO
+    // `event: error` name and NO top-level `type:'error'` — the exact shape that
+    // used to slip past detection and穿透 to the host.
+    const frames = `data: ${JSON_500}\n\n`;
+    vi.stubGlobal('fetch', vi.fn(async () => sseResponse(frames)));
+    const err = (await drain(transport()).catch((e) => e)) as APIStatusError;
+    expect(err).toBeInstanceOf(APIStatusError);
+    // status comes from the body (an in-stream error carries no HTTP status).
+    expect(err.status).toBe(500);
+    expect(err.message).toBe('Internal server error');
+    expect(err.requestId).toBe('test-500');
+  });
+
+  it('an SSE event:error frame keeps the error text and request id', async () => {
+    const frames =
+      `event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded","request_id":"rid-x"}}\n\n`;
+    vi.stubGlobal('fetch', vi.fn(async () => sseResponse(frames)));
+    const err = (await drain(transport()).catch((e) => e)) as APIStatusError;
+    expect(err).toBeInstanceOf(APIStatusError);
+    expect(err.message).toBe('Overloaded');
+    expect(err.requestId).toBe('rid-x');
+    expect(err.errorType).toBe('overloaded_error');
+  });
+});
+
+describe('OpenAIChatTransport error extraction', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function transport(): OpenAIChatTransport {
+    return new OpenAIChatTransport({
+      provider: { protocol: 'openai-chat', apiKey: 'sk-test', maxRetries: 0 },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: () => {},
+    });
+  }
+
+  async function drain(t: Transport): Promise<void> {
+    for await (const _ of t.stream({
+      model: 'gpt-x',
+      max_tokens: 16,
+      messages: [{ role: 'user', content: 'hi' }],
+    } as StreamRequest)) {
+      // no-op
+    }
+  }
+
+  it('HTTP 500 JSON error -> APIStatusError(500) with a readable message', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => errorResponse(500, JSON_500)));
+    const err = (await drain(transport()).catch((e) => e)) as APIStatusError;
+    expect(err).toBeInstanceOf(APIStatusError);
+    expect(err.status).toBe(500);
+    expect(err.message).toBe('Internal server error');
+    expect(err.requestId).toBe('test-500');
+  });
+
+  it('non-JSON text/plain HTTP 500 -> a readable message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(500, 'Internal server error', { 'content-type': 'text/plain' })),
+    );
+    const err = (await drain(transport()).catch((e) => e)) as APIStatusError;
+    expect(err.status).toBe(500);
+    expect(err.message).toBe('Internal server error');
+    expect(err.message).not.toContain('[object Object]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: the host receives a NormalizedProviderError, not a raw object
+// ---------------------------------------------------------------------------
+
+function makeDeps(transport: Transport): EngineDeps {
+  return {
+    transport,
+    builtinTools: new Map(),
+    mcp: new FakeMcp(),
+    permissions: new FakeGate(),
+    hooks: new FakeHookRunner(),
+    toolContext: {
+      cwd: '/tmp/err-test',
+      additionalDirectories: [],
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      signal: new AbortController().signal,
+      debug: () => {},
+    },
+    debug: () => {},
+  };
+}
+
+function makeConfig(overrides: Partial<EngineConfig> = {}): EngineConfig {
+  return {
+    model: 'claude-x',
+    providerLabel: 'anthropic',
+    maxOutputTokens: 1024,
+    systemPrompt: 'You are a test agent.',
+    includePartialMessages: false,
+    sessionId: 'sess-err',
+    cwd: '/tmp/err-test',
+    ...overrides,
+  };
+}
+
+async function collect(gen: AsyncGenerator<SDKMessage, void>): Promise<SDKMessage[]> {
+  const out: SDKMessage[] = [];
+  for await (const m of gen) out.push(m);
+  return out;
+}
+
+describe('runAgentLoop surfaces a NormalizedProviderError for HTTP 500', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function transport(): AnthropicTransport {
+    return new AnthropicTransport({
+      provider: { apiKey: 'k', maxRetries: 0 },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: () => {},
+    });
+  }
+
+  it('JSON 500 -> error result with providerError {status:500, retryable, requestId, readable}', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => errorResponse(500, JSON_500)));
+    const messages = await collect(
+      runAgentLoop([{ role: 'user', content: 'hi' }], makeDeps(transport()), makeConfig()),
+    );
+    const result = messages[messages.length - 1] as SDKResultMessage;
+    expect(result.type).toBe('result');
+    expect(result.subtype).toBe('error_during_execution');
+    expect(result.is_error).toBe(true);
+    // The run is NOT a silent empty success.
+    expect(messages.some((m) => m.type === 'result' && m.subtype === 'success')).toBe(false);
+    expect(result.api_error_status).toBe(500);
+    const pe = result.providerError;
+    expect(pe).toBeDefined();
+    expect(pe!.status).toBe(500);
+    expect(pe!.retryable).toBe(true);
+    expect(pe!.requestId).toBe('test-500');
+    expect(pe!.message).toBe('Internal server error');
+    expect(pe!.provider).toBe('anthropic');
+    expect(pe!.model).toBe('claude-x');
+    expect(pe!.message).not.toContain('[object Object]');
+  });
+
+  it('non-JSON text/plain 500 -> error result with a readable providerError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(500, 'Internal server error', { 'content-type': 'text/plain' })),
+    );
+    const messages = await collect(
+      runAgentLoop([{ role: 'user', content: 'hi' }], makeDeps(transport()), makeConfig()),
+    );
+    const result = messages[messages.length - 1] as SDKResultMessage;
+    expect(result.subtype).toBe('error_during_execution');
+    const pe = result.providerError;
+    expect(pe!.status).toBe(500);
+    expect(pe!.retryable).toBe(true);
+    expect(pe!.message).toBe('Internal server error');
+  });
+
+  it('the穿透 case end-to-end: a bare {error} SSE frame does not become an empty success', async () => {
+    const frames = `data: ${JSON_500}\n\n`;
+    vi.stubGlobal('fetch', vi.fn(async () => sseResponse(frames)));
+    const messages = await collect(
+      runAgentLoop([{ role: 'user', content: 'hi' }], makeDeps(transport()), makeConfig()),
+    );
+    const result = messages[messages.length - 1] as SDKResultMessage;
+    expect(result.subtype).toBe('error_during_execution');
+    expect(messages.some((m) => m.type === 'result' && m.subtype === 'success')).toBe(false);
+    expect(result.providerError!.status).toBe(500);
+    expect(result.providerError!.message).toBe('Internal server error');
+  });
+
+  it('a retried 503 emits an api_retry carrying a retryable providerError', async () => {
+    // maxRetries 1: first 503 retries, second attempt succeeds via a normal SSE.
+    const okFrames =
+      `event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"claude-x","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}}\n\n` +
+      `event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n` +
+      `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n` +
+      `event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n` +
+      `event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}\n\n` +
+      `event: message_stop\ndata: {"type":"message_stop"}\n\n`;
+    let call = 0;
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const fetchFn = vi.fn(async () => {
+      call += 1;
+      return call === 1
+        ? errorResponse(503, '{"error":{"message":"Service Unavailable","code":"overloaded","status":503}}')
+        : sseResponse(okFrames);
+    });
+    vi.stubGlobal('fetch', fetchFn);
+    const t = new AnthropicTransport({
+      provider: { apiKey: 'k', maxRetries: 1 },
+      env: { BPT_HTTP_CLIENT: 'fetch' },
+      debug: () => {},
+    });
+    const messages = await collect(
+      runAgentLoop([{ role: 'user', content: 'hi' }], makeDeps(t), makeConfig()),
+    );
+    const result = messages[messages.length - 1] as SDKResultMessage;
+    expect(result.subtype).toBe('success');
+    const retry = messages.find((m) => m.type === 'api_retry');
+    expect(retry).toBeDefined();
+    const r = retry as Extract<SDKMessage, { type: 'api_retry' }>;
+    expect(r.retryable).toBe(true);
+    expect(r.status).toBe(503);
+    expect(r.providerError).toBeDefined();
+    expect(r.providerError!.retryable).toBe(true);
+    expect(r.providerError!.status).toBe(503);
+    expect(r.providerError!.code).toBe('overloaded');
+  });
+});

--- a/projects/silver-core-sdk/tests/error-normalize.test.ts
+++ b/projects/silver-core-sdk/tests/error-normalize.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the unified upstream-error normalization layer
+ * (src/error-normalize.ts, BPT P1 keeper ruling 2026-07-14).
+ *
+ * Covers: the gateway TOP-LEVEL `{ error: { message, code, status } }` shape
+ * that穿透ed un-classified before this work, the bare `{ message, status }`
+ * shape, non-JSON text, APIStatusError / APIConnectionError inputs, the retry
+ * table (408/429/5xx retryable; 401/403/404/400 not), request-id spellings,
+ * [object Object] non-regression, and redaction of secrets.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  APIConnectionError,
+  APIStatusError,
+  AbortError,
+} from '../src/errors.js';
+import {
+  extractProviderErrorObject,
+  isRetryableHttpStatus,
+  looksLikeErrorObject,
+  normalizeProviderError,
+  normalizeRetry,
+  type NormalizedProviderError,
+} from '../src/error-normalize.js';
+
+describe('isRetryableHttpStatus (default policy table)', () => {
+  it('408 and 429 are retryable', () => {
+    expect(isRetryableHttpStatus(408)).toBe(true);
+    expect(isRetryableHttpStatus(429)).toBe(true);
+  });
+
+  it('every 5xx is retryable (transient provider fault)', () => {
+    for (const s of [500, 502, 503, 504, 529]) {
+      expect(isRetryableHttpStatus(s)).toBe(true);
+    }
+  });
+
+  it('terminal 4xx are NOT retryable (missing model / perms / bad key / params)', () => {
+    for (const s of [400, 401, 403, 404, 422]) {
+      expect(isRetryableHttpStatus(s)).toBe(false);
+    }
+  });
+});
+
+describe('extractProviderErrorObject', () => {
+  it('extracts the wrapped { error: { message, code, status } } shape', () => {
+    const obj = extractProviderErrorObject({
+      error: { message: 'Internal server error', code: null, status: 500 },
+    });
+    expect(obj).not.toBeNull();
+    expect(obj!.message).toBe('Internal server error');
+    expect(obj!.status).toBe(500);
+    // code was null in the body -> not a usable slug -> undefined
+    expect(obj!.code).toBeUndefined();
+  });
+
+  it('extracts a string code and body request_id', () => {
+    const obj = extractProviderErrorObject({
+      error: {
+        message: 'overloaded',
+        code: 'model_overloaded',
+        status: 503,
+        request_id: 'req_abc',
+      },
+    });
+    expect(obj!.code).toBe('model_overloaded');
+    expect(obj!.status).toBe(503);
+    expect(obj!.requestId).toBe('req_abc');
+  });
+
+  it('extracts the bare top-level { message, status } shape', () => {
+    const obj = extractProviderErrorObject({ message: 'Internal server error', status: 500 });
+    expect(obj!.message).toBe('Internal server error');
+    expect(obj!.status).toBe(500);
+  });
+
+  it('accepts every request-id spelling', () => {
+    for (const key of ['request_id', 'requestId', 'x-request-id', 'X-Request-Id']) {
+      const obj = extractProviderErrorObject({ message: 'x', status: 500, [key]: 'rid' });
+      expect(obj!.requestId).toBe('rid');
+    }
+  });
+
+  it('returns null for a non-error object (no message, no error envelope)', () => {
+    expect(extractProviderErrorObject({ type: 'message_start' })).toBeNull();
+    expect(extractProviderErrorObject(null)).toBeNull();
+    expect(extractProviderErrorObject('nope')).toBeNull();
+  });
+});
+
+describe('looksLikeErrorObject (SSE detection helper)', () => {
+  it('recognizes the wrapped and bare error shapes', () => {
+    expect(looksLikeErrorObject({ error: { message: 'x' } })).toBe(true);
+    expect(looksLikeErrorObject({ message: 'x', status: 500 })).toBe(true);
+  });
+
+  it('does NOT swallow a real stream event (has a type discriminator)', () => {
+    expect(looksLikeErrorObject({ type: 'message_start', message: {} })).toBe(false);
+    expect(looksLikeErrorObject({ type: 'content_block_delta' })).toBe(false);
+  });
+});
+
+describe('normalizeProviderError — gateway object (the穿透 case)', () => {
+  it('normalizes { error: { message, code, status: 500 } } to a retryable 500', () => {
+    const n = normalizeProviderError(
+      { error: { message: 'Internal server error', code: null, status: 500, request_id: 'test-500' } },
+      { provider: 'anthropic', model: 'claude-x' },
+    );
+    expect(n.status).toBe(500);
+    expect(n.message).toBe('Internal server error');
+    expect(n.retryable).toBe(true);
+    expect(n.requestId).toBe('test-500');
+    expect(n.provider).toBe('anthropic');
+    expect(n.model).toBe('claude-x');
+    expect(n.phase).toBe('response');
+  });
+
+  it('never serializes an object message to [object Object]', () => {
+    const n = normalizeProviderError({ error: { code: 'x', status: 500 } });
+    expect(n.message).not.toContain('[object Object]');
+    expect(n.message.length).toBeGreaterThan(0);
+  });
+});
+
+describe('normalizeProviderError — SDK error inputs', () => {
+  it('maps an APIStatusError 500 to a retryable response error', () => {
+    const err = new APIStatusError(500, 'api_error', 'Internal server error', 'rid-1', {
+      providerErrorCode: 'server_error',
+    });
+    const n = normalizeProviderError(err);
+    expect(n.name).toBe('APIStatusError');
+    expect(n.status).toBe(500);
+    expect(n.retryable).toBe(true);
+    expect(n.requestId).toBe('rid-1');
+    expect(n.code).toBe('server_error'); // body code wins over errorType
+    expect(n.rawType).toBe('api_error');
+    expect(n.phase).toBe('response');
+  });
+
+  it('maps an APIStatusError 401 to a NON-retryable error', () => {
+    const n = normalizeProviderError(new APIStatusError(401, 'authentication_error', 'bad key'));
+    expect(n.retryable).toBe(false);
+    expect(n.code).toBe('authentication_error');
+  });
+
+  it('carries retryAfterMs from an APIStatusError', () => {
+    const err = new APIStatusError(429, 'rate_limit_error', 'slow down', undefined, {
+      retryAfterMs: 5_000,
+    });
+    const n = normalizeProviderError(err);
+    expect(n.retryable).toBe(true);
+    expect(n.retryAfterMs).toBe(5_000);
+  });
+
+  it('maps a network APIConnectionError to a retryable transport error', () => {
+    const err = new APIConnectionError('socket hang up');
+    err.turnReplaySafe = true;
+    const n = normalizeProviderError(err);
+    expect(n.name).toBe('APIConnectionError');
+    expect(n.retryable).toBe(true);
+    expect(n.phase).toBe('transport');
+  });
+
+  it('a mid-stream truncation is NOT freely retryable (replay-safe rules)', () => {
+    const err = new APIConnectionError('dropped', undefined);
+    err.midStreamTruncation = true;
+    const n = normalizeProviderError(err);
+    expect(n.retryable).toBe(false);
+    expect(n.phase).toBe('stream');
+  });
+
+  it('an empty_message (started stream, no content) is NOT retryable', () => {
+    const err = new APIConnectionError('empty message', undefined, 'empty_message');
+    const n = normalizeProviderError(err);
+    expect(n.retryable).toBe(false);
+    expect(n.code).toBe('empty_message');
+  });
+
+  it('an AbortError is not an upstream fault and never retryable', () => {
+    const n = normalizeProviderError(new AbortError());
+    expect(n.name).toBe('AbortError');
+    expect(n.retryable).toBe(false);
+  });
+
+  it('a plain Error keeps a readable message and is not retryable', () => {
+    const n = normalizeProviderError(new Error('boom'));
+    expect(n.message).toBe('boom');
+    expect(n.retryable).toBe(false);
+  });
+});
+
+describe('normalizeProviderError — redaction (硬约束)', () => {
+  it('scrubs API keys, bearer tokens, and authorization from the message', () => {
+    const n = normalizeProviderError({
+      error: {
+        message:
+          'auth failed with Authorization: Bearer sk-ant-secret123456 and x-api-key: sk-abcdef_LEAK99',
+        status: 401,
+      },
+    });
+    expect(n.message).not.toContain('sk-ant-secret123456');
+    expect(n.message).not.toContain('sk-abcdef_LEAK99');
+    expect(n.message).not.toMatch(/Bearer\s+sk-/);
+    expect(n.message).toContain('[REDACTED]');
+  });
+
+  it('bounds a giant error page so it cannot bloat the surface', () => {
+    const big = 'x'.repeat(5_000);
+    const n = normalizeProviderError({ message: big, status: 500 });
+    expect(n.message.length).toBeLessThanOrEqual(2_001 + 1); // 2000 + ellipsis
+  });
+});
+
+describe('normalizeRetry (retry-in-progress event)', () => {
+  it('builds a retryable normalized error carrying status/code/requestId', () => {
+    const n: NormalizedProviderError = normalizeRetry(
+      {
+        status: 503,
+        errorType: 'overloaded_error',
+        code: 'server_overloaded',
+        message: 'Service Unavailable',
+        requestId: 'rid-9',
+        retryAfterMs: 2_000,
+        kind: 'http_status',
+      },
+      { provider: 'anthropic', model: 'claude-x' },
+    );
+    expect(n.retryable).toBe(true);
+    expect(n.status).toBe(503);
+    expect(n.code).toBe('server_overloaded');
+    expect(n.requestId).toBe('rid-9');
+    expect(n.retryAfterMs).toBe(2_000);
+    expect(n.provider).toBe('anthropic');
+    expect(n.model).toBe('claude-x');
+  });
+
+  it('falls back to a readable message when the body carried none', () => {
+    const n = normalizeRetry({ kind: 'network' });
+    expect(n.message.length).toBeGreaterThan(0);
+    expect(n.message).not.toContain('[object Object]');
+  });
+});

--- a/projects/silver-core-sdk/tests/helpers/engine-fakes.ts
+++ b/projects/silver-core-sdk/tests/helpers/engine-fakes.ts
@@ -1,0 +1,77 @@
+/**
+ * Minimal engine collaborators for driving runAgentLoop in tests that only care
+ * about the transport/error path (no tools, no hooks, no MCP). Mirrors the
+ * inline fakes in engine.test.ts, extracted so other suites can reuse them.
+ */
+
+import type {
+  AggregatedHookResult,
+  HookRunner,
+  McpRegistry,
+  PermissionCheckResult,
+  PermissionGate,
+} from '../../src/internal/contracts.js';
+import type {
+  CallToolResult,
+  HookEvent,
+  HookInput,
+  McpServerStatus,
+  PermissionMode,
+  PermissionUpdate,
+  SDKPermissionDenial,
+} from '../../src/types.js';
+
+/** Allow-everything permission gate. */
+export class FakeGate implements PermissionGate {
+  private mode: PermissionMode = 'default';
+  async check(
+    _toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<PermissionCheckResult> {
+    return { decision: 'allow', updatedInput: input };
+  }
+  setMode(mode: PermissionMode): void {
+    this.mode = mode;
+  }
+  getMode(): PermissionMode {
+    return this.mode;
+  }
+  applyUpdates(_updates: PermissionUpdate[]): void {}
+  denials(): SDKPermissionDenial[] {
+    return [];
+  }
+}
+
+/** No-op hook runner (no hooks registered for any event). */
+export class FakeHookRunner implements HookRunner {
+  hasHooks(_event: HookEvent): boolean {
+    return false;
+  }
+  async run(_event: HookEvent, _input: HookInput): Promise<AggregatedHookResult> {
+    return {
+      continue: true,
+      systemMessages: [],
+      additionalContext: [],
+    };
+  }
+}
+
+/** Empty MCP registry (no servers, no tools). */
+export class FakeMcp implements McpRegistry {
+  async connectAll(): Promise<void> {}
+  statuses(): McpServerStatus[] {
+    return [];
+  }
+  allTools(): [] {
+    return [];
+  }
+  has(_qualifiedName: string): boolean {
+    return false;
+  }
+  async call(): Promise<CallToolResult> {
+    return { content: [{ type: 'text', text: 'unexpected mcp call' }], isError: true };
+  }
+  async reconnect(_serverName: string): Promise<void> {}
+  setEnabled(_serverName: string, _enabled: boolean): void {}
+  async closeAll(): Promise<void> {}
+}

--- a/projects/silver-core-sdk/tests/import-discipline.test.ts
+++ b/projects/silver-core-sdk/tests/import-discipline.test.ts
@@ -8,9 +8,10 @@
  * this guard, the import rule existed only as prose and had decayed into 13
  * unguarded violations including an engine<->subagents package cycle.
  *
- * Everywhere-allowed: src/types.ts, src/errors.ts, src/version.ts, anything
- * under src/internal/, and files inside the importer's own top-level module.
- * Composition roots (query.ts, session-manager.ts, index.ts) import freely.
+ * Everywhere-allowed: src/types.ts, src/errors.ts, src/version.ts,
+ * src/error-normalize.ts, anything under src/internal/, and files inside the
+ * importer's own top-level module. Composition roots (query.ts,
+ * session-manager.ts, index.ts) import freely.
  */
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
@@ -25,7 +26,12 @@ const archDoc = readFileSync(
 );
 
 const COMPOSITION_ROOTS = new Set(['query.ts', 'session-manager.ts', 'index.ts']);
-const ALWAYS_ALLOWED_FILES = new Set(['types.ts', 'errors.ts', 'version.ts']);
+const ALWAYS_ALLOWED_FILES = new Set([
+  'types.ts',
+  'errors.ts',
+  'version.ts',
+  'error-normalize.ts',
+]);
 
 /** Parse the "Import edges" table: `src/x/` -> set of allowed `src/y/`. */
 function parseEdges(doc: string): Map<string, Set<string>> {


### PR DESCRIPTION
## 概述

silver-core-sdk P1：网关把上游故障包成顶层 `{ error: { message, code, status: 500 } }` 裸对象时，Anthropic 侧 SSE 错误探测只认 `type:'error'`，导致该形态既不被识别为错误、也不是合法流事件，裸对象穿透到宿主层、绕过 retry / error 链。本 PR 建立统一上游错误归一化层，把任何形态的上游失败收敛成稳定的 `NormalizedProviderError`。版本 0.57.0 → 0.57.1（patch）。

---

## 变更类型

- [x] Bug 修复
- [ ] 数据补全 / 翻译 / 文档 / 视觉
- [x] 其他：新增 SDK 公开能力（`NormalizedProviderError` + `normalizeProviderError`），append-only drop-in surface

---

## 来源声明

不适用——纯 SDK 工程改动，不涉及游戏数据 / 翻译，无外部素材引用。

---

## 安全声明（强制）

- [x] 不含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。
- [x] 不上传内部美术资产 / 客户端解包原始文件 / 未公开草稿。归一化 message 限长 2 KB 且擦除 API key / Bearer / Authorization，原始错误对象不附带（脱敏硬约束）。
- [x] 同意按 MIT License 提交。

---

## 变更清单

新增 `src/error-normalize.ts`：
- `NormalizedProviderError`（name/message/status/code/provider/model/requestId/retryable/retryAfterMs/phase/rawType），message 永不退化为 `[object Object]`。
- `normalizeProviderError()` 归一化 APIStatusError / APIConnectionError / 裸网关对象 / 普通 Error / 不透明值；`normalizeRetry()` 供重试事件用；`looksLikeErrorObject()` 拓宽 SSE 探测（认 `{error}`/`{message,status}`，不吞真流事件）。

两协议 + SSE + 非流式全覆盖：从错误体提取 code/status/request_id（四种拼写，header 优先）；`APIStatusError` 追加 `providerErrorCode`/`retryAfterMs`（append-only）。

重试判定基于状态码（不因 quota/allocation 字样强判密钥故障）：408/429 + 全部 5xx 可重试，其余 4xx 不可；APIConnectionError 遵守既有 replay-safe 契约。

宿主面：`error_during_execution` 结果、`api_retry`（+retryable/retry_remaining/retry_reason）、`rate_limit_event` 均携带 `providerError`；500 后无内容 = 显式 error，非空成功。

---

## 验证清单

- [x] 全量测试对话内跑绿：`vitest run` → 123 文件 / 2289 通过 / 2 跳过 / 0 失败。
- [x] 新增 24 归一化单测 + 11 传输/端到端集成测（含两处强制形态：JSON `{error:{…,request_id:"test-500"}}` 与 `text/plain` 500）。
- [x] `npm run typecheck` 绿；版本守卫 `check-version-bump.mjs` 绿（0.57.0→0.57.1 三方一致）。
- [x] 不引入 emoji。
- [x] 未动 `memory/decisions.md` / `memory/lessons-learned.md`。
- [x] 更新 `CHANGELOG.md` + `docs/ARCHITECTURE.md`（import edges）；tarball `silver-core-sdk-0.57.1.tgz` 本地构建（发货物、不入 git）。

---

## 关联 Issue

- Refs: BPT P1 裸 500 穿透

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFfS3RkQmFM4BbUPSss8F9)_