### PR TITLE
silver-core-sdk 0.58.0: audit P1 batch — all 13 MEDIUM findings fixed

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,55 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.58.0 — 2026-07-14
+
+Audit 2026-07-14 P1 batch — all 13 MEDIUM findings, each with regressions:
+
+- **M-1 (hooks)**: per-matcher `failureMode: 'open' | 'closed'` override (a
+  crashed security hook can now be made blocking per matcher); global
+  default stays 'open' for official drop-in parity; fail-open discards now
+  log loudly.
+- **M-2 (tools)**: shared ReDoS guard (`src/internal/regex-guard.ts`,
+  extracted from hooks/matcher) now also protects Grep patterns and
+  BashOutput filters — catastrophic patterns are rejected with a readable
+  tool error instead of freezing the event loop.
+- **M-3 (webfetch)**: DNS pinning — the default fetch path now dials only
+  the SSRF-guard-validated addresses (node lookup override, Host/SNI
+  preserved), closing the rebinding window; per-hop re-validation on
+  redirects. An injected fetchImpl still bypasses pinning (documented).
+- **M-4 (mcp)**: registry entries are retired on closeAll()/setServers();
+  in-flight handshakes are awaited and their connections closed instead of
+  leaking zombie child processes.
+- **M-5 (openai)**: a stream ending without finish_reason after tool_call
+  deltas now infers stop_reason 'tool_use' — non-conformant gateways no
+  longer silently drop tool calls.
+- **M-6 (transport)**: with proxy env vars set and no explicit httpClient
+  choice, the default resolves to 'fetch' (proxy-capable) instead of the
+  proxy-blind 'node' adapter.
+- **M-7 (session-manager)**: auto-resume folds pre-resume total_cost_usd /
+  modelUsage into a base offset — mgr.usage() reports the sum, not just
+  post-resume spend.
+- **M-8 (engine)**: pause_turn continuation now checks budgetStopReason()
+  like every other continuation path — maxBudgetUsd can no longer be
+  bypassed by repeated server pause_turn.
+- **M-9 (sessions)**: JsonlSessionStore.append heals a crash-torn tail
+  (missing trailing newline) exactly like file-store — a torn line no
+  longer swallows the next record with it.
+- **M-10 (subagents)**: concurrent foreground subagents fork their own
+  persistent shell cwd/env namespace (seeded from the parent's snapshot) —
+  batch-mate cd/export no longer cross-pollutes; background-shell registry
+  stays query-wide.
+- **M-11 (subagents)**: foreground kill path — 'killed' status no longer
+  clobbered to 'failed'; notifications word foreground/background
+  correctly; stopping a foreground child resolves an isError tool result
+  instead of aborting the whole parent query.
+- **M-12 (reporting)**: run-log lines are shape-validated at the shared
+  readWindow choke point — a well-formed-JSON-but-wrong-shape line counts
+  as a bad line instead of killing the whole report.
+- **M-13 (workflow)**: resume cache lookup is now (hash, occurrence)-keyed
+  instead of global-sequence-keyed — parallel-branch timing permutations no
+  longer silently disable prefix caching; old journals stay resumable.
+
 ## 0.57.3 — 2026-07-14
 
 Audit 2026-07-14 P0 batch — the three HIGH findings, each with regressions:

--- a/projects/silver-core-sdk/docs/CONCURRENCY.md
+++ b/projects/silver-core-sdk/docs/CONCURRENCY.md
@@ -3,7 +3,10 @@
 The SDK supports true parallelism at three levels: **many conversations** over
 one `SessionManager`, **parallel-safe tools within a turn** (grouped
 `Promise.all`: read-only tools plus foreground `Agent` calls, which are
-`parallelSafe` because each child runs its own isolated loop; writes stay
+`parallelSafe` because each child runs its own isolated loop AND its own
+persistent Bash cwd/env namespace — forked from the parent's snapshot at
+spawn, so batch-mates' `cd`/`export` never cross-pollute (audit 2026-07-14
+M-10); the background-shell registry stays query-wide by design; writes stay
 serial), and **background subagents**. This doc is about the first level and
 the two knobs that make a large fan-out safe.
 

--- a/projects/silver-core-sdk/docs/SUBAGENTS.md
+++ b/projects/silver-core-sdk/docs/SUBAGENTS.md
@@ -98,6 +98,15 @@ engine groups the batch under one `Promise.all` like read-only tools instead
 of awaiting one child at a time. Background exists to not block the *turn* —
 it is not a prerequisite for parallelism within the batch.
 
+Each spawned child also gets its **own persistent Bash cwd/env namespace**,
+seeded from the parent's snapshot at spawn time (audit 2026-07-14 M-10): the
+child starts where the parent's last foreground Bash left off, but its own
+`cd` / `export` mutations stay private — they never replay into a concurrent
+batch-mate's next Bash call, nor back into the parent's. The
+**background-shell registry stays query-wide** on purpose: children list,
+read (`BashOutput`/`TaskOutput`) and stop (`KillShell`/`TaskStop`) the same
+background shells as the root loop.
+
 Delegation discipline (reproduced from the official main-loop prompt — have your
 host follow it):
 
@@ -154,6 +163,13 @@ non-existent capability.
   isolated child with a `tools` allowlist for that.
 - **The child sees only the `prompt`,** not the conversation. An underspecified
   prompt yields an underspecified result.
+- **Stopping a FOREGROUND child** (`query.stopTask(agentId)` or `TaskStop`
+  with its agentId) aborts only that child: its record reads `killed`, the
+  notification says "foreground subagent ... stopped", and the spawning
+  `Agent` call resolves to an error tool result ("stopped") so the parent
+  turn continues (audit 2026-07-14 M-11). A parent-side abort
+  (`interrupt()` / query close) still propagates as an abort — it cancels
+  the parent, not just the child.
 - **Bare model aliases 400 on your gateway** (§3). Pass full ids.
 
 ## 7. Worked example

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.57.3",
+  "version": "0.58.0",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -1257,6 +1257,16 @@ export async function* runAgentLoop(
           yield errorResult('error_max_turns', `Reached maxTurns limit (${config.maxTurns})`);
           return;
         }
+        // The continuation re-issues a billable API call: honor the same
+        // budget gate as the tool-continue / structured-retry / bg-drain /
+        // stop-hook-block paths (audit 2026-07-14 M-8 — this was the one
+        // continuation branch that checked only maxTurns, so a paused turn
+        // could keep billing past maxBudgetUsd).
+        const pauseBudgetStop = budgetStopReason();
+        if (pauseBudgetStop !== undefined) {
+          yield errorResult('error_max_budget_usd', pauseBudgetStop);
+          return;
+        }
         deps.debug('engine: turn paused (stop_reason: pause_turn); continuing the turn');
         continue;
       }

--- a/projects/silver-core-sdk/src/hooks/matcher.ts
+++ b/projects/silver-core-sdk/src/hooks/matcher.ts
@@ -21,74 +21,21 @@
  * closed (treat as no-match) by (a) capping the pattern and value lengths fed
  * to the engine and (b) refusing patterns with a nested quantifier. This never
  * throws; on a guard trip it returns false and emits an optional debug warning.
+ *
+ * The heuristic itself lives in src/internal/regex-guard.ts since the audit
+ * 2026-07-14 M-2 batch (Grep and BashOutput compile model-supplied patterns
+ * over far larger inputs and now share the exact same defense); this module's
+ * observable behavior is unchanged.
  */
+
+import { hasNestedQuantifier, MAX_REGEX_PATTERN_LENGTH } from '../internal/regex-guard.js';
 
 /** Charset that selects exact-set semantics instead of regex semantics. */
 const EXACT_SET_RE = /^[A-Za-z0-9_\-, |]*$/;
 
 /** Regex-path input ceilings. Tool names are short; these are generous. */
-const MAX_MATCHER_LENGTH = 1024;
-const MAX_VALUE_LENGTH = 1024;
-
-/**
- * Detects a repetition quantifier applied to a group whose body already
- * contains a repetition (star height >= 2), the classic catastrophic-
- * backtracking signature: `(a+)+`, `(a*)+`, `(a+)*`, `(.*x)+`, `(a+){2,}`, ...
- * Intentionally conservative: safe linear patterns like `(foo|bar)+`, `Edit.*`
- * or `^mcp__` do not match and keep working.
- *
- * A single flat regex CANNOT do this correctly: the old detector
- * `/\([^()]*[*+][^()]*\)\s*[*+{]/` used `[^()]*` around the inner quantifier,
- * so it only saw a nested quantifier when the quantified group held NO further
- * parens — `((a+))+` and `(a(b+))+` slipped through and still froze the event
- * loop. We instead walk the pattern with a paren stack, tracking (at every
- * nesting depth) whether the group body contains a repetition, and flag the
- * moment a repetition-bearing group is itself quantified.
- */
-function hasNestedQuantifier(pattern: string): boolean {
-  const isRepeatQuant = (c: string | undefined): boolean =>
-    c === '*' || c === '+' || c === '{';
-  // Per open group: does its body (at ANY depth) contain a repetition quantifier?
-  const bodyHasRepeat: boolean[] = [];
-  const markAllOpenGroups = (): void => {
-    for (let k = 0; k < bodyHasRepeat.length; k += 1) bodyHasRepeat[k] = true;
-  };
-  for (let i = 0; i < pattern.length; i += 1) {
-    const ch = pattern[i];
-    if (ch === '\\') {
-      i += 1; // escaped metachar is a literal atom; skip it
-      continue;
-    }
-    if (ch === '[') {
-      // character class: consume to the closing ']' so parens/quantifier chars
-      // inside it are treated as literals, not structure.
-      i += 1;
-      while (i < pattern.length && pattern[i] !== ']') {
-        if (pattern[i] === '\\') i += 1;
-        i += 1;
-      }
-      continue;
-    }
-    if (ch === '(') {
-      bodyHasRepeat.push(false);
-      continue;
-    }
-    if (ch === ')') {
-      const closedBodyRepeat = bodyHasRepeat.pop() ?? false;
-      // Look past optional whitespace for a quantifier applied to THIS group.
-      let j = i + 1;
-      while (j < pattern.length && /\s/.test(pattern[j] ?? '')) j += 1;
-      const outerQuantified = isRepeatQuant(pattern[j]);
-      // A repetition-bearing group that is itself repeated = star height >= 2.
-      if (outerQuantified && closedBodyRepeat) return true;
-      // A quantified group counts as a repetition within its parent's body.
-      if (outerQuantified) markAllOpenGroups();
-      continue;
-    }
-    if (isRepeatQuant(ch)) markAllOpenGroups(); // in-body repetition at this depth
-  }
-  return false;
-}
+const MAX_MATCHER_LENGTH = MAX_REGEX_PATTERN_LENGTH;
+const MAX_VALUE_LENGTH = MAX_REGEX_PATTERN_LENGTH;
 
 export function matcherMatches(
   matcher: string | undefined,

--- a/projects/silver-core-sdk/src/hooks/runner.ts
+++ b/projects/silver-core-sdk/src/hooks/runner.ts
@@ -6,8 +6,11 @@
  * (matcher.timeout ?? 60 seconds) combined with the caller's AbortSignal.
  * Rejected or timed-out callbacks are logged via the debug callback and
  * otherwise ignored (failureMode 'open', the default) or converted into a
- * deny (failureMode 'closed' — see HookRunnerConfig.failureMode); a callback
- * can never crash the agent loop.
+ * deny (failureMode 'closed' — see HookRunnerConfig.failureMode; a matcher's
+ * own HookCallbackMatcher.failureMode overrides the global setting for that
+ * matcher's callbacks, audit 2026-07-14 M-1); a callback can never crash the
+ * agent loop. A failure resolved 'open' emits a loud debug line stating the
+ * hook's outcome was DISCARDED fail-open.
  *
  * Aggregation rules (across the outputs, in REGISTRATION order — parallel
  * execution, deterministic fold):
@@ -70,6 +73,10 @@ export type HookRunnerConfig = {
    * the aggregate, so hook-enforced policy fails safe at the cost of blocking
    * tool calls while a policy hook is broken. Outer-signal cancellation is
    * never converted to a deny (the whole run is being cancelled).
+   * Per-matcher override: HookCallbackMatcher.failureMode wins over this
+   * global setting for that matcher's callbacks (audit 2026-07-14 M-1), so a
+   * single security-critical matcher can fail closed while the global default
+   * keeps official drop-in parity ('open').
    */
   failureMode?: 'open' | 'closed';
 };
@@ -141,7 +148,11 @@ export class DefaultHookRunner implements HookRunner {
     const admitted = await this.filterByCondition(event, matched, input, signal);
 
     // Collect every callback of every admitted matcher.
-    const tasks: Array<{ cb: HookCallback; timeoutMs: number }> = [];
+    const tasks: Array<{
+      cb: HookCallback;
+      timeoutMs: number;
+      failureMode: 'open' | 'closed';
+    }> = [];
     for (const matcher of admitted) {
       const seconds =
         typeof matcher.timeout === 'number' &&
@@ -149,8 +160,12 @@ export class DefaultHookRunner implements HookRunner {
         matcher.timeout > 0
           ? matcher.timeout
           : DEFAULT_TIMEOUT_SECONDS;
+      // Per-matcher failure policy wins over the runner-wide setting (audit
+      // 2026-07-14 M-1): a security-critical matcher can fail closed while
+      // the global default keeps official drop-in parity ('open').
+      const failureMode = matcher.failureMode ?? this.failureMode;
       for (const cb of matcher.hooks) {
-        tasks.push({ cb, timeoutMs: seconds * 1000 });
+        tasks.push({ cb, timeoutMs: seconds * 1000, failureMode });
       }
     }
 
@@ -160,7 +175,15 @@ export class DefaultHookRunner implements HookRunner {
     // completion order (audit 2026-07-10 L4). runOne never rejects.
     const settled = await Promise.all(
       tasks.map((task) =>
-        this.runOne(event, task.cb, task.timeoutMs, input, toolUseID, signal),
+        this.runOne(
+          event,
+          task.cb,
+          task.timeoutMs,
+          task.failureMode,
+          input,
+          toolUseID,
+          signal,
+        ),
       ),
     );
     const outputs = settled.filter((out): out is HookJSONOutput => out !== undefined);

--- a/projects/silver-core-sdk/src/hooks/runner.ts
+++ b/projects/silver-core-sdk/src/hooks/runner.ts
@@ -244,11 +244,13 @@ export class DefaultHookRunner implements HookRunner {
     return matched.filter((_m, i) => verdicts[i] === true);
   }
 
-  /** Run one callback with its own timeout; failures become debug warnings. */
+  /** Run one callback with its own timeout; failures become debug warnings
+   *  (or a deny under the effective failureMode 'closed'). */
   private async runOne(
     event: HookEvent,
     cb: HookCallback,
     timeoutMs: number,
+    failureMode: 'open' | 'closed',
     input: HookInput,
     toolUseID: string | undefined,
     signal: AbortSignal,
@@ -322,20 +324,30 @@ export class DefaultHookRunner implements HookRunner {
         stderr: msg,
         outcome: signal.aborted ? 'cancelled' : 'error',
       });
-      // failureMode 'closed' (audit 2026-07-10 P1-5): a broken/timed-out hook
-      // must not silently wave the call through — contribute a deny (legacy
-      // 'block' maps onto deny in aggregate()). Cancellation of the whole run
-      // is never a deny; run() rethrows AbortError right after.
-      if (this.failureMode === 'closed' && !signal.aborted) {
+      // failureMode 'closed' (audit 2026-07-10 P1-5; per-matcher override
+      // audit 2026-07-14 M-1): a broken/timed-out hook must not silently wave
+      // the call through — contribute a deny (legacy 'block' maps onto deny
+      // in aggregate()). Cancellation of the whole run is never a deny;
+      // run() rethrows AbortError right after.
+      if (failureMode === 'closed' && !signal.aborted) {
         this.debug(
-          `hooks(${event}): callback failed or timed out; hookFailureMode 'closed' denies (${msg})`,
+          `hooks(${event}): callback failed or timed out; failureMode 'closed' denies (${msg})`,
         );
         return {
           decision: 'block',
-          reason: `hook "${hookName}" failed or timed out (${msg}); denied by hookFailureMode 'closed'`,
+          reason: `hook "${hookName}" failed or timed out (${msg}); denied by failureMode 'closed'`,
         };
       }
-      this.debug(`hooks(${event}): callback failed or timed out, ignored (${msg})`);
+      // Loud fail-open notice (audit 2026-07-14 M-1): the hook DID fail and
+      // whatever it would have decided is being DISCARDED — the tool call
+      // proceeds as if the hook had no opinion. A quiet one-liner here let a
+      // crashed PreToolUse security hook be bypassed invisibly.
+      this.debug(
+        `hooks(${event}): WARNING hook "${hookName}" failed or timed out and its ` +
+          `outcome was DISCARDED fail-open (failureMode 'open'): the tool call ` +
+          `proceeds as if the hook had no opinion. Set failureMode 'closed' on ` +
+          `the matcher (or Options.hookFailureMode) to fail safe. (${msg})`,
+      );
       return undefined;
     }
   }

--- a/projects/silver-core-sdk/src/internal/contracts.ts
+++ b/projects/silver-core-sdk/src/internal/contracts.ts
@@ -175,7 +175,10 @@ export type ToolContext = {
   };
   /** v0.2 WebFetch escape hatch for localhost/private hosts (default false). */
   allowPrivateWebFetch?: boolean;
-  /** Injectable fetch for tests; defaults to globalThis.fetch when undefined. */
+  /** Injectable fetch for tests. When undefined, WebFetch uses its DNS-pinned
+   *  node:https path (audit 2026-07-14 M-3); an injected impl still passes the
+   *  per-hop SSRF guard but does its own connection handling and therefore
+   *  BYPASSES DNS pinning. */
   fetchImpl?: typeof fetch;
   /**
    * File-checkpoint recorder. When enableFileCheckpointing is on, fs tools

--- a/projects/silver-core-sdk/src/internal/regex-guard.ts
+++ b/projects/silver-core-sdk/src/internal/regex-guard.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared ReDoS guard for model/user-supplied regular expressions
+ * (audit 2026-07-14 M-2).
+ *
+ * The hooks matcher (src/hooks/matcher.ts) has carried this defense since
+ * finding #24: a nested-quantifier pattern such as `(a+)+$` run against an
+ * adversarial subject triggers catastrophic backtracking that freezes the
+ * event loop SYNCHRONOUSLY — no timeout or AbortSignal can interrupt it. The
+ * same attack surface exists wherever a model-supplied pattern is compiled and
+ * executed over bulk text (Grep over up-to-10MB files, BashOutput's per-line
+ * `filter`), so the heuristic lives here once and every consumer imports it:
+ *  - src/hooks/matcher.ts (fails closed: guarded pattern matches nothing)
+ *  - src/tools/grep.ts (rejected pattern -> descriptive tool error result)
+ *  - src/tools/shells.ts BashOutput filter (same)
+ */
+
+/**
+ * Ceiling on the length of a pattern (and, for the hooks matcher, the value)
+ * fed to the RegExp engine. Backtracking cost grows with input size; tool
+ * patterns and tool names are far shorter than this in practice.
+ */
+export const MAX_REGEX_PATTERN_LENGTH = 1024;
+
+/**
+ * Detects a repetition quantifier applied to a group whose body already
+ * contains a repetition (star height >= 2), the classic catastrophic-
+ * backtracking signature: `(a+)+`, `(a*)+`, `(a+)*`, `(.*x)+`, `(a+){2,}`, ...
+ * Intentionally conservative: safe linear patterns like `(foo|bar)+`, `Edit.*`
+ * or `^mcp__` do not match and keep working.
+ *
+ * A single flat regex CANNOT do this correctly: the old detector
+ * `/\([^()]*[*+][^()]*\)\s*[*+{]/` used `[^()]*` around the inner quantifier,
+ * so it only saw a nested quantifier when the quantified group held NO further
+ * parens — `((a+))+` and `(a(b+))+` slipped through and still froze the event
+ * loop. We instead walk the pattern with a paren stack, tracking (at every
+ * nesting depth) whether the group body contains a repetition, and flag the
+ * moment a repetition-bearing group is itself quantified.
+ */
+export function hasNestedQuantifier(pattern: string): boolean {
+  const isRepeatQuant = (c: string | undefined): boolean =>
+    c === '*' || c === '+' || c === '{';
+  // Per open group: does its body (at ANY depth) contain a repetition quantifier?
+  const bodyHasRepeat: boolean[] = [];
+  const markAllOpenGroups = (): void => {
+    for (let k = 0; k < bodyHasRepeat.length; k += 1) bodyHasRepeat[k] = true;
+  };
+  for (let i = 0; i < pattern.length; i += 1) {
+    const ch = pattern[i];
+    if (ch === '\\') {
+      i += 1; // escaped metachar is a literal atom; skip it
+      continue;
+    }
+    if (ch === '[') {
+      // character class: consume to the closing ']' so parens/quantifier chars
+      // inside it are treated as literals, not structure.
+      i += 1;
+      while (i < pattern.length && pattern[i] !== ']') {
+        if (pattern[i] === '\\') i += 1;
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === '(') {
+      bodyHasRepeat.push(false);
+      continue;
+    }
+    if (ch === ')') {
+      const closedBodyRepeat = bodyHasRepeat.pop() ?? false;
+      // Look past optional whitespace for a quantifier applied to THIS group.
+      let j = i + 1;
+      while (j < pattern.length && /\s/.test(pattern[j] ?? '')) j += 1;
+      const outerQuantified = isRepeatQuant(pattern[j]);
+      // A repetition-bearing group that is itself repeated = star height >= 2.
+      if (outerQuantified && closedBodyRepeat) return true;
+      // A quantified group counts as a repetition within its parent's body.
+      if (outerQuantified) markAllOpenGroups();
+      continue;
+    }
+    if (isRepeatQuant(ch)) markAllOpenGroups(); // in-body repetition at this depth
+  }
+  return false;
+}
+
+/**
+ * Convenience gate for tool inputs: returns a human-readable rejection reason
+ * for a pattern the guard refuses, or null when the pattern is safe to
+ * compile. The reason is written for a model to act on (rephrase the pattern),
+ * so callers can embed it verbatim in a tool error result. Never throws;
+ * syntactic validity is NOT checked here (callers keep their own
+ * new RegExp try/catch for that).
+ */
+export function guardRegexPattern(pattern: string): string | null {
+  if (pattern.length > MAX_REGEX_PATTERN_LENGTH) {
+    return (
+      `pattern length ${pattern.length} exceeds the ` +
+      `${MAX_REGEX_PATTERN_LENGTH}-character cap`
+    );
+  }
+  if (hasNestedQuantifier(pattern)) {
+    return (
+      'pattern applies a repetition quantifier to a group that already ' +
+      'contains a repetition (nested quantifier, e.g. "(a+)+"), which risks ' +
+      'catastrophic backtracking; rewrite it without repeating a repeated group'
+    );
+  }
+  return null;
+}

--- a/projects/silver-core-sdk/src/mcp/registry.ts
+++ b/projects/silver-core-sdk/src/mcp/registry.ts
@@ -68,6 +68,11 @@ type ServerEntry = {
    *  connect+listTools await so a concurrent connectAll()/reconnect() for the
    *  same entry coalesces onto it instead of spawning a second connection. */
   connecting?: Promise<void> | null;
+  /** audit 2026-07-14 M-4 — set when closeAll()/setServers() abandons this
+   *  entry. A handshake that resolves AFTERWARDS must close its fresh
+   *  connection instead of publishing it onto the abandoned entry, where the
+   *  child process would leak forever (nothing closes it again). */
+  retired?: boolean;
 };
 
 export class DefaultMcpRegistry implements McpRegistry {
@@ -286,8 +291,27 @@ export class DefaultMcpRegistry implements McpRegistry {
 
   /** Close every connection (best-effort, parallel). */
   async closeAll(): Promise<void> {
+    // audit 2026-07-14 M-4: retire every entry FIRST, synchronously, so a
+    // handshake that resolves while we await below sees the flag and closes
+    // its fresh connection instead of publishing onto an abandoned entry.
+    // (setServers() replaces the entry array afterwards; the query teardown
+    // paths never reconnect a closed registry, so retirement is final.)
+    for (const entry of this.entries) entry.retired = true;
     await Promise.all(
       this.entries.map(async (entry) => {
+        // Await any in-flight handshake so the child it may have spawned is
+        // settled before we sweep: it either published entry.connection
+        // (closed below) or self-closed on the retired flag. connectEntryInner
+        // never rejects, but guard anyway — closeAll stays best-effort.
+        if (entry.connecting) {
+          try {
+            await entry.connecting;
+          } catch (err) {
+            this.debug(
+              `[mcp] error awaiting in-flight connect of '${entry.name}': ${errMessage(err)}`,
+            );
+          }
+        }
         if (!entry.connection) return;
         try {
           await entry.connection.close();
@@ -310,6 +334,8 @@ export class DefaultMcpRegistry implements McpRegistry {
    *  `!entry.connection` guard and spawned a SECOND child process; the loser
    *  was never close()d and leaked. */
   private connectEntry(entry: ServerEntry): Promise<void> {
+    // audit 2026-07-14 M-4: an abandoned entry never starts a new connect.
+    if (entry.retired) return Promise.resolve();
     if (entry.connecting) return entry.connecting;
     const p = this.connectEntryInner(entry).finally(() => {
       entry.connecting = null;
@@ -346,6 +372,22 @@ export class DefaultMcpRegistry implements McpRegistry {
             { serverLabel: entry.name, phase: 'connect', timeoutMs: CONNECT_TIMEOUT_MS },
           ),
       );
+      // audit 2026-07-14 M-4: closeAll()/setServers() may have retired this
+      // entry while the (up to 60s) handshake was in flight. Publishing now
+      // would hang a live connection on an abandoned entry — nothing would
+      // ever close it again and the child process would leak forever. Close
+      // the fresh connection instead and leave the entry unpublished.
+      if (entry.retired) {
+        this.debug(
+          `[mcp] '${entry.name}' was retired during connect; closing the fresh connection`,
+        );
+        try {
+          await conn.close();
+        } catch (err) {
+          this.debug(`[mcp] error closing retired '${entry.name}': ${errMessage(err)}`);
+        }
+        return;
+      }
       entry.connection = conn;
       entry.serverInfo = conn.serverInfo();
       entry.tools = tools.map((t) => ({

--- a/projects/silver-core-sdk/src/reporting/compare-reports.ts
+++ b/projects/silver-core-sdk/src/reporting/compare-reports.ts
@@ -67,6 +67,12 @@ export async function aggregateDay(logDir: string, date: string): Promise<DayAgg
   }
   const from = new Date(`${date}T00:00:00.000Z`);
   const to = new Date(`${date}T23:59:59.999Z`);
+  // Shape safety (audit 2026-07-14 M-12): this aggregation duplicates
+  // runtime-report.ts's (L-7) and dereferences the same nested fields
+  // (r.usage.*, r.total_cost_usd, r.transport_health, r.per_tool). Both
+  // consumers are guarded at the shared readWindow choke point — its
+  // isRunLogRecord() validator diverts wrong-shape lines into the bad-line
+  // counter, so every record that reaches this loop is safe to dereference.
   const { records } = await readWindow(logDir, from, to);
 
   const named = records.filter((r) => r.incognito !== true);

--- a/projects/silver-core-sdk/src/reporting/runtime-report.ts
+++ b/projects/silver-core-sdk/src/reporting/runtime-report.ts
@@ -73,6 +73,49 @@ function fmtPct(x: number): string {
   return `${(x * 100).toFixed(1)}%`;
 }
 
+/**
+ * Shape guard for one parsed ledger line (audit 2026-07-14 M-12): a
+ * well-formed-JSON-but-wrong-shape line (external producer, schema drift)
+ * must land in the bad-line counter, not throw out of the aggregation —
+ * "bad lines are counted, not fatal". Checks exactly the fields the
+ * aggregations dereference (in this file AND in compare-reports.ts, which
+ * consumes the same guarded readWindow): `ts` string; `usage` object with
+ * the four numeric token counters; `total_cost_usd` number;
+ * `transport_health`, when present, an object (Object.entries target);
+ * `per_tool`, when present, an array of objects with numeric calls/errors.
+ * Unknown record types / extra fields pass through untouched — they cannot
+ * crash the aggregation.
+ */
+function isRunLogRecord(x: unknown): x is RunLogRecord {
+  if (typeof x !== 'object' || x === null || Array.isArray(x)) return false;
+  const r = x as Record<string, unknown>;
+  if (typeof r['ts'] !== 'string') return false;
+  const usage = r['usage'];
+  if (typeof usage !== 'object' || usage === null || Array.isArray(usage)) return false;
+  const u = usage as Record<string, unknown>;
+  for (const k of [
+    'input_tokens',
+    'output_tokens',
+    'cache_read_input_tokens',
+    'cache_creation_input_tokens',
+  ]) {
+    if (typeof u[k] !== 'number') return false;
+  }
+  if (typeof r['total_cost_usd'] !== 'number') return false;
+  const th = r['transport_health'];
+  if (th !== undefined && (typeof th !== 'object' || th === null)) return false;
+  const pt = r['per_tool'];
+  if (pt !== undefined) {
+    if (!Array.isArray(pt)) return false;
+    for (const t of pt) {
+      if (typeof t !== 'object' || t === null) return false;
+      const tool = t as Record<string, unknown>;
+      if (typeof tool['calls'] !== 'number' || typeof tool['errors'] !== 'number') return false;
+    }
+  }
+  return true;
+}
+
 /** Parse every ledger line in the window (bad lines are counted, not fatal).
  *  Internal contract shared with compare-reports.ts — not part of the
  *  public package surface. */
@@ -99,7 +142,14 @@ export async function readWindow(
     for (const line of text.split('\n')) {
       if (line.trim().length === 0) continue;
       try {
-        const rec = JSON.parse(line) as RunLogRecord;
+        const rec: unknown = JSON.parse(line);
+        // Shape guard (audit 2026-07-14 M-12): wrong-shape lines join the
+        // torn/non-JSON lines in the bad-line counter instead of throwing
+        // later when the aggregation dereferences rec.usage.* etc.
+        if (!isRunLogRecord(rec)) {
+          badLines += 1;
+          continue;
+        }
         const t = new Date(rec.ts).getTime();
         if (t >= from.getTime() && t <= to.getTime()) records.push(rec);
       } catch {

--- a/projects/silver-core-sdk/src/session-manager.ts
+++ b/projects/silver-core-sdk/src/session-manager.ts
@@ -106,8 +106,11 @@ function mergeModelUsage(
 /**
  * Per-conversation ledger. Result messages carry two reporting semantics
  * (E2/KD-L5-04): `usage` is THAT turn's own figures (summed here), while
- * `total_cost_usd` / `modelUsage` are conversation-cumulative (latest snapshot
- * wins here). usage() folds the ledgers at read time.
+ * `total_cost_usd` / `modelUsage` are cumulative PER QUERY RUN (latest snapshot
+ * wins here). Within one run "latest wins" is exact; across a transparent
+ * auto-resume the fresh run's accumulator restarts at 0, so the supervised
+ * path adds a base offset of the swallowed runs' spend (audit 2026-07-14 M-7).
+ * usage() folds the ledgers at read time.
  */
 type QueryLedger = {
   usage: NonNullableUsage;
@@ -439,6 +442,35 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
     // before the retried query's first message.
     const observations: SDKMessage[] = [];
 
+    // audit 2026-07-14 M-7: `total_cost_usd` / `modelUsage` are cumulative PER
+    // QUERY RUN, but a transparent resume starts a FRESH run whose accumulator
+    // restarts at 0 — plain "latest wins" recording would let the post-resume
+    // snapshot OVERWRITE the pre-resume spend and under-report mgr.usage().
+    // So the supervised path keeps a base offset: each swallowed recoverable
+    // error result folds its cumulative figures into the base, and every
+    // recorded snapshot is accounted as base + latest. (`usage` needs no base:
+    // each result's usage covers only its own run, and record() already SUMS
+    // it — that semantics is preserved below.)
+    let costBase = 0;
+    const modelUsageBase: Record<string, ModelUsage> = {};
+
+    /** Base-aware record(): same single-tick read-modify-write discipline. */
+    const recordSupervised = (r: SDKResultMessage): void => {
+      ledger.usage = addUsage(ledger.usage, r.usage); // per-turn figures: sum
+      ledger.costUsd = costBase + r.total_cost_usd; // swallowed runs + latest run
+      const snapshot: Record<string, ModelUsage> = {};
+      mergeModelUsage(snapshot, modelUsageBase);
+      mergeModelUsage(snapshot, r.modelUsage);
+      ledger.modelUsage = snapshot;
+    };
+
+    /** Fold a swallowed run's cumulative spend into the base (called exactly
+     *  once per swallowed error result, right before the resume re-drive). */
+    const foldIntoBase = (r: SDKResultMessage): void => {
+      costBase += r.total_cost_usd;
+      mergeModelUsage(modelUsageBase, r.modelUsage);
+    };
+
     /** Arm a transparent resume: emit the observation, re-drive, bump count. */
     const scheduleResume = async (code: string, reason: string): Promise<void> => {
       attempts += 1;
@@ -509,13 +541,18 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
 
           // The `subtype` discriminant (not is_error) narrows to the error arm.
           if (v.type === 'result' && v.subtype !== 'success') {
-            record(ledger, v);
+            recordSupervised(v);
             if (
               isRecoverableResult(v) &&
               sessionId !== undefined &&
               attempts < maxResumes
             ) {
-              // Swallow this error result and re-drive transparently.
+              // Swallow this error result and re-drive transparently. Its
+              // cumulative spend goes into the base FIRST (audit 2026-07-14
+              // M-7): the resumed run restarts its accumulator at 0, so
+              // without the fold its first result would overwrite this run's
+              // spend in the ledger.
+              foldIntoBase(v);
               await scheduleResume(
                 v.error_code ?? `http_${v.api_error_status ?? 'error'}`,
                 v.errorMessage ?? 'recoverable error',
@@ -533,7 +570,7 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
             return r;
           }
 
-          if (v.type === 'result') record(ledger, v);
+          if (v.type === 'result') recordSupervised(v);
           return r;
         }
       },

--- a/projects/silver-core-sdk/src/sessions/store.ts
+++ b/projects/silver-core-sdk/src/sessions/store.ts
@@ -16,7 +16,16 @@
  * damaged transcript never blocks a resume.
  */
 
-import { appendFileSync, createReadStream, mkdirSync } from 'node:fs';
+import { Buffer } from 'node:buffer';
+import {
+  appendFileSync,
+  closeSync,
+  createReadStream,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+} from 'node:fs';
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -254,6 +263,9 @@ export class JsonlSessionStore implements SessionStore {
    *  streaming hot path, 4-5 calls per turn). Reset-and-retried on failure so
    *  an externally removed directory still self-heals. */
   private dirEnsured = false;
+  /** Files whose tail byte was already verified by this instance (torn-tail
+   *  self-heal below — audit 2026-07-14 M-9, mirrors FileSessionStore). */
+  private readonly tailChecked = new Set<string>();
 
   constructor(cfg: JsonlSessionStoreConfig = {}) {
     this.dir = resolveSessionsDir(cfg.sessionDir, cfg.env);
@@ -263,6 +275,30 @@ export class JsonlSessionStore implements SessionStore {
   /** Absolute path of one session's transcript file. */
   filePath(sessionId: string): string {
     return join(this.dir, `${sessionId}${JSONL_EXT}`);
+  }
+
+  /**
+   * True when the file exists, is non-empty and does NOT end in a newline —
+   * i.e. a previous process crashed mid-append and left a torn tail.
+   * Reads ONLY the last byte (append sits on the streaming hot path; never
+   * read the whole file here). Sync twin of FileSessionStore's check.
+   */
+  private endsWithoutNewlineSync(file: string): boolean {
+    let fd: number;
+    try {
+      fd = openSync(file, 'r');
+    } catch {
+      return false; // ENOENT etc.: nothing to heal
+    }
+    try {
+      const size = fstatSync(fd).size;
+      if (size === 0) return false;
+      const buf = Buffer.alloc(1);
+      readSync(fd, buf, 0, 1, size - 1);
+      return buf[0] !== 0x0a;
+    } finally {
+      closeSync(fd);
+    }
   }
 
   /**
@@ -276,20 +312,33 @@ export class JsonlSessionStore implements SessionStore {
       );
       return;
     }
-    const line = `${JSON.stringify(entry)}\n`;
+    const file = this.filePath(sessionId);
+    let line = `${JSON.stringify(entry)}\n`;
     try {
       if (!this.dirEnsured) {
         mkdirSync(this.dir, { recursive: true });
         this.dirEnsured = true;
       }
-      appendFileSync(this.filePath(sessionId), line, 'utf8');
+      // Torn-tail self-heal (audit 2026-07-14 M-9, ported from
+      // FileSessionStore.append): the FIRST append to each file per store
+      // instance checks the file's last byte and, when it is not a newline
+      // (a previous process died mid-append), prefixes this line with '\n'.
+      // Otherwise the fresh record would glue onto the torn tail and BOTH
+      // lines would be lost on load — this way the crash corrupts only
+      // itself, never the next record. A racing double check at worst writes
+      // an extra blank line, which load() skips.
+      if (!this.tailChecked.has(file)) {
+        this.tailChecked.add(file);
+        if (this.endsWithoutNewlineSync(file)) line = `\n${line}`;
+      }
+      appendFileSync(file, line, 'utf8');
     } catch {
       // The directory may have been removed after we ensured it: re-ensure
       // and retry ONCE before giving up (append must never throw).
       try {
         mkdirSync(this.dir, { recursive: true });
         this.dirEnsured = true;
-        appendFileSync(this.filePath(sessionId), line, 'utf8');
+        appendFileSync(file, line, 'utf8');
       } catch (err) {
         this.debug(
           `session store: append failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,

--- a/projects/silver-core-sdk/src/subagents/agent-tool.ts
+++ b/projects/silver-core-sdk/src/subagents/agent-tool.ts
@@ -51,7 +51,12 @@ export function createAgentTool(agentNames: string[]): BuiltinTool {
     // Foreground Agent calls batched in one assistant turn must run
     // concurrently (official parity: "send them in a single message with
     // multiple tool uses so they run concurrently"). Each child runs in its
-    // own isolated loop/session, so batch-mates share no mutable state here.
+    // own isolated loop/session, and the runtime forks the persistent Bash
+    // cwd/env namespace per child — seeded from the parent's snapshot at
+    // spawn, mutations private (audit 2026-07-14 M-10) — so batch-mates
+    // share no mutable state here. Deliberately still shared: the
+    // background-shell registry (query-wide by design, append-only ids) and
+    // the read-before-write path Set (monotonic adds, no replay hazard).
     parallelSafe: true,
     inputSchema: {
       type: 'object',

--- a/projects/silver-core-sdk/src/subagents/runtime.ts
+++ b/projects/silver-core-sdk/src/subagents/runtime.ts
@@ -1662,6 +1662,12 @@ export function createSubagentRuntime(
       backgroundTasks.delete(taskId);
       return { outcome: 'not_running', status: record.status };
     }
+    // Word the kill honestly by the record (audit 2026-07-14 M-11b): this
+    // path also stops FOREGROUND children (their agentId is registered too),
+    // and the old text hardcoded "background". A bare backgroundTasks entry
+    // with no record is by construction background.
+    const kind: 'foreground' | 'background' =
+      record !== undefined && !record.background ? 'foreground' : 'background';
     (task?.controller ?? record?.controller)?.abort();
     backgroundTasks.delete(taskId);
     if (record !== undefined) record.status = 'killed';
@@ -1679,10 +1685,10 @@ export function createSubagentRuntime(
       task_id: taskId,
       status: 'stopped',
       output_file: '',
-      summary: `background subagent "${taskId}" stopped via stopTask`,
+      summary: `${kind} subagent "${taskId}" stopped via stopTask`,
     });
-    debug(`stopTask: aborted background subagent "${taskId}"`);
-    return { outcome: 'stopped' };
+    debug(`stopTask: aborted ${kind} subagent "${taskId}"`);
+    return { outcome: 'stopped', kind };
   }
 
   return {
@@ -1695,7 +1701,7 @@ export function createSubagentRuntime(
     stopTask(taskId: string): void {
       const res = killAgent(taskId);
       if (res.outcome === 'unknown') {
-        debug(`stopTask: no background subagent with id "${taskId}"`);
+        debug(`stopTask: no subagent with id "${taskId}"`);
       } else if (res.outcome === 'not_running') {
         debug(`stopTask: subagent "${taskId}" already ${res.status}`);
       }
@@ -1706,7 +1712,8 @@ export function createSubagentRuntime(
       if (res.outcome === 'not_running') {
         return `Subagent ${taskId} already ${res.status}.`;
       }
-      return `Stopped background subagent ${taskId}.`;
+      // Honest wording per record (audit 2026-07-14 M-11b).
+      return `Stopped ${res.kind} subagent ${taskId}.`;
     },
     async sendMessage(params: {
       to: string;

--- a/projects/silver-core-sdk/src/subagents/runtime.ts
+++ b/projects/silver-core-sdk/src/subagents/runtime.ts
@@ -71,6 +71,7 @@ import type {
 } from '../internal/contracts.js';
 import type { CanUseTool } from '../types.js';
 import { DefaultPermissionGate } from '../permissions/gate.js';
+import { forkShellSession } from '../tools/shells.js';
 import { runAgentLoop } from '../engine/loop.js';
 import { matchToolName, parseRule } from '../permissions/rules.js';
 import { addUsage } from '../engine/pricing.js';
@@ -95,8 +96,14 @@ export type SubagentUsageLedger = {
 };
 
 export interface SubagentRuntime {
-  /** SpawnSubagentFn bound to a nesting depth (root ToolContext uses depth 0). */
-  makeSpawnFn(depth: number): SpawnSubagentFn;
+  /**
+   * SpawnSubagentFn bound to a nesting depth (root ToolContext uses depth 0).
+   * `parentShells` is the SPAWNING context's shell session — each spawned
+   * child forks its persistent cwd/env namespace from it (audit 2026-07-14
+   * M-10), so nested children seed from their immediate parent, not the root.
+   * Omitted -> the runtime's query-wide manager (the root loop's session).
+   */
+  makeSpawnFn(depth: number, parentShells?: ShellManager): SpawnSubagentFn;
   /** Pull + clear completed background-subagent result notes (root loop drains). */
   drainCompletedResults(): TextBlockParam[];
   /** Pull + reset the accumulated child usage/cost/modelUsage. */
@@ -182,7 +189,10 @@ export type SubagentRuntimeOptions = {
    *  encoding since v0.7) are pushed here (the runtime cannot yield);
    *  the query layer drains them into the SDKMessage stream. */
   emitObservability?: (msg: SDKMessage) => void;
-  /** v0.5 query-wide shell session (shared with children's ToolContext). */
+  /** v0.5 query-wide shell session. The BACKGROUND-shell registry is shared
+   *  with children's ToolContext as-is; the PERSISTENT cwd/env namespace is
+   *  forked per spawned child (audit 2026-07-14 M-10), seeded from the
+   *  spawning context's snapshot at spawn time. */
   shells?: ShellManager;
   /** v0.6 sandbox context (shared with children's ToolContext). */
   sandbox?: SandboxContext;
@@ -899,7 +909,11 @@ export function createSubagentRuntime(
   }
 
   // --- The spawn closure factory -------------------------------------------
-  function makeSpawnFn(depth: number): SpawnSubagentFn {
+  function makeSpawnFn(depth: number, parentShells?: ShellManager): SpawnSubagentFn {
+    // The shell session this spawner's CALLER runs on: children fork their
+    // persistent cwd/env namespace from it (audit 2026-07-14 M-10). The root
+    // loop's spawner (depth 0, no override) forks from the query-wide manager.
+    const sessionShells = parentShells ?? opts.shells;
     return async function spawn(
       params: SpawnSubagentParams,
     ): Promise<SpawnSubagentResult> {
@@ -1249,19 +1263,30 @@ export function createSubagentRuntime(
       const childController = new AbortController();
       const parentSignal = isBackground ? outerSignal : params.signal;
       const childSignal = AbortSignal.any([parentSignal, childController.signal]);
+      // Persistent shell state is FORKED per spawned child (audit 2026-07-14
+      // M-10): the child's namespace is seeded from the parent's cwd/env
+      // snapshot as of spawn time (it still sees the parent's persistent
+      // state), but its own cd/exports stay private — they never replay into
+      // concurrent batch-mates' Bash calls nor back into the parent's next
+      // foreground Bash. The BACKGROUND-shell registry stays query-wide:
+      // forkShellSession delegates spawnBackground/get/kill to the shared
+      // manager, so BashOutput/KillShell see the same shells everywhere.
+      const childShells =
+        sessionShells !== undefined ? forkShellSession(sessionShells) : undefined;
       const childToolContext: ToolContext = {
         cwd: childCwd,
         additionalDirectories,
         env,
         signal: childSignal,
         debug,
-        spawnSubagent: makeSpawnFn(childDepth),
-        // One shell session per query: children see the same background
-        // shells and persistent cwd/env as the root loop. KNOWN LIMIT for
-        // worktree isolation: the shared persistent-state replay may `cd` a
-        // child Bash call back to the last recorded cwd (outside the
-        // worktree); Read/Write/Edit and childConfig.cwd stay confined.
-        shells: opts.shells,
+        // Nested spawns fork their shell namespace from THIS child's session
+        // (lineage seeding), not from the root manager.
+        spawnSubagent: makeSpawnFn(childDepth, childShells),
+        // KNOWN LIMIT for worktree isolation: the SEED is the parent's last
+        // recorded cwd, which may lie outside the worktree, so the child's
+        // first Bash call can still start outside it (its later cds are its
+        // own); Read/Write/Edit and childConfig.cwd stay confined.
+        shells: childShells,
         // Children inherit the same sandbox as the root loop.
         sandbox: opts.sandbox,
         // Same SESSION for the read-before-write gate: a parent Read
@@ -1486,7 +1511,38 @@ export function createSubagentRuntime(
       try {
         result = await run;
       } catch (err) {
-        record.status = 'failed';
+        // Do not clobber a terminal status: killAgent may have set 'killed'
+        // before this catch runs — same guard as the background path (audit
+        // 2026-07-14 M-11a).
+        if (record.status === 'running') record.status = 'failed';
+        // killAgent on a FOREGROUND child aborts only that child: resolve the
+        // spawn to an error result so the Agent tool returns "stopped" and
+        // the PARENT loop continues — rethrowing the AbortError here would
+        // propagate through the Agent tool and kill the whole parent query
+        // (audit 2026-07-14 M-11c). A genuine parent-side abort (the spawning
+        // tool call's signal or the query-wide signal) still rethrows: the
+        // parent itself is being cancelled, and swallowing that would fake a
+        // completed turn.
+        if (
+          isAbortError(err) &&
+          record.status === 'killed' &&
+          !params.signal.aborted &&
+          !outerSignal.aborted
+        ) {
+          // The child is done (stopped); fire its stop hook like every other
+          // terminal path, with a fresh signal, never gating the return.
+          await fireSubagentStop(
+            agentId,
+            resolved.type,
+            new AbortController().signal,
+          ).catch(() => undefined);
+          return {
+            content: `Subagent was stopped before completing (agentId: ${agentId}).`,
+            isError: true,
+            agentId,
+            background: false,
+          };
+        }
         throw err;
       } finally {
         await releaseWorktree().catch(() => undefined);
@@ -1589,7 +1645,10 @@ export function createSubagentRuntime(
   /** Shared kill path for stopTask (Query API) and stopAgent (TaskStop bridge). */
   function killAgent(
     taskId: string,
-  ): { outcome: 'stopped' } | { outcome: 'not_running'; status: string } | { outcome: 'unknown' } {
+  ):
+    | { outcome: 'stopped'; kind: 'foreground' | 'background' }
+    | { outcome: 'not_running'; status: string }
+    | { outcome: 'unknown' } {
     const task = backgroundTasks.get(taskId);
     const record = childRegistry.get(taskId);
     if (task === undefined && record === undefined) return { outcome: 'unknown' };

--- a/projects/silver-core-sdk/src/tools/bash.ts
+++ b/projects/silver-core-sdk/src/tools/bash.ts
@@ -247,6 +247,12 @@ function formatStreams(stdout: string, stderr: string): string {
  * cwd + `export -p`. Functions/aliases/unexported vars do NOT persist — this
  * is a state-file replay, not a long-lived shell process (docs/COMPAT.md).
  *
+ * `stateDir` is the caller's PER-CONTEXT namespace: the root loop replays the
+ * query-wide dir, while each spawned subagent's ToolContext carries a forked
+ * dir seeded from its parent at spawn time (shells.ts forkShellSession), so
+ * concurrent batch-mates never replay each other's cd/exports and a child's
+ * mutations never reach the parent's next call (audit 2026-07-14 M-10).
+ *
  * The state dir comes from mkdtemp, so single-quoting it is safe against word
  * splitting. But on Windows mkdtemp returns a BACKSLASH path
  * (`C:\Users\…\bpt-shell-X`); embedded verbatim, those backslashes corrupt

--- a/projects/silver-core-sdk/src/tools/grep.ts
+++ b/projects/silver-core-sdk/src/tools/grep.ts
@@ -11,6 +11,7 @@ import fg from 'fast-glob';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { AbortError } from '../errors.js';
+import { guardRegexPattern } from '../internal/regex-guard.js';
 import { GREP_DESCRIPTION } from './descriptions.js';
 import type {
   BuiltinTool,
@@ -337,6 +338,18 @@ export const grepTool: BuiltinTool = {
     let flags = 'm';
     if (caseInsensitive) flags += 'i';
     if (multiline) flags += 's';
+    // ReDoS guard (audit 2026-07-14 M-2, shared with hooks/matcher.ts): the
+    // model-supplied pattern runs synchronously over up to 10MB per file, so a
+    // catastrophic-backtracking pattern would freeze the event loop with no
+    // timeout or AbortSignal able to interrupt it. Rejected patterns come back
+    // as a descriptive tool error the model can rephrase — never a throw.
+    const guardReason = guardRegexPattern(pattern);
+    if (guardReason !== null) {
+      return {
+        content: `Grep: unsafe regular expression rejected: ${guardReason}.`,
+        isError: true,
+      };
+    }
     try {
       void new RegExp(pattern, flags);
     } catch (err) {

--- a/projects/silver-core-sdk/src/tools/shells.ts
+++ b/projects/silver-core-sdk/src/tools/shells.ts
@@ -14,11 +14,12 @@
  */
 
 import { spawn } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { copyFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { AbortError } from '../errors.js';
+import { guardRegexPattern } from '../internal/regex-guard.js';
 import { planShellSpawn } from '../sandbox/backend.js';
 import { planProcessKill, terminalStatus } from './kill-plan.js';
 import { detectSandboxEvidence, sandboxFailureHint } from '../sandbox/evidence.js';
@@ -224,6 +225,67 @@ export function createShellManager(debug: (msg: string) => void): ShellManager {
 }
 
 // ---------------------------------------------------------------------------
+// Per-subagent persistent-state fork (audit 2026-07-14 M-10)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fork the PERSISTENT-STATE namespace of a shell session for one spawned
+ * subagent (audit 2026-07-14 M-10). Before this, every concurrent foreground
+ * subagent shared the query's single cwd/env state file, so one batch-mate's
+ * `cd`/`export` replayed into its siblings' (and the parent's) next Bash call
+ * — cross-pollution plus a write race on the shared file. The fork:
+ *   - creates a child state dir SEEDED from the parent's current cwd/env
+ *     snapshot, so the child still sees the parent's persistent state as it
+ *     was at spawn time, but its own mutations stay in its namespace and
+ *     never leak to siblings or back to the parent;
+ *   - nests the child dir UNDER the parent state dir, so the query-wide
+ *     dispose() removes every fork with no extra lifecycle plumbing (a
+ *     SendMessage continuation between-times still finds its state intact);
+ *   - scopes ONLY the persistent state: spawnBackground/get/kill delegate to
+ *     the query-wide manager, so children list, read and stop the SAME
+ *     background shells as the root loop.
+ * A parent with no state dir (persistence already degraded to stateless) has
+ * nothing to fork or pollute and is returned as-is; a fork whose own mkdtemp
+ * fails degrades that child to stateless ('' state dir) rather than falling
+ * back onto the shared parent file.
+ */
+export function forkShellSession(parent: ShellManager): ShellManager {
+  if (parent.stateDir === '') return parent;
+  let childDir = '';
+  try {
+    childDir = mkdtempSync(join(parent.stateDir, 'fork-'));
+    for (const name of ['cwd', 'env']) {
+      try {
+        copyFileSync(join(parent.stateDir, name), join(childDir, name));
+      } catch {
+        // No parent snapshot for this file yet (no foreground Bash ran
+        // before the spawn) — the child simply starts without one.
+      }
+    }
+  } catch {
+    childDir = ''; // degrade to stateless, never back to the shared file
+  }
+  return {
+    stateDir: childDir,
+    spawnBackground: (shell, command, ctx, disableSandbox) =>
+      parent.spawnBackground(shell, command, ctx, disableSandbox),
+    get: (id) => parent.get(id),
+    kill: (id) => parent.kill(id),
+    // Scoped dispose: drop only this fork's namespace. Background shells
+    // belong to the query-wide manager and are disposed there.
+    dispose: () => {
+      if (childDir !== '') {
+        try {
+          rmSync(childDir, { recursive: true, force: true });
+        } catch {
+          /* best-effort */
+        }
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // BashOutput / KillShell built-in tools
 // ---------------------------------------------------------------------------
 
@@ -240,7 +302,11 @@ function describeStatus(rec: BackgroundShell): string {
   return `status: ${rec.status} (${exit})`;
 }
 
-/** Apply an optional per-line regex filter to an output chunk. */
+/** Apply an optional per-line regex filter to an output chunk.
+ *  Callers must pre-screen `filter` with guardRegexPattern (audit 2026-07-14
+ *  M-2): this helper only handles SYNTACTIC invalidity (passes everything);
+ *  ReDoS-risky patterns are rejected at the tool boundary with a descriptive
+ *  error so the model can rephrase. */
 function filterLines(chunk: string, filter: string | undefined): string {
   if (filter === undefined || filter.length === 0 || chunk.length === 0) {
     return chunk;
@@ -296,6 +362,21 @@ export const bashOutputTool: BuiltinTool = {
       return { content: `BashOutput: no background shell with id "${id}".`, isError: true };
     }
     const filter = typeof input['filter'] === 'string' ? input['filter'] : undefined;
+    // ReDoS guard (audit 2026-07-14 M-2, shared with Grep and hooks/matcher):
+    // the filter regex runs per line over up to 500K chars of accumulated
+    // shell output, synchronously. Reject risky patterns with a message the
+    // model can act on, BEFORE the cursors advance (so no output is lost).
+    if (filter !== undefined) {
+      const guardReason = guardRegexPattern(filter);
+      if (guardReason !== null) {
+        return {
+          content:
+            `BashOutput: unsafe "filter" regular expression rejected: ` +
+            `${guardReason}. Retry with a simpler filter (or none).`,
+          isError: true,
+        };
+      }
+    }
     const newOut = rec.stdout.slice(rec.cursorOut);
     const newErr = rec.stderr.slice(rec.cursorErr);
     rec.cursorOut = rec.stdout.length;

--- a/projects/silver-core-sdk/src/tools/webfetch.ts
+++ b/projects/silver-core-sdk/src/tools/webfetch.ts
@@ -8,12 +8,26 @@
  *
  * Safety: an SSRF guard blocks localhost / private / link-local / ULA / CGNAT
  * addresses (IP literals AND resolved DNS results) unless
- * ctx.allowPrivateWebFetch is true. Residual DNS-rebinding risk between the
- * lookup and the fetch is documented and not fully closed.
+ * ctx.allowPrivateWebFetch is true.
+ *
+ * DNS pinning (audit 2026-07-14 M-3): the guard's lookup and the fetch used
+ * to be two INDEPENDENT resolutions, leaving a classic DNS-rebinding window
+ * (validate public IP, then the attacker's DNS answers a private IP for the
+ * actual connection). The default path now connects through node:https with a
+ * custom `lookup` that returns ONLY the guard-validated addresses, while Host
+ * and TLS SNI/cert verification stay on the original hostname. Redirect hops
+ * re-run guard + pinning per hop. HONEST LIMIT: a caller-injected
+ * ctx.fetchImpl does its own connection handling and BYPASSES pinning (it
+ * still goes through the per-hop guard); injection is a test/ops escape hatch
+ * and inherits the old rebinding window.
  */
 
 import { isIP } from 'node:net';
 import { lookup } from 'node:dns/promises';
+import { request as httpsRequest } from 'node:https';
+import type { RequestOptions } from 'node:https';
+import type { IncomingMessage } from 'node:http';
+import { Readable } from 'node:stream';
 import type {
   BuiltinTool,
   ToolContext,
@@ -145,11 +159,23 @@ function addressBlocked(address: string, family: number): boolean {
   return false;
 }
 
-/** Returns a blocked-reason string, or null when the host is permitted. */
-async function ssrfGuard(hostname: string, signal: AbortSignal): Promise<string | null> {
+/** One guard-validated address, pinned for the actual connection (M-3). */
+export type PinnedAddress = { address: string; family: number };
+
+type SsrfVerdict =
+  | { blocked: string; addresses?: undefined }
+  | { blocked: null; addresses: PinnedAddress[] };
+
+/**
+ * Validates a host and, when permitted, returns the exact addresses the
+ * validation saw so the connection can be PINNED to them (audit 2026-07-14
+ * M-3 — without pinning, the fetch's own second resolution reopened the
+ * DNS-rebinding window this guard exists to close).
+ */
+async function ssrfGuard(hostname: string, signal: AbortSignal): Promise<SsrfVerdict> {
   const host = hostname.toLowerCase();
   if (host === 'localhost' || host.endsWith('.localhost')) {
-    return `blocked host "${hostname}" (localhost)`;
+    return { blocked: `blocked host "${hostname}" (localhost)` };
   }
   // URL.hostname keeps the surrounding brackets on an IPv6 literal
   // (e.g. "[2606:4700:4700::1111]"); strip them so isIP()/lookup() see the
@@ -158,9 +184,11 @@ async function ssrfGuard(hostname: string, signal: AbortSignal): Promise<string 
   const literalFamily = isIP(bare);
   if (literalFamily !== 0) {
     if (addressBlocked(bare, literalFamily)) {
-      return `blocked IP literal "${hostname}" (private/loopback/link-local range)`;
+      return {
+        blocked: `blocked IP literal "${hostname}" (private/loopback/link-local range)`,
+      };
     }
-    return null;
+    return { blocked: null, addresses: [{ address: bare, family: literalFamily }] };
   }
   // Resolve and reject if ANY resolved address is in a blocked range.
   let records: Array<{ address: string; family: number }>;
@@ -168,15 +196,137 @@ async function ssrfGuard(hostname: string, signal: AbortSignal): Promise<string 
     records = await lookup(bare, { all: true });
   } catch (e) {
     if (isAbortError(e)) throw e;
-    return `could not resolve host "${hostname}": ${(e as Error).message}`;
+    return { blocked: `could not resolve host "${hostname}": ${(e as Error).message}` };
   }
   if (signal.aborted) throw new AbortError();
   for (const rec of records) {
     if (addressBlocked(rec.address, rec.family)) {
-      return `blocked host "${hostname}" -> ${rec.address} (private/loopback/link-local range)`;
+      return {
+        blocked: `blocked host "${hostname}" -> ${rec.address} (private/loopback/link-local range)`,
+      };
     }
   }
-  return null;
+  return {
+    blocked: null,
+    addresses: records.map((r) => ({ address: r.address, family: r.family })),
+  };
+}
+
+// -- DNS-pinned fetch (default path, audit 2026-07-14 M-3) --------------------
+
+/** Module-private sentinel: the pinned set has no address usable for the
+ *  socket's requested family. Mirrors an ENOTFOUND lookup failure. */
+class PinnedLookupExhaustedError extends Error {
+  readonly code = 'ENOTFOUND';
+  constructor(hostname: string, family: number) {
+    super(
+      `DNS pinning: no validated${family === 4 ? ' IPv4' : family === 6 ? ' IPv6' : ''} ` +
+        `address available for "${hostname}"`,
+    );
+    this.name = 'PinnedLookupExhaustedError';
+  }
+}
+
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address?: string | Array<{ address: string; family: number }>,
+  family?: number,
+) => void;
+
+/**
+ * Builds a node `lookup` override that answers ONLY from the guard-validated
+ * address set — the socket can no longer be steered to a different (private)
+ * address by a second DNS answer, because no second DNS query ever happens.
+ * Handles both node call shapes: (hostname, cb) and (hostname, options, cb),
+ * with options.family / options.all honored. Exported for unit tests.
+ */
+export function makePinnedLookup(
+  addresses: PinnedAddress[],
+): (hostname: string, options: unknown, callback?: LookupCallback) => void {
+  return (hostname, options, callback) => {
+    const cb: LookupCallback =
+      typeof options === 'function' ? (options as LookupCallback) : (callback as LookupCallback);
+    const opts =
+      typeof options === 'object' && options !== null
+        ? (options as { family?: number | string; all?: boolean })
+        : {};
+    const family =
+      opts.family === 4 || opts.family === 'IPv4'
+        ? 4
+        : opts.family === 6 || opts.family === 'IPv6'
+          ? 6
+          : 0;
+    const usable = family === 0 ? addresses : addresses.filter((a) => a.family === family);
+    const first = usable[0];
+    if (first === undefined) {
+      cb(new PinnedLookupExhaustedError(hostname, family));
+      return;
+    }
+    if (opts.all === true) {
+      cb(
+        null,
+        usable.map((a) => ({ address: a.address, family: a.family })),
+        0,
+      );
+      return;
+    }
+    cb(null, first.address, first.family);
+  };
+}
+
+/** Minimal request-issuing seam so tests can observe the pinned wiring
+ *  without touching the network. Defaults to node:https request. */
+export type PinnedRequestImpl = (
+  options: RequestOptions,
+) => ReturnType<typeof httpsRequest>;
+
+/**
+ * Fetch-shaped GET over node:https with the connection pinned to the
+ * guard-validated addresses (`pinned`; null = no pinning, used only under
+ * ctx.allowPrivateWebFetch where nothing was validated). Host header and TLS
+ * SNI / certificate verification stay on the ORIGINAL hostname — node derives
+ * both from `hostname`, and the custom `lookup` only replaces the address the
+ * socket dials. Returns a real WHATWG Response wrapping the socket stream, so
+ * the existing redirect / body-cap / conversion pipeline is unchanged.
+ */
+export async function pinnedFetch(
+  url: URL,
+  init: { signal: AbortSignal; headers: Record<string, string> },
+  pinned: PinnedAddress[] | null,
+  requestImpl: PinnedRequestImpl = httpsRequest,
+): Promise<Response> {
+  const hostname =
+    url.hostname.startsWith('[') && url.hostname.endsWith(']')
+      ? url.hostname.slice(1, -1)
+      : url.hostname;
+  const res = await new Promise<IncomingMessage>((resolve, reject) => {
+    const req = requestImpl({
+      hostname,
+      port: url.port !== '' ? Number(url.port) : 443,
+      path: `${url.pathname}${url.search}`,
+      method: 'GET',
+      headers: init.headers,
+      signal: init.signal,
+      ...(pinned !== null ? { lookup: makePinnedLookup(pinned) } : {}),
+    } as RequestOptions);
+    req.once('response', resolve);
+    req.once('error', reject);
+    req.end();
+  });
+  const status = res.statusCode ?? 0;
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(res.headers)) {
+    if (Array.isArray(value)) headers.set(key, value.join(', '));
+    else if (typeof value === 'string') headers.set(key, value);
+  }
+  const statusText = res.statusMessage ?? '';
+  // Null-body statuses may not carry a body per the Response contract.
+  if (status === 204 || status === 205 || status === 304) {
+    res.resume(); // drain so the socket is released
+    return new Response(null, { status, statusText, headers });
+  }
+  const body = Readable.toWeb(res) as ReadableStream<Uint8Array>;
+  return new Response(body, { status, statusText, headers });
 }
 
 // -- HTML -> text conversion -------------------------------------------------
@@ -318,24 +468,41 @@ export const webFetchTool: BuiltinTool = {
       if (!normalized.ok) return errorResult(normalized.message);
       let current = normalized.url;
 
-      const fetchImpl = ctx.fetchImpl ?? globalThis.fetch;
+      // Injection bypasses DNS pinning (audit 2026-07-14 M-3): an injected
+      // fetch does its own connection handling, so we can only run the guard
+      // per hop and hand it the URL — the rebinding window stays open on that
+      // path. The DEFAULT path pins the connection to the guard's addresses.
+      const injectedFetch = ctx.fetchImpl;
       let response: Response | undefined;
 
       for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+        // Guard + pinning re-run on EVERY hop, so a redirect cannot smuggle
+        // the connection onto an unvalidated (or re-bound) address either.
+        let pinned: PinnedAddress[] | null = null;
         if (!ctx.allowPrivateWebFetch) {
-          const blocked = await ssrfGuard(current.hostname, ctx.signal);
-          if (blocked) return errorResult(`WebFetch failed: ${blocked}.`);
+          const verdict = await ssrfGuard(current.hostname, ctx.signal);
+          if (verdict.blocked !== null) {
+            return errorResult(`WebFetch failed: ${verdict.blocked}.`);
+          }
+          pinned = verdict.addresses;
         }
 
         const signal = AbortSignal.any([ctx.signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)]);
-        const res = await fetchImpl(current.toString(), {
-          redirect: 'manual',
-          signal,
-          headers: { 'user-agent': USER_AGENT, accept: ACCEPT_HEADER },
-        });
+        const headers = { 'user-agent': USER_AGENT, accept: ACCEPT_HEADER };
+        const res =
+          injectedFetch !== undefined
+            ? await injectedFetch(current.toString(), {
+                redirect: 'manual',
+                signal,
+                headers,
+              })
+            : await pinnedFetch(current, { signal, headers }, pinned);
 
         // Manual redirect handling.
         if (res.status >= 300 && res.status < 400) {
+          // The hop's body is never read; release its stream (and, on the
+          // pinned path, the underlying socket) before moving on.
+          if (res.body !== null) void res.body.cancel().catch(() => {});
           const location = res.headers.get('location');
           if (!location) {
             return errorResult(

--- a/projects/silver-core-sdk/src/tools/workflow-engine.ts
+++ b/projects/silver-core-sdk/src/tools/workflow-engine.ts
@@ -41,11 +41,16 @@
  *    unparsable reply yields null (same null semantics as a dead agent).
  *
  * Resume: each run journals its agent() calls in invocation order as
- * (input-hash, result) pairs. Resuming replays the longest unchanged prefix
- * from the journal (official semantics: the first edited/new call and
- * everything after it runs live); a call whose inputs match but which never
- * completed (returned null) re-runs live without breaking the prefix.
- * Journals live in memory — resume is same-session only.
+ * (input-hash, result) pairs. Resume lookup is ORDER-INDEPENDENT (audit
+ * 2026-07-14 M-13): parallel branches' post-await agent() calls interleave
+ * nondeterministically, so a rerun's sequence permutation must not defeat
+ * the cache — the Nth live call with hash H replays the Nth journal entry
+ * with hash H (two calls with identical hash are interchangeable by
+ * construction: the hash covers prompt + opts). A changed/new call simply
+ * runs live without disabling other lookups; a call whose inputs match but
+ * which never completed (returned null) re-runs live. The journal WRITE
+ * format is unchanged (entries in invocation order), so old journals stay
+ * resumable. Journals live in memory — resume is same-session only.
  */
 
 import * as os from 'node:os';
@@ -102,7 +107,9 @@ export type WorkflowRunOptions = {
   signal: AbortSignal;
   debug: (msg: string) => void;
   limits?: Partial<WorkflowLimits>;
-  /** Prior run's journal (prefix cache) for resumeFromRunId. */
+  /** Prior run's journal for resumeFromRunId. Replayed by (hash, occurrence),
+   *  not by position (audit 2026-07-14 M-13), so parallel-branch reorderings
+   *  between runs still hit the cache. */
   resumeJournal?: WorkflowJournalEntry[];
   /** Resolve a saved workflow name to script source (workflow(name) hook).
    *  Must throw a descriptive Error for an unknown name. */
@@ -639,9 +646,30 @@ export async function runWorkflow(opts: WorkflowRunOptions): Promise<WorkflowRun
   let seq = 0; // agent() invocation counter (lifetime cap + journal index)
   let agentsLive = 0;
   let agentsCached = 0;
-  let cacheActive = opts.resumeJournal !== undefined;
   let topMeta: WorkflowMeta | undefined;
   let started = false;
+
+  // Resume cache index (audit 2026-07-14 M-13): keyed by (hash, occurrence)
+  // instead of global call sequence. Parallel branches' post-await agent()
+  // calls interleave nondeterministically, so on a rerun the seq permutation
+  // would break a journal[index] comparison and silently disable the cache;
+  // instead the Nth live call with hash H looks up the Nth journal entry
+  // with hash H (journal order). Identical-hash calls are interchangeable by
+  // construction (the hash covers prompt + opts), so occurrence-matching is
+  // semantically safe. Each lookup is independent — a miss means only THAT
+  // call runs live. The journal write format (invocation-ordered array) is
+  // unchanged, so journals from before this change resume fine.
+  const resumeByHash = new Map<string, WorkflowJournalEntry[]>();
+  if (opts.resumeJournal !== undefined) {
+    for (const e of opts.resumeJournal) {
+      if (e === undefined) continue; // tolerate a sparse journal
+      const arr = resumeByHash.get(e.hash);
+      if (arr === undefined) resumeByHash.set(e.hash, [e]);
+      else arr.push(e);
+    }
+  }
+  /** Per-hash count of occurrences already consumed by live calls. */
+  const resumeSeen = new Map<string, number>();
 
   const pushProgress = (line: string): void => {
     if (progress.length < MAX_PROGRESS_LINES) progress.push(line);
@@ -683,12 +711,16 @@ export async function runWorkflow(opts: WorkflowRunOptions): Promise<WorkflowRun
     const entry: WorkflowJournalEntry = { hash, completed: false, result: null };
     journal[index] = entry;
 
-    // Resume prefix cache: unchanged + completed -> cached result; unchanged
-    // but never completed -> re-run live without breaking the prefix; changed
-    // or new -> everything after runs live.
-    if (cacheActive) {
-      const prior = opts.resumeJournal![index];
-      if (prior !== undefined && prior.hash === hash) {
+    // Resume cache, order-independent (audit 2026-07-14 M-13): the Nth live
+    // call with this hash consumes the Nth journal entry with this hash.
+    // Completed -> cached result; matching but uncompleted -> re-run live
+    // (the occurrence is still consumed so later duplicates stay aligned);
+    // no entry -> this call runs live, other lookups are unaffected.
+    if (resumeByHash.size > 0) {
+      const occurrence = resumeSeen.get(hash) ?? 0;
+      const prior = resumeByHash.get(hash)?.[occurrence];
+      if (prior !== undefined) {
+        resumeSeen.set(hash, occurrence + 1);
         if (prior.completed) {
           agentsCached += 1;
           entry.completed = true;
@@ -696,9 +728,7 @@ export async function runWorkflow(opts: WorkflowRunOptions): Promise<WorkflowRun
           pushProgress(`[agent#${index}] ${display}: cached (resume)`);
           return prior.result;
         }
-        // fall through: matching inputs, uncompleted -> live, prefix intact
-      } else {
-        cacheActive = false;
+        // fall through: matching inputs, uncompleted -> live
       }
     }
 

--- a/projects/silver-core-sdk/src/transport/node-http.ts
+++ b/projects/silver-core-sdk/src/transport/node-http.ts
@@ -22,9 +22,11 @@
  * untouched; this module only changes what the seam RESOLVES TO by default.
  *
  * Resolution order (resolveHttpClient): provider.fetch (always wins, it IS
- * the override seam) > provider.httpClient > env BPT_HTTP_CLIENT > 'node'.
- * `'fetch'` restores the exact pre-v0.45 behavior (late-bound global fetch)
- * for environments that need undici semantics — e.g. Node's
+ * the override seam) > provider.httpClient > env BPT_HTTP_CLIENT >
+ * proxy-env autodetect (any of HTTPS_PROXY/HTTP_PROXY/ALL_PROXY set, either
+ * case, resolves to 'fetch' — audit 2026-07-14 M-6, see resolveHttpClient) >
+ * 'node'. `'fetch'` restores the exact pre-v0.45 behavior (late-bound global
+ * fetch) for environments that need undici semantics — e.g. Node's
  * NODE_USE_ENV_PROXY / setGlobalDispatcher proxying, or a test suite that
  * stubs global fetch (this repo's own suite pins it via vitest env).
  *
@@ -262,10 +264,34 @@ export function getNodeFetch(): NodeFetch {
 }
 
 /**
+ * Proxy env vars that flip the default HTTP client to 'fetch' (audit
+ * 2026-07-14 M-6). Both cases are listed because both are conventional and
+ * the env record passed in is case-sensitive (unlike Windows process env).
+ */
+const PROXY_ENV_VARS = [
+  'HTTPS_PROXY',
+  'https_proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+] as const;
+
+/**
  * HTTP-client resolution: provider.httpClient (explicit override) >
- * BPT_HTTP_CLIENT env ('node' | 'fetch') > default 'node' (the built-in
- * keep-alive adapter). provider.fetch is NOT decided here — it always wins
- * at the transport's call site regardless of this setting.
+ * BPT_HTTP_CLIENT env ('node' | 'fetch') > proxy-env autodetect (below) >
+ * default 'node' (the built-in keep-alive adapter). provider.fetch is NOT
+ * decided here — it always wins at the transport's call site regardless of
+ * this setting.
+ *
+ * Proxy autodetect (audit 2026-07-14 M-6): the built-in node adapter dials
+ * origins DIRECTLY — it never reads HTTPS_PROXY/HTTP_PROXY/ALL_PROXY — so in
+ * a proxy-only environment defaulting to 'node' makes every request fail (or
+ * silently bypass an audit proxy where direct egress is open). When no
+ * explicit choice was made and any proxy env var is set non-empty, resolve
+ * to 'fetch': global fetch (undici) can be proxied via NODE_USE_ENV_PROXY or
+ * setGlobalDispatcher. An explicit 'node' (provider or BPT_HTTP_CLIENT)
+ * always wins over the autodetect.
  */
 export function resolveHttpClient(
   provider: ProviderConfig,
@@ -276,6 +302,10 @@ export function resolveHttpClient(
   }
   const fromEnv = env.BPT_HTTP_CLIENT;
   if (fromEnv === 'node' || fromEnv === 'fetch') return fromEnv;
+  for (const name of PROXY_ENV_VARS) {
+    const value = env[name];
+    if (typeof value === 'string' && value.length > 0) return 'fetch';
+  }
   return 'node';
 }
 

--- a/projects/silver-core-sdk/src/transport/openai.ts
+++ b/projects/silver-core-sdk/src/transport/openai.ts
@@ -787,9 +787,21 @@ export class OpenAIStreamTranslator {
     this.open.clear();
     const cached = this.usage?.prompt_tokens_details?.cached_tokens ?? 0;
     const prompt = this.usage?.prompt_tokens ?? 0;
+    // Missing finish_reason + tool calls => infer 'tool_use' (audit 2026-07-14
+    // M-5): some gateways end a tool-call stream with a bare [DONE] (or EOF)
+    // and never send finish_reason='tool_calls'. mapFinishReason(null) defaults
+    // to 'end_turn', which makes the engine treat the turn as FINAL and
+    // silently drop the model's tool calls. If this message opened/buffered at
+    // least one tool_use block, the only honest stop_reason is 'tool_use'.
+    // Streams that DID carry a finish_reason are untouched (finishReason is
+    // only set from a non-empty string, so every explicit path is unchanged).
+    const stopReason: StopReason =
+      this.finishReason === null && this.toolBuffers.size > 0
+        ? 'tool_use'
+        : mapFinishReason(this.finishReason);
     events.push({
       type: 'message_delta',
-      delta: { stop_reason: mapFinishReason(this.finishReason), stop_sequence: null },
+      delta: { stop_reason: stopReason, stop_sequence: null },
       // OpenAI prompt_tokens INCLUDES cached tokens; Anthropic input_tokens
       // excludes cache reads — split so pricing/usage semantics line up.
       usage: {

--- a/projects/silver-core-sdk/src/types.ts
+++ b/projects/silver-core-sdk/src/types.ts
@@ -757,6 +757,18 @@ export type HookCallbackMatcher = {
    * path, zero model calls.
    */
   condition?: string;
+  /**
+   * BPT-EXTENSION (audit 2026-07-14 M-1): per-matcher failure policy for THIS
+   * matcher's callbacks, overriding Options.hookFailureMode when set. The
+   * global default stays 'open' (official drop-in parity), which means a
+   * crashed or timed-out callback is treated as "no opinion" — a security
+   * PreToolUse hook that WOULD have denied silently stops denying. Marking
+   * the security-critical matcher 'closed' turns its callback failures into a
+   * deny (fail safe) without changing behavior for every other hook; 'open'
+   * likewise wins over a global 'closed' for a best-effort matcher. Omitted
+   * -> the global setting applies.
+   */
+  failureMode?: 'open' | 'closed';
   hooks: HookCallback[];
   /** Timeout in seconds for each callback (default 60). */
   timeout?: number;
@@ -1667,6 +1679,8 @@ export type Options = {
    * silently stops denying. 'closed': the failure contributes a deny, so
    * hook-enforced policy fails safe (tool calls block while the hook is
    * broken). Cancellation via the caller's signal is never treated as a deny.
+   * A matcher-level HookCallbackMatcher.failureMode overrides this global
+   * setting for that matcher's callbacks (audit 2026-07-14 M-1).
    */
   hookFailureMode?: 'open' | 'closed';
   /** v0.4: surface hook execution as system/hook_started + system/

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.57.3';
+export const SDK_VERSION = '0.58.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/compare-reports.test.ts
+++ b/projects/silver-core-sdk/tests/compare-reports.test.ts
@@ -118,6 +118,22 @@ describe('compareReports', () => {
     expect(cmp.markdown).toContain('| midStreamCuts | 2 | 0 | -2 |');
   });
 
+  it('does not throw on wrong-shape ledger lines; aggregates only valid ones (audit 2026-07-14 M-12)', async () => {
+    await seedDay('2026-07-10', [
+      line(),
+      // well-formed JSON, wrong shape: no usage object at all
+      '{"ts":"2026-07-10T11:00:00.000Z"}\n',
+      // well-formed JSON, wrong-typed usage
+      `${JSON.stringify({ v: 1, ts: '2026-07-10T12:00:00.000Z', usage: 'nonsense', total_cost_usd: 0.5 })}\n`,
+    ]);
+    await seedDay('2026-07-11', [line({ ts: '2026-07-11T10:00:00.000Z' })]);
+    const cmp = await compareReports('2026-07-10', '2026-07-11', { logDir: dir });
+    expect(cmp.a.records).toBe(1);
+    expect(cmp.a.tokens?.input).toBe(100);
+    expect(cmp.a.tokens?.costUsd).toBeCloseTo(0.01);
+    expect(cmp.b.records).toBe(1);
+  });
+
   it('marks a data-less side 无数据 and nulls its deltas', async () => {
     await seedDay('2026-07-11', [line({ ts: '2026-07-11T10:00:00.000Z' })]);
     const cmp = await compareReports('2026-07-01', '2026-07-11', { logDir: dir });

--- a/projects/silver-core-sdk/tests/engine.test.ts
+++ b/projects/silver-core-sdk/tests/engine.test.ts
@@ -1879,6 +1879,36 @@ describe('runAgentLoop', () => {
     expect(lastResult(messages).subtype).toBe('error_max_turns');
   });
 
+  it('C4: a pause_turn continuation is gated by maxBudgetUsd like every other continuation (audit 2026-07-14 M-8)', async () => {
+    // Before the fix the pause_turn branch checked only maxTurns before
+    // re-issuing a billed API call — the ONE continuation path without the
+    // budget gate the tool-continue / structured-retry / bg-drain /
+    // stop-hook-block paths all share.
+    const transport = new MockTransport([
+      textReplyEvents('partial…', {
+        stopReason: 'pause_turn',
+        model: 'claude-sonnet-4-5',
+        usage: { input_tokens: 1000 }, // $0.003105 > the cap below
+      }),
+      textReplyEvents('should never run'),
+    ]);
+    const deps = makeDeps(transport);
+    const history: APIMessageParam[] = [{ role: 'user', content: 'go' }];
+    const messages = await collect(
+      runAgentLoop(history, deps, makeConfig({ maxBudgetUsd: 0.000001 })),
+    );
+
+    // No second billed call was issued past the cap.
+    expect(transport.requests).toHaveLength(1);
+    // Same result shaping as the other budget-gated continuation paths.
+    const result = lastResult(messages);
+    expect(result.subtype).toBe('error_max_budget_usd');
+    expect(result.is_error).toBe(true);
+    if (result.subtype === 'error_max_budget_usd') {
+      expect(result.errorMessage).toContain('maxBudgetUsd');
+    }
+  });
+
   it('C5: refusal surfaces as an ERROR result (not success) with error_code refusal', async () => {
     const transport = new MockTransport([textReplyEvents('', { stopReason: 'refusal' })]);
     const deps = makeDeps(transport);

--- a/projects/silver-core-sdk/tests/mcp-registry-retire.test.ts
+++ b/projects/silver-core-sdk/tests/mcp-registry-retire.test.ts
@@ -1,0 +1,149 @@
+/**
+ * audit 2026-07-14 M-4: MCP registry retired-entry sweep.
+ *
+ * Before: closeAll()/setServers() only closed entries whose connection was
+ * ALREADY published. An entry still handshaking (entry.connection null,
+ * entry.connecting in flight — up to 60s) was skipped; when the handshake
+ * later resolved it published a live connection onto the abandoned entry and
+ * nothing ever closed it again — the stdio child process leaked forever.
+ * After: closeAll retires every entry first, awaits in-flight handshakes and
+ * sweeps what they produced; connectEntryInner checks the retired flag after
+ * the handshake and closes the fresh connection instead of publishing it.
+ *
+ * Harness: buildConnection is stubbed per-instance (the configs are inert),
+ * so connect timing is fully scripted and no child process is ever spawned.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { DefaultMcpRegistry } from '../src/mcp/registry.js';
+import type { McpServerConfig } from '../src/types.js';
+
+type FakeConn = {
+  connect: (signal?: AbortSignal) => Promise<void>;
+  serverInfo: () => { name: string; version: string } | undefined;
+  listTools: (signal?: AbortSignal) => Promise<Array<{ name: string; inputSchema: object }>>;
+  callTool: () => Promise<{ content: never[] }>;
+  listResources: () => Promise<never[]>;
+  readResource: () => Promise<never[]>;
+  close: () => Promise<void>;
+  closed: boolean;
+};
+
+/** A fake connection whose connect() blocks until release() is called. */
+function makeGatedConn(name: string): { conn: FakeConn; release: () => void } {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const conn: FakeConn = {
+    closed: false,
+    connect: async () => {
+      await gate;
+    },
+    serverInfo: () => ({ name, version: '1.0.0' }),
+    listTools: async () => [{ name: 'tick', inputSchema: { type: 'object' } }],
+    callTool: async () => ({ content: [] }),
+    listResources: async () => [],
+    readResource: async () => [],
+    close: async () => {
+      conn.closed = true;
+    },
+  };
+  return { conn, release };
+}
+
+/** A fake connection that connects immediately. */
+function makeInstantConn(name: string): FakeConn {
+  const { conn, release } = makeGatedConn(name);
+  release();
+  return conn;
+}
+
+/** Registry over inert configs, with buildConnection stubbed to the fakes. */
+function stubRegistry(fakes: Record<string, FakeConn>): DefaultMcpRegistry {
+  const servers = Object.fromEntries(
+    Object.keys(fakes).map((n) => [n, { command: 'noop' } as McpServerConfig]),
+  );
+  const reg = new DefaultMcpRegistry({ servers, debug: () => {} });
+  restub(reg, fakes);
+  return reg;
+}
+
+/** Point (or re-point, for setServers) buildConnection at a fake set. */
+function restub(reg: DefaultMcpRegistry, fakes: Record<string, FakeConn>): void {
+  (reg as unknown as { buildConnection: (name: string) => FakeConn }).buildConnection = (
+    name: string,
+  ) => {
+    const fake = fakes[name];
+    if (fake === undefined) throw new Error(`no fake connection scripted for '${name}'`);
+    return fake;
+  };
+}
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('DefaultMcpRegistry retired-entry sweep (audit 2026-07-14 M-4)', () => {
+  it('a connect resolving AFTER closeAll() gets its fresh connection closed (no zombie)', async () => {
+    const { conn, release } = makeGatedConn('slow');
+    const reg = stubRegistry({ slow: conn });
+
+    const connecting = reg.connectAll(); // handshake parked on the gate
+    await tick();
+    expect(conn.closed).toBe(false);
+
+    const closing = reg.closeAll(); // entry.connection is still null here
+    release(); // handshake resolves only now
+    await Promise.all([connecting, closing]);
+
+    // The late handshake must NOT have published a live connection.
+    expect(conn.closed).toBe(true);
+    expect(reg.statuses()[0]!.status).not.toBe('connected');
+    expect(reg.allTools()).toEqual([]);
+  });
+
+  it('setServers() during connectAll() closes the old in-flight connection and connects the new set', async () => {
+    const { conn: oldConn, release } = makeGatedConn('old');
+    const reg = stubRegistry({ old: oldConn });
+
+    const connecting = reg.connectAll();
+    await tick();
+
+    restub(reg, { fresh: makeInstantConn('fresh') });
+    const swapping = reg.setServers({ fresh: { command: 'noop' } as McpServerConfig });
+    release(); // the old handshake resolves while the swap is in progress
+    await Promise.all([connecting, swapping]);
+
+    expect(oldConn.closed).toBe(true); // no zombie from the replaced set
+    const statuses = reg.statuses();
+    expect(statuses.map((s) => s.name)).toEqual(['fresh']);
+    expect(statuses[0]!.status).toBe('connected');
+    expect(reg.allTools().map((t) => t.qualifiedName)).toEqual(['mcp__fresh__tick']);
+  });
+
+  it('normal connect -> use -> closeAll stays unchanged', async () => {
+    const conn = makeInstantConn('srv');
+    const reg = stubRegistry({ srv: conn });
+
+    await reg.connectAll();
+    expect(reg.statuses()[0]!.status).toBe('connected');
+    expect(reg.has('mcp__srv__tick')).toBe(true);
+
+    await reg.closeAll();
+    expect(conn.closed).toBe(true);
+    expect(reg.statuses()[0]!.status).toBe('pending');
+    expect(reg.allTools()).toEqual([]);
+  });
+
+  it('connectAll() after closeAll() does not resurrect a retired entry', async () => {
+    const conn = makeInstantConn('srv');
+    const reg = stubRegistry({ srv: conn });
+    await reg.connectAll();
+    await reg.closeAll();
+    conn.closed = false; // would flip back if a new connect published
+
+    await reg.connectAll(); // retired entries must not start a new connect
+    expect(reg.statuses()[0]!.status).not.toBe('connected');
+    expect(reg.allTools()).toEqual([]);
+  });
+});

--- a/projects/silver-core-sdk/tests/permissions-hooks.test.ts
+++ b/projects/silver-core-sdk/tests/permissions-hooks.test.ts
@@ -1526,3 +1526,136 @@ describe('DefaultHookRunner', () => {
     ).rejects.toBeInstanceOf(AbortError);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Per-matcher failureMode override + loud fail-open notice (audit 2026-07-14 M-1)
+// ---------------------------------------------------------------------------
+
+describe('DefaultHookRunner per-matcher failureMode (audit 2026-07-14 M-1)', () => {
+  it("matcher failureMode 'closed' denies a crashing PreToolUse hook while the global default stays 'open'", async () => {
+    // No runner-level failureMode: the global default is 'open'. The security
+    // matcher opts into 'closed' for itself only.
+    const r = new DefaultHookRunner({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: '*',
+            failureMode: 'closed',
+            hooks: [
+              async function securityHook() {
+                throw new Error('policy backend down');
+              },
+            ],
+          },
+        ],
+      },
+      debug: () => {},
+    });
+    const agg = await r.run('PreToolUse', PRE_TOOL_INPUT, 'toolu_m1a', 'Bash', freshSignal());
+    expect(agg.decision).toBe('deny');
+    expect(agg.decisionReason).toContain('securityHook');
+    expect(agg.decisionReason).toContain('policy backend down');
+  });
+
+  it("matcher failureMode 'closed' denies a timed-out hook under the global default", async () => {
+    const r = new DefaultHookRunner({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: '*',
+            failureMode: 'closed',
+            timeout: 0.05, // 50ms
+            hooks: [
+              async () => {
+                await new Promise((resolve) => setTimeout(resolve, 5_000).unref?.());
+                return decisionOutput('deny', 'should have denied');
+              },
+            ],
+          },
+        ],
+      },
+      debug: () => {},
+    });
+    const agg = await r.run('PreToolUse', PRE_TOOL_INPUT, 'toolu_m1b', 'Bash', freshSignal());
+    expect(agg.decision).toBe('deny');
+  });
+
+  it("matcher failureMode 'open' wins over a global 'closed' (override works both ways)", async () => {
+    const r = new DefaultHookRunner({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: '*',
+            failureMode: 'open',
+            hooks: [
+              async () => {
+                throw new Error('best-effort hook, failure tolerated');
+              },
+            ],
+          },
+        ],
+      },
+      debug: () => {},
+      failureMode: 'closed',
+    });
+    const agg = await r.run('PreToolUse', PRE_TOOL_INPUT, 'toolu_m1c', 'Bash', freshSignal());
+    expect(agg.decision).toBeUndefined();
+  });
+
+  it('the override is scoped to ITS matcher: a sibling matcher still follows the global default', async () => {
+    const r = new DefaultHookRunner({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: '*',
+            failureMode: 'closed',
+            hooks: [
+              async function guardedHook() {
+                throw new Error('guarded matcher down');
+              },
+            ],
+          },
+          {
+            matcher: '*',
+            hooks: [
+              async () => {
+                throw new Error('default matcher down');
+              },
+            ],
+          },
+        ],
+      },
+      debug: () => {},
+    });
+    const agg = await r.run('PreToolUse', PRE_TOOL_INPUT, 'toolu_m1d', 'Bash', freshSignal());
+    // The 'closed' matcher contributes the deny; the sibling stays neutral
+    // under the global 'open' default (registration order keeps the reason).
+    expect(agg.decision).toBe('deny');
+    expect(agg.decisionReason).toContain('guardedHook');
+  });
+
+  it("a failure resolved fail-open emits a LOUD debug line saying the outcome was discarded", async () => {
+    const lines: string[] = [];
+    const r = makeRunner(
+      {
+        PreToolUse: [
+          {
+            matcher: '*',
+            hooks: [
+              async function fragileHook() {
+                throw new Error('boom');
+              },
+            ],
+          },
+        ],
+      },
+      (m) => lines.push(m),
+    );
+    const agg = await r.run('PreToolUse', PRE_TOOL_INPUT, 'toolu_m1e', 'Bash', freshSignal());
+    expect(agg.decision).toBeUndefined();
+    const loud = lines.find((l) => l.includes('DISCARDED fail-open'));
+    expect(loud).toBeDefined();
+    expect(loud).toContain('fragileHook');
+    expect(loud).toContain("failureMode 'closed'"); // points at the remedy
+  });
+});

--- a/projects/silver-core-sdk/tests/regex-guard.test.ts
+++ b/projects/silver-core-sdk/tests/regex-guard.test.ts
@@ -1,0 +1,205 @@
+/**
+ * audit 2026-07-14 M-2: shared ReDoS guard for model-supplied regexes.
+ *
+ * The nested-quantifier heuristic + pattern length cap moved from
+ * hooks/matcher.ts into src/internal/regex-guard.ts and now also gates the
+ * Grep pattern compilation and the BashOutput per-line `filter` — both run a
+ * model-supplied pattern synchronously over bulk text (up to 10MB per file /
+ * 500K chars of shell output), where catastrophic backtracking freezes the
+ * event loop beyond the reach of any timeout or AbortSignal. A rejected
+ * pattern surfaces as a descriptive tool ERROR result the model can rephrase,
+ * never an uncaught throw. The hooks matcher's own behavior is unchanged
+ * (regression suite in permissions-hooks.test.ts stays green).
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  guardRegexPattern,
+  hasNestedQuantifier,
+  MAX_REGEX_PATTERN_LENGTH,
+} from '../src/internal/regex-guard.js';
+import { grepTool } from '../src/tools/grep.js';
+import { createShellManager, bashOutputTool } from '../src/tools/shells.js';
+import { matcherMatches } from '../src/hooks/matcher.js';
+import type { ShellManager, ToolContext } from '../src/internal/contracts.js';
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let sandboxes: string[] = [];
+let manager: ShellManager | undefined;
+
+afterEach(async () => {
+  manager?.dispose();
+  manager = undefined;
+  await Promise.all(sandboxes.map((d) => rm(d, { recursive: true, force: true })));
+  sandboxes = [];
+});
+
+async function makeCorpus(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'regex-guard-'));
+  sandboxes.push(dir);
+  await writeFile(
+    path.join(dir, 'a.ts'),
+    'function greet(name) {\n  console.log.error("log fatal Error");\n}\nplain line\n',
+  );
+  return dir;
+}
+
+function makeCtx(cwd: string, withShells = false): ToolContext {
+  if (withShells && manager === undefined) manager = createShellManager(() => {});
+  return {
+    cwd,
+    additionalDirectories: [],
+    env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    signal: new AbortController().signal,
+    debug: () => {},
+    ...(withShells ? { shells: manager } : {}),
+  };
+}
+
+function contentOf(res: { content: unknown }): string {
+  return typeof res.content === 'string' ? res.content : JSON.stringify(res.content);
+}
+
+async function until(cond: () => boolean, ms = 5000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > ms) throw new Error('condition not met in time');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The shared guard itself
+// ---------------------------------------------------------------------------
+
+describe('internal/regex-guard: shared heuristic + length cap', () => {
+  it.each([['(a+)+$'], ['(a*)+'], ['(a+)*'], ['((a+))+'], ['(a(b+))+'], ['(.*x)+'], ['(a+){2,}']])(
+    'flags the catastrophic-backtracking signature %s',
+    (pattern) => {
+      expect(hasNestedQuantifier(pattern)).toBe(true);
+      expect(guardRegexPattern(pattern)).toContain('nested quantifier');
+    },
+  );
+
+  it.each([
+    ['\\bfunction\\s+\\w+\\('], // escaped paren + linear repeats
+    ['log.*Error'],
+    ['(foo|bar)+'], // quantified group WITHOUT inner repeat is linear
+    ['^mcp__'],
+    ['Edit.*'],
+    ['[a+]+'], // quantifier chars inside a class are literals
+  ])('passes the safe real-world pattern %s', (pattern) => {
+    expect(hasNestedQuantifier(pattern)).toBe(false);
+    expect(guardRegexPattern(pattern)).toBeNull();
+  });
+
+  it('caps over-long patterns with a reason naming the cap', () => {
+    const reason = guardRegexPattern('a'.repeat(MAX_REGEX_PATTERN_LENGTH + 1));
+    expect(reason).toContain(String(MAX_REGEX_PATTERN_LENGTH));
+    expect(guardRegexPattern('a'.repeat(MAX_REGEX_PATTERN_LENGTH))).toBeNull();
+  });
+
+  it('hooks matcher regression: guarded pattern still matches nothing, safe ones still work', () => {
+    expect(matcherMatches('(a+)+$', 'a'.repeat(40) + 'b')).toBe(false);
+    expect(matcherMatches('^mcp__', 'mcp__srv__tool')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grep pattern compilation
+// ---------------------------------------------------------------------------
+
+describe('Grep rejects ReDoS-risky patterns as a tool error (audit 2026-07-14 M-2)', () => {
+  it("rejects '(a+)+$' with a clear, rephrasable message and never throws", async () => {
+    const dir = await makeCorpus();
+    const r = await grepTool.execute({ pattern: '(a+)+$', path: dir }, makeCtx(dir));
+    expect(r.isError).toBe(true);
+    expect(contentOf(r)).toContain('unsafe regular expression rejected');
+    expect(contentOf(r)).toContain('nested quantifier');
+  });
+
+  it('rejects the same pattern in multiline mode (guard sits before every compile)', async () => {
+    const dir = await makeCorpus();
+    const r = await grepTool.execute(
+      { pattern: '(a+)+$', path: dir, multiline: true, output_mode: 'content' },
+      makeCtx(dir),
+    );
+    expect(r.isError).toBe(true);
+    expect(contentOf(r)).toContain('unsafe regular expression rejected');
+  });
+
+  it("moderately complex real patterns still work: '\\bfunction\\s+\\w+\\('", async () => {
+    const dir = await makeCorpus();
+    const r = await grepTool.execute(
+      { pattern: '\\bfunction\\s+\\w+\\(', path: dir, output_mode: 'content' },
+      makeCtx(dir),
+    );
+    expect(r.isError).toBeUndefined();
+    expect(contentOf(r)).toContain('function greet(');
+  });
+
+  it("'log.*Error' still works", async () => {
+    const dir = await makeCorpus();
+    const r = await grepTool.execute(
+      { pattern: 'log.*Error', path: dir, output_mode: 'content' },
+      makeCtx(dir),
+    );
+    expect(r.isError).toBeUndefined();
+    expect(contentOf(r)).toContain('log fatal Error');
+  });
+
+  it('a syntactically invalid pattern keeps its dedicated error message', async () => {
+    const dir = await makeCorpus();
+    const r = await grepTool.execute({ pattern: '(unclosed', path: dir }, makeCtx(dir));
+    expect(r.isError).toBe(true);
+    expect(contentOf(r)).toContain('invalid regular expression');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BashOutput filter
+// ---------------------------------------------------------------------------
+
+describe('BashOutput filter guard (audit 2026-07-14 M-2)', () => {
+  it("rejects a '(a+)+$' filter with a clear error and does NOT advance the cursors", async () => {
+    const dir = await makeCorpus();
+    const ctx = makeCtx(dir, true);
+    const launched = manager!.spawnBackground('bash', 'echo keep-me', ctx) as { id: string };
+    const id = launched.id;
+    await until(() => manager!.get(id)!.status !== 'running');
+
+    const rejected = await bashOutputTool.execute({ bash_id: id, filter: '(a+)+$' }, ctx);
+    expect(rejected.isError).toBe(true);
+    expect(contentOf(rejected)).toContain('unsafe "filter" regular expression rejected');
+    expect(contentOf(rejected)).toContain('nested quantifier');
+
+    // The rejection happened BEFORE the read cursors advanced: a retry
+    // without the bad filter still sees the output.
+    const retry = await bashOutputTool.execute({ bash_id: id }, ctx);
+    expect(contentOf(retry)).toContain('keep-me');
+  });
+
+  it('a normal filter still applies per line', async () => {
+    const dir = await makeCorpus();
+    const ctx = makeCtx(dir, true);
+    const launched = manager!.spawnBackground(
+      'bash',
+      'echo keep-alpha; echo drop-beta',
+      ctx,
+    ) as { id: string };
+    const id = launched.id;
+    await until(() => manager!.get(id)!.status !== 'running');
+
+    const read = await bashOutputTool.execute({ bash_id: id, filter: '^keep' }, ctx);
+    expect(read.isError).toBeUndefined();
+    expect(contentOf(read)).toContain('keep-alpha');
+    expect(contentOf(read)).not.toContain('drop-beta');
+  });
+});

--- a/projects/silver-core-sdk/tests/runtime-report.test.ts
+++ b/projects/silver-core-sdk/tests/runtime-report.test.ts
@@ -251,6 +251,29 @@ describe('generateRuntimeReport', () => {
     expect(report.summary.records).toBe(1);
   });
 
+  it('wrong-shape JSON lines count as bad lines, never kill the report (audit 2026-07-14 M-12)', async () => {
+    const good = {
+      ...buildRunLogRecord(resultFixture(), { incognito: false, scenario: 'coding' }),
+      ts: '2026-07-11T11:00:00Z',
+    };
+    const logDir = join(dir, 'ledger');
+    await mkdir(logDir, { recursive: true });
+    await writeFile(
+      join(logDir, 'runlog-2026-07-11.jsonl'),
+      `${JSON.stringify(good)}\n` +
+        // well-formed JSON, wrong shape: no usage object at all
+        '{"ts":"2026-07-11T11:00:00Z"}\n' +
+        // well-formed JSON, wrong-typed usage
+        `${JSON.stringify({ ...good, usage: 'nonsense' })}\n`,
+    );
+
+    const report = await generateRuntimeReport({ logDir, now: T0, outDir: null });
+    // Succeeds; aggregates ONLY the valid record and counts the 2 bad lines.
+    expect(report.summary.records).toBe(1);
+    expect(report.summary.tokens?.input).toBe(100);
+    expect(report.markdown).toContain('2 unparseable lines skipped');
+  });
+
   it('missing log directory degrades to an all-无数据 report, not a throw', async () => {
     const report = await generateRuntimeReport({
       logDir: join(dir, 'does-not-exist'),

--- a/projects/silver-core-sdk/tests/session-recovery.test.ts
+++ b/projects/silver-core-sdk/tests/session-recovery.test.ts
@@ -282,6 +282,84 @@ describe('supervised auto-resume', () => {
 
     await mgr.close();
   });
+
+  // -------------------------------------------------------------------------
+  // ⑩ auto-resume must not lose the pre-resume spend (audit 2026-07-14 M-7)
+  // -------------------------------------------------------------------------
+  it('⑩ mgr.usage() sums spend across an auto-resume instead of keeping only the post-resume snapshot', async () => {
+    // total_cost_usd / modelUsage are cumulative PER QUERY RUN. The resumed
+    // run restarts its accumulator at 0, so before the M-7 fix the success
+    // result's snapshot OVERWROTE the swallowed run's spend in the ledger and
+    // mgr.usage().totalCostUsd under-reported by exactly the attempt-1 cost.
+    const counter = { n: 0 };
+    const ping = tool(
+      'ping',
+      'count invocations',
+      {},
+      async () => {
+        counter.n += 1;
+        return { content: [{ type: 'text', text: 'pong' }] };
+      },
+    );
+    const srv = createSdkMcpServer({ name: 'c', tools: [ping] });
+    const store = new InMemorySessionStore();
+
+    // Attempt 1: a PRICED tool_use turn (spend lands in the run accumulator),
+    // then the follow-up request crashes -> recoverable error RESULT carrying
+    // attempt 1's cumulative cost. Resume: a priced text turn completes ->
+    // success result carrying ONLY the resumed run's own cost.
+    const { fn, calls } = scriptedFetch([
+      toolUseReplyEvents('mcp__c__ping', {}, { id: 'toolu_m7' }),
+      'crash',
+      textReplyEvents('recovered'),
+    ]);
+    vi.stubGlobal('fetch', fn);
+
+    const mgr = createBptSession(
+      managerOptions({
+        sessionStore: store,
+        recovery: { autoResume: true, maxResumes: 2 },
+        mcpServers: { c: srv } as unknown as Options['mcpServers'],
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        provider: {
+          apiKey: 'test-key',
+          promptCaching: false,
+          maxRetries: 0,
+          // The mock replies report model 'claude-test-1' (not in the static
+          // price table); price it explicitly so both runs carry real cost.
+          // 100 USD/MTok makes the figures round: attempt 1 = (25 in + 11 out)
+          // tokens = $0.0036; the resumed run = (25 in + 7 out) = $0.0032.
+          pricing: { 'claude-test-1': { input: 100, output: 100 } },
+        },
+      }),
+    );
+    const messages = await collect(mgr.query({ prompt: 'use the tool' }));
+
+    // Sanity: the scenario really exercised swallow + resume + fresh run.
+    const last = lastResult(messages);
+    expect(last.subtype).toBe('success');
+    expect(resumeObservations(messages)).toHaveLength(1);
+    expect(calls()).toBe(3);
+    expect(counter.n).toBe(1);
+    // The success result is the resumed run's OWN snapshot (accumulator
+    // restarted at 0) — before the fix this became the whole ledger.
+    expect(last.total_cost_usd).toBeCloseTo(0.0032, 9);
+
+    const u = mgr.usage();
+    // KEY (M-7): the ledger is the SUM of both runs, not the last snapshot.
+    expect(u.totalCostUsd).toBeCloseTo(0.0036 + 0.0032, 9);
+    // modelUsage folds the swallowed run's figures under the same model id.
+    expect(u.modelUsage['claude-test-1']!.costUSD).toBeCloseTo(0.0068, 9);
+    expect(u.modelUsage['claude-test-1']!.inputTokens).toBe(50);
+    expect(u.modelUsage['claude-test-1']!.outputTokens).toBe(18);
+    // `usage` was ALREADY summed per result before the fix (each result's
+    // usage covers only its own run) — verify the fix did not break that.
+    expect(u.usage.input_tokens).toBe(50);
+    expect(u.usage.output_tokens).toBe(18);
+
+    await mgr.close();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/projects/silver-core-sdk/tests/sessions-store.test.ts
+++ b/projects/silver-core-sdk/tests/sessions-store.test.ts
@@ -6,7 +6,7 @@
 // @ts-nocheck
 
 
-import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -112,6 +112,63 @@ describe('JsonlSessionStore path traversal (findings #10/#40)', () => {
     const loaded = await store.load('good-id');
     expect(loaded).not.toBeNull();
     expect(loaded?.messages).toEqual([{ role: 'user', content: 'hello' }]);
+  });
+});
+
+describe('JsonlSessionStore torn-tail self-heal (audit 2026-07-14 M-9)', () => {
+  it('append after a crash-torn tail loses only the torn line; the new record survives', async () => {
+    const sid = 'torn-1';
+    const { store } = makeStore();
+    store.append(sid, { type: 'meta', sessionId: sid, createdAt: 1, cwd: '/w' });
+    store.append(sid, { type: 'user', message: { role: 'user', content: 'kept' } });
+    store.append(sid, { type: 'assistant', message: { role: 'assistant', content: 'reply' } });
+    store.append(sid, { type: 'user', message: { role: 'user', content: 'to-be-torn' } });
+
+    // Simulate a crash mid-append: drop the trailing newline AND part of the
+    // last record's JSON, leaving a torn tail.
+    const file = join(dir, `${sid}.jsonl`);
+    const raw = readFileSync(file, 'utf8');
+    expect(raw.endsWith('\n')).toBe(true);
+    writeFileSync(file, raw.slice(0, raw.length - 12), 'utf8');
+
+    // A FRESH store instance (fresh process after the crash) appends the next
+    // record. Without the self-heal the new line glues onto the torn tail and
+    // BOTH are lost; with it, only the torn line is lost.
+    const { store: restarted } = makeStore();
+    restarted.append(sid, { type: 'user', message: { role: 'user', content: 'after-crash' } });
+
+    const loaded = await restarted.load(sid);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.messages).toEqual([
+      { role: 'user', content: 'kept' },
+      { role: 'assistant', content: 'reply' },
+      { role: 'user', content: 'after-crash' },
+    ]);
+    // The healed file carries the new record on its OWN line (a '\n' was
+    // prefixed ahead of it, sealing the torn tail into its own line).
+    const healed = readFileSync(file, 'utf8').split('\n').filter((l) => l.trim().length > 0);
+    expect(JSON.parse(healed[healed.length - 1]!)).toEqual({
+      type: 'user',
+      message: { role: 'user', content: 'after-crash' },
+    });
+  });
+
+  it('does not inject blank lines when the tail is intact (heal fires only on a torn tail)', async () => {
+    const sid = 'clean-1';
+    const { store } = makeStore();
+    store.append(sid, { type: 'meta', sessionId: sid, createdAt: 1, cwd: '/w' });
+    store.append(sid, { type: 'user', message: { role: 'user', content: 'one' } });
+
+    // Fresh instance, intact newline-terminated tail: no '\n' prefix.
+    const { store: restarted } = makeStore();
+    restarted.append(sid, { type: 'user', message: { role: 'user', content: 'two' } });
+
+    const raw = readFileSync(join(dir, `${sid}.jsonl`), 'utf8');
+    expect(raw).not.toContain('\n\n');
+    const loaded = await restarted.load(sid);
+    // Consecutive user turns merge in pairing repair; both texts survive.
+    expect(JSON.stringify(loaded?.messages)).toContain('one');
+    expect(JSON.stringify(loaded?.messages)).toContain('two');
   });
 });
 

--- a/projects/silver-core-sdk/tests/shells.test.ts
+++ b/projects/silver-core-sdk/tests/shells.test.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 import {
   createShellManager,
   bashOutputTool,
+  forkShellSession,
   killShellTool,
   taskOutputTool,
   taskStopTool,
@@ -319,5 +320,99 @@ describe('Bash persistent cwd/env state', () => {
     await bashTool.execute({ command: `cd '${sub}'` }, ctx);
     const out = await bashTool.execute({ command: 'pwd' }, ctx);
     expect(text(out.content).trim()).toBe(fs.realpathSync(sandbox));
+  });
+});
+
+describe('forkShellSession — per-subagent persistent-state fork (audit 2026-07-14 M-10)', () => {
+  const firstLine = (r: { content: unknown }): string =>
+    text(r.content).trim().split('\n')[0] ?? '';
+
+  it('two forked children do not inherit each other\'s cd; both see the parent cwd as of spawn', async () => {
+    const ctx = makeCtx(true);
+    const parentDir = path.join(sandbox, 'parent-dir');
+    const aDir = path.join(sandbox, 'a-dir');
+    fs.mkdirSync(parentDir);
+    fs.mkdirSync(aDir);
+    // Parent records a persistent cwd BEFORE the spawns.
+    await bashTool.execute({ command: `cd '${parentDir}'` }, ctx);
+
+    const ctxA: ToolContext = { ...ctx, shells: forkShellSession(manager!) };
+    const ctxB: ToolContext = { ...ctx, shells: forkShellSession(manager!) };
+
+    // A child sees the parent's persistent cwd that existed at spawn time.
+    expect(firstLine(await bashTool.execute({ command: 'pwd' }, ctxA))).toBe(
+      fs.realpathSync(parentDir),
+    );
+    // A cd's away; B's SUBSEQUENT Bash call must NOT inherit A's cwd.
+    await bashTool.execute({ command: `cd '${aDir}'` }, ctxA);
+    expect(firstLine(await bashTool.execute({ command: 'pwd' }, ctxB))).toBe(
+      fs.realpathSync(parentDir),
+    );
+    // ... and A keeps its own cwd across its own calls.
+    expect(firstLine(await bashTool.execute({ command: 'pwd' }, ctxA))).toBe(
+      fs.realpathSync(aDir),
+    );
+    // The parent's next foreground Bash is untouched by A's cd.
+    expect(firstLine(await bashTool.execute({ command: 'pwd' }, ctx))).toBe(
+      fs.realpathSync(parentDir),
+    );
+  });
+
+  it('a child export does not leak to the parent; the child sees parent exports from spawn time', async () => {
+    const ctx = makeCtx(true);
+    await bashTool.execute({ command: 'export BPT_FORK_SEED=fromparent' }, ctx);
+    const childCtx: ToolContext = { ...ctx, shells: forkShellSession(manager!) };
+    // Seeded: the child sees the parent's exported env as of spawn.
+    const seed = await bashTool.execute(
+      { command: 'echo "seed=$BPT_FORK_SEED"' },
+      childCtx,
+    );
+    expect(text(seed.content)).toContain('seed=fromparent');
+    // The child's own export stays in its namespace.
+    await bashTool.execute({ command: 'export BPT_FORK_LEAK=child' }, childCtx);
+    const parentOut = await bashTool.execute(
+      { command: 'echo "leak=${BPT_FORK_LEAK:-none}"' },
+      ctx,
+    );
+    expect(text(parentOut.content)).toContain('leak=none');
+  });
+
+  it('background shells stay query-wide through a fork (get/kill delegate to the shared manager)', async () => {
+    const ctx = makeCtx(true);
+    const child = forkShellSession(manager!);
+    const childCtx: ToolContext = { ...ctx, shells: child };
+    const launch = await bashTool.execute(
+      { command: 'echo bg-through-fork', run_in_background: true },
+      childCtx,
+    );
+    const idMatch = /id: (bash_\d+)/.exec(text(launch.content));
+    expect(idMatch).not.toBeNull();
+    const id = idMatch![1]!;
+    // Registered on the QUERY-WIDE manager, visible from both sides.
+    await until(() => manager!.get(id)!.status !== 'running');
+    expect(manager!.get(id)!.stdout).toContain('bg-through-fork');
+    expect(child.get(id)).toBe(manager!.get(id));
+  });
+
+  it('fork dirs nest under the parent state dir and die with the query-wide dispose()', () => {
+    makeCtx(true);
+    const child = forkShellSession(manager!);
+    expect(child.stateDir).not.toBe(manager!.stateDir);
+    expect(child.stateDir.startsWith(manager!.stateDir)).toBe(true);
+    expect(fs.existsSync(child.stateDir)).toBe(true);
+    manager!.dispose();
+    expect(fs.existsSync(child.stateDir)).toBe(false);
+    manager = undefined;
+  });
+
+  it('a stateless parent (no state dir) is returned as-is — nothing to fork or pollute', () => {
+    const stateless: ShellManager = {
+      stateDir: '',
+      spawnBackground: () => ({ error: 'unused' }),
+      get: () => undefined,
+      kill: () => false,
+      dispose: () => {},
+    };
+    expect(forkShellSession(stateless)).toBe(stateless);
   });
 });

--- a/projects/silver-core-sdk/tests/subagents.test.ts
+++ b/projects/silver-core-sdk/tests/subagents.test.ts
@@ -32,12 +32,14 @@ import {
 } from '../src/subagents/runtime.js';
 import { DefaultHookRunner } from '../src/hooks/runner.js';
 import { DefaultPermissionGate } from '../src/permissions/gate.js';
+import { createShellManager } from '../src/tools/shells.js';
 import { AbortError } from '../src/errors.js';
 import type {
   BuiltinTool,
   EngineConfig,
   McpRegistry,
   SessionStore,
+  ShellManager,
   SpawnSubagentParams,
   StoredSession,
   StreamRequest,
@@ -53,6 +55,7 @@ import type {
   McpServerStatus,
   Options,
   RawMessageStreamEvent,
+  SDKMessage,
 } from '../src/types.js';
 import {
   MockTransport,
@@ -165,6 +168,10 @@ function makeRuntime(cfg: {
   transport?: MockTransport | Transport;
   /** Spawn-time checkpoint recorder resolver (audit 2026-07-14 H-3). */
   getRecordFileChange?: SubagentRuntimeOptions['getRecordFileChange'];
+  /** Query-wide shell session (per-child persistent-state fork, M-10). */
+  shells?: ShellManager;
+  /** Task lifecycle sink (task_started/... observability messages). */
+  emitObservability?: (msg: SDKMessage) => void;
 }): RuntimeHarness {
   const transport = (cfg.transport ?? new MockTransport(cfg.scripts)) as MockTransport;
   const starts: string[] = [];
@@ -225,6 +232,8 @@ function makeRuntime(cfg: {
     debug: () => {},
     familyBudget: cfg.familyBudget,
     getRecordFileChange: cfg.getRecordFileChange,
+    shells: cfg.shells,
+    emitObservability: cfg.emitObservability,
   };
   return { runtime: createSubagentRuntime(opts), transport, starts, stops, stopInputs };
 }
@@ -1479,6 +1488,164 @@ describe('subagent runtime — task control', () => {
       },
     });
     expect(h.runtime.agentNames()).toEqual(['a', 'b', 'general-purpose']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-child persistent shell-state fork (audit 2026-07-14 M-10)
+// ---------------------------------------------------------------------------
+
+describe('subagent runtime — per-child shell-state fork (audit 2026-07-14 M-10)', () => {
+  it('each spawned child gets a FORKED persistent namespace seeded from the parent snapshot', async () => {
+    const parentShells = createShellManager(() => {});
+    expect(parentShells.stateDir).not.toBe('');
+    writeFileSync(join(parentShells.stateDir, 'cwd'), '/tmp/parent-was-here');
+    const seen: Array<ShellManager | undefined> = [];
+    const probe: BuiltinTool = {
+      name: 'Probe',
+      description: 'captures ctx.shells',
+      inputSchema: { type: 'object', properties: {} },
+      readOnly: true,
+      async execute(_input, ctx) {
+        seen.push(ctx.shells);
+        return { content: 'ok' };
+      },
+    };
+    try {
+      const h = makeRuntime({
+        scripts: [
+          toolUseReplyEvents('Probe', {}, { model: 'claude-sonnet-4-5' }),
+          textReplyEvents('done A', { model: 'claude-sonnet-4-5' }),
+          toolUseReplyEvents('Probe', {}, { model: 'claude-sonnet-4-5' }),
+          textReplyEvents('done B', { model: 'claude-sonnet-4-5' }),
+        ],
+        baseBuiltins: new Map([['Probe', probe]]),
+        shells: parentShells,
+      });
+      await h.runtime.makeSpawnFn(0)(baseParams());
+      await h.runtime.makeSpawnFn(0)(baseParams());
+      expect(seen).toHaveLength(2);
+      const [a, b] = seen;
+      // Each child got its OWN namespace — not the parent's, not a sibling's.
+      expect(a!.stateDir).not.toBe('');
+      expect(a!.stateDir).not.toBe(parentShells.stateDir);
+      expect(b!.stateDir).not.toBe(parentShells.stateDir);
+      expect(a!.stateDir).not.toBe(b!.stateDir);
+      // Seeded from the parent's snapshot as of spawn time.
+      expect(readFileSync(join(a!.stateDir, 'cwd'), 'utf8')).toBe('/tmp/parent-was-here');
+      expect(readFileSync(join(b!.stateDir, 'cwd'), 'utf8')).toBe('/tmp/parent-was-here');
+      // A child-side mutation stays in ITS namespace: the parent's next
+      // foreground Bash and the sibling both keep the original snapshot.
+      writeFileSync(join(a!.stateDir, 'cwd'), '/tmp/child-a-moved');
+      expect(readFileSync(join(parentShells.stateDir, 'cwd'), 'utf8')).toBe(
+        '/tmp/parent-was-here',
+      );
+      expect(readFileSync(join(b!.stateDir, 'cwd'), 'utf8')).toBe('/tmp/parent-was-here');
+    } finally {
+      parentShells.dispose();
+    }
+  });
+
+  it('no shell manager wired -> children still get no shells (no phantom fork)', async () => {
+    const seen: Array<ShellManager | undefined> = [];
+    const probe: BuiltinTool = {
+      name: 'Probe',
+      description: 'captures ctx.shells',
+      inputSchema: { type: 'object', properties: {} },
+      readOnly: true,
+      async execute(_input, ctx) {
+        seen.push(ctx.shells);
+        return { content: 'ok' };
+      },
+    };
+    const h = makeRuntime({
+      scripts: [
+        toolUseReplyEvents('Probe', {}, { model: 'claude-sonnet-4-5' }),
+        textReplyEvents('done', { model: 'claude-sonnet-4-5' }),
+      ],
+      baseBuiltins: new Map([['Probe', probe]]),
+    });
+    await h.runtime.makeSpawnFn(0)(baseParams());
+    expect(seen).toEqual([undefined]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Foreground kill path (audit 2026-07-14 M-11)
+// ---------------------------------------------------------------------------
+
+/** Transport whose stream hangs until the request signal aborts. */
+class HangUntilAbortTransport implements Transport {
+  apiKeySource(): ApiKeySource {
+    return 'user';
+  }
+  async *stream(req: StreamRequest): AsyncGenerator<RawMessageStreamEvent, void> {
+    await new Promise<void>((_, reject) => {
+      const sig = req.signal;
+      if (sig?.aborted) {
+        reject(new AbortError());
+        return;
+      }
+      sig?.addEventListener('abort', () => reject(new AbortError()), { once: true });
+    });
+  }
+}
+
+describe('subagent runtime — foreground kill path (audit 2026-07-14 M-11)', () => {
+  it('killAgent on a running foreground child: status killed (not failed), foreground wording, spawn resolves isError', async () => {
+    const emitted: SDKMessage[] = [];
+    const h = makeRuntime({
+      scripts: [],
+      transport: new HangUntilAbortTransport(),
+      emitObservability: (m) => emitted.push(m),
+    });
+    const pending = h.runtime.makeSpawnFn(0)(baseParams());
+    // Discover the agentId from the task_started observability message, then
+    // stop it mid-run via the TaskStop bridge (poll: the child registers in
+    // the registry just after task_started fires).
+    let agentId: string | undefined;
+    for (let i = 0; i < 200 && agentId === undefined; i++) {
+      await tick(1);
+      const started = emitted.find(
+        (m) => 'subtype' in m && m.subtype === 'task_started',
+      );
+      if (started !== undefined) agentId = (started as { task_id: string }).task_id;
+    }
+    expect(agentId).toBeDefined();
+    let stopped: string | undefined;
+    for (let i = 0; i < 200 && stopped === undefined; i++) {
+      stopped = h.runtime.stopAgent(agentId!);
+      if (stopped === undefined) await tick(1);
+    }
+    // (b) honest wording: this record is FOREGROUND, not background.
+    expect(stopped).toBe(`Stopped foreground subagent ${agentId}.`);
+    const note = emitted.find(
+      (m) => 'subtype' in m && m.subtype === 'task_notification',
+    ) as { summary: string } | undefined;
+    expect(note?.summary).toContain('foreground subagent');
+    expect(note?.summary).not.toContain('background');
+    // (c) the spawn RESOLVES to an isError result — the AbortError must not
+    // propagate through the Agent tool and kill the whole parent query.
+    const res = await pending;
+    expect(res.isError).toBe(true);
+    expect(res.content).toContain('stopped');
+    expect(res.background).toBe(false);
+    expect(res.agentId).toBe(agentId);
+    // (a) the record's terminal status stayed 'killed' — the foreground catch
+    // did not clobber it to 'failed' (observable via the TaskStop bridge).
+    expect(h.runtime.stopAgent(agentId!)).toBe(`Subagent ${agentId} already killed.`);
+  });
+
+  it('a genuine parent-signal abort still rethrows AbortError from a foreground spawn', async () => {
+    const h = makeRuntime({
+      scripts: [],
+      transport: new HangUntilAbortTransport(),
+    });
+    const ac = new AbortController();
+    const pending = h.runtime.makeSpawnFn(0)(baseParams({ signal: ac.signal }));
+    await tick(5);
+    ac.abort();
+    await expect(pending).rejects.toBeInstanceOf(AbortError);
   });
 });
 

--- a/projects/silver-core-sdk/tests/tools-workflow.test.ts
+++ b/projects/silver-core-sdk/tests/tools-workflow.test.ts
@@ -683,6 +683,86 @@ return [a, b]`;
     expect(calls).toHaveLength(3);
   });
 
+  it('parallel branches completing in a different order still hit the cache (audit 2026-07-14 M-13)', async () => {
+    // Run 1 holds branch A's first agent until branch B's SECOND call has
+    // been issued, so the journal lands in order [A1, B1, B2, A2]. On
+    // resume the cached calls resolve instantly, making the lookup order
+    // [A1, B1, A2, B2] — a seq permutation. The order-independent
+    // (hash, occurrence) lookup must still serve A2 from cache; only B2
+    // (failed in run 1, journaled uncompleted) runs live. The old
+    // journal[index] comparison saw A2 at B2's old index, broke, and ran
+    // BOTH live.
+    let phase = 1;
+    const calls: SpawnSubagentParams[] = [];
+    const spawn: SpawnSubagentFn = async (p) => {
+      calls.push(p);
+      const head = p.prompt.split('\n')[0]!;
+      if (phase === 1) {
+        if (head === 'A1') {
+          await waitUntil(() => calls.some((c) => c.prompt.startsWith('B2:')));
+        }
+        if (head.startsWith('B2:')) {
+          return { content: 'dead', isError: true, agentId: 'x', background: false };
+        }
+      }
+      return { content: `R:${head}`, isError: false, agentId: 'x', background: false };
+    };
+    const script = `${meta('par-resume')}
+const [a, b] = await parallel([
+  async () => {
+    const r = await agent('A1')
+    return await agent('A2:' + r)
+  },
+  async () => {
+    const r = await agent('B1')
+    return await agent('B2:' + r)
+  },
+])
+return [a, b]`;
+    const tool = createWorkflowTool({ limits: { maxConcurrentAgents: 2 } });
+    const ctx = makeCtx({ spawnSubagent: spawn });
+    const first = await tool.execute({ script }, ctx);
+    expect(resultValue(first)).toEqual(['R:A2:R:A1', null]);
+    expect(calls).toHaveLength(4);
+    const runId = /runId: (wf-run-\d+)/.exec(text(first))![1]!;
+
+    phase = 2;
+    const second = await tool.execute({ script, resumeFromRunId: runId }, ctx);
+    // Only B2 ran live; A1/B1/A2 all replayed from cache despite the permutation.
+    expect(calls).toHaveLength(5);
+    expect(calls[4]!.prompt.startsWith('B2:')).toBe(true);
+    expect(text(second)).toContain('1 run live, 3 from cache');
+    expect(resultValue(second)).toEqual(['R:A2:R:A1', 'R:B2:R:B1']);
+  });
+
+  it('identical-hash calls map to distinct journal occurrences on resume (audit 2026-07-14 M-13)', async () => {
+    let failSecondDup = true;
+    const calls: SpawnSubagentParams[] = [];
+    const spawn: SpawnSubagentFn = async (p) => {
+      calls.push(p);
+      const dupCount = calls.filter((c) => c.prompt.startsWith('dup')).length;
+      if (failSecondDup && dupCount === 2) {
+        return { content: 'dead', isError: true, agentId: 'x', background: false };
+      }
+      return { content: `R:${calls.length}`, isError: false, agentId: 'x', background: false };
+    };
+    const script = `${meta('dup')}
+const a = await agent('dup')
+const b = await agent('dup')
+return [a, b]`;
+    const ctx = makeCtx({ spawnSubagent: spawn });
+    const first = await workflowTool.execute({ script }, ctx);
+    expect(resultValue(first)).toEqual(['R:1', null]);
+    const runId = /runId: (wf-run-\d+)/.exec(text(first))![1]!;
+
+    failSecondDup = false;
+    const second = await workflowTool.execute({ script, resumeFromRunId: runId }, ctx);
+    // Occurrence 0 (completed) replays from cache; occurrence 1 (uncompleted)
+    // re-runs live — the per-hash counter keeps duplicates aligned.
+    expect(text(second)).toContain('1 run live, 1 from cache');
+    expect(resultValue(second)).toEqual(['R:1', 'R:3']);
+  });
+
   it('rejects an unknown runId (resume is same-session only)', async () => {
     const r = await workflowTool.execute(
       { script: `${meta()}return 1`, resumeFromRunId: 'wf-run-999' },

--- a/projects/silver-core-sdk/tests/transport-node-http.test.ts
+++ b/projects/silver-core-sdk/tests/transport-node-http.test.ts
@@ -198,6 +198,33 @@ describe('node-http adapter (unit)', () => {
     expect(resolvePreconnect({ preconnect: true }, {})).toBe(true);
     expect(getNodeFetch()).toBe(getNodeFetch()); // process-wide singleton
   });
+
+  it('proxy env autodetect resolves to fetch unless an explicit choice overrides it (audit 2026-07-14 M-6)', () => {
+    // The node adapter ignores proxy env vars, so a proxy-only environment
+    // must default to the proxiable global fetch (NODE_USE_ENV_PROXY /
+    // setGlobalDispatcher path). Every conventional variable, both cases:
+    for (const name of [
+      'HTTPS_PROXY',
+      'https_proxy',
+      'HTTP_PROXY',
+      'http_proxy',
+      'ALL_PROXY',
+      'all_proxy',
+    ]) {
+      expect(resolveHttpClient({}, { [name]: 'http://proxy:8080' })).toBe('fetch');
+    }
+    // Explicit overrides always win over the autodetect.
+    expect(
+      resolveHttpClient({ httpClient: 'node' }, { HTTPS_PROXY: 'http://proxy:8080' }),
+    ).toBe('node');
+    expect(
+      resolveHttpClient({}, { BPT_HTTP_CLIENT: 'node', HTTPS_PROXY: 'http://proxy:8080' }),
+    ).toBe('node');
+    // Empty-string proxy vars do not count as "set".
+    expect(resolveHttpClient({}, { HTTPS_PROXY: '', http_proxy: '' })).toBe('node');
+    // No proxy vars: the default stays 'node'.
+    expect(resolveHttpClient({}, {})).toBe('node');
+  });
 });
 
 describe('node client through the transport (default path)', () => {

--- a/projects/silver-core-sdk/tests/transport-openai.test.ts
+++ b/projects/silver-core-sdk/tests/transport-openai.test.ts
@@ -656,6 +656,76 @@ describe('OpenAIStreamTranslator', () => {
     ]);
   });
 
+  // Missing-finish_reason inference (audit 2026-07-14 M-5): a gateway that
+  // ends a tool-call stream with a bare [DONE] / EOF and never sends
+  // finish_reason must still yield stop_reason 'tool_use' — mapping it to
+  // 'end_turn' makes the engine treat the turn as final and silently drop
+  // the model's tool calls.
+  it('infers stop_reason tool_use when the stream ends without finish_reason after tool_call deltas', () => {
+    const t = new OpenAIStreamTranslator('m');
+    const events = [
+      ...t.feed({
+        id: 'c',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, id: 'call_a', function: { name: 'Read', arguments: '{}' } },
+              ],
+            },
+          },
+        ],
+      }),
+      // Bare [DONE] / EOF: the transport calls finish() with no finish_reason seen.
+      ...t.finish(),
+    ];
+    const acc = new MessageAccumulator();
+    for (const ev of events) acc.feed(ev);
+    const msg = acc.finalize();
+    expect(msg.stop_reason).toBe('tool_use');
+    expect(msg.content).toEqual([{ type: 'tool_use', id: 'call_a', name: 'Read', input: {} }]);
+  });
+
+  it('keeps stop_reason end_turn for a text-only stream that ends without finish_reason', () => {
+    // The M-5 inference must be scoped to tool calls: a text stream ending in
+    // a bare [DONE] is still a plain final turn.
+    const t = new OpenAIStreamTranslator('m');
+    const events = [
+      ...t.feed({ id: 'c', choices: [{ delta: { content: 'Hello' } }] }),
+      ...t.finish(),
+    ];
+    const acc = new MessageAccumulator();
+    for (const ev of events) acc.feed(ev);
+    const msg = acc.finalize();
+    expect(msg.stop_reason).toBe('end_turn');
+    expect(msg.content).toEqual([{ type: 'text', text: 'Hello' }]);
+  });
+
+  it('never overrides an EXPLICIT finish_reason, even when tool calls were emitted', () => {
+    // A stream that DID carry finish_reason must behave exactly as before
+    // M-5: 'stop' maps to 'end_turn' regardless of open tool_use blocks.
+    const t = new OpenAIStreamTranslator('m');
+    const events = [
+      ...t.feed({
+        id: 'c',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, id: 'call_a', function: { name: 'Read', arguments: '{}' } },
+              ],
+            },
+          },
+        ],
+      }),
+      ...t.feed({ choices: [{ delta: {}, finish_reason: 'stop' }] }),
+      ...t.finish(),
+    ];
+    const acc = new MessageAccumulator();
+    for (const ev of events) acc.feed(ev);
+    expect(acc.finalize().stop_reason).toBe('end_turn');
+  });
+
   // A tool-call delta chunk built without deep inline nesting (the embedded
   // JSON braces in `arguments` make hand-counting the object literal error-prone).
   const toolChunk = (

--- a/projects/silver-core-sdk/tests/webfetch-pinning.test.ts
+++ b/projects/silver-core-sdk/tests/webfetch-pinning.test.ts
@@ -1,0 +1,313 @@
+/**
+ * audit 2026-07-14 M-3: WebFetch DNS pinning.
+ *
+ * Before: ssrfGuard resolved + validated a hostname's addresses, then the
+ * fetch performed its OWN second resolution — a classic DNS-rebinding window
+ * (answer public on the guard's query, private on the connection's query).
+ * After: the default path connects via node:https with a `lookup` override
+ * that answers ONLY from the guard-validated address set, while Host / TLS
+ * SNI stay on the original hostname. Redirect hops re-run guard + pinning.
+ *
+ * No network: node:dns/promises is mocked (guard resolution) and the pinned
+ * request path is exercised through a fake node:https request impl injected
+ * into pinnedFetch, plus a module-level node:https mock for the end-to-end
+ * default-path wiring through webFetchTool.execute.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+
+// Mock DNS so hostname-based SSRF resolution is deterministic + offline.
+vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
+import { lookup } from 'node:dns/promises';
+
+// Mock node:https so the DEFAULT (non-injected) WebFetch path is observable
+// offline: `request` is a vi.fn the tests re-program per scenario.
+vi.mock('node:https', () => ({ request: vi.fn() }));
+import { request as httpsRequest } from 'node:https';
+
+import {
+  makePinnedLookup,
+  pinnedFetch,
+  webFetchTool,
+  type PinnedAddress,
+} from '../src/tools/webfetch.js';
+import type { ToolContext } from '../src/internal/contracts.js';
+
+const mockLookup = vi.mocked(lookup);
+const mockRequest = vi.mocked(httpsRequest);
+
+function makeCtx(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    cwd: '/tmp',
+    additionalDirectories: [],
+    env: {},
+    signal: new AbortController().signal,
+    debug: () => {},
+    ...overrides,
+  };
+}
+
+/** Fake IncomingMessage: a Readable with the http response metadata bolted on. */
+function fakeResponse(
+  status: number,
+  headers: Record<string, string>,
+  body: string,
+): Readable & { statusCode: number; statusMessage: string; headers: Record<string, string> } {
+  const res = Readable.from(body.length > 0 ? [Buffer.from(body)] : []) as Readable & {
+    statusCode: number;
+    statusMessage: string;
+    headers: Record<string, string>;
+  };
+  res.statusCode = status;
+  res.statusMessage = 'OK';
+  res.headers = headers;
+  return res;
+}
+
+type CapturedOptions = {
+  hostname?: string;
+  port?: number;
+  path?: string;
+  headers?: Record<string, string>;
+  lookup?: (hostname: string, options: unknown, cb: unknown) => void;
+};
+
+/** Fake https.request: captures options, emits the scripted response on end(). */
+function fakeRequestImpl(
+  responses: Array<ReturnType<typeof fakeResponse>>,
+  captured: CapturedOptions[],
+) {
+  let call = 0;
+  return ((options: CapturedOptions) => {
+    captured.push(options);
+    const res = responses[Math.min(call, responses.length - 1)];
+    call++;
+    const req = new EventEmitter() as EventEmitter & { end: () => void };
+    req.end = () => {
+      queueMicrotask(() => req.emit('response', res));
+    };
+    return req;
+  }) as never;
+}
+
+/** Drive a captured lookup override and collect what it answers. */
+function resolveVia(
+  lookupFn: NonNullable<CapturedOptions['lookup']>,
+  options: unknown,
+): Promise<{ err: Error | null; address?: unknown; family?: unknown }> {
+  return new Promise((resolve) => {
+    lookupFn('irrelevant.example', options, (err: Error | null, address?: unknown, family?: unknown) =>
+      resolve({ err, address, family }),
+    );
+  });
+}
+
+beforeEach(() => {
+  mockLookup.mockReset();
+  mockRequest.mockReset();
+  mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+});
+
+// ---------------------------------------------------------------------------
+// makePinnedLookup: the connection can only ever dial validated addresses
+// ---------------------------------------------------------------------------
+
+describe('makePinnedLookup', () => {
+  const pinned: PinnedAddress[] = [
+    { address: '93.184.216.34', family: 4 },
+    { address: '2606:2800:220:1::1', family: 6 },
+  ];
+
+  it('answers the single-address shape with the FIRST validated address', async () => {
+    const r = await resolveVia(makePinnedLookup(pinned), { family: 0 });
+    expect(r.err).toBeNull();
+    expect(r.address).toBe('93.184.216.34');
+    expect(r.family).toBe(4);
+  });
+
+  it('answers the all:true shape with EXACTLY the validated set', async () => {
+    const r = await resolveVia(makePinnedLookup(pinned), { all: true });
+    expect(r.err).toBeNull();
+    expect(r.address).toEqual([
+      { address: '93.184.216.34', family: 4 },
+      { address: '2606:2800:220:1::1', family: 6 },
+    ]);
+  });
+
+  it('honors a family filter (4 / 6 / "IPv6")', async () => {
+    const v4 = await resolveVia(makePinnedLookup(pinned), { family: 4 });
+    expect(v4.address).toBe('93.184.216.34');
+    const v6 = await resolveVia(makePinnedLookup(pinned), { family: 6 });
+    expect(v6.address).toBe('2606:2800:220:1::1');
+    const v6s = await resolveVia(makePinnedLookup(pinned), { family: 'IPv6' });
+    expect(v6s.address).toBe('2606:2800:220:1::1');
+  });
+
+  it('supports the (hostname, cb) legacy call shape', async () => {
+    const fn = makePinnedLookup(pinned);
+    const r = await new Promise<{ address?: unknown }>((resolve) => {
+      fn('irrelevant.example', (err: unknown, address?: unknown) => resolve({ address }));
+    });
+    expect(r.address).toBe('93.184.216.34');
+  });
+
+  it('errs (ENOTFOUND-shaped) instead of falling back to real DNS when the family filter empties the set', async () => {
+    const v4only: PinnedAddress[] = [{ address: '93.184.216.34', family: 4 }];
+    const r = await resolveVia(makePinnedLookup(v4only), { family: 6 });
+    expect(r.err).toBeInstanceOf(Error);
+    expect((r.err as NodeJS.ErrnoException).code).toBe('ENOTFOUND');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pinnedFetch: request wiring (hostname/SNI preserved, lookup pinned)
+// ---------------------------------------------------------------------------
+
+describe('pinnedFetch', () => {
+  it('dials with the ORIGINAL hostname (Host/SNI) while lookup answers only validated IPs', async () => {
+    const captured: CapturedOptions[] = [];
+    const impl = fakeRequestImpl(
+      [fakeResponse(200, { 'content-type': 'text/plain' }, 'pinned-hello')],
+      captured,
+    );
+    const res = await pinnedFetch(
+      new URL('https://public.example/data?q=1'),
+      { signal: new AbortController().signal, headers: { accept: 'text/plain' } },
+      [{ address: '93.184.216.34', family: 4 }],
+      impl,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('pinned-hello');
+
+    expect(captured).toHaveLength(1);
+    const opts = captured[0]!;
+    // The hostname stays the NAME: node derives the Host header and the TLS
+    // servername (SNI + cert verification) from it, not from the pinned IP.
+    expect(opts.hostname).toBe('public.example');
+    expect(opts.port).toBe(443);
+    expect(opts.path).toBe('/data?q=1');
+    expect(typeof opts.lookup).toBe('function');
+    const answered = await resolveVia(opts.lookup!, { family: 0 });
+    expect(answered.address).toBe('93.184.216.34');
+  });
+
+  it('omits the lookup override when pinning is disabled (allowPrivateWebFetch path)', async () => {
+    const captured: CapturedOptions[] = [];
+    const impl = fakeRequestImpl(
+      [fakeResponse(200, { 'content-type': 'text/plain' }, 'ok')],
+      captured,
+    );
+    await pinnedFetch(
+      new URL('https://public.example/'),
+      { signal: new AbortController().signal, headers: {} },
+      null,
+      impl,
+    );
+    expect(captured[0]!.lookup).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end default path: webFetchTool without an injected fetchImpl
+// ---------------------------------------------------------------------------
+
+describe('webFetchTool default path uses guard-validated pinning per hop', () => {
+  function scriptHttps(responses: Array<ReturnType<typeof fakeResponse>>): CapturedOptions[] {
+    const captured: CapturedOptions[] = [];
+    mockRequest.mockImplementation(fakeRequestImpl(responses, captured) as never);
+    return captured;
+  }
+
+  it('fetches through node:https with the lookup pinned to the guard result', async () => {
+    const captured = scriptHttps([
+      fakeResponse(200, { 'content-type': 'text/plain' }, 'default-path body'),
+    ]);
+    const r = await webFetchTool.execute(
+      { url: 'https://public.example/page', prompt: 'x' },
+      makeCtx(), // no fetchImpl -> default pinned path
+    );
+    expect(r.isError).toBeUndefined();
+    expect(String(r.content)).toContain('default-path body');
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.hostname).toBe('public.example');
+    const answered = await resolveVia(captured[0]!.lookup!, { family: 0 });
+    expect(answered.address).toBe('93.184.216.34'); // exactly what the guard validated
+    expect(mockLookup).toHaveBeenCalledTimes(1); // the guard's resolution is the ONLY one
+  });
+
+  it('re-runs guard + pinning on a same-host redirect hop', async () => {
+    const captured = scriptHttps([
+      fakeResponse(302, { location: 'https://public.example/final' }, ''),
+      fakeResponse(200, { 'content-type': 'text/plain' }, 'landed'),
+    ]);
+    // Hop 2's guard resolution returns a DIFFERENT validated address; the
+    // second connection must pin to it (per-hop re-validation, not a cache).
+    mockLookup
+      .mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }] as never)
+      .mockResolvedValueOnce([{ address: '203.0.113.7', family: 4 }] as never);
+
+    const r = await webFetchTool.execute(
+      { url: 'https://public.example/start', prompt: 'x' },
+      makeCtx(),
+    );
+    expect(r.isError).toBeUndefined();
+    expect(String(r.content)).toContain('landed');
+
+    expect(captured).toHaveLength(2);
+    expect(mockLookup).toHaveBeenCalledTimes(2); // one guard resolution per hop
+    const hop1 = await resolveVia(captured[0]!.lookup!, { family: 0 });
+    expect(hop1.address).toBe('93.184.216.34');
+    const hop2 = await resolveVia(captured[1]!.lookup!, { family: 0 });
+    expect(hop2.address).toBe('203.0.113.7');
+  });
+
+  it('a redirect hop resolving to a private address is blocked before any second connection', async () => {
+    const captured = scriptHttps([
+      fakeResponse(302, { location: 'https://public.example/final' }, ''),
+      fakeResponse(200, { 'content-type': 'text/plain' }, 'must never land'),
+    ]);
+    mockLookup
+      .mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }] as never)
+      .mockResolvedValueOnce([{ address: '10.0.0.9', family: 4 }] as never); // rebound!
+
+    const r = await webFetchTool.execute(
+      { url: 'https://public.example/start', prompt: 'x' },
+      makeCtx(),
+    );
+    expect(r.isError).toBe(true);
+    expect(String(r.content)).toContain('10.0.0.9');
+    expect(captured).toHaveLength(1); // second connection never happened
+  });
+
+  it('an IP-literal URL pins to that literal (no DNS at all)', async () => {
+    const captured = scriptHttps([
+      fakeResponse(200, { 'content-type': 'text/plain' }, 'literal ok'),
+    ]);
+    const r = await webFetchTool.execute(
+      { url: 'https://93.184.216.34/x', prompt: 'x' },
+      makeCtx(),
+    );
+    expect(r.isError).toBeUndefined();
+    expect(mockLookup).not.toHaveBeenCalled();
+    const answered = await resolveVia(captured[0]!.lookup!, { family: 0 });
+    expect(answered.address).toBe('93.184.216.34');
+  });
+
+  it('an injected ctx.fetchImpl still bypasses pinning (documented escape hatch): node:https untouched', async () => {
+    const impl = vi.fn(
+      async () => new Response('injected ok', { headers: { 'content-type': 'text/plain' } }),
+    );
+    const r = await webFetchTool.execute(
+      { url: 'https://public.example/', prompt: 'x' },
+      makeCtx({ fetchImpl: impl as unknown as typeof fetch }),
+    );
+    expect(r.isError).toBeUndefined();
+    expect(String(r.content)).toContain('injected ok');
+    expect(impl).toHaveBeenCalledTimes(1);
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockLookup).toHaveBeenCalledTimes(1); // the guard still runs
+  });
+});


### PR DESCRIPTION
## 内容

守密人丙案（全量清账）批二：2026-07-14 审计报告的 13 条中危全部修复，每条附回归测试。

### 安全面
- **M-1** hooks：per-matcher `failureMode` 覆盖（安全钩子可单独 fail-closed），全局默认保持 'open'（官方 drop-in parity），fail-open 丢弃时响亮告警
- **M-2** 共享 ReDoS 守卫 `src/internal/regex-guard.ts`（自 hooks/matcher 抽取），覆盖 Grep 模式与 BashOutput filter——灾难性回溯模式改为可读工具错误
- **M-3** WebFetch DNS 固定：默认路径只拨 SSRF 守卫验证过的地址（lookup 覆盖，Host/SNI 保名），重定向逐跳重验；注入 fetchImpl 路径诚实标注残留
- **M-4** MCP registry：closeAll/setServers 置 retired + 等待在途握手并关闭其连接，僵尸子进程口子封死

### 协议与传输
- **M-5** openai 臂：tool_call 后缺 finish_reason 推断 stop_reason 'tool_use'
- **M-6** 代理环境自动回退 'fetch'（显式覆盖恒胜）

### 资金账
- **M-7** auto-resume 费用基底折账（mgr.usage() 报总和）
- **M-8** pause_turn 续跑补 budgetStopReason() 闸

### 数据与并发
- **M-9** 主 JSONL 存储撕裂尾自愈（与 file-store 对齐）
- **M-10** 并发前台子代理持久 shell 状态按子分叉（出生继承快照、互不串扰）
- **M-11** 前台 kill 路径：killed 状态不被覆写 / 通知措辞如实 / 停子代理不再炸整个父查询
- **M-12** 报告 JSONL 行形状守卫（坏行计数不炸整份日报）
- **M-13** workflow 恢复缓存 (hash, occurrence) 键控，并行时序置换不再作废缓存

### 验证
- `tsc --noEmit` 零错误
- 合并态全量 vitest：**2359 通过 / 3 跳过 / 0 失败**（127 文件，+55 测试）
- 版本纪律：0.57.3 → 0.58.0 + CHANGELOG 逐条记账

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG)_