### PR TITLE
silver-core-sdk 0.59.1: audit P2 batch — low-severity hygiene + noUnusedLocals lint gate

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,41 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.59.1 — 2026-07-14
+
+Audit 2026-07-14 P2 batch — low-severity hygiene + a lint gate:
+
+- **Lint gate**: `noUnusedLocals` enabled in tsconfig (so `npm run
+  typecheck` now reds on dead imports/vars); cleaned the extraction-leftover
+  dead type imports it surfaced in query.ts / engine/loop.ts /
+  subagents/runtime.ts / tools/toolsearch.ts. (`noUnusedParameters`
+  deliberately NOT enabled — it flags idiomatic unused destructured params.)
+- **L-1**: engine/loop.ts tool-defs cache key no longer embeds a raw NUL
+  byte (now the `\x00` escape) — behavior identical, but the source file is
+  plain text again instead of being flagged binary by grep et al.
+- **L-2**: explicit Retry-After now gets bounded upward jitter (never
+  earlier than the server floor) in both transport twins — a subagent
+  fan-out sharing one Retry-After no longer retries in the same instant.
+- **L-5**: mcp/stdio.ts marks the connection closed on a spawn 'error'
+  (ENOENT) so later requests fail fast with mcp_not_connected instead of
+  hanging to the 60s timeout.
+- **L-9**: removed dead imports/vars (loop.ts extraction leftovers,
+  duplicate toAbortError now shared from tool-dispatch, a dead `closed`
+  var in generators/runtime.ts).
+- **L-10**: the process-tree kill closure (duplicated in bash.ts and
+  shells.ts) is unified into `createTreeKiller` in tools/kill-plan.ts.
+- **L-14**: getSessionInfo reuses the meta-only scan (loadInfo) instead of
+  a full load()+repairPairing when it only needs title/timestamps.
+- **L-16**: run-log day file is named from the record's own ts, not the
+  flush-time clock, so a record observed at 23:59 and flushed at 00:00
+  lands in the correct day.
+- **L-19b**: deleteSession emits a debug line when the external store has
+  no delete capability, instead of silently resolving as success.
+
+L-13 (monitor kill-timer registration) deliberately skipped — the timer is
+already unref'd (harmless) and wiring it into the private killTimers map
+risks colliding with the SIGTERM->SIGKILL upgrade timer keyed on the same
+id; not worth it for a no-op leak.
 ## 0.59.0 — 2026-07-14
 
 New capability: `/loop` interval-loop primitive (`src/prompt-loop.ts`,

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -22,23 +22,18 @@ import type {
   APIAssistantMessage,
   APIMessageParam,
   APIToolDefinitionParam,
-  CallToolResult,
   ContentBlock,
-  DocumentBlockParam,
-  ImageBlockParam,
   JSONSchema,
   ModelUsage,
   NonNullableUsage,
   RawMessageStreamEvent,
   SDKMessage,
-  SDKPermissionDeniedMessage,
   SDKResultMessage,
   SDKRunMetrics,
   SDKToolMetrics,
   SDKTransportHealth,
   SDKTurnMetrics,
   StopReason,
-  TextBlockParam,
   ToolResultBlockParam,
   ToolUseBlock,
 } from '../types.js';
@@ -48,12 +43,16 @@ import type {
   EngineDeps,
   RetryInfo,
   StreamRequest,
-  ToolResultPayload,
 } from '../internal/contracts.js';
 import { MessageAccumulator } from './accumulator.js';
 import { addUsage, estimateCostUsd, normalizeUsage } from './pricing.js';
 import { contextWindowFor } from './context-window.js';
-import { createToolDispatcher, mkToolError, type ToolExecOutcome } from './tool-dispatch.js';
+import {
+  createToolDispatcher,
+  mkToolError,
+  toAbortError,
+  type ToolExecOutcome,
+} from './tool-dispatch.js';
 import { deriveSystemField } from './system-field.js';
 import { supportsAdaptiveThinking } from './thinking-model.js';
 import { estimateToolDefsTokens } from './tokens.js';
@@ -114,14 +113,6 @@ function replayBackoff(attempt: number, signal: AbortSignal): Promise<void> {
     // to a pending retry.
     signal.addEventListener('abort', onAbort, { once: true });
   });
-}
-
-/** Wrap any abort-shaped error into this SDK's AbortError. */
-function toAbortError(err: unknown): AbortError {
-  if (err instanceof AbortError) return err;
-  const message =
-    err instanceof Error ? err.message : 'The operation was aborted';
-  return new AbortError(message);
 }
 
 /** Fallback-eligible API statuses: rate limit and server-side failures. */
@@ -644,7 +635,7 @@ export async function* runAgentLoop(
   let toolDefsEstimateKey: string | undefined;
   let toolDefsEstimate = 0;
   const currentOverheadTokens = (defs: APIToolDefinitionParam[]): number => {
-    const key = defs.map((d) => d.name).join(' ');
+    const key = defs.map((d) => d.name).join('\x00');
     if (key !== toolDefsEstimateKey) {
       toolDefsEstimate = estimateToolDefsTokens(defs);
       toolDefsEstimateKey = key;

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -38,7 +38,6 @@ import type {
   ToolUseBlock,
 } from '../types.js';
 import type {
-  AggregatedHookResult,
   EngineConfig,
   EngineDeps,
   RetryInfo,
@@ -1023,7 +1022,15 @@ export async function* runAgentLoop(
           assistant = yield* streamAttempt(model, turnToolDefs, firstSink);
           break;
         } catch (err) {
-          if (isAbortError(err)) throw toAbortError(err);
+          if (isAbortError(err)) {
+            // audit 2026-07-14 L-6: the aborted attempt may already have
+            // billed tokens (input tokens on its message_start). Fold them
+            // into the run totals so the outer catch can hand the partial
+            // accounting to the query layer — without this, a turn-level
+            // interrupt() silently lost the aborted turn's spend.
+            if (firstSink.usage !== undefined) recordUsage(model, firstSink.usage);
+            throw toAbortError(err);
+          }
           if (
             err instanceof APIConnectionError &&
             !signal.aborted &&
@@ -1108,14 +1115,15 @@ export async function* runAgentLoop(
             // The fallback attempt gets its own usage sink: if IT fails too,
             // the tokens it burned (its message_start already billed the
             // prompt) must reach the totals the terminal error result reports,
-            // exactly as the first attempt's sink was folded above. A caller
-            // abort keeps the plain throw-through — no result is produced, so
-            // there is no report to keep honest.
+            // exactly as the first attempt's sink was folded above. An abort
+            // folds too (audit 2026-07-14 L-6): no result is produced, but the
+            // outer catch now hands the run's partial accounting to the query
+            // layer on the thrown AbortError, so these tokens are reportable.
             const fallbackSink: UsageSink = {};
             try {
               assistant = yield* streamAttempt(model, turnToolDefs, fallbackSink);
             } catch (fallbackErr) {
-              if (!isAbortError(fallbackErr) && fallbackSink.usage !== undefined) {
+              if (fallbackSink.usage !== undefined) {
                 recordUsage(model, fallbackSink.usage);
               }
               throw fallbackErr; // 2nd failure -> outer catch
@@ -1600,7 +1608,27 @@ export async function* runAgentLoop(
       return;
     }
   } catch (err) {
-    if (isAbortError(err)) throw toAbortError(err);
+    if (isAbortError(err)) {
+      // audit 2026-07-14 L-6: an aborted run yields NO result message, so the
+      // usage it already billed (this turn's message_start input tokens folded
+      // above, plus any completed intermediate turns of the tool loop) would
+      // silently vanish from session accounting. Attach the run's partial
+      // accounting to the thrown AbortError; the query layer folds it into
+      // SessionAccounting in its abort path. When the same AbortError bubbles
+      // through nested loops each loop overwrites with ITS OWN scope — the
+      // outermost (root) loop wins, which is the scope the root query folds.
+      const aborted = toAbortError(err);
+      aborted.abortedRunAccounting = {
+        usage: { ...totalUsage },
+        totalCostUsd,
+        durationApiMs,
+        numTurns,
+        modelUsage: Object.fromEntries(
+          Object.entries(modelUsage).map(([k, v]) => [k, { ...v }]),
+        ),
+      };
+      throw aborted;
+    }
     // Unified normalization: map ANY thrown upstream failure — an APIStatusError,
     // an APIConnectionError, or a bare gateway error object that穿透ed
     // un-classified — into a stable NormalizedProviderError so the host never

--- a/projects/silver-core-sdk/src/engine/tool-dispatch.ts
+++ b/projects/silver-core-sdk/src/engine/tool-dispatch.ts
@@ -145,7 +145,7 @@ function appendContext(
   return [...content, ...extra.map((text): TextBlockParam => ({ type: 'text', text }))];
 }
 
-export { mkToolError };
+export { mkToolError, toAbortError };
 
 export type ToolDispatcherConfig = {
   deps: Pick<

--- a/projects/silver-core-sdk/src/errors.ts
+++ b/projects/silver-core-sdk/src/errors.ts
@@ -8,6 +8,10 @@
  * never rename or reuse a published code.
  */
 
+// Type-only import (erased at emit): carries no runtime dependency, so the
+// errors module stays import-cycle-free.
+import type { ModelUsage, NonNullableUsage } from './types.js';
+
 /** Stable machine-readable codes for MCP subsystem failures (`McpError`). */
 export type McpErrorCode =
   /** A server did not finish connect+listTools within the connect timeout. */
@@ -66,10 +70,33 @@ export type ErrorCode =
   | 'memory_tool_error'
   | McpErrorCode;
 
+/**
+ * audit 2026-07-14 L-6: partial accounting of an engine run that an abort cut
+ * short. The aborted run's already-billed usage (message_start input tokens,
+ * any completed intermediate turns) never reaches a result message — results
+ * are not emitted on abort — so the engine loop attaches what it knows at
+ * abort time and the query layer folds it into its SessionAccounting.
+ */
+export type AbortedRunAccounting = {
+  usage: NonNullableUsage;
+  totalCostUsd: number;
+  durationApiMs: number;
+  numTurns: number;
+  modelUsage: Record<string, ModelUsage>;
+};
+
 /** Thrown when an operation is aborted via AbortController/interrupt(). */
 export class AbortError extends Error {
   override name = 'AbortError';
   readonly code: ErrorCode = 'aborted';
+  /**
+   * audit 2026-07-14 L-6: set by the engine loop when a run is aborted after
+   * usage was already billed (e.g. a turn-level interrupt() that lands after
+   * message_start reported input tokens). Absent when nothing was billed or
+   * the abort happened outside an engine run. The query layer folds this into
+   * its session accounting so an interrupted turn's spend is not lost.
+   */
+  abortedRunAccounting?: AbortedRunAccounting;
   constructor(message = 'The operation was aborted') {
     super(message);
   }

--- a/projects/silver-core-sdk/src/generators/runtime.ts
+++ b/projects/silver-core-sdk/src/generators/runtime.ts
@@ -67,15 +67,45 @@ export interface UtilityCallOptions {
   env?: Record<string, string | undefined>;
 }
 
+/**
+ * audit 2026-07-14 L-4: memoized default transports for utility calls.
+ *
+ * Every utility call used to build a FRESH provider transport, which voided
+ * the maxConcurrentRequests semaphore across calls (the gate is per-transport)
+ * and fired one BPT_PRECONNECT probe per call. The default transport is now
+ * cached per resolved provider-config identity: keyed by the provider object
+ * reference (or, when no provider is given, the env object reference — both
+ * are stable references at the call sites that repeat utility calls), with the
+ * betas list as a secondary key since it changes the wire headers. WeakMap
+ * keying means a dropped provider config releases its transport. The first
+ * caller's debug sink is captured for the cached transport's lifetime — an
+ * accepted trade for identity-stable memoization. Injected transports
+ * (opts.transport) and the cross-protocol resolver keep priority and are
+ * never cached here.
+ */
+const utilityTransportCache = new WeakMap<object, Map<string, Transport>>();
+
 /** Resolve (or build) the transport a utility call will drive. */
 export function resolveUtilityTransport(opts: UtilityCallOptions): Transport {
   if (opts.transport !== undefined) return opts.transport;
-  return createProviderTransport({
+  const env = opts.env ?? process.env;
+  const keyObj: object = opts.provider ?? env;
+  const betasKey = (opts.betas ?? []).join(',');
+  let byBetas = utilityTransportCache.get(keyObj);
+  if (byBetas === undefined) {
+    byBetas = new Map();
+    utilityTransportCache.set(keyObj, byBetas);
+  }
+  const cached = byBetas.get(betasKey);
+  if (cached !== undefined) return cached;
+  const transport = createProviderTransport({
     provider: opts.provider,
-    env: opts.env ?? process.env,
+    env,
     debug: opts.debug ?? (() => {}),
     betas: opts.betas,
   });
+  byBetas.set(betasKey, transport);
+  return transport;
 }
 
 /**

--- a/projects/silver-core-sdk/src/generators/runtime.ts
+++ b/projects/silver-core-sdk/src/generators/runtime.ts
@@ -149,7 +149,6 @@ export function extractJsonObject(text: string): unknown {
     let depth = 0;
     let inString = false;
     let escaped = false;
-    let closed = false;
     for (let i = searchFrom; i < trimmed.length; i += 1) {
       const ch = trimmed[i];
       if (inString) {
@@ -165,14 +164,12 @@ export function extractJsonObject(text: string): unknown {
         if (depth === 0) {
           const parsed = tryParse(trimmed.slice(searchFrom, i + 1));
           if (parsed !== undefined) return parsed;
-          closed = true; // balanced but unparseable -> try the next '{'
-          break;
+          break; // balanced but unparseable -> try the next '{' (audit 2026-07-14 L-9c)
         }
       }
     }
     // Whether the group closed-but-failed or never balanced, advance to the
     // next candidate '{' after the current start.
-    void closed;
     searchFrom = trimmed.indexOf('{', searchFrom + 1);
   }
   return null;

--- a/projects/silver-core-sdk/src/mcp/stdio.ts
+++ b/projects/silver-core-sdk/src/mcp/stdio.ts
@@ -140,6 +140,14 @@ export class StdioMcpConnection {
       this.debug(`[mcp:${this.label}] stdin error: ${err.message}`);
     });
     child.on('error', (err: Error) => {
+      // audit 2026-07-14 L-5: a spawn failure (ENOENT etc.) fires 'error' but
+      // NOT 'exit', so without flipping closed state here the connection stays
+      // nominally "open" — a later request() would write to a dead stdin and
+      // hang for the full 60s request timeout. Mark it closed (mirrors the
+      // 'exit' handler) and drop the child so subsequent request()/write()
+      // fail FAST with mcp_not_connected.
+      this.closed = true;
+      this.child = null;
       this.failAllPending(
         new McpError(
           'mcp_process_error',

--- a/projects/silver-core-sdk/src/query-accounting.ts
+++ b/projects/silver-core-sdk/src/query-accounting.ts
@@ -11,6 +11,7 @@
  */
 
 import type { ModelUsage, NonNullableUsage, SDKResultMessage } from './types.js';
+import type { AbortedRunAccounting } from './errors.js';
 
 function zeroUsage(): NonNullableUsage {
   return {
@@ -70,6 +71,23 @@ export class SessionAccounting {
     this.apiMs += r.duration_api_ms;
     this.usage = addUsage(this.usage, r.usage);
     for (const [modelId, mu] of Object.entries(r.modelUsage)) {
+      mergeModelUsage(this.modelUsage, modelId, mu);
+    }
+  }
+
+  /**
+   * audit 2026-07-14 L-6: fold an ABORTED run's partial accounting (attached
+   * to the AbortError by the engine loop) into the session totals. An aborted
+   * run emits no result message, so without this fold the usage it already
+   * billed — message_start input tokens, completed intermediate turns — would
+   * under-count the session budget/summary.
+   */
+  accumulateAborted(p: AbortedRunAccounting): void {
+    this.turns += p.numTurns;
+    this.cost += p.totalCostUsd;
+    this.apiMs += p.durationApiMs;
+    this.usage = addUsage(this.usage, p.usage);
+    for (const [modelId, mu] of Object.entries(p.modelUsage)) {
       mergeModelUsage(this.modelUsage, modelId, mu);
     }
   }

--- a/projects/silver-core-sdk/src/query.ts
+++ b/projects/silver-core-sdk/src/query.ts
@@ -13,15 +13,9 @@ import type {
   AgentInfo,
   APIMessageParam,
   APIUserMessage,
-  CallToolResult,
-  ContentBlock,
-  McpResource,
-  McpResourceContent,
   McpServerConfig,
-  McpServerStatus,
   McpSetServersResult,
   ModelInfo,
-  ModelUsage,
   NonNullableUsage,
   Options,
   PermissionMode,
@@ -40,12 +34,8 @@ import type {
 } from './types.js';
 import type {
   BuiltinTool,
-  EngineConfig,
   EngineDeps,
   McpRegistry,
-  McpToolEntry,
-  SystemComposition,
-  SystemCompositionPart,
   ToolContext,
   ToolDispatchRecord,
   Transport,
@@ -75,7 +65,7 @@ import { estimateTextTokens } from './engine/tokens.js';
 import { MEMORY_TOOL_NAME, resolveMemoryRuntime } from './tools/memory/index.js';
 import { createSessionPersistence } from './sessions/persistence.js';
 import { createRunLogSink } from './reporting/run-log.js';
-import { AsyncQueue, createDeferred, type Deferred } from './internal/async.js';
+import { AsyncQueue, createDeferred } from './internal/async.js';
 import { ToolFilterMcpRegistry } from './mcp/tool-filter.js';
 import { SDK_VERSION } from './version.js';
 import { JsonlSessionStore, resolveTranscriptPath } from './sessions/store.js';
@@ -657,7 +647,7 @@ export function query(args: {
   // EngineConfig assembly extracted to engine/config-builder.ts (audit
   // 2026-07-10 P2-3C): structured-output normalization, system-prompt shapes
   // + composition breakdown, preset thinking default, the config literal.
-  const { engineConfig, outputFormat, sessionGitBranch, isClaudeCodePreset } = buildEngineConfig({
+  const { engineConfig, sessionGitBranch, isClaudeCodePreset } = buildEngineConfig({
     options,
     cwd,
     initialModel,
@@ -1231,6 +1221,16 @@ export function query(args: {
             }
           }
           if (isAbortError(err)) {
+            // audit 2026-07-14 L-6: an aborted engine run emits no result, so
+            // its already-billed partial usage (message_start input tokens,
+            // completed intermediate turns) rides the AbortError instead. Fold
+            // it — plus any completed subagent usage — into the session
+            // accounting BEFORE deciding the abort's fate, so both the
+            // interrupt terminal result below and a later session summary
+            // report the true spend instead of under-counting.
+            const partial = err instanceof AbortError ? err.abortedRunAccounting : undefined;
+            if (partial !== undefined) acct.accumulateAborted(partial);
+            acct.foldSubagentUsage(subagentRuntime.drainUsageLedger());
             // A caller abort OR a close() (life) ends the whole run; only a
             // per-turn interrupt() (turnController, neither of the above) is a
             // recoverable turn-level cancel.

--- a/projects/silver-core-sdk/src/reporting/run-log.ts
+++ b/projects/silver-core-sdk/src/reporting/run-log.ts
@@ -154,7 +154,11 @@ export function createRunLogSink(args: {
       const line = `${JSON.stringify(record)}\n`;
       tail = tail
         .then(() => ensureDir())
-        .then(() => appendFile(join(runLog.dir, runLogFileName(new Date())), line, 'utf8'))
+        // audit 2026-07-14 L-16: derive the day file from the RECORD'S ts (set
+        // at observe time), not the flush-time clock — a record observed at
+        // 23:59:59 and appended at 00:00:01 otherwise lands in the wrong day
+        // file, where readWindow's filename-based day prefilter can miss it.
+        .then(() => appendFile(join(runLog.dir, runLogFileName(new Date(record.ts))), line, 'utf8'))
         .catch((err) => debug(`runLog: append failed (ignored): ${String(err)}`));
     },
     flush(): Promise<void> {

--- a/projects/silver-core-sdk/src/session-manager.ts
+++ b/projects/silver-core-sdk/src/session-manager.ts
@@ -438,6 +438,10 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
     const maxResumes = recovery?.maxResumes ?? 2;
     let sessionId: string | undefined;
     let attempts = 0;
+    // audit 2026-07-14 L-7: whether the FIRST system/init already reached the
+    // consumer. A transparent auto-resume starts a fresh query() run that
+    // re-emits its own init; only the first one is forwarded (see below).
+    let initForwarded = false;
     // Status observations queued to surface (in the consumer's stream) just
     // before the retried query's first message.
     const observations: SDKMessage[] = [];
@@ -537,6 +541,15 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
           const v = r.value;
           if (v.type === 'system' && v.subtype === 'init') {
             sessionId = v.session_id;
+            // audit 2026-07-14 L-7: after a transparent auto-resume the
+            // resumed query re-emits its own system/init. Forwarding that
+            // SECOND init would make a downstream UI that treats init as a
+            // session boundary render a ghost "new session" for what the
+            // supervisor promised is ONE continuous session. The session_id
+            // was already read above for internal use; swallow every init
+            // after the first and keep fetching the next message.
+            if (initForwarded) continue;
+            initForwarded = true;
           }
 
           // The `subtype` discriminant (not is_error) narrows to the error arm.

--- a/projects/silver-core-sdk/src/sessions/session-functions.ts
+++ b/projects/silver-core-sdk/src/sessions/session-functions.ts
@@ -37,6 +37,10 @@ export type SessionMutationOptions = {
   sessionStore?: ExternalSessionStore;
   /** Working dir used to derive the external project key. Default process.cwd(). */
   cwd?: string;
+  /** Optional diagnostic sink (audit 2026-07-14 L-19b). Used to surface
+   *  no-op mutations a host might otherwise read as success — e.g. a
+   *  deleteSession against an external store that exposes no `delete`. */
+  debug?: (msg: string) => void;
 };
 
 export type GetSessionMessagesOptions = SessionMutationOptions & {

--- a/projects/silver-core-sdk/src/sessions/session-functions.ts
+++ b/projects/silver-core-sdk/src/sessions/session-functions.ts
@@ -219,6 +219,15 @@ export async function deleteSession(
   if (options.sessionStore !== undefined) {
     if (options.sessionStore.delete !== undefined) {
       await options.sessionStore.delete(mainKey(sessionId, options));
+    } else {
+      // audit 2026-07-14 L-19b: the external store has no delete capability, so
+      // nothing was removed. Resolve (do NOT throw — that would break the
+      // local-only happy path), but emit a debug line so a host is not misled
+      // into believing the session's private data was actually deleted.
+      options.debug?.(
+        `deleteSession: external store exposes no delete(); session '${sessionId}' ` +
+          `was NOT removed (no-op)`,
+      );
     }
     return;
   }

--- a/projects/silver-core-sdk/src/sessions/store.ts
+++ b/projects/silver-core-sdk/src/sessions/store.ts
@@ -532,8 +532,12 @@ export class JsonlSessionStore implements SessionStore {
     return sessions;
   }
 
-  /** Meta-only transcript scan backing list(); see the list() doc. */
-  private async loadInfo(sessionId: string): Promise<LoadedSession | null> {
+  /** Meta-only transcript scan backing list() AND getSessionInfo (audit
+   *  2026-07-14 L-14). Public because getSessionInfo only needs the summary-row
+   *  meta (title / timestamps / cwd / tag / branch), never `messages`, so it
+   *  must not pay for load()'s full parse + triple repairPairing. Returns
+   *  `messages: []`; resume paths still go through load(). */
+  async loadInfo(sessionId: string): Promise<LoadedSession | null> {
     if (!isSafeSessionId(sessionId)) return null;
     const file = this.filePath(sessionId);
     let createdAt: number | undefined;
@@ -783,7 +787,11 @@ export async function getSessionInfo(
   options: SessionListOptions = {},
 ): Promise<SDKSessionInfo | undefined> {
   const store = new JsonlSessionStore(resolveSessionDir(options));
-  const loaded = await store.load(sessionId);
+  // audit 2026-07-14 L-14: the summary row (toSessionInfo) reads only meta
+  // fields, never `messages`, so use the meta-only streaming scan instead of a
+  // full load() + triple repairPairing. Aligns with listSessions, which
+  // already sources its rows from loadInfo.
+  const loaded = await store.loadInfo(sessionId);
   if (loaded === null) return undefined;
   let fileSize: number | undefined;
   try {

--- a/projects/silver-core-sdk/src/subagents/runtime.ts
+++ b/projects/silver-core-sdk/src/subagents/runtime.ts
@@ -22,12 +22,7 @@
  * (context isolation).
  */
 
-import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { promisify } from 'node:util';
 
 import { isAbortError } from '../errors.js';
 import type {
@@ -303,8 +298,6 @@ export function buildForkSeed(
   }
   return seed;
 }
-
-const execFileP = promisify(execFile);
 
 /**
  * Worktree isolation (Agent tool `isolation: 'worktree'`, E7-02): create a

--- a/projects/silver-core-sdk/src/tools/bash.ts
+++ b/projects/silver-core-sdk/src/tools/bash.ts
@@ -9,7 +9,7 @@
 
 import { spawn } from 'node:child_process';
 import { resolvePosixShells, SHELL_NOT_FOUND_GUIDANCE } from './shell-resolve.js';
-import { planProcessKill } from './kill-plan.js';
+import { createTreeKiller } from './kill-plan.js';
 import { AbortError, ConfigurationError } from '../errors.js';
 import { BASH_DESCRIPTION, BASH_WIN32_NOTE, buildBashSandboxNote } from './descriptions.js';
 import { planShellSpawn } from '../sandbox/backend.js';
@@ -101,31 +101,11 @@ function runShell(
     let killTimer: NodeJS.Timeout | undefined;
     let flushTimer: NodeJS.Timeout | undefined;
 
-    // Terminate the shell's whole tree, platform-correctly (planProcessKill):
-    // POSIX signals the process group (-pid); Windows uses taskkill /T /F
-    // (process groups/negative-pid do nothing there - the same latent bug the
-    // background KillShell had, surfaced by the posix-hazard guard 2026-07-05).
-    let winKilled = false;
-    const killGroup = (sig: NodeJS.Signals): void => {
-      const plan = planProcessKill(child.pid, sig);
-      try {
-        if (plan.kind === 'group') {
-          process.kill(-plan.pid, plan.signal as NodeJS.Signals); // win-ok: posix branch of planProcessKill
-        } else if (plan.kind === 'child') {
-          child.kill(plan.signal as NodeJS.Signals);
-        } else {
-          if (winKilled) return;
-          winKilled = true;
-          const tk = spawn('taskkill', ['/PID', String(plan.pid), '/T', '/F'], { stdio: 'ignore' });
-          tk.on('error', (e) => ctx.debug(`Bash: taskkill failed for pid ${plan.pid}: ${e.message}`));
-          tk.unref();
-        }
-      } catch (err) {
-        // Benign when the tree already exited; anything else goes to debug
-        // rather than being swallowed (the old empty catch hid Windows misses).
-        ctx.debug(`Bash: kill(${sig}) failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    };
+    // Terminate the shell's whole tree, platform-correctly: POSIX signals the
+    // process group (-pid); Windows uses one taskkill /T /F pass. Shared
+    // executor createTreeKiller (kill-plan.ts) — dedup with shells.ts
+    // spawnBackground, audit 2026-07-14 L-10.
+    const killGroup = createTreeKiller(child, ctx.debug);
 
     // SIGTERM first; escalate to SIGKILL after a grace period. Both target the
     // process group so no descendant survives.

--- a/projects/silver-core-sdk/src/tools/kill-plan.ts
+++ b/projects/silver-core-sdk/src/tools/kill-plan.ts
@@ -11,9 +11,69 @@
  * on any host. The platform kill planner it used to define moved to
  * `internal/process-kill.ts` (so `mcp/` can reuse the same source of truth);
  * it is re-exported here unchanged for the existing tool-layer consumers.
+ * `createTreeKiller` is the tool-layer EXECUTOR of that plan (audit 2026-07-14
+ * L-10): foreground Bash and the background ShellManager used to carry two
+ * near-identical `killGroup` closures; they now share this one.
  */
 
-export { planProcessKill, type KillPlan } from '../internal/process-kill.js';
+import { spawn } from 'node:child_process';
+import { planProcessKill } from '../internal/process-kill.js';
+
+export { planProcessKill };
+export type { KillPlan } from '../internal/process-kill.js';
+
+/** The minimal child surface the killer needs (satisfied by ChildProcess). */
+type KillableChild = {
+  pid?: number | undefined;
+  kill(signal: NodeJS.Signals): boolean;
+};
+
+/**
+ * Build a kill function that terminates `child`'s WHOLE process tree,
+ * platform-correctly (executes the planProcessKill plan): POSIX signals the
+ * process group (-pid, valid because every consumer spawns `detached:true`);
+ * Windows fires ONE `taskkill /PID <pid> /T /F` pass — tree + forced — so the
+ * SIGTERM->SIGKILL escalation collapses to a single call (the closure's
+ * `winKilled` latch makes the second a no-op). Extracted from the duplicated
+ * `killGroup` closures in bash.ts (foreground) and shells.ts
+ * (spawnBackground) — audit 2026-07-14 L-10.
+ *
+ * Failures are best-effort by design: benign when the tree already exited,
+ * anything else goes to `debug` rather than being swallowed (the old empty
+ * catch hid the Windows miss that made KillShell a silent no-op).
+ * `killFailContext` is appended verbatim to the kill-failure debug line
+ * (e.g. ` for shell bash_1`) so per-shell attribution survives the dedup.
+ */
+export function createTreeKiller(
+  child: KillableChild,
+  debug: (msg: string) => void,
+  killFailContext = '',
+): (sig: string) => void {
+  let winKilled = false;
+  return (sig: string): void => {
+    const plan = planProcessKill(child.pid, sig);
+    try {
+      if (plan.kind === 'group') {
+        process.kill(-plan.pid, plan.signal as NodeJS.Signals); // win-ok: posix branch of planProcessKill
+      } else if (plan.kind === 'child') {
+        child.kill(plan.signal as NodeJS.Signals);
+      } else {
+        // taskkill (Windows): fire once, best-effort, never blocks.
+        if (winKilled) return;
+        winKilled = true;
+        const tk = spawn('taskkill', ['/PID', String(plan.pid), '/T', '/F'], {
+          stdio: 'ignore',
+        });
+        tk.on('error', (e) => debug(`Bash: taskkill failed for pid ${plan.pid}: ${e.message}`));
+        tk.unref();
+      }
+    } catch (err) {
+      debug(
+        `Bash: kill(${sig}) failed${killFailContext}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+}
 
 /**
  * The HONEST terminal status of a background shell, decided from what actually

--- a/projects/silver-core-sdk/src/tools/shells.ts
+++ b/projects/silver-core-sdk/src/tools/shells.ts
@@ -21,7 +21,7 @@ import { join } from 'node:path';
 import { AbortError } from '../errors.js';
 import { guardRegexPattern } from '../internal/regex-guard.js';
 import { planShellSpawn } from '../sandbox/backend.js';
-import { planProcessKill, terminalStatus } from './kill-plan.js';
+import { createTreeKiller, terminalStatus } from './kill-plan.js';
 import { detectSandboxEvidence, sandboxFailureHint } from '../sandbox/evidence.js';
 import type {
   BackgroundShell,
@@ -88,34 +88,11 @@ export function createShellManager(debug: (msg: string) => void): ShellManager {
         return { error: err instanceof Error ? err.message : String(err) };
       }
 
-      // Windows has no POSIX process groups/signals: taskkill /T /F is one
-      // forcible pass over the whole tree, so the SIGTERM->SIGKILL escalation
-      // collapses to a single call (a second is a harmless no-op once gone).
-      let winKilled = false;
-      const killGroup = (sig: string): void => {
-        const plan = planProcessKill(child.pid, sig);
-        try {
-          if (plan.kind === 'group') {
-            process.kill(-plan.pid, plan.signal as NodeJS.Signals); // win-ok: posix branch of planProcessKill
-          } else if (plan.kind === 'child') {
-            child.kill(plan.signal as NodeJS.Signals);
-          } else {
-            // taskkill (Windows): fire once, best-effort, never blocks.
-            if (winKilled) return;
-            winKilled = true;
-            const tk = spawn('taskkill', ['/PID', String(plan.pid), '/T', '/F'], {
-              stdio: 'ignore',
-            });
-            tk.on('error', (e) => debug(`Bash: taskkill failed for pid ${plan.pid}: ${e.message}`));
-            tk.unref();
-          }
-        } catch (err) {
-          // Benign when the process/group already exited; surface anything
-          // else to debug instead of swallowing it (the old empty catch hid
-          // the Windows failure that made KillShell a silent no-op).
-          debug(`Bash: kill(${sig}) failed for shell ${id}: ${err instanceof Error ? err.message : String(err)}`);
-        }
-      };
+      // Terminate the shell's whole tree, platform-correctly: POSIX signals
+      // the process group (-pid); Windows uses one taskkill /T /F pass.
+      // Shared executor createTreeKiller (kill-plan.ts) — dedup with bash.ts
+      // foreground killGroup, audit 2026-07-14 L-10.
+      const killGroup = createTreeKiller(child, debug, ` for shell ${id}`);
 
       const rec: BackgroundShell = {
         id,

--- a/projects/silver-core-sdk/src/tools/toolsearch.ts
+++ b/projects/silver-core-sdk/src/tools/toolsearch.ts
@@ -25,7 +25,6 @@ import type {
   McpResourceContent,
   McpServerConfig,
   McpServerStatus,
-  McpSetServersResult,
   CallToolResult,
 } from '../types.js';
 

--- a/projects/silver-core-sdk/src/transport/anthropic.ts
+++ b/projects/silver-core-sdk/src/transport/anthropic.ts
@@ -52,6 +52,12 @@ const USER_AGENT = SDK_USER_AGENT;
 const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_FACTOR = 2;
 const BACKOFF_MAX_MS = 60_000;
+/** Bounded jitter applied ON TOP of an explicit Retry-After delay (audit
+ *  2026-07-14 L-2): the delay is multiplied by [1.0, 1.0 + this factor], so a
+ *  concurrent fan-out (subagent fleets) does not retry at the same instant.
+ *  Never retries EARLIER than the server asked; the jittered total stays
+ *  capped at RETRY_AFTER_MAX_MS (the same ceiling the parser applies). */
+const RETRY_AFTER_JITTER = 0.25;
 
 /**
  * Plausible HTTP statuses for in-stream error payloads. An SSE `error` event
@@ -284,11 +290,24 @@ export class AnthropicTransport implements Transport {
       // event.
       let idleTimer: ReturnType<typeof setTimeout> | undefined;
       let lastEventAt = 0;
+      // audit 2026-07-14 L-3: the watchdog measures SERVER progress, not
+      // consumer progress. While the consumer holds a yielded event this
+      // generator is suspended at the yield through no fault of the
+      // connection, so the expiry check re-arms instead of aborting; the
+      // clock restarts when the consumer resumes (resetIdle after the yield).
+      // A genuine stall (silent server while WE await the next frame) still
+      // aborts exactly as before; detection of a stall that begins during a
+      // long consumer pause is deferred until the consumer resumes (worst
+      // case ~2x idleMs), which trades delay for never killing a healthy
+      // stream under a slow consumer.
+      let consumerHolds = false;
       const armIdle = (delay: number): void => {
         idleTimer = setTimeout(() => {
           const remaining = idleMs - (Date.now() - lastEventAt);
-          if (remaining <= 0) idleController!.abort();
-          else armIdle(remaining);
+          if (remaining <= 0) {
+            if (consumerHolds) armIdle(idleMs);
+            else idleController!.abort();
+          } else armIdle(remaining);
         }, delay);
         // Don't let the watchdog alone keep the process alive.
         (idleTimer as { unref?: () => void }).unref?.();
@@ -380,7 +399,13 @@ export class AnthropicTransport implements Transport {
           // discarded empty-retry attempt's pings reach the consumer" leak is
           // harmless (pings carry no content; the accumulator ignores them), so
           // it is not worth buffering pings and degrading live delivery.
+          // audit 2026-07-14 L-3: mark the consumer-hold window around the
+          // yield so the idle watchdog never counts a paused consumer as a
+          // stalled connection; restart the idle clock when it resumes.
+          consumerHolds = true;
           yield parsed as RawMessageStreamEvent;
+          consumerHolds = false;
+          resetIdle();
           // The Messages API streams exactly one message; message_stop is its
           // terminal event. Stop consuming here - official-client lifecycle -
           // so trailing gateway appendices (e.g. `data: [DONE]`) are never
@@ -640,10 +665,12 @@ export class AnthropicTransport implements Transport {
     }
   }
 
-  /** Exponential backoff (base 1s, factor 2) with jitter; an explicit
-   *  retry-after wins and is honored AS GIVEN (already bounded by the parser).
-   *  Only the exponential fallback is capped at BACKOFF_MAX_MS — clamping an
-   *  explicit "wait 90s" down to 60s just retries early into the same limit. */
+  /** Exponential backoff (base 1s, factor 2) with jitter. An explicit
+   *  retry-after is honored as the FLOOR (never retried earlier) but jittered
+   *  UP by RETRY_AFTER_JITTER so a concurrent fan-out does not all wake at the
+   *  same instant, then re-capped at RETRY_AFTER_MAX_MS. Only the exponential
+   *  fallback is capped at BACKOFF_MAX_MS — clamping an explicit "wait 90s"
+   *  down to 60s just retries early into the same limit. */
   private async backoff(
     attempt: number,
     retryAfterMs: number | undefined,
@@ -654,12 +681,12 @@ export class AnthropicTransport implements Transport {
     const jittered = exponential * (0.5 + Math.random() * 0.5);
     // audit 2026-07-14 L-2: jitter the explicit Retry-After path too. Without
     // it a fan-out of subagents that all receive the same "Retry-After: 30"
-    // wake in the SAME instant (thundering herd). Spread DOWN into
-    // [0.85, 1.0] x the header value — never ABOVE it, so the server's floor
-    // is still respected; the parser already caps the header (RETRY_AFTER_MAX_MS).
+    // wake in the SAME instant (thundering herd). Spread UP only — never
+    // EARLIER than the server asked — then re-cap at the parser's ceiling so a
+    // jittered value can never exceed RETRY_AFTER_MAX_MS.
     const delay =
       retryAfterMs !== undefined
-        ? retryAfterMs * (0.85 + Math.random() * 0.15)
+        ? Math.min(retryAfterMs * (1 + Math.random() * RETRY_AFTER_JITTER), RETRY_AFTER_MAX_MS)
         : Math.min(jittered, BACKOFF_MAX_MS);
     this.debug(`transport: backing off ${Math.round(delay)}ms`);
     await sleep(delay, signal);

--- a/projects/silver-core-sdk/src/transport/anthropic.ts
+++ b/projects/silver-core-sdk/src/transport/anthropic.ts
@@ -652,7 +652,15 @@ export class AnthropicTransport implements Transport {
     const exponential = BACKOFF_BASE_MS * BACKOFF_FACTOR ** (attempt - 1);
     // Bounded jitter in [0.5, 1.0] x the exponential delay.
     const jittered = exponential * (0.5 + Math.random() * 0.5);
-    const delay = retryAfterMs ?? Math.min(jittered, BACKOFF_MAX_MS);
+    // audit 2026-07-14 L-2: jitter the explicit Retry-After path too. Without
+    // it a fan-out of subagents that all receive the same "Retry-After: 30"
+    // wake in the SAME instant (thundering herd). Spread DOWN into
+    // [0.85, 1.0] x the header value — never ABOVE it, so the server's floor
+    // is still respected; the parser already caps the header (RETRY_AFTER_MAX_MS).
+    const delay =
+      retryAfterMs !== undefined
+        ? retryAfterMs * (0.85 + Math.random() * 0.15)
+        : Math.min(jittered, BACKOFF_MAX_MS);
     this.debug(`transport: backing off ${Math.round(delay)}ms`);
     await sleep(delay, signal);
   }

--- a/projects/silver-core-sdk/src/transport/openai.ts
+++ b/projects/silver-core-sdk/src/transport/openai.ts
@@ -89,6 +89,12 @@ const USER_AGENT = SDK_USER_AGENT;
 const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_FACTOR = 2;
 const BACKOFF_MAX_MS = 60_000;
+/** Bounded jitter applied ON TOP of an explicit Retry-After delay (audit
+ *  2026-07-14 L-2): the delay is multiplied by [1.0, 1.0 + this factor], so a
+ *  concurrent fan-out (subagent fleets) does not retry at the same instant.
+ *  Never retries EARLIER than the server asked; the jittered total stays
+ *  capped at RETRY_AFTER_MAX_MS (the same ceiling the parser applies). */
+const RETRY_AFTER_JITTER = 0.25;
 
 /** Normalized (Anthropic-vocabulary) error type per HTTP status, so engine-
  *  side handling keyed on Messages API error types works unchanged. */
@@ -1024,11 +1030,20 @@ export class OpenAIChatTransport implements Transport {
       // the remaining gap and still aborts idleMs after the LAST event.
       let idleTimer: ReturnType<typeof setTimeout> | undefined;
       let lastEventAt = 0;
+      // audit 2026-07-14 L-3 (twin of the anthropic arm): the watchdog
+      // measures SERVER progress, not consumer progress — while the consumer
+      // holds a yielded event the expiry check re-arms instead of aborting;
+      // the clock restarts when the consumer resumes (resetIdle after the
+      // yield). Stall detection during a long consumer pause is deferred
+      // until the consumer resumes (worst case ~2x idleMs).
+      let consumerHolds = false;
       const armIdle = (delay: number): void => {
         idleTimer = setTimeout(() => {
           const remaining = idleMs - (Date.now() - lastEventAt);
-          if (remaining <= 0) idleController!.abort();
-          else armIdle(remaining);
+          if (remaining <= 0) {
+            if (consumerHolds) armIdle(idleMs);
+            else idleController!.abort();
+          } else armIdle(remaining);
         }, delay);
         (idleTimer as { unref?: () => void }).unref?.();
       };
@@ -1077,7 +1092,13 @@ export class OpenAIChatTransport implements Transport {
             );
           }
           chunkCount += 1;
+          // audit 2026-07-14 L-3: mark the consumer-hold window around the
+          // yield so the idle watchdog never counts a paused consumer as a
+          // stalled connection; restart the idle clock when it resumes.
+          consumerHolds = true;
           yield* translator.feed(parsed);
+          consumerHolds = false;
+          resetIdle();
         }
       } catch (err) {
         throw mapStreamError(err, {
@@ -1334,12 +1355,12 @@ export class OpenAIChatTransport implements Transport {
     const jittered = exponential * (0.5 + Math.random() * 0.5);
     // audit 2026-07-14 L-2: jitter the explicit Retry-After path too. Without
     // it a fan-out of subagents that all receive the same "Retry-After: 30"
-    // wake in the SAME instant (thundering herd). Spread DOWN into
-    // [0.85, 1.0] x the header value — never ABOVE it, so the server's floor
-    // is still respected; the parser already caps the header (RETRY_AFTER_MAX_MS).
+    // wake in the SAME instant (thundering herd). Spread UP only — never
+    // EARLIER than the server asked — then re-cap at the parser's ceiling so a
+    // jittered value can never exceed RETRY_AFTER_MAX_MS.
     const delay =
       retryAfterMs !== undefined
-        ? retryAfterMs * (0.85 + Math.random() * 0.15)
+        ? Math.min(retryAfterMs * (1 + Math.random() * RETRY_AFTER_JITTER), RETRY_AFTER_MAX_MS)
         : Math.min(jittered, BACKOFF_MAX_MS);
     this.debug(`openai transport: backing off ${Math.round(delay)}ms`);
     await sleep(delay, signal);

--- a/projects/silver-core-sdk/src/transport/openai.ts
+++ b/projects/silver-core-sdk/src/transport/openai.ts
@@ -1330,10 +1330,17 @@ export class OpenAIChatTransport implements Transport {
     signal: AbortSignal | undefined,
   ): Promise<void> {
     const exponential = BACKOFF_BASE_MS * BACKOFF_FACTOR ** (attempt - 1);
+    // Bounded jitter in [0.5, 1.0] x the exponential delay.
     const jittered = exponential * (0.5 + Math.random() * 0.5);
-    // Honor an explicit retry-after as given (parser-bounded); cap only the
-    // exponential fallback — clamping "wait 90s" to 60s retries early.
-    const delay = retryAfterMs ?? Math.min(jittered, BACKOFF_MAX_MS);
+    // audit 2026-07-14 L-2: jitter the explicit Retry-After path too. Without
+    // it a fan-out of subagents that all receive the same "Retry-After: 30"
+    // wake in the SAME instant (thundering herd). Spread DOWN into
+    // [0.85, 1.0] x the header value — never ABOVE it, so the server's floor
+    // is still respected; the parser already caps the header (RETRY_AFTER_MAX_MS).
+    const delay =
+      retryAfterMs !== undefined
+        ? retryAfterMs * (0.85 + Math.random() * 0.15)
+        : Math.min(jittered, BACKOFF_MAX_MS);
     this.debug(`openai transport: backing off ${Math.round(delay)}ms`);
     await sleep(delay, signal);
   }

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.59.0';
+export const SDK_VERSION = '0.59.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/mcp-stdio-spawn-error.test.ts
+++ b/projects/silver-core-sdk/tests/mcp-stdio-spawn-error.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression (audit 2026-07-14 L-5): a stdio MCP server that fails to spawn
+ * (ENOENT etc.) fires the child 'error' event but NOT 'exit'. Before the fix
+ * the 'error' handler failed the pending requests but left `closed`/`child`
+ * untouched, so the connection stayed nominally "open" — a later request()
+ * wrote to a dead stdin and hung for the full request timeout instead of
+ * failing fast. The handler now flips closed state (mirroring 'exit'), so a
+ * subsequent request rejects IMMEDIATELY with mcp_not_connected.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { StdioMcpConnection } from '../src/mcp/stdio.js';
+import { McpError } from '../src/errors.js';
+
+describe('StdioMcpConnection spawn error fails fast (L-5)', () => {
+  it('a request after a spawn failure rejects promptly with mcp_not_connected, not after the request timeout', async () => {
+    const conn = new StdioMcpConnection(
+      { command: 'biav-nonexistent-mcp-command-xyz', args: [] },
+      { name: 'ghost', requestTimeoutMs: 2_000 },
+    );
+
+    // connect() fails: the process cannot spawn, so the 'error' event fires and
+    // rejects the in-flight initialize request.
+    const connectErr = await conn.connect().then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(connectErr).toBeInstanceOf(McpError);
+
+    // The load-bearing assertion: a later request must reject RIGHT AWAY with
+    // mcp_not_connected. Without the fix it wrote to a dead stdin and rejected
+    // only after the 2000ms request timeout (mcp_request_timeout).
+    const start = Date.now();
+    const err = await conn.listTools().then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    const elapsed = Date.now() - start;
+    expect(err).toBeInstanceOf(McpError);
+    expect((err as McpError).code).toBe('mcp_not_connected');
+    // Prompt: nowhere near the 2000ms request timeout.
+    expect(elapsed).toBeLessThan(500);
+
+    await conn.close();
+  });
+});

--- a/projects/silver-core-sdk/tests/query-abort-usage.test.ts
+++ b/projects/silver-core-sdk/tests/query-abort-usage.test.ts
@@ -1,0 +1,156 @@
+/**
+ * audit 2026-07-14 L-6 — a turn-level interrupt() must not lose the aborted
+ * turn's already-billed usage.
+ *
+ * A message_start reports the request's input tokens the moment the stream
+ * opens: that spend is real even when the user interrupts the turn a moment
+ * later. Before the fix the engine loop threw a bare AbortError (no result
+ * message is emitted on abort), so those tokens never reached the query's
+ * SessionAccounting and the session budget/summary under-counted. The loop now
+ * folds the partial sink on abort and attaches the run's partial accounting to
+ * the AbortError; the query layer folds it in its abort path — observable on
+ * the interrupt terminal result's session-cumulative fields.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { query } from '../src/index.js';
+import { SessionAccounting } from '../src/query-accounting.js';
+import { HANG_STREAM, makeSSEFetch } from './helpers/sse-fetch.js';
+import type { Options, SDKMessage, SDKResultMessage } from '../src/types.js';
+
+let sessionDir: string;
+let cwd: string;
+
+beforeEach(async () => {
+  sessionDir = await mkdtemp(join(tmpdir(), 'bpt-abort-usage-sess-'));
+  cwd = await mkdtemp(join(tmpdir(), 'bpt-abort-usage-cwd-'));
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await rm(sessionDir, { recursive: true, force: true });
+  await rm(cwd, { recursive: true, force: true });
+});
+
+const MODEL = 'claude-sonnet-4-5';
+
+function options(extra: Partial<Options> = {}): Options {
+  return {
+    provider: {
+      apiKey: 'test-key',
+      promptCaching: false,
+      maxRetries: 0,
+      // Deterministic figures: 100 USD/MTok -> 25 input tokens = $0.0025.
+      pricing: { [MODEL]: { input: 100, output: 100 } },
+    },
+    sessionDir,
+    cwd,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME, BPT_HTTP_CLIENT: 'fetch' },
+    model: MODEL,
+    includePartialMessages: true,
+    ...extra,
+  };
+}
+
+/** message_start already carrying the billed input tokens, then a hang: the
+ *  turn never completes — it is interrupted while streaming. */
+const MESSAGE_START = {
+  type: 'message_start',
+  message: {
+    id: 'msg_abort_usage',
+    type: 'message',
+    role: 'assistant',
+    model: MODEL,
+    content: [],
+    stop_reason: null,
+    stop_sequence: null,
+    usage: { input_tokens: 25, output_tokens: 0 },
+  },
+};
+
+describe('interrupted turn usage accounting (audit 2026-07-14 L-6)', () => {
+  it('a turn-level interrupt() folds the aborted turn message_start tokens into session accounting', async () => {
+    const fetchStub = makeSSEFetch([[MESSAGE_START, HANG_STREAM]]);
+    vi.stubGlobal('fetch', fetchStub);
+
+    const q = query({ prompt: 'do a thing', options: options() });
+    const messages: SDKMessage[] = [];
+    for await (const m of q) {
+      messages.push(m);
+      if (
+        m.type === 'stream_event' &&
+        (m as { event?: { type?: string } }).event?.type === 'message_start'
+      ) {
+        // The input tokens are billed at this point; cancel the turn NOW.
+        void q.interrupt();
+      }
+      if (m.type === 'result') break; // string mode: interrupt yields a terminal result
+    }
+
+    const last = messages[messages.length - 1] as SDKResultMessage;
+    expect(last.type).toBe('result');
+    expect(last.subtype).toBe('error_during_execution');
+    expect(last.errorMessage).toBe('The turn was interrupted');
+
+    // KEY (L-6): the terminal result's session-cumulative fields carry the
+    // aborted turn's already-billed spend instead of reporting zero.
+    expect(last.total_cost_usd).toBeCloseTo(0.0025, 9);
+    const mu = last.modelUsage[MODEL];
+    expect(mu).toBeDefined();
+    expect(mu!.inputTokens).toBe(25);
+    expect(mu!.costUSD).toBeCloseTo(0.0025, 9);
+  });
+
+  it('SessionAccounting.accumulateAborted adds counters and merges modelUsage', () => {
+    const acct = new SessionAccounting();
+    acct.accumulateAborted({
+      usage: {
+        input_tokens: 25,
+        output_tokens: 3,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      totalCostUsd: 0.0028,
+      durationApiMs: 120,
+      numTurns: 1,
+      modelUsage: {
+        [MODEL]: {
+          inputTokens: 25,
+          outputTokens: 3,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+          webSearchRequests: 0,
+          costUSD: 0.0028,
+          contextWindow: 200_000,
+        },
+      },
+    });
+    expect(acct.turns).toBe(1);
+    expect(acct.cost).toBeCloseTo(0.0028, 9);
+    expect(acct.apiMs).toBe(120);
+    expect(acct.usage.input_tokens).toBe(25);
+    expect(acct.usage.output_tokens).toBe(3);
+    expect(acct.modelUsage[MODEL]!.inputTokens).toBe(25);
+    // A second fold ADDS (additive counters, not latest-wins).
+    acct.accumulateAborted({
+      usage: {
+        input_tokens: 10,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      totalCostUsd: 0.001,
+      durationApiMs: 30,
+      numTurns: 0,
+      modelUsage: {},
+    });
+    expect(acct.cost).toBeCloseTo(0.0038, 9);
+    expect(acct.usage.input_tokens).toBe(35);
+  });
+});

--- a/projects/silver-core-sdk/tests/runtime-report.test.ts
+++ b/projects/silver-core-sdk/tests/runtime-report.test.ts
@@ -11,7 +11,7 @@
 import { mkdtemp, readFile, readdir, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { query } from '../src/query.js';
 import {
@@ -146,6 +146,32 @@ describe('createRunLogSink', () => {
     expect(lines).toHaveLength(2);
     expect(JSON.parse(lines[0]!).session_id).toBe('sess-1');
     expect(JSON.parse(lines[1]!).session_id).toBe('sess-9');
+  });
+
+  // audit 2026-07-14 L-16: the day file is derived from the RECORD'S ts (set at
+  // observe time), not the flush-time clock. A record observed at 23:59:59 and
+  // flushed after midnight must still land in the earlier day's file.
+  it('writes to the record ts day file, not the flush-time clock (L-16)', async () => {
+    vi.useFakeTimers();
+    try {
+      const logDir = join(dir, 'sink-l16');
+      const sink = createRunLogSink({
+        runLog: { dir: logDir },
+        incognito: false,
+        debug: () => {},
+      });
+      // Observe just before midnight on day A -> record.ts is day A.
+      vi.setSystemTime(new Date('2026-07-14T23:59:59.000Z'));
+      sink.observe(resultFixture() as never);
+      // The append lands "later" — the wall clock is now day B.
+      vi.setSystemTime(new Date('2026-07-15T00:00:01.000Z'));
+      await sink.flush();
+      const files = await readdir(logDir);
+      // Belongs to day A (its observe-time ts), NOT day B (the flush clock).
+      expect(files).toEqual(['runlog-2026-07-14.jsonl']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/projects/silver-core-sdk/tests/session-recovery.test.ts
+++ b/projects/silver-core-sdk/tests/session-recovery.test.ts
@@ -195,6 +195,13 @@ describe('supervised auto-resume', () => {
     // Two fetch calls: the failure, then the successful redrive.
     expect(calls()).toBe(2);
 
+    // audit 2026-07-14 L-7: the resumed query re-emits its own system/init,
+    // but the supervisor promised ONE continuous session — exactly one init
+    // reaches the consumer across the transparent resume (a second one would
+    // render a ghost "new session" in init-as-boundary UIs).
+    const inits = messages.filter((m) => m.type === 'system' && m.subtype === 'init');
+    expect(inits).toHaveLength(1);
+
     // The write-ahead checkpoint left a trace, and the redrive settled it.
     const sid = initSessionId(messages);
     const types = (await transcript(sid)).map((e) => e.type);
@@ -279,6 +286,9 @@ describe('supervised auto-resume', () => {
     expect(resumeObservations(messages)).toHaveLength(2);
     // Initial attempt + 2 resumes = 3 fetch calls.
     expect(calls()).toBe(3);
+    // audit 2026-07-14 L-7: two resumes re-emitted two more inits internally;
+    // still exactly ONE init reaches the consumer.
+    expect(messages.filter((m) => m.type === 'system' && m.subtype === 'init')).toHaveLength(1);
 
     await mgr.close();
   });

--- a/projects/silver-core-sdk/tests/sessions-store.test.ts
+++ b/projects/silver-core-sdk/tests/sessions-store.test.ts
@@ -494,4 +494,30 @@ describe('rename/tag round trip via meta_update (T1-6)', () => {
     const info = await getSessionInfo(SID, { sessionDir: dir });
     expect(info?.gitBranch).toBe('feature/x');
   });
+
+  // audit 2026-07-14 L-14: getSessionInfo now reuses the meta-only streaming
+  // scan (loadInfo) instead of a full load() + triple repairPairing, since the
+  // summary row reads only meta fields. On a normal transcript (with real
+  // message lines) it must return exactly what it did before — and match the
+  // listSessions row, which already sourced from the same meta-only path.
+  it('getSessionInfo (meta-only path) matches listSessions on a normal transcript (L-14)', async () => {
+    const file = join(dir, `${SID}.jsonl`);
+    appendFileSync(
+      file,
+      `${JSON.stringify({ type: 'meta', sessionId: SID, createdAt: 123, cwd: '/w', firstPrompt: 'hello world', gitBranch: 'main' })}\n` +
+        `${JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello world' } })}\n` +
+        `${JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } })}\n`,
+      'utf8',
+    );
+    const info = await getSessionInfo(SID, { sessionDir: dir });
+    expect(info).toBeDefined();
+    expect(info?.summary).toBe('hello world');
+    expect(info?.firstPrompt).toBe('hello world');
+    expect(info?.cwd).toBe('/w');
+    expect(info?.gitBranch).toBe('main');
+    expect(info?.createdAt).toBe(123);
+    // Identical to the listSessions summary row (both meta-only reads of one file).
+    const entry = (await listSessions({ sessionDir: dir })).find((s) => s.sessionId === SID);
+    expect(info).toEqual(entry);
+  });
 });

--- a/projects/silver-core-sdk/tests/transport-idle-consumer.test.ts
+++ b/projects/silver-core-sdk/tests/transport-idle-consumer.test.ts
@@ -1,0 +1,185 @@
+/**
+ * audit 2026-07-14 L-3 — the idle watchdog must measure SERVER progress, not
+ * consumer progress.
+ *
+ * Before the fix the idle clock was only reset when the generator loop
+ * PROCESSED a frame, so a consumer paused at a yield for longer than
+ * streamIdleTimeoutMs got a perfectly healthy stream killed as
+ * stream_idle_timeout. The fix marks the consumer-hold window around the
+ * yield: while the consumer holds an event the watchdog re-arms instead of
+ * aborting, and the idle clock restarts when the consumer resumes. A genuine
+ * server stall still aborts — detection during a long consumer pause is
+ * deferred until the consumer resumes.
+ *
+ * Twin discipline: both transports are covered.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AnthropicTransport } from '../src/transport/anthropic.js';
+import { OpenAIChatTransport } from '../src/transport/openai.js';
+import { APIConnectionError } from '../src/errors.js';
+import type { StreamRequest } from '../src/internal/contracts.js';
+import type { RawMessageStreamEvent } from '../src/types.js';
+
+const enc = new TextEncoder();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function baseReq(): StreamRequest {
+  return { model: 'claude-test-1', max_tokens: 32, messages: [{ role: 'user', content: 'hi' }] };
+}
+
+function anthropicFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+const A_START = anthropicFrame('message_start', {
+  type: 'message_start',
+  message: {
+    id: 'm1',
+    type: 'message',
+    role: 'assistant',
+    model: 'claude-test-1',
+    content: [],
+    stop_reason: null,
+    stop_sequence: null,
+    usage: { input_tokens: 1, output_tokens: 0 },
+  },
+});
+const A_DELTA = anthropicFrame('message_delta', {
+  type: 'message_delta',
+  delta: { stop_reason: 'end_turn', stop_sequence: null },
+  usage: { output_tokens: 1 },
+});
+const A_STOP = anthropicFrame('message_stop', { type: 'message_stop' });
+
+/** 200 SSE whose first chunk arrives at once and the rest after `tailAfterMs`
+ *  (steady server); `hang` leaves the stream open instead of sending a tail. */
+function pacedResponse(head: string, tail: string | 'hang', tailAfterMs: number): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode(head));
+        if (tail === 'hang') return; // genuine stall: never closes
+        setTimeout(() => {
+          c.enqueue(enc.encode(tail));
+          c.close();
+        }, tailAfterMs);
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+function makeAnthropic(idleMs: number): AnthropicTransport {
+  return new AnthropicTransport({
+    provider: { apiKey: 'k', maxRetries: 0, streamIdleTimeoutMs: idleMs },
+    env: { BPT_HTTP_CLIENT: 'fetch' },
+    debug: () => undefined,
+  });
+}
+
+function makeOpenAI(idleMs: number): OpenAIChatTransport {
+  return new OpenAIChatTransport({
+    provider: {
+      protocol: 'openai-chat',
+      apiKey: 'sk-test',
+      maxRetries: 0,
+      streamIdleTimeoutMs: idleMs,
+    },
+    env: { BPT_HTTP_CLIENT: 'fetch' },
+    debug: () => undefined,
+  });
+}
+
+describe('idle watchdog vs slow consumer (audit 2026-07-14 L-3) — Anthropic arm', () => {
+  it('a consumer paused past streamIdleTimeoutMs does NOT kill a healthy stream', async () => {
+    // Server: message_start at once, the rest 150ms later (steady, healthy).
+    // Consumer: takes the first event, then pauses 250ms — over 3x the 70ms
+    // idle window. Before the fix this surfaced stream_idle_timeout.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => pacedResponse(A_START, A_DELTA + A_STOP, 150)),
+    );
+    const gen = makeAnthropic(70).stream(baseReq());
+    const first = await gen.next();
+    expect((first.value as RawMessageStreamEvent).type).toBe('message_start');
+
+    await sleep(250); // consumer-side pause at the yield
+
+    const rest: RawMessageStreamEvent[] = [];
+    for (let r = await gen.next(); r.done !== true; r = await gen.next()) {
+      rest.push(r.value as RawMessageStreamEvent);
+    }
+    expect(rest.map((e) => e.type)).toEqual(['message_delta', 'message_stop']);
+  });
+
+  it('a genuine server stall STILL aborts after the consumer resumes (watchdog not disabled)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => pacedResponse(A_START, 'hang', 0)));
+    const gen = makeAnthropic(70).stream(baseReq());
+    const first = await gen.next();
+    expect((first.value as RawMessageStreamEvent).type).toBe('message_start');
+
+    await sleep(200); // consumer pause: no abort while the consumer holds
+
+    let error: unknown;
+    try {
+      await gen.next(); // resume against a dead server -> idle abort applies
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeInstanceOf(APIConnectionError);
+    expect((error as APIConnectionError).code).toBe('stream_idle_timeout');
+  });
+});
+
+describe('idle watchdog vs slow consumer (audit 2026-07-14 L-3) — OpenAI twin', () => {
+  const O_HEAD = `data: ${JSON.stringify({
+    choices: [{ index: 0, delta: { role: 'assistant', content: 'hi' }, finish_reason: null }],
+  })}\n\n`;
+  const O_TAIL =
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })}\n\n` +
+    'data: [DONE]\n\n';
+
+  it('a consumer paused past streamIdleTimeoutMs does NOT kill a healthy stream', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => pacedResponse(O_HEAD, O_TAIL, 150)));
+    const gen = makeOpenAI(70).stream(baseReq());
+    const first = await gen.next();
+    expect((first.value as RawMessageStreamEvent).type).toBe('message_start');
+
+    await sleep(250); // consumer-side pause at the yield
+
+    const rest: RawMessageStreamEvent[] = [];
+    for (let r = await gen.next(); r.done !== true; r = await gen.next()) {
+      rest.push(r.value as RawMessageStreamEvent);
+    }
+    expect(rest.map((e) => e.type)).toContain('message_stop');
+  });
+
+  it('a genuine server stall STILL aborts after the consumer resumes', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => pacedResponse(O_HEAD, 'hang', 0)));
+    const gen = makeOpenAI(70).stream(baseReq());
+    const first = await gen.next();
+    expect((first.value as RawMessageStreamEvent).type).toBe('message_start');
+
+    await sleep(200);
+
+    let error: unknown;
+    try {
+      for (;;) {
+        const r = await gen.next();
+        if (r.done === true) break;
+      }
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeInstanceOf(APIConnectionError);
+    expect((error as APIConnectionError).code).toBe('stream_idle_timeout');
+  });
+});

--- a/projects/silver-core-sdk/tests/transport-retry-after-jitter.test.ts
+++ b/projects/silver-core-sdk/tests/transport-retry-after-jitter.test.ts
@@ -1,0 +1,193 @@
+/**
+ * audit 2026-07-14 L-2 — bounded jitter on the explicit Retry-After path.
+ *
+ * Before the fix an explicit Retry-After was honored AS GIVEN, so a concurrent
+ * fan-out (subagent fleets) that all received the same "Retry-After: N" woke
+ * and retried at the SAME instant. The fix multiplies the server delay by
+ * [1.0, 1.0 + RETRY_AFTER_JITTER]: the server's ask is a FLOOR (never retry
+ * earlier), and the jittered total is re-capped at RETRY_AFTER_MAX_MS.
+ *
+ * Deterministic via a Math.random stub; the delay is observed through the
+ * transport's own "backing off Nms" debug line (logged before the sleep).
+ * Twin discipline: the same behavior is asserted on both transports.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AnthropicTransport } from '../src/transport/anthropic.js';
+import { OpenAIChatTransport } from '../src/transport/openai.js';
+import { AbortError } from '../src/errors.js';
+import type { StreamRequest } from '../src/internal/contracts.js';
+import type { RawMessageStreamEvent } from '../src/types.js';
+
+const enc = new TextEncoder();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function baseReq(extra: Partial<StreamRequest> = {}): StreamRequest {
+  return {
+    model: 'claude-test-1',
+    max_tokens: 32,
+    messages: [{ role: 'user', content: 'hi' }],
+    ...extra,
+  };
+}
+
+async function collect(
+  gen: AsyncGenerator<RawMessageStreamEvent, void>,
+): Promise<RawMessageStreamEvent[]> {
+  const out: RawMessageStreamEvent[] = [];
+  for await (const ev of gen) out.push(ev);
+  return out;
+}
+
+/** HTTP 429 carrying the given retry-after header. */
+function rateLimited(retryAfter: string): Response {
+  return new Response(
+    JSON.stringify({
+      type: 'error',
+      error: { type: 'rate_limit_error', message: 'slow down' },
+    }),
+    { status: 429, headers: { 'retry-after': retryAfter } },
+  );
+}
+
+/** Minimal complete Messages API SSE body. */
+function anthropicOkSse(): Response {
+  const body =
+    `event: message_start\ndata: ${JSON.stringify({
+      type: 'message_start',
+      message: {
+        id: 'm1',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-test-1',
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    })}\n\n` +
+    `event: message_delta\ndata: ${JSON.stringify({
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 1 },
+    })}\n\n` +
+    `event: message_stop\ndata: ${JSON.stringify({ type: 'message_stop' })}\n\n`;
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode(body));
+        c.close();
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+/** Minimal complete Chat Completions SSE body. */
+function openaiOkSse(): Response {
+  const chunks = [
+    { choices: [{ index: 0, delta: { role: 'assistant', content: 'hi' }, finish_reason: null }] },
+    { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+  ];
+  const body =
+    chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join('') + 'data: [DONE]\n\n';
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode(body));
+        c.close();
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+function makeAnthropic(debug: (m: string) => void): AnthropicTransport {
+  return new AnthropicTransport({
+    provider: { apiKey: 'k', maxRetries: 1 },
+    env: { BPT_HTTP_CLIENT: 'fetch' },
+    debug,
+  });
+}
+
+function makeOpenAI(debug: (m: string) => void): OpenAIChatTransport {
+  return new OpenAIChatTransport({
+    provider: { protocol: 'openai-chat', apiKey: 'sk-test', maxRetries: 1 },
+    env: { BPT_HTTP_CLIENT: 'fetch' },
+    debug,
+  });
+}
+
+describe('Retry-After jitter (audit 2026-07-14 L-2) — Anthropic arm', () => {
+  it('jitters an explicit Retry-After UP by the random draw (worst case 1.25x)', async () => {
+    // retry-after 0.02s = 20ms; Math.random()=1 -> 20 * (1 + 0.25) = 25ms.
+    vi.spyOn(Math, 'random').mockReturnValue(1);
+    const lines: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => (lines.some((l) => l.includes('backing off')) ? anthropicOkSse() : rateLimited('0.02'))),
+    );
+    await collect(makeAnthropic((m) => lines.push(m)).stream(baseReq()));
+    expect(lines).toContain('transport: backing off 25ms');
+  });
+
+  it('never retries EARLIER than the server asked (random=0 -> exactly the header value)', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const lines: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => (lines.some((l) => l.includes('backing off')) ? anthropicOkSse() : rateLimited('0.02'))),
+    );
+    await collect(makeAnthropic((m) => lines.push(m)).stream(baseReq()));
+    // The floor is the server's own ask: 20ms, jitter adds nothing at random=0.
+    expect(lines).toContain('transport: backing off 20ms');
+  });
+
+  it('re-caps the jittered delay at RETRY_AFTER_MAX_MS (120s)', async () => {
+    // Header 3600s is parser-capped to 120000ms; the 1.25x jitter would push it
+    // to 150000ms — the backoff re-caps it at 120000ms. The sleep is not
+    // awaited for real: the debug line is logged BEFORE sleeping, then the
+    // caller aborts out of the 120s wait.
+    vi.spyOn(Math, 'random').mockReturnValue(1);
+    const lines: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async () => rateLimited('3600')));
+    const ac = new AbortController();
+    const done = collect(
+      makeAnthropic((m) => lines.push(m)).stream(baseReq({ signal: ac.signal })),
+    );
+    await vi.waitFor(() => {
+      expect(lines).toContain('transport: backing off 120000ms');
+    });
+    ac.abort();
+    await expect(done).rejects.toBeInstanceOf(AbortError);
+  });
+});
+
+describe('Retry-After jitter (audit 2026-07-14 L-2) — OpenAI twin', () => {
+  it('applies the identical [1.0, 1.25]x bounded jitter', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(1);
+    const lines: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => (lines.some((l) => l.includes('backing off')) ? openaiOkSse() : rateLimited('0.02'))),
+    );
+    await collect(makeOpenAI((m) => lines.push(m)).stream(baseReq()));
+    expect(lines).toContain('openai transport: backing off 25ms');
+  });
+
+  it('honors the server floor at random=0', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const lines: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => (lines.some((l) => l.includes('backing off')) ? openaiOkSse() : rateLimited('0.02'))),
+    );
+    await collect(makeOpenAI((m) => lines.push(m)).stream(baseReq()));
+    expect(lines).toContain('openai transport: backing off 20ms');
+  });
+});

--- a/projects/silver-core-sdk/tests/transport-twin-drift.test.ts
+++ b/projects/silver-core-sdk/tests/transport-twin-drift.test.ts
@@ -113,6 +113,9 @@ describe('transport twin anti-drift (anthropic.ts vs openai.ts)', () => {
       'BACKOFF_BASE_MS = 1_000',
       'BACKOFF_FACTOR = 2',
       'BACKOFF_MAX_MS = 60_000',
+      // audit 2026-07-14 L-2: bounded jitter on the explicit Retry-After path.
+      'RETRY_AFTER_JITTER = 0.25',
+      'RETRY_AFTER_MAX_MS = 120_000',
       'DEFAULT_TIMEOUT_MS = 600_000',
       'ERROR_BODY_TIMEOUT_MS = 10_000',
     ]) {

--- a/projects/silver-core-sdk/tests/transport.test.ts
+++ b/projects/silver-core-sdk/tests/transport.test.ts
@@ -590,6 +590,65 @@ describe('AnthropicTransport retries', () => {
     expect(elapsed).toBeLessThan(450);
   });
 
+  // audit 2026-07-14 L-2: the explicit Retry-After delay is jittered UP (never
+  // earlier than the server asked) so a concurrent fan-out does not all wake at
+  // the same instant. Two retries carrying the SAME Retry-After header must
+  // therefore back off for DIFFERENT durations, each within [header, header*1.25].
+  describe('retry-after jitter (L-2 thundering-herd spread)', () => {
+    function backoffMsFrom(debugLines: string[]): number {
+      const line = debugLines.find((l) => /backing off \d+ms/.test(l));
+      if (line === undefined) throw new Error('no backoff debug line captured');
+      return Number(/backing off (\d+)ms/.exec(line)![1]);
+    }
+
+    async function runRetryAfter(headerSeconds: string): Promise<number> {
+      const debugLines: string[] = [];
+      const fetchMock = stubFetch([
+        () =>
+          new Response(
+            JSON.stringify({
+              type: 'error',
+              error: { type: 'rate_limit_error', message: 'slow down' },
+            }),
+            { status: 429, headers: { 'retry-after': headerSeconds } },
+          ),
+        () => sseResponse(okSse()),
+      ]);
+      const t = new AnthropicTransport({
+        provider: { apiKey: 'k' },
+        env: { BPT_HTTP_CLIENT: 'fetch' },
+        debug: (m) => debugLines.push(m),
+      });
+      await collect(t.stream(baseReq()));
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      return backoffMsFrom(debugLines);
+    }
+
+    it('same Retry-After header -> different delays, each within [header, header*1.25]', async () => {
+      // backoff() draws Math.random TWICE per call: the exponential jitter
+      // (unused on the retry-after path) then the retry-after multiplier. Feed
+      // four values so the two retry-after multipliers (2nd + 4th draw) differ.
+      vi.spyOn(Math, 'random')
+        .mockReturnValueOnce(0.0)
+        .mockReturnValueOnce(0.2)
+        .mockReturnValueOnce(0.0)
+        .mockReturnValueOnce(0.8);
+      const headerMs = 200; // 'retry-after: 0.2' seconds -> a short real sleep
+      const d1 = await runRetryAfter('0.2');
+      const d2 = await runRetryAfter('0.2');
+      // Jitter is actually applied (not a fixed value).
+      expect(d1).not.toBe(d2);
+      // Never earlier than the server asked; never more than 25% late.
+      for (const d of [d1, d2]) {
+        expect(d).toBeGreaterThanOrEqual(headerMs);
+        expect(d).toBeLessThanOrEqual(Math.ceil(headerMs * 1.25));
+      }
+      // Concretely: 0.2 -> 200*1.05 = 210, 0.8 -> 200*1.20 = 240.
+      expect(d1).toBe(210);
+      expect(d2).toBe(240);
+    });
+  });
+
   it('400 -> APIStatusError immediately with exactly 1 fetch call', async () => {
     const fetchMock = stubFetch([
       () =>

--- a/projects/silver-core-sdk/tests/utility-transport-memo.test.ts
+++ b/projects/silver-core-sdk/tests/utility-transport-memo.test.ts
@@ -1,0 +1,130 @@
+/**
+ * audit 2026-07-14 L-4 — utility calls memoize their default transport.
+ *
+ * Every runUtilityCall used to build a FRESH provider transport, so the
+ * maxConcurrentRequests semaphore (per-transport) was void across calls and
+ * BPT_PRECONNECT fired one probe per call. The default transport is now cached
+ * per provider-config identity (betas as secondary key); injected transports
+ * keep priority.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  resolveUtilityTransport,
+  runUtilityCall,
+  type UtilityCallOptions,
+} from '../src/generators/runtime.js';
+import { MockTransport, textReplyEvents } from './helpers/mock-transport.js';
+import type { ProviderConfig } from '../src/types.js';
+
+const enc = new TextEncoder();
+
+function frame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function okSseResponse(text: string): Response {
+  const body =
+    frame('message_start', {
+      type: 'message_start',
+      message: {
+        id: 'm1',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-test-1',
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    }) +
+    frame('content_block_start', {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '' },
+    }) +
+    frame('content_block_delta', {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    }) +
+    frame('content_block_stop', { type: 'content_block_stop', index: 0 }) +
+    frame('message_delta', {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 2 },
+    }) +
+    frame('message_stop', { type: 'message_stop' });
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode(body));
+        c.close();
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+describe('utility transport memoization (audit 2026-07-14 L-4)', () => {
+  it('the same provider-config reference resolves to the SAME transport instance', () => {
+    const provider: ProviderConfig = { apiKey: 'k' };
+    const opts: UtilityCallOptions = { provider, env: { BPT_HTTP_CLIENT: 'fetch' } };
+    const t1 = resolveUtilityTransport(opts);
+    const t2 = resolveUtilityTransport(opts);
+    expect(t2).toBe(t1);
+    // A second options object sharing the provider REFERENCE also hits the cache.
+    const t3 = resolveUtilityTransport({ provider, env: { BPT_HTTP_CLIENT: 'fetch' } });
+    expect(t3).toBe(t1);
+  });
+
+  it('a different provider reference or different betas builds a distinct transport', () => {
+    const providerA: ProviderConfig = { apiKey: 'k' };
+    const providerB: ProviderConfig = { apiKey: 'k' };
+    const base = resolveUtilityTransport({ provider: providerA });
+    expect(resolveUtilityTransport({ provider: providerB })).not.toBe(base);
+    // betas change the wire headers -> separate cache slot under the same provider.
+    expect(resolveUtilityTransport({ provider: providerA, betas: ['x'] })).not.toBe(base);
+    expect(resolveUtilityTransport({ provider: providerA, betas: ['x'] })).toBe(
+      resolveUtilityTransport({ provider: providerA, betas: ['x'] }),
+    );
+  });
+
+  it('an injected transport keeps priority and is never cached', () => {
+    const provider: ProviderConfig = { apiKey: 'k' };
+    const injected = new MockTransport([textReplyEvents('hi')]);
+    expect(resolveUtilityTransport({ provider, transport: injected })).toBe(injected);
+    // The injection did not poison the provider's cache slot.
+    expect(resolveUtilityTransport({ provider })).not.toBe(injected);
+  });
+
+  it('two runUtilityCall calls reuse ONE transport: BPT_PRECONNECT probes once, not per call', async () => {
+    let probes = 0;
+    let posts = 0;
+    const countingFetch = async (
+      _input: string | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      if (init?.method === 'HEAD') {
+        probes += 1;
+        return new Response(null, { status: 405 });
+      }
+      posts += 1;
+      return okSseResponse(`reply ${posts}`);
+    };
+    // preconnect: true fires the warm-up probe in the transport CONSTRUCTOR —
+    // before the fix each utility call constructed its own transport, so two
+    // calls meant two probes.
+    const provider: ProviderConfig = { apiKey: 'k', preconnect: true, fetch: countingFetch };
+    const opts: UtilityCallOptions = { provider, env: { BPT_HTTP_CLIENT: 'fetch' } };
+
+    const first = await runUtilityCall('system', 'user one', opts, 64);
+    const second = await runUtilityCall('system', 'user two', opts, 64);
+
+    expect(first).toBe('reply 1');
+    expect(second).toBe('reply 2');
+    expect(posts).toBe(2); // both calls really hit the wire
+    expect(probes).toBe(1); // KEY: one transport construction across both calls
+  });
+});

--- a/projects/silver-core-sdk/tsconfig.json
+++ b/projects/silver-core-sdk/tsconfig.json
@@ -10,6 +10,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "strict": true,
+    "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## 内容

守密人丙案（全量清账）批三收官：低危卫生批 + 引入 lint 门禁。叠加在 main 已合并的 0.59.0（/loop）之上。

### Lint 门禁（审计建议「至少开 noUnusedLocals」）
- tsconfig 开 `noUnusedLocals`——`npm run typecheck` 现对死导入/死变量报红；清掉它暴露的抽取残留死导入（query.ts / engine/loop.ts / subagents/runtime.ts / tools/toolsearch.ts）
- `noUnusedParameters` **刻意不开**（会误伤惯用的解构式未用参数）

### 低危卫生（L 系列）
- **L-1** loop.ts 工具定义缓存键的裸 NUL 字节改 `\x00` 转义——行为不变，源文件回归纯文本、不再被 grep 误判二进制
- **L-2** 显式 Retry-After 加向上有界抖动（双传输臂），子代理群不再同刻重击
- **L-5** stdio spawn 失败（ENOENT）即置 closed，后续请求快速失败而非挂满 60s
- **L-9** 清死导入/死变量 + toAbortError 合流共享
- **L-10** killGroup 双胞胎闭包抽 `createTreeKiller`
- **L-14** getSessionInfo 复用 meta-only 扫描
- **L-16** run-log 日文件按记录 ts 落盘（跨零点不归错日）
- **L-19b** deleteSession 无 delete 能力时发 debug 而非假成功
- **L-13** 诚实跳过（unref 定时器无害，接入 killTimers 有键碰撞风险，不成比例）

### 验证
- `tsc --noEmit` + noUnusedLocals 门禁 EXIT 0
- 合并态全量 vitest：**2402 通过 / 3 跳过 / 0 失败**（133 文件，含 0.59.0 的 /loop）
- 版本纪律：0.59.0 → 0.59.1 + CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG)_