### PR TITLE
silver-core-sdk: backfill L-3/L-4/L-6/L-7 into 0.59.1 CHANGELOG (docs-only)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -31,6 +31,23 @@ Audit 2026-07-14 P2 batch — low-severity hygiene + a lint gate:
 - **L-2**: explicit Retry-After now gets bounded upward jitter (never
   earlier than the server floor) in both transport twins — a subagent
   fan-out sharing one Retry-After no longer retries in the same instant.
+- **L-3**: the stream idle watchdog now measures server silence, not
+  consumer progress — a slow/paused consumer holding a yielded event past
+  idleMs no longer trips a false `stream_idle_timeout` (both twins). A
+  genuine mid-pause server stall is still killed, at worst ~2x idleMs late
+  (documented trade; no unbounded buffering).
+- **L-4**: utility model calls (generators/runtime.ts) memoize the transport
+  per provider-config reference (WeakMap), so the concurrency gate and any
+  BPT_PRECONNECT probe take effect ONCE across calls instead of per call;
+  injected transports still bypass the cache.
+- **L-6**: a turn interrupted by interrupt() no longer loses its already-
+  billed usage — the engine attaches the aborted run's accounting
+  (usage/cost/apiMs/turns/modelUsage) to the AbortError and the query layer
+  folds it into the session ledger (incl. settled subagents), so
+  maxBudgetUsd accounting no longer under-counts on repeated interrupts.
+- **L-7**: transparent auto-resume suppresses the duplicate system/init that
+  the re-driven query would emit, so a consumer modeling "one init per
+  stream" no longer sees a phantom new session after a recovery.
 - **L-5**: mcp/stdio.ts marks the connection closed on a spawn 'error'
   (ENOENT) so later requests fail fast with mcp_not_connected instead of
   hanging to the 60s timeout.


### PR DESCRIPTION
## 内容

诚实补账:批三另一工位(更早派发、完成较晚)的 L-3/L-4/L-6/L-7 四项修复,其源码已随 0.59.1(PR #691)工作树一并合并入 main 并通过全量测试,但当时的 CHANGELOG 条目漏记了这四项已发货的运行时改动。本 PR 纯文档补记,记录已合并代码,**不新增 src、不再 bump**。

- **L-3** 空闲看门狗改测「服务器沉默」而非「消费者进度」——慢/暂停消费者不再误触发 `stream_idle_timeout`
- **L-4** utility 调用按 provider 配置引用记忆化 transport(WeakMap)——并发闸与 preconnect 探测跨调用只生效一次
- **L-6** interrupt() 中断轮不再丢失已计费用量——引擎把中断账挂 AbortError、query 层折入会话台账
- **L-7** 透明续传吞掉重复 system/init——消费者不再见幽灵新会话

已核实四项均在 main(accumulateAborted / resolveUtilityTransport / consumerHolds / initForwarded 皆在),对应测试(query-abort-usage / transport-idle-consumer / utility-transport-memo)亦已随 0.59.1 合并。

### 验证
- changelog 一致性测试 6 绿;版本守卫「无发货运行时改动」通过(纯文档)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG)_