### PR TITLE
silver-core-sdk 0.59.0: /loop interval-loop primitive

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -199,6 +199,15 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.59.0（2026-07-14，BPT `/loop` 缺口收口，守密人同日裁定「SDK 侧加循环原语」）**：
+  BPT 调查确认 `/loop 10m <任务>` 未被任何层解释、原样透传为一次性 prompt（GUI 未注册 /loop、
+  SDK 斜杠层仅 /compact 内建 + markdown 展开、周期语义静默丢失）。新公开模块 `src/prompt-loop.ts`
+  （BPT-EXTENSION）：`parseLoopCommand` 语法唯一真相源（`/loop [<interval>] <task>`，s/m/h + 别名 +
+  小数，缺省 10m，三态返回、数字开头非法区间 fail-closed、界 [1s, 2^31-1ms] 防 setTimeout 溢出）+
+  `createPromptLoop` 固定延迟控制器（立即首跑、结清后再计时绝不重叠、maxIterations / AbortSignal /
+  onError 策略、done 摘要永不 reject）+ `LOOP_SLASH_COMMAND` 菜单元数据（刻意不进引擎内建，守诚实
+  红线）。BPT 侧只余十行桥接（README 附范本）。+24 测试，全量 **2384 绿 + 2 skipped**；
+  「循环/调度」自 v0.5 推迟清单转正落地。
 - **v0.53.3（2026-07-13，BPT 稳定性《keep-alive 空闲 socket TTL》）**：修复黑池升 pin 后
   「回合卡住无输出、并发对话越多越易发」——0.45.0 默认 node HTTP 客户端把池化 socket 握到
   「服务端来关」为止，但 azure/* 等网关中间设备**静默丢弃**空闲连接（不发 FIN/RST），池内积累

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,31 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.59.0 — 2026-07-14
+
+New capability: `/loop` interval-loop primitive (`src/prompt-loop.ts`,
+BPT-EXTENSION). Closes the 2026-07-14 gap report — `/loop 10m <task>` in BPT
+passed through as a one-shot plain prompt and the recurrence semantics were
+silently lost.
+
+- `parseLoopCommand`: single source of truth for the
+  `/loop [<interval>] <task>` grammar (units s|m|h + aliases, decimals,
+  default 10m). Three-way result: null (not /loop — route as usual),
+  `{ok:false, error}` (IS /loop but unusable — hosts must surface the error,
+  never pass through), `{ok:true, directive}`. Fail-closed on digit-leading
+  non-interval tokens; bounds [1s, 2^31-1 ms] (Node setTimeout overflow
+  fires immediately — a real hot-loop hazard above the ceiling).
+- `createPromptLoop`: fixed-delay controller over a host-owned `run`
+  callback — immediate first run, next run `intervalMs` after the previous
+  SETTLES (never overlaps), `maxIterations` / `AbortSignal` / `onError`
+  ('stop' default | 'continue' | per-error callback), `done` summary promise
+  (never rejects).
+- `LOOP_SLASH_COMMAND` menu metadata; deliberately NOT an engine built-in
+  (the engine cannot re-invoke itself over wall-clock time; advertising a
+  command the engine would swallow as plain text breaks the honesty red
+  line). README section documents the thin host bridge.
+- +24 tests (`tests/prompt-loop.test.ts`).
+
 ## 0.58.0 — 2026-07-14
 
 Audit 2026-07-14 P1 batch — all 13 MEDIUM findings, each with regressions:

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -67,6 +67,16 @@ src/
 
 ## 当前状态
 
+**v0.59.0（2026-07-14）：/loop 区间循环原语（BPT /loop 缺口收口，守密人同日裁定「SDK 侧加循环原语」）**——
+BPT 中 `/loop 10m <任务>` 原样透传为一次性 prompt、周期语义静默丢失（缺口调查同日）。新公开模块
+`src/prompt-loop.ts`：`parseLoopCommand`（`/loop [<interval>] <task>` 语法唯一真相源，s/m/h + 别名 + 小数，
+缺省 10m；三态返回 null / `{ok:false,error}` / `{ok:true,directive}`，数字开头非法区间 fail-closed，
+界 [1s, 2^31-1ms] 防 Node setTimeout 溢出热循环）+ `createPromptLoop`（宿主自有 runner 上的固定延迟
+控制器：立即首跑、上次**结清**后隔 intervalMs 再跑绝不重叠、maxIterations / AbortSignal / onError
+三态策略、done 摘要 promise 永不 reject）+ `LOOP_SLASH_COMMAND` 菜单元数据（**刻意不进引擎内建**——
+引擎环无法跨墙钟自唤起，广告吞字命令踩诚实红线）。非法配置按层白名单掷 `ConfigurationError`
+（ARCHITECTURE.md 表补行）。+24 测试，全量 2384 绿 + 2 skipped。「循环/调度」自 v0.5 续期推迟清单转正落地（Tier 2 首件）。
+
 **v0.53.8（2026-07-13）：前台子代理批量调用串行化修复（子代理串行化报告）**——同一 assistant
 批次内多个互不依赖的前台 `Agent` 调用被逐个 await（三个 5 秒计时子代理零重叠、启动间隔约 12 秒），
 后台模式却正常并发。根因唯一：`engine/loop.ts` 并发分组谓词只收「只读工具」，Agent `readOnly: false`

--- a/projects/silver-core-sdk/README.md
+++ b/projects/silver-core-sdk/README.md
@@ -183,6 +183,38 @@ and injects the docs-verbatim protocol itself — same consuming code, identical
 store artifacts. The head of `/memories/MEMORY.md` is auto-injected at session
 start (capped; lazily `view` the rest). See [docs/MEMORY.md](./docs/MEMORY.md).
 
+## /loop interval loops (BPT-EXTENSION)
+
+The official SDK has no recurring-prompt facility, so an unrecognized
+`/loop 10m <task>` would fall through slash-command expansion as a ONE-SHOT
+plain prompt and the recurrence would be silently lost. `parseLoopCommand`
+is the single source of truth for the `/loop [<interval>] <task>` grammar
+(units `s|m|h`, default `10m`), and `createPromptLoop` drives a host-owned
+runner on a fixed-delay cadence (next run scheduled `intervalMs` after the
+previous one settles — runs never overlap). The host bridge is thin:
+
+```ts
+import { parseLoopCommand, createPromptLoop, LOOP_SLASH_COMMAND } from 'silver-core-sdk';
+
+const parsed = parseLoopCommand(userInput);
+if (parsed) {
+  if (!parsed.ok) return showError(parsed.error); // never pass through as a prompt
+  const loop = createPromptLoop({
+    ...parsed.directive,                // intervalMs + prompt
+    run: (prompt) => submitTurn(prompt), // host-owned: e.g. a new query() turn
+    onError: 'stop',                    // default; 'continue' or a callback
+    signal: sessionAbort.signal,
+  });
+  loop.start();                         // immediate first run, then fixed-delay
+  await loop.done;                      // { iterations, stopReason, error? }
+}
+```
+
+`LOOP_SLASH_COMMAND` is menu metadata for hosts that wire this bridge; it is
+deliberately NOT an engine built-in — the engine loop cannot re-invoke itself
+over wall-clock time, and advertising a command the engine would swallow as
+plain text is the honesty red line.
+
 ## Examples
 
 Runnable examples live in [examples/](./examples):

--- a/projects/silver-core-sdk/docs/ARCHITECTURE.md
+++ b/projects/silver-core-sdk/docs/ARCHITECTURE.md
@@ -439,6 +439,7 @@ build red.
 | `src/sessions/` | `ConfigurationError` |
 | `src/query.ts` | `ConfigurationError` |
 | `src/session-manager.ts` | `ConfigurationError` |
+| `src/prompt-loop.ts` | `ConfigurationError` |
 | `src/tools/bash.ts` | `ConfigurationError` |
 | `src/tools/memory/` | `MemoryToolError`, `ConfigurationError` |
 | `src/reporting/` | `ConfigurationError` |

--- a/projects/silver-core-sdk/package-lock.json
+++ b/projects/silver-core-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.57.2",
+  "version": "0.59.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silver-core-sdk",
-      "version": "0.57.2",
+      "version": "0.59.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/index.ts
+++ b/projects/silver-core-sdk/src/index.ts
@@ -26,6 +26,27 @@ export type {
 // SessionManagerOptions / SessionManagerUsage types ride the types.js export).
 export { createBptSession, runConcurrent } from './session-manager.js';
 export type { ManagedTask, RunConcurrentOutcome } from './session-manager.js';
+// BPT-EXTENSION: /loop interval-loop primitive (parser is the grammar's
+// single source of truth; the controller drives a host-owned runner on a
+// fixed-delay cadence — see src/prompt-loop.ts module header).
+export {
+  createPromptLoop,
+  parseLoopCommand,
+  DEFAULT_LOOP_INTERVAL_MS,
+  DEFAULT_LOOP_INTERVAL_LABEL,
+  MIN_LOOP_INTERVAL_MS,
+  MAX_LOOP_INTERVAL_MS,
+  LOOP_SLASH_COMMAND,
+} from './prompt-loop.js';
+export type {
+  LoopCommandParse,
+  LoopDirective,
+  LoopErrorDecision,
+  LoopStopReason,
+  PromptLoopController,
+  PromptLoopOptions,
+  PromptLoopSummary,
+} from './prompt-loop.js';
 // Built-in durable session store (SM-乙a): fileSessionStore(dir) for the
 // SessionManager's `store` option and options.sessionStore recovery.
 export { FileSessionStore, fileSessionStore } from './sessions/file-store.js';

--- a/projects/silver-core-sdk/src/prompt-loop.ts
+++ b/projects/silver-core-sdk/src/prompt-loop.ts
@@ -1,0 +1,305 @@
+/**
+ * /loop interval-loop primitive. BPT-EXTENSION — the official SDK has no
+ * recurring-prompt facility; in Claude Code the `/loop` surface is a skill
+ * layered on the CLI harness. This module is the SDK-side primitive so a
+ * host (BPT Desktop) only needs a thin bridge: parse the user's `/loop`
+ * invocation here, then drive its own query submission through the
+ * controller. Without it an unrecognized `/loop 10m <task>` passes through
+ * the slash-command expansion layer as a one-shot plain prompt and the
+ * recurrence semantics are silently lost (the 2026-07-14 gap report).
+ *
+ * Grammar (single source of truth — hosts must not re-implement it):
+ *   /loop [<interval>] <prompt-or-slash-command>
+ * where <interval> is `<number><unit>` with unit s|sec|secs|m|min|mins|
+ * h|hr|hrs (case-insensitive), e.g. `30s`, `10m`, `1.5h`. Omitted interval
+ * defaults to 10m (Claude Code's documented default). A first token that
+ * starts with a digit but is NOT a valid interval is rejected rather than
+ * silently treated as prompt text — misreading a typo'd interval as the
+ * task would loop the wrong thing every 10 minutes (fail-closed, house
+ * rule).
+ *
+ * Scheduling semantics mirror the Claude Code skill: run once immediately
+ * on start, then FIXED-DELAY — the next run is scheduled `intervalMs`
+ * after the previous run SETTLES, so runs never overlap and a slow
+ * iteration cannot stampede the host. The controller never executes
+ * anything itself; the host-supplied `run` callback owns the actual query.
+ *
+ * NOT registered in BUILTIN_SLASH_COMMANDS: the engine loop does not
+ * execute /loop (a query cannot re-invoke itself over wall-clock time), and
+ * advertising a command the engine would swallow as plain text is exactly
+ * the dishonesty red line. `LOOP_SLASH_COMMAND` is exported as metadata for
+ * hosts that DO wire the bridge to merge into their command menus.
+ */
+
+import { ConfigurationError } from './errors.js';
+import type { SlashCommand } from './types.js';
+
+/** Default cadence when the invocation omits the interval token. */
+export const DEFAULT_LOOP_INTERVAL_MS = 600_000;
+export const DEFAULT_LOOP_INTERVAL_LABEL = '10m';
+
+/** Floor: sub-second loops are always a mistake at this layer. */
+export const MIN_LOOP_INTERVAL_MS = 1_000;
+/**
+ * Ceiling: Node's setTimeout treats delays above 2^31-1 ms as overflow and
+ * fires them IMMEDIATELY, which would turn "every 30 days" into a hot loop.
+ */
+export const MAX_LOOP_INTERVAL_MS = 2_147_483_647;
+
+/** Menu metadata for hosts that wire the bridge (see module header). */
+export const LOOP_SLASH_COMMAND: SlashCommand = {
+  name: 'loop',
+  description:
+    'Run a prompt or slash command on a recurring interval (defaults to 10m)',
+  argumentHint: '[interval] <prompt-or-command>',
+};
+
+export type LoopDirective = {
+  intervalMs: number;
+  /** The interval as written (`'30s'`), or the default label when omitted. */
+  intervalLabel: string;
+  explicitInterval: boolean;
+  /** The task text; may itself be a slash command the host resubmits. */
+  prompt: string;
+};
+
+export type LoopCommandParse =
+  | { ok: true; directive: LoopDirective }
+  | { ok: false; error: string };
+
+const LOOP_INVOCATION_RE = /^\/loop(?:\s+([\s\S]+))?$/;
+const INTERVAL_TOKEN_RE = /^(\d+(?:\.\d+)?)(s|secs?|m|mins?|h|hrs?)$/i;
+
+const UNIT_MS: Record<string, number> = {
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+};
+
+function intervalTokenToMs(token: string): number | null {
+  const m = INTERVAL_TOKEN_RE.exec(token);
+  if (!m) return null;
+  const unitMs = UNIT_MS[(m[2] ?? '').toLowerCase().charAt(0)];
+  if (unitMs === undefined) return null;
+  const ms = Math.round(Number(m[1] ?? '') * unitMs);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Parse a `/loop` invocation. Returns null when the input is not a /loop
+ * command at all (route it as usual); `{ ok: false }` when it IS /loop but
+ * unusable — hosts must surface that error instead of passing the text
+ * through as a plain prompt.
+ */
+export function parseLoopCommand(input: string): LoopCommandParse | null {
+  const m = LOOP_INVOCATION_RE.exec(input.trim());
+  if (!m) return null;
+  const args = m[1]?.trim() ?? '';
+  if (!args) {
+    return { ok: false, error: '/loop requires a prompt or slash command to run' };
+  }
+  const first = /^(\S+)([\s\S]*)$/.exec(args);
+  const token = first?.[1] ?? args;
+  const rest = (first?.[2] ?? '').trimStart();
+
+  let intervalMs = DEFAULT_LOOP_INTERVAL_MS;
+  let intervalLabel = DEFAULT_LOOP_INTERVAL_LABEL;
+  let explicitInterval = false;
+  let prompt = args;
+
+  const tokenMs = intervalTokenToMs(token);
+  if (tokenMs !== null) {
+    if (tokenMs < MIN_LOOP_INTERVAL_MS) {
+      return { ok: false, error: `/loop interval must be at least 1s (got "${token}")` };
+    }
+    if (tokenMs > MAX_LOOP_INTERVAL_MS) {
+      return { ok: false, error: `/loop interval must be at most ${MAX_LOOP_INTERVAL_MS} ms (got "${token}")` };
+    }
+    if (!rest) {
+      return { ok: false, error: '/loop requires a prompt or slash command after the interval' };
+    }
+    intervalMs = tokenMs;
+    intervalLabel = token;
+    explicitInterval = true;
+    prompt = rest;
+  } else if (/^\d/.test(token)) {
+    return {
+      ok: false,
+      error: `/loop: "${token}" is not a valid interval (use e.g. 30s, 10m, 1.5h)`,
+    };
+  }
+
+  return {
+    ok: true,
+    directive: { intervalMs, intervalLabel, explicitInterval, prompt },
+  };
+}
+
+export type LoopStopReason = 'stopped' | 'aborted' | 'max_iterations' | 'error';
+
+export type PromptLoopSummary = {
+  /** run() invocations that settled (including the one that errored). */
+  iterations: number;
+  stopReason: LoopStopReason;
+  /** Present when stopReason is 'error'. */
+  error?: unknown;
+};
+
+export type LoopErrorDecision = 'stop' | 'continue';
+
+export type PromptLoopOptions = {
+  prompt: string;
+  /**
+   * Host-owned executor: submit `prompt` as a fresh turn/query and resolve
+   * when it settles. `iteration` is 1-based. Rejections route to `onError`.
+   */
+  run: (prompt: string, iteration: number) => unknown | Promise<unknown>;
+  /** Default DEFAULT_LOOP_INTERVAL_MS; integer within [MIN, MAX]. */
+  intervalMs?: number;
+  /** Stop after this many settled runs (default: unbounded). */
+  maxIterations?: number;
+  /** Run the first iteration immediately on start() (default true). */
+  immediate?: boolean;
+  signal?: AbortSignal;
+  /**
+   * Policy when run() rejects: 'stop' (default — a silently failing loop is
+   * worse than a dead one) or 'continue', or a callback deciding per error.
+   */
+  onError?: LoopErrorDecision | ((error: unknown, iteration: number) => LoopErrorDecision);
+};
+
+export type PromptLoopController = {
+  /** Idempotent; a stopped loop cannot be restarted. */
+  start(): void;
+  /** Idempotent. Cancels a pending timer; an in-flight run settles first. */
+  stop(): void;
+  readonly running: boolean;
+  readonly iterations: number;
+  /** Resolves (never rejects) once the loop has fully stopped. */
+  done: Promise<PromptLoopSummary>;
+};
+
+export function createPromptLoop(options: PromptLoopOptions): PromptLoopController {
+  const {
+    prompt,
+    run,
+    intervalMs = DEFAULT_LOOP_INTERVAL_MS,
+    maxIterations,
+    immediate = true,
+    signal,
+    onError = 'stop',
+  } = options;
+  if (typeof prompt !== 'string' || prompt.trim() === '') {
+    throw new ConfigurationError('createPromptLoop: prompt must be a non-empty string');
+  }
+  if (
+    !Number.isInteger(intervalMs) ||
+    intervalMs < MIN_LOOP_INTERVAL_MS ||
+    intervalMs > MAX_LOOP_INTERVAL_MS
+  ) {
+    throw new ConfigurationError(
+      `createPromptLoop: intervalMs must be an integer in [${MIN_LOOP_INTERVAL_MS}, ${MAX_LOOP_INTERVAL_MS}]`,
+    );
+  }
+  if (maxIterations !== undefined && (!Number.isInteger(maxIterations) || maxIterations < 1)) {
+    throw new ConfigurationError('createPromptLoop: maxIterations must be a positive integer');
+  }
+
+  let started = false;
+  let finished = false;
+  let inFlight = false;
+  let iterations = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  /** Set by stop()/abort while a run is in flight; applied when it settles. */
+  let pendingStop: LoopStopReason | undefined;
+
+  let resolveDone!: (summary: PromptLoopSummary) => void;
+  const done = new Promise<PromptLoopSummary>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  const onAbort = () => requestStop('aborted');
+
+  function finish(stopReason: LoopStopReason, error?: unknown): void {
+    if (finished) return;
+    finished = true;
+    if (timer !== undefined) clearTimeout(timer);
+    timer = undefined;
+    signal?.removeEventListener('abort', onAbort);
+    resolveDone(error === undefined ? { iterations, stopReason } : { iterations, stopReason, error });
+  }
+
+  function requestStop(reason: LoopStopReason): void {
+    if (finished) return;
+    if (inFlight) {
+      // Keep the strongest reason: an abort must not be downgraded.
+      if (pendingStop !== 'aborted') pendingStop = reason;
+      return;
+    }
+    finish(reason);
+  }
+
+  function scheduleNext(): void {
+    timer = setTimeout(() => {
+      timer = undefined;
+      void runOnce();
+    }, intervalMs);
+  }
+
+  async function runOnce(): Promise<void> {
+    if (finished) return;
+    inFlight = true;
+    const iteration = iterations + 1;
+    let error: unknown;
+    let errored = false;
+    try {
+      await run(prompt, iteration);
+    } catch (e) {
+      errored = true;
+      error = e;
+    }
+    iterations = iteration;
+    inFlight = false;
+
+    if (pendingStop !== undefined) {
+      finish(pendingStop);
+      return;
+    }
+    if (errored) {
+      const decision = typeof onError === 'function' ? onError(error, iteration) : onError;
+      if (decision !== 'continue') {
+        finish('error', error);
+        return;
+      }
+    }
+    if (maxIterations !== undefined && iterations >= maxIterations) {
+      finish('max_iterations');
+      return;
+    }
+    scheduleNext();
+  }
+
+  return {
+    start(): void {
+      if (started || finished) return;
+      started = true;
+      if (signal?.aborted) {
+        finish('aborted');
+        return;
+      }
+      signal?.addEventListener('abort', onAbort, { once: true });
+      if (immediate) void runOnce();
+      else scheduleNext();
+    },
+    stop(): void {
+      requestStop('stopped');
+    },
+    get running(): boolean {
+      return started && !finished;
+    },
+    get iterations(): number {
+      return iterations;
+    },
+    done,
+  };
+}

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.58.0';
+export const SDK_VERSION = '0.59.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/prompt-loop.test.ts
+++ b/projects/silver-core-sdk/tests/prompt-loop.test.ts
@@ -1,0 +1,349 @@
+/**
+ * /loop interval-loop primitive (BPT-EXTENSION, src/prompt-loop.ts) —
+ * parser grammar (the single source of truth hosts consume) and controller
+ * scheduling semantics (immediate first run, fixed-delay, no overlap,
+ * stop/abort/error policies).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createPromptLoop,
+  parseLoopCommand,
+  ConfigurationError,
+  DEFAULT_LOOP_INTERVAL_LABEL,
+  DEFAULT_LOOP_INTERVAL_MS,
+  LOOP_SLASH_COMMAND,
+  MAX_LOOP_INTERVAL_MS,
+  MIN_LOOP_INTERVAL_MS,
+} from '../src/index.js';
+
+function expectDirective(input: string) {
+  const parsed = parseLoopCommand(input);
+  expect(parsed).not.toBeNull();
+  if (!parsed || !parsed.ok) throw new Error(`expected ok parse, got ${JSON.stringify(parsed)}`);
+  return parsed.directive;
+}
+
+function expectInvalid(input: string): string {
+  const parsed = parseLoopCommand(input);
+  expect(parsed).not.toBeNull();
+  if (!parsed || parsed.ok) throw new Error(`expected invalid parse, got ${JSON.stringify(parsed)}`);
+  return parsed.error;
+}
+
+describe('parseLoopCommand', () => {
+  it('returns null for anything that is not a /loop invocation', () => {
+    expect(parseLoopCommand('hello')).toBeNull();
+    expect(parseLoopCommand('/compact')).toBeNull();
+    expect(parseLoopCommand('/loops every day')).toBeNull(); // no prefix confusion
+    expect(parseLoopCommand('/Loop 10m x')).toBeNull(); // command names are case-sensitive
+    expect(parseLoopCommand('say /loop 10m x')).toBeNull();
+  });
+
+  it('parses interval + prompt', () => {
+    const d = expectDirective('/loop 10m 继续查bpt的bug');
+    expect(d.intervalMs).toBe(600_000);
+    expect(d.intervalLabel).toBe('10m');
+    expect(d.explicitInterval).toBe(true);
+    expect(d.prompt).toBe('继续查bpt的bug');
+  });
+
+  it('defaults to 10m when the interval is omitted', () => {
+    const d = expectDirective('/loop check the deploy status');
+    expect(d.intervalMs).toBe(DEFAULT_LOOP_INTERVAL_MS);
+    expect(d.intervalLabel).toBe(DEFAULT_LOOP_INTERVAL_LABEL);
+    expect(d.explicitInterval).toBe(false);
+    expect(d.prompt).toBe('check the deploy status');
+  });
+
+  it('supports s/m/h with aliases and decimals', () => {
+    expect(expectDirective('/loop 30s x').intervalMs).toBe(30_000);
+    expect(expectDirective('/loop 45sec x').intervalMs).toBe(45_000);
+    expect(expectDirective('/loop 45secs x').intervalMs).toBe(45_000);
+    expect(expectDirective('/loop 5min x').intervalMs).toBe(300_000);
+    expect(expectDirective('/loop 5mins x').intervalMs).toBe(300_000);
+    expect(expectDirective('/loop 2h x').intervalMs).toBe(7_200_000);
+    expect(expectDirective('/loop 1hr x').intervalMs).toBe(3_600_000);
+    expect(expectDirective('/loop 2hrs x').intervalMs).toBe(7_200_000);
+    expect(expectDirective('/loop 1.5m x').intervalMs).toBe(90_000);
+    expect(expectDirective('/loop 10M x').intervalMs).toBe(600_000); // unit case-insensitive
+  });
+
+  it('keeps a slash-command task verbatim for host resubmission', () => {
+    const d = expectDirective('/loop 5m /daily-news');
+    expect(d.prompt).toBe('/daily-news');
+  });
+
+  it('preserves multiline prompts', () => {
+    const d = expectDirective('/loop 10m first line\nsecond line');
+    expect(d.prompt).toBe('first line\nsecond line');
+    const noInterval = expectDirective('/loop first line\nsecond line');
+    expect(noInterval.prompt).toBe('first line\nsecond line');
+  });
+
+  it('rejects /loop without a task, loudly', () => {
+    expect(expectInvalid('/loop')).toMatch(/requires a prompt/);
+    expect(expectInvalid('/loop 10m')).toMatch(/after the interval/);
+    expect(expectInvalid('/loop   ')).toMatch(/requires a prompt/);
+  });
+
+  it('rejects a digit-leading first token that is not a valid interval (fail-closed)', () => {
+    expect(expectInvalid('/loop 10x task')).toMatch(/not a valid interval/);
+    expect(expectInvalid('/loop 10 task')).toMatch(/not a valid interval/);
+  });
+
+  it('rejects out-of-bounds intervals', () => {
+    expect(expectInvalid('/loop 0s task')).toMatch(/at least 1s/);
+    expect(expectInvalid('/loop 0.5s task')).toMatch(/at least 1s/);
+    expect(expectInvalid('/loop 9999999h task')).toMatch(/at most/);
+    expect(expectDirective('/loop 1s task').intervalMs).toBe(MIN_LOOP_INTERVAL_MS);
+  });
+
+  it('accepts the setTimeout ceiling boundary', () => {
+    // 596h = 2_145_600_000 ms, just under 2^31-1.
+    expect(expectDirective('/loop 596h task').intervalMs).toBeLessThanOrEqual(MAX_LOOP_INTERVAL_MS);
+  });
+
+  it('exports honest menu metadata without registering an engine built-in', async () => {
+    expect(LOOP_SLASH_COMMAND.name).toBe('loop');
+    expect(LOOP_SLASH_COMMAND.argumentHint).toContain('interval');
+    const { BUILTIN_SLASH_COMMANDS } = await import('../src/engine/slash-commands.js');
+    expect(BUILTIN_SLASH_COMMANDS.some((c) => c.name === 'loop')).toBe(false);
+  });
+});
+
+describe('createPromptLoop', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('validates options at construction (ConfigurationError per the layer whitelist)', () => {
+    const run = vi.fn();
+    expect(() => createPromptLoop({ prompt: '', run })).toThrow(ConfigurationError);
+    expect(() => createPromptLoop({ prompt: 'x', run, intervalMs: MIN_LOOP_INTERVAL_MS - 1 })).toThrow(
+      ConfigurationError,
+    );
+    expect(() => createPromptLoop({ prompt: 'x', run, intervalMs: 60_000.5 })).toThrow(
+      ConfigurationError,
+    );
+    expect(() =>
+      createPromptLoop({ prompt: 'x', run, intervalMs: MAX_LOOP_INTERVAL_MS + 1 }),
+    ).toThrow(ConfigurationError);
+    expect(() => createPromptLoop({ prompt: 'x', run, maxIterations: 0 })).toThrow(
+      ConfigurationError,
+    );
+  });
+
+  it('runs immediately on start, then on a fixed delay after each completion', async () => {
+    const calls: Array<{ iteration: number; at: number }> = [];
+    const loop = createPromptLoop({
+      prompt: 'p',
+      intervalMs: 60_000,
+      run: async (prompt, iteration) => {
+        expect(prompt).toBe('p');
+        calls.push({ iteration, at: Date.now() });
+        // Each run takes 10s: fixed-delay means period = 70s, not 60s.
+        await new Promise((r) => setTimeout(r, 10_000));
+      },
+    });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls.map((c) => c.iteration)).toEqual([1]);
+
+    await vi.advanceTimersByTimeAsync(10_000 + 60_000);
+    expect(calls.map((c) => c.iteration)).toEqual([1, 2]);
+    expect(calls[1].at - calls[0].at).toBe(70_000);
+
+    await vi.advanceTimersByTimeAsync(10_000 + 60_000);
+    expect(loop.iterations).toBe(2);
+    expect(calls).toHaveLength(3);
+    loop.stop();
+    await vi.runAllTimersAsync();
+  });
+
+  it('immediate: false waits one interval before the first run', async () => {
+    const run = vi.fn();
+    const loop = createPromptLoop({ prompt: 'p', run, intervalMs: 60_000, immediate: false });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(run).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(run).toHaveBeenCalledTimes(1);
+    loop.stop();
+    await vi.runAllTimersAsync();
+  });
+
+  it('stops after maxIterations with the right summary', async () => {
+    const run = vi.fn();
+    const loop = createPromptLoop({ prompt: 'p', run, intervalMs: 60_000, maxIterations: 3 });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(300_000);
+    const summary = await loop.done;
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(summary).toEqual({ iterations: 3, stopReason: 'max_iterations' });
+    expect(loop.running).toBe(false);
+  });
+
+  it('stop() while idle resolves done without another run', async () => {
+    const run = vi.fn();
+    const loop = createPromptLoop({ prompt: 'p', run, intervalMs: 60_000 });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(run).toHaveBeenCalledTimes(1);
+    loop.stop();
+    loop.stop(); // idempotent
+    const summary = await loop.done;
+    expect(summary).toEqual({ iterations: 1, stopReason: 'stopped' });
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop() during an in-flight run lets it settle, then stops', async () => {
+    let settled = false;
+    const loop = createPromptLoop({
+      prompt: 'p',
+      intervalMs: 60_000,
+      run: async () => {
+        await new Promise((r) => setTimeout(r, 5_000));
+        settled = true;
+      },
+    });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(0);
+    loop.stop();
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const summary = await loop.done;
+    expect(settled).toBe(true);
+    expect(summary).toEqual({ iterations: 1, stopReason: 'stopped' });
+  });
+
+  it('honors AbortSignal, including pre-aborted and mid-flight', async () => {
+    const run = vi.fn();
+    const pre = new AbortController();
+    pre.abort();
+    const dead = createPromptLoop({ prompt: 'p', run, signal: pre.signal });
+    dead.start();
+    expect((await dead.done).stopReason).toBe('aborted');
+    expect(run).not.toHaveBeenCalled();
+
+    const ctrl = new AbortController();
+    const loop = createPromptLoop({
+      prompt: 'p',
+      intervalMs: 60_000,
+      signal: ctrl.signal,
+      run: () => new Promise((r) => setTimeout(r, 5_000)),
+    });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(0);
+    ctrl.abort();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(await loop.done).toEqual({ iterations: 1, stopReason: 'aborted' });
+  });
+
+  it('abort wins over a concurrent stop() while in flight', async () => {
+    const ctrl = new AbortController();
+    const loop = createPromptLoop({
+      prompt: 'p',
+      signal: ctrl.signal,
+      run: () => new Promise((r) => setTimeout(r, 5_000)),
+    });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(0);
+    ctrl.abort();
+    loop.stop();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect((await loop.done).stopReason).toBe('aborted');
+  });
+
+  it('defaults to stopping on error with the error in the summary', async () => {
+    const boom = new Error('boom');
+    const loop = createPromptLoop({
+      prompt: 'p',
+      intervalMs: 60_000,
+      run: () => Promise.reject(boom),
+    });
+    loop.start();
+    const summary = await loop.done;
+    expect(summary.stopReason).toBe('error');
+    expect(summary.error).toBe(boom);
+    expect(summary.iterations).toBe(1);
+  });
+
+  it("onError: 'continue' keeps looping through failures", async () => {
+    let attempts = 0;
+    const loop = createPromptLoop({
+      prompt: 'p',
+      intervalMs: 60_000,
+      onError: 'continue',
+      maxIterations: 3,
+      run: () => {
+        attempts += 1;
+        return Promise.reject(new Error(`fail ${attempts}`));
+      },
+    });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(attempts).toBe(3);
+    expect((await loop.done).stopReason).toBe('max_iterations');
+  });
+
+  it('onError callback decides per error and sees the iteration index', async () => {
+    const seen: Array<[string, number]> = [];
+    const loop = createPromptLoop({
+      prompt: 'p',
+      intervalMs: 60_000,
+      onError: (error, iteration) => {
+        seen.push([(error as Error).message, iteration]);
+        return iteration < 2 ? 'continue' : 'stop';
+      },
+      run: (_p, i) => Promise.reject(new Error(`fail ${i}`)),
+    });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(300_000);
+    const summary = await loop.done;
+    expect(seen).toEqual([
+      ['fail 1', 1],
+      ['fail 2', 2],
+    ]);
+    expect(summary.stopReason).toBe('error');
+    expect(summary.iterations).toBe(2);
+  });
+
+  it('start() is idempotent and a stopped loop cannot restart', async () => {
+    const run = vi.fn();
+    const loop = createPromptLoop({ prompt: 'p', run, intervalMs: 60_000 });
+    loop.start();
+    loop.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(run).toHaveBeenCalledTimes(1);
+    loop.stop();
+    await loop.done;
+    loop.start();
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(loop.running).toBe(false);
+  });
+
+  it('bridges a parsed directive end-to-end (the thin host wiring)', async () => {
+    const parsed = parseLoopCommand('/loop 1m /daily-news');
+    if (!parsed?.ok) throw new Error('parse failed');
+    const submitted: string[] = [];
+    const loop = createPromptLoop({
+      prompt: parsed.directive.prompt,
+      intervalMs: parsed.directive.intervalMs,
+      maxIterations: 2,
+      run: (prompt) => {
+        submitted.push(prompt);
+      },
+    });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(submitted).toEqual(['/daily-news', '/daily-news']);
+    expect((await loop.done).stopReason).toBe('max_iterations');
+  });
+});


### PR DESCRIPTION
## Background

The 2026-07-14 gap investigation confirmed `/loop 10m <task>` in BPT is executed by NO layer: the GUI has no `/loop` registration, the SDK slash layer only does markdown expansion + the `/compact` built-in, so the invocation passes through as a ONE-SHOT plain prompt and the recurrence semantics are silently lost. Keeper ruling (same day): ship the loop primitive SDK-side; BPT consumes thinly.

## Changes

- **`src/prompt-loop.ts` (BPT-EXTENSION, new)**
  - `parseLoopCommand` — single source of truth for the `/loop [<interval>] <task>` grammar (units `s|m|h` + aliases, decimals, default `10m`). Three-way result: `null` (not /loop — route as usual), `{ok:false, error}` (IS /loop but unusable — hosts must surface the error, never pass through), `{ok:true, directive}`. Fail-closed on digit-leading non-interval tokens; interval bounds `[1s, 2^31-1 ms]` (Node `setTimeout` overflow fires immediately — a hot-loop hazard above the ceiling).
  - `createPromptLoop` — fixed-delay controller over a host-owned `run` callback: immediate first run, next run `intervalMs` after the previous one SETTLES (runs never overlap), `maxIterations` / `AbortSignal` / `onError` (`'stop'` default | `'continue'` | per-error callback), `done` summary promise (never rejects).
  - `LOOP_SLASH_COMMAND` menu metadata; deliberately NOT an engine built-in — the engine loop cannot re-invoke itself over wall-clock time, and advertising a command the engine would swallow as plain text breaks the honesty red line.
- Invalid construction options throw `ConfigurationError` per the layer whitelist (`docs/ARCHITECTURE.md` table row added).
- README "/loop interval loops (BPT-EXTENSION)" section with the ~10-line host bridge example.
- Version 0.58.0 → 0.59.0 (new capability = minor) + CHANGELOG entry; package-lock version fields synced (they had been left at 0.57.2).
- `CONTEXT.md` / `memory/project-status.md` status entries.

## Verification

- `tests/prompt-loop.test.ts` +24 tests (grammar incl. CJK/multiline/slash-command tasks, bounds, fixed-delay timing under fake timers, overlap-free stop/abort races, error policies, end-to-end bridge wiring).
- Full vitest: **2384 passed + 2 skipped** (128 files); `tsc` typecheck + build exit 0; `check-version-bump` guard OK.
- Repo pytest: **2923 passed + 12 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJo9pCQWTMd3MrMsfshFVa

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJo9pCQWTMd3MrMsfshFVa)_