### PR TITLE
silver-core-sdk 0.60.0: /goal session-goal primitive

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -199,6 +199,13 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.60.0（2026-07-14，`/goal` 会话目标原语，守密人「把 goal 命令也给实现了吧」派单）**：
+  与 /loop 同类表面缺口——引擎 Stop-hook block 语义（v0.39）与 stop 变体条件评估器（v0.6）早已
+  发货，`/goal` 却无人解析。新模块 `src/hooks/session-goal.ts`（BPT-EXTENSION）：`parseGoalCommand`
+  （set / clear）+ `createSessionGoal`（Stop matcher：未达成 block 停止并回喂理由续跑、达成自动
+  撤防、impossible 逃生口撤防；`handleCommand` 一调用桥接、`onEvent` 通知、`maxBlocks` 帽、
+  transcript 尾部有界上下文）。失败方向与通用条件门**刻意反向**：坏裁判（评估器故障 / 乱码 /
+  零上下文）一律放行停止、目标保持布防，绝不困死 agent；零上下文不盲判。+20 测试。
 - **v0.59.0（2026-07-14，BPT `/loop` 缺口收口，守密人同日裁定「SDK 侧加循环原语」）**：
   BPT 调查确认 `/loop 10m <任务>` 未被任何层解释、原样透传为一次性 prompt（GUI 未注册 /loop、
   SDK 斜杠层仅 /compact 内建 + markdown 展开、周期语义静默丢失）。新公开模块 `src/prompt-loop.ts`

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,33 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.60.0 — 2026-07-14
+
+New capability: `/goal` session-goal primitive (`src/hooks/session-goal.ts`,
+BPT-EXTENSION) — the surface companion to the engine's Stop-hook block
+semantics (v0.39) and the stop-variant condition evaluator (v0.6), both of
+which already shipped; without this surface a `/goal <condition>` invocation
+fell through as a one-shot plain prompt exactly like the /loop gap.
+
+- `parseGoalCommand`: single source of truth for `/goal <condition>` /
+  `/goal clear` (three-way result like parseLoopCommand; bare `/goal`
+  errors loudly, `clear <text>` is a condition, multiline preserved).
+- `createSessionGoal`: goal manager producing a Stop matcher via
+  `.hooks()` — "not met" verdict blocks the stop (reason fed back as a user
+  turn by the existing engine path; maxTurns/maxBudgetUsd still cap),
+  "met" auto-clears, `impossible` escape hatch auto-clears. `set`/`clear`/
+  `handleCommand` one-call host bridge, `onEvent` lifecycle notifications,
+  optional `maxBlocks` host-policy cap, bounded transcript-tail context
+  (32 KiB default, `context` override).
+- INVERTED failure direction vs the generic hook-condition gate, documented
+  and tested: an errored / unparseable / context-less evaluation ALLOWS the
+  stop and keeps the goal armed — a broken judge must never trap the agent
+  in a forced loop. Never judges blind (no transcript → no evaluator call).
+- `GOAL_SLASH_COMMAND` menu metadata; NOT an engine built-in (same honesty
+  red line as /loop). ConfigurationError on invalid options (whitelist row).
+- +20 tests (`tests/session-goal.test.ts`); engine chain already locked by
+  `tests/stop-hook-block.test.ts` + hook-runner aggregation tests.
+
 ## 0.59.1 — 2026-07-14
 
 Audit 2026-07-14 P2 batch — low-severity hygiene + a lint gate:

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -67,6 +67,16 @@ src/
 
 ## 当前状态
 
+**v0.60.0（2026-07-14）：/goal 会话目标原语（同日守密人「把 goal 命令也给实现了吧」派单）**——
+`/goal <条件>` 布防会话级 Stop 门：引擎 Stop-hook block 语义（v0.39）与 stop 变体条件评估器（v0.6）
+早已发货，缺的只是 `/goal` 表面。新公开模块 `src/hooks/session-goal.ts`：`parseGoalCommand`（set / clear
+双动作三态返回）+ `createSessionGoal`（目标管理器出 Stop matcher——「未达成」判决 block 停止、
+理由回喂用户轮续跑（maxTurns / maxBudgetUsd 照常封顶）、「已达成」自动撤防、`impossible` 逃生口
+撤防防死循环；`handleCommand` 一调用桥接、`onEvent` 生命周期通知、`maxBlocks` 宿主策略帽、
+transcript 尾部有界上下文）。**失败方向与通用 hook 条件门刻意反向**：评估器故障 / 乱码 / 零上下文
+一律放行停止、目标保持布防——坏裁判绝不把 agent 困进强制循环；零上下文不盲判（不调评估器）。
+`GOAL_SLASH_COMMAND` 仅菜单元数据不进内建（同 /loop 诚实红线）。+20 测试。
+
 **v0.59.0（2026-07-14）：/loop 区间循环原语（BPT /loop 缺口收口，守密人同日裁定「SDK 侧加循环原语」）**——
 BPT 中 `/loop 10m <任务>` 原样透传为一次性 prompt、周期语义静默丢失（缺口调查同日）。新公开模块
 `src/prompt-loop.ts`：`parseLoopCommand`（`/loop [<interval>] <task>` 语法唯一真相源，s/m/h + 别名 + 小数，

--- a/projects/silver-core-sdk/README.md
+++ b/projects/silver-core-sdk/README.md
@@ -215,6 +215,40 @@ deliberately NOT an engine built-in — the engine loop cannot re-invoke itself
 over wall-clock time, and advertising a command the engine would swallow as
 plain text is the honesty red line.
 
+## /goal session goals (BPT-EXTENSION)
+
+`/goal <condition>` arms a session-scoped Stop gate: when the agent tries to
+stop, the faithful stop-variant condition evaluator judges the transcript;
+"not met" blocks the stop (the reason is fed back as a user turn and the
+loop keeps working — engine `maxTurns` / `maxBudgetUsd` still cap it), "met"
+auto-clears, and the evaluator's `impossible` escape hatch clears without
+looping forever. `/goal clear` disarms early. The engine's Stop-hook block
+semantics (v0.39) and the evaluator prompt already shipped; this module is
+the missing surface. Host bridge:
+
+```ts
+import { createSessionGoal, GOAL_SLASH_COMMAND } from 'silver-core-sdk';
+
+const goal = createSessionGoal({
+  utility: { provider },              // evaluator credentials (Haiku default)
+  onEvent: (e) => updateBadge(e),     // set/met/blocked/impossible/...
+});
+// wire ONCE into every query of the session:
+const q = query({ prompt, options: { hooks: { ...goal.hooks() } } });
+// route user input BEFORE submitting it as a prompt:
+const outcome = goal.handleCommand(userInput);
+if (outcome.handled) {
+  return outcome.ok ? showInfo(outcome.message) : showError(outcome.error);
+}
+```
+
+Failure direction is deliberately INVERTED from the generic hook-condition
+gate: there the dangerous act is firing a hook (unverified → don't fire);
+here the dangerous act is BLOCKING the stop, so an errored/unparseable/
+context-less evaluation ALLOWS the stop and keeps the goal armed — a broken
+judge must never trap the agent in a forced loop. `GOAL_SLASH_COMMAND` is
+menu metadata only, not an engine built-in (same honesty red line as /loop).
+
 ## Examples
 
 Runnable examples live in [examples/](./examples):

--- a/projects/silver-core-sdk/docs/ARCHITECTURE.md
+++ b/projects/silver-core-sdk/docs/ARCHITECTURE.md
@@ -440,6 +440,7 @@ build red.
 | `src/query.ts` | `ConfigurationError` |
 | `src/session-manager.ts` | `ConfigurationError` |
 | `src/prompt-loop.ts` | `ConfigurationError` |
+| `src/hooks/session-goal.ts` | `ConfigurationError` |
 | `src/tools/bash.ts` | `ConfigurationError` |
 | `src/tools/memory/` | `MemoryToolError`, `ConfigurationError` |
 | `src/reporting/` | `ConfigurationError` |

--- a/projects/silver-core-sdk/package-lock.json
+++ b/projects/silver-core-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silver-core-sdk",
-      "version": "0.59.0",
+      "version": "0.60.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.59.1",
+  "version": "0.60.0",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/hooks/session-goal.ts
+++ b/projects/silver-core-sdk/src/hooks/session-goal.ts
@@ -1,0 +1,322 @@
+/**
+ * /goal session-goal primitive. BPT-EXTENSION — the surface companion to the
+ * engine's Stop-hook block semantics (v0.39): in Claude Code, `/goal
+ * <condition>` arms a session-scoped Stop hook that BLOCKS stopping until
+ * the condition holds (judged by the stop-variant condition evaluator over
+ * the transcript) and auto-clears once met. The engine side of that loop
+ * already exists here — engine/loop.ts honors a Stop-hook 'block' decision
+ * by feeding the reason back as a user turn (root loop only, maxTurns /
+ * maxBudgetUsd still cap it), and hooks/condition.ts ships the faithful
+ * stop-variant evaluator prompt. What was missing is the /goal surface
+ * itself; without it the invocation falls through as a one-shot plain
+ * prompt exactly like the /loop gap (same 2026-07-14 report).
+ *
+ * Grammar (single source of truth — hosts must not re-implement it):
+ *   /goal <condition>   arm (replaces any previous goal)
+ *   /goal clear         disarm early
+ *
+ * FAILURE DIRECTION (deliberately INVERTED from hooks/condition.ts): there
+ * the dangerous act is FIRING a hook, so an unverified condition fails
+ * closed to "not met / don't fire". Here the dangerous act is BLOCKING the
+ * stop — an evaluator outage that kept blocking would trap the agent in a
+ * forced loop with no working judge. So an errored/unparseable evaluation
+ * ALLOWS the stop (the goal stays armed and the host is told via
+ * systemMessage); only an affirmative "not met" verdict blocks. The
+ * evaluator's `impossible` escape hatch likewise allows the stop and
+ * disarms the goal — same runaway protection, judged, not assumed.
+ *
+ * NOT registered in BUILTIN_SLASH_COMMANDS for the same honesty red line as
+ * /loop: arming a goal is a host routing concern (the command arrives as a
+ * user message), and the engine must not advertise a command it would
+ * swallow as plain text. `GOAL_SLASH_COMMAND` is menu metadata for hosts
+ * that wire the bridge.
+ */
+
+import { closeSync, fstatSync, openSync, readSync } from 'node:fs';
+
+import { ConfigurationError } from '../errors.js';
+import { HOOK_STOP_CONDITION_SYSTEM } from './condition.js';
+import { parseHookCondition } from './condition.js';
+import {
+  extractJsonObject,
+  runUtilityCall,
+  type UtilityCallOptions,
+} from '../generators/runtime.js';
+import type {
+  HookCallbackMatcher,
+  HookEvent,
+  HookInput,
+  HookJSONOutput,
+  SlashCommand,
+  StopHookInput,
+} from '../types.js';
+
+/** Menu metadata for hosts that wire the bridge (see module header). */
+export const GOAL_SLASH_COMMAND: SlashCommand = {
+  name: 'goal',
+  description:
+    'Set a session goal that blocks stopping until the condition holds (auto-clears when met); /goal clear disarms',
+  argumentHint: '<condition> | clear',
+};
+
+export type GoalCommandAction =
+  | { kind: 'set'; condition: string }
+  | { kind: 'clear' };
+
+export type GoalCommandParse =
+  | { ok: true; action: GoalCommandAction }
+  | { ok: false; error: string };
+
+const GOAL_INVOCATION_RE = /^\/goal(?:\s+([\s\S]+))?$/;
+
+/**
+ * Parse a `/goal` invocation. Returns null when the input is not a /goal
+ * command at all (route it as usual); `{ ok: false }` when it IS /goal but
+ * unusable — hosts must surface that error instead of passing the text
+ * through as a plain prompt.
+ */
+export function parseGoalCommand(input: string): GoalCommandParse | null {
+  const m = GOAL_INVOCATION_RE.exec(input.trim());
+  if (!m) return null;
+  const args = m[1]?.trim() ?? '';
+  if (!args) {
+    return { ok: false, error: '/goal requires a goal condition (or "clear")' };
+  }
+  if (args === 'clear') return { ok: true, action: { kind: 'clear' } };
+  return { ok: true, action: { kind: 'set', condition: args } };
+}
+
+/** Host-observable lifecycle notifications (UI badges, logs). */
+export type SessionGoalEvent =
+  | { kind: 'set'; condition: string }
+  | { kind: 'cleared'; condition: string }
+  | { kind: 'met'; condition: string; reason: string }
+  | { kind: 'impossible'; condition: string; reason: string }
+  | { kind: 'blocked'; condition: string; reason: string; blocks: number }
+  | { kind: 'evaluator_error'; condition: string; reason: string }
+  | { kind: 'block_limit'; condition: string; blocks: number };
+
+export type SessionGoalOptions = {
+  /** Credentials / model / transport for the evaluator call (test seam). */
+  utility?: UtilityCallOptions;
+  /**
+   * Optional cap on consecutive stop-blocks per armed goal; exceeding it
+   * allows the stop (goal stays armed, `block_limit` event fires). Default
+   * unbounded — the ENGINE already caps the forced loop via maxTurns /
+   * maxBudgetUsd, so this is an extra host-policy knob, not the safety net.
+   */
+  maxBlocks?: number;
+  /**
+   * Evaluator context override. Default: the tail of the Stop hook input's
+   * `transcript_path` file (bounded by `transcriptTailBytes`). When NO
+   * context can be assembled the evaluator is not called blind — the stop is
+   * allowed with an `evaluator_error` event (judging "insufficient evidence"
+   * over an empty transcript would block forever).
+   */
+  context?: (input: StopHookInput) => string | Promise<string>;
+  /** Bounded transcript-tail read for the default context (default 32 KiB). */
+  transcriptTailBytes?: number;
+  onEvent?: (event: SessionGoalEvent) => void;
+};
+
+export type GoalCommandOutcome =
+  | { handled: false }
+  | { handled: true; ok: false; error: string }
+  | { handled: true; ok: true; action: GoalCommandAction; message: string };
+
+export type SessionGoal = {
+  /** Arm (or replace) the goal; resets the block counter. */
+  set(condition: string): void;
+  /** Disarm early (the /goal clear path). No-op when nothing is armed. */
+  clear(): void;
+  readonly condition: string | null;
+  /** Consecutive stop-blocks for the currently armed goal. */
+  readonly blocks: number;
+  /**
+   * One-call host bridge: route any user input through this before
+   * submitting it as a prompt. `{handled:false}` means "not /goal — submit
+   * as usual"; an ok:false outcome must be surfaced, never passed through.
+   */
+  handleCommand(input: string): GoalCommandOutcome;
+  /** Merge into `options.hooks` (spread-friendly: `{...goal.hooks()}`). */
+  hooks(): Partial<Record<HookEvent, HookCallbackMatcher[]>>;
+};
+
+/** Bounded tail read; any I/O trouble degrades to ''. */
+function readFileTail(path: string, maxBytes: number): string {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, 'r');
+    const size = fstatSync(fd).size;
+    const want = Math.min(size, maxBytes);
+    if (want === 0) return '';
+    const buf = Buffer.alloc(want);
+    readSync(fd, buf, 0, want, size - want);
+    return buf.toString('utf8');
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+const DEFAULT_TRANSCRIPT_TAIL_BYTES = 32_768;
+
+export function createSessionGoal(options: SessionGoalOptions = {}): SessionGoal {
+  const {
+    utility = {},
+    maxBlocks,
+    context,
+    transcriptTailBytes = DEFAULT_TRANSCRIPT_TAIL_BYTES,
+    onEvent,
+  } = options;
+  if (maxBlocks !== undefined && (!Number.isInteger(maxBlocks) || maxBlocks < 1)) {
+    throw new ConfigurationError('createSessionGoal: maxBlocks must be a positive integer');
+  }
+  if (!Number.isInteger(transcriptTailBytes) || transcriptTailBytes < 1) {
+    throw new ConfigurationError(
+      'createSessionGoal: transcriptTailBytes must be a positive integer',
+    );
+  }
+
+  let condition: string | null = null;
+  let blocks = 0;
+  const emit = (event: SessionGoalEvent) => onEvent?.(event);
+
+  async function contextFor(input: StopHookInput): Promise<string> {
+    if (context !== undefined) return await context(input);
+    const parts: string[] = [];
+    if (typeof input.last_assistant_message === 'string' && input.last_assistant_message !== '') {
+      parts.push(`Last assistant message:\n${input.last_assistant_message}`);
+    }
+    if (typeof input.transcript_path === 'string' && input.transcript_path !== '') {
+      const tail = readFileTail(input.transcript_path, transcriptTailBytes);
+      if (tail !== '') parts.push(`Transcript tail:\n${tail}`);
+    }
+    return parts.join('\n\n');
+  }
+
+  async function onStop(
+    input: HookInput,
+    _toolUseId: string | undefined,
+    callbackOptions: { signal: AbortSignal },
+  ): Promise<HookJSONOutput> {
+    if (condition === null || input.hook_event_name !== 'Stop') return {};
+    const goal = condition;
+
+    let ctx: string;
+    try {
+      ctx = await contextFor(input);
+    } catch {
+      ctx = '';
+    }
+    if (ctx === '') {
+      // Never judge blind: an empty transcript reads as "insufficient
+      // evidence" and would block every stop forever.
+      const reason = 'no transcript context available for goal evaluation';
+      emit({ kind: 'evaluator_error', condition: goal, reason });
+      return { systemMessage: `Session goal "${goal}" could not be verified (${reason}); allowing stop, goal stays armed` };
+    }
+
+    let raw: string;
+    try {
+      raw = await runUtilityCall(
+        HOOK_STOP_CONDITION_SYSTEM,
+        `Condition:\n${goal}\n\nContext:\n${ctx}`,
+        { ...utility, signal: callbackOptions.signal },
+        256,
+      );
+    } catch (err) {
+      if (callbackOptions.signal.aborted) throw err; // an abort is not a verdict
+      const reason = err instanceof Error ? err.message : String(err);
+      emit({ kind: 'evaluator_error', condition: goal, reason });
+      return { systemMessage: `Session goal "${goal}" could not be verified (${reason}); allowing stop, goal stays armed` };
+    }
+    if (extractJsonObject(raw) === null) {
+      // Unparseable is NOT a "not met" verdict here (inverted failure
+      // direction, see module header): allow the stop, keep the goal armed.
+      const reason = 'unparseable condition-evaluator reply';
+      emit({ kind: 'evaluator_error', condition: goal, reason });
+      return { systemMessage: `Session goal "${goal}" could not be verified (${reason}); allowing stop, goal stays armed` };
+    }
+
+    const verdict = parseHookCondition(raw);
+    if (verdict.ok) {
+      condition = null;
+      blocks = 0;
+      emit({ kind: 'met', condition: goal, reason: verdict.reason });
+      return { systemMessage: `Session goal met (${verdict.reason}); goal cleared` };
+    }
+    if (verdict.impossible === true) {
+      condition = null;
+      blocks = 0;
+      emit({ kind: 'impossible', condition: goal, reason: verdict.reason });
+      return {
+        systemMessage: `Session goal "${goal}" judged impossible (${verdict.reason}); goal cleared`,
+      };
+    }
+    if (maxBlocks !== undefined && blocks >= maxBlocks) {
+      emit({ kind: 'block_limit', condition: goal, blocks });
+      return {
+        systemMessage: `Session goal "${goal}" still unmet after ${blocks} blocked stops (maxBlocks); allowing stop, goal stays armed`,
+      };
+    }
+    blocks += 1;
+    emit({ kind: 'blocked', condition: goal, reason: verdict.reason, blocks });
+    return {
+      decision: 'block',
+      reason:
+        `Session goal not yet met: "${goal}". Evaluator: ${verdict.reason}. ` +
+        'Continue working toward the goal; it auto-clears once the condition holds.',
+    };
+  }
+
+  return {
+    set(next: string): void {
+      if (typeof next !== 'string' || next.trim() === '') {
+        throw new ConfigurationError('SessionGoal.set: condition must be a non-empty string');
+      }
+      condition = next.trim();
+      blocks = 0;
+      emit({ kind: 'set', condition });
+    },
+    clear(): void {
+      if (condition === null) return;
+      const previous = condition;
+      condition = null;
+      blocks = 0;
+      emit({ kind: 'cleared', condition: previous });
+    },
+    get condition(): string | null {
+      return condition;
+    },
+    get blocks(): number {
+      return blocks;
+    },
+    handleCommand(input: string): GoalCommandOutcome {
+      const parsed = parseGoalCommand(input);
+      if (parsed === null) return { handled: false };
+      if (!parsed.ok) return { handled: true, ok: false, error: parsed.error };
+      if (parsed.action.kind === 'clear') {
+        const hadGoal = condition !== null;
+        this.clear();
+        return {
+          handled: true,
+          ok: true,
+          action: parsed.action,
+          message: hadGoal ? 'Goal cleared' : 'No active goal to clear',
+        };
+      }
+      this.set(parsed.action.condition);
+      return {
+        handled: true,
+        ok: true,
+        action: parsed.action,
+        message: `Goal set: ${parsed.action.condition}`,
+      };
+    },
+    hooks(): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
+      return { Stop: [{ hooks: [onStop] }] };
+    },
+  };
+}

--- a/projects/silver-core-sdk/src/index.ts
+++ b/projects/silver-core-sdk/src/index.ts
@@ -47,6 +47,19 @@ export type {
   PromptLoopOptions,
   PromptLoopSummary,
 } from './prompt-loop.js';
+// BPT-EXTENSION: /goal session-goal primitive (the surface companion to the
+// engine's Stop-hook block semantics — parser + goal manager producing the
+// Stop matcher; see src/hooks/session-goal.ts module header for the deliberately
+// inverted failure direction).
+export { createSessionGoal, parseGoalCommand, GOAL_SLASH_COMMAND } from './hooks/session-goal.js';
+export type {
+  GoalCommandAction,
+  GoalCommandOutcome,
+  GoalCommandParse,
+  SessionGoal,
+  SessionGoalEvent,
+  SessionGoalOptions,
+} from './hooks/session-goal.js';
 // Built-in durable session store (SM-乙a): fileSessionStore(dir) for the
 // SessionManager's `store` option and options.sessionStore recovery.
 export { FileSessionStore, fileSessionStore } from './sessions/file-store.js';

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.59.1';
+export const SDK_VERSION = '0.60.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/session-goal.test.ts
+++ b/projects/silver-core-sdk/tests/session-goal.test.ts
@@ -1,0 +1,303 @@
+/**
+ * /goal session-goal primitive (BPT-EXTENSION, src/hooks/session-goal.ts) —
+ * parser grammar, goal manager lifecycle, and the Stop matcher's verdict
+ * handling with its deliberately INVERTED failure direction (an unverified
+ * evaluation allows the stop; only an affirmative "not met" blocks).
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  createSessionGoal,
+  parseGoalCommand,
+  ConfigurationError,
+  GOAL_SLASH_COMMAND,
+  type SessionGoalEvent,
+  type StopHookInput,
+} from '../src/index.js';
+import { MockTransport, textReplyEvents } from './helpers/mock-transport.js';
+
+const tmp = mkdtempSync(join(tmpdir(), 'session-goal-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+function transcriptFile(content: string): string {
+  const p = join(tmp, `transcript-${Math.random().toString(36).slice(2)}.jsonl`);
+  writeFileSync(p, content);
+  return p;
+}
+
+function stopInput(transcriptPath?: string): StopHookInput {
+  return {
+    session_id: 's1',
+    cwd: '/tmp',
+    hook_event_name: 'Stop',
+    stop_hook_active: false,
+    ...(transcriptPath !== undefined ? { transcript_path: transcriptPath } : {}),
+  } as StopHookInput;
+}
+
+async function fireStop(
+  goal: ReturnType<typeof createSessionGoal>,
+  input: StopHookInput,
+  signal: AbortSignal = new AbortController().signal,
+) {
+  const matchers = goal.hooks().Stop;
+  expect(matchers).toHaveLength(1);
+  const callback = matchers![0]!.hooks[0]!;
+  return await callback(input, undefined, { signal });
+}
+
+describe('parseGoalCommand', () => {
+  it('returns null for anything that is not a /goal invocation', () => {
+    expect(parseGoalCommand('hello')).toBeNull();
+    expect(parseGoalCommand('/goals are great')).toBeNull();
+    expect(parseGoalCommand('/Goal x')).toBeNull();
+    expect(parseGoalCommand('say /goal x')).toBeNull();
+  });
+
+  it('parses set and clear actions', () => {
+    expect(parseGoalCommand('/goal 也给实现了吧')).toEqual({
+      ok: true,
+      action: { kind: 'set', condition: '也给实现了吧' },
+    });
+    expect(parseGoalCommand('/goal clear')).toEqual({ ok: true, action: { kind: 'clear' } });
+    expect(parseGoalCommand('/goal clear the build cache')).toEqual({
+      ok: true,
+      action: { kind: 'set', condition: 'clear the build cache' },
+    });
+  });
+
+  it('preserves multiline conditions', () => {
+    const parsed = parseGoalCommand('/goal all tests green\nand docs updated');
+    expect(parsed).toEqual({
+      ok: true,
+      action: { kind: 'set', condition: 'all tests green\nand docs updated' },
+    });
+  });
+
+  it('rejects a bare /goal, loudly', () => {
+    const parsed = parseGoalCommand('/goal');
+    expect(parsed && !parsed.ok && parsed.error).toMatch(/requires a goal condition/);
+  });
+
+  it('exports honest menu metadata without registering an engine built-in', async () => {
+    expect(GOAL_SLASH_COMMAND.name).toBe('goal');
+    const { BUILTIN_SLASH_COMMANDS } = await import('../src/engine/slash-commands.js');
+    expect(BUILTIN_SLASH_COMMANDS.some((c) => c.name === 'goal')).toBe(false);
+  });
+});
+
+describe('createSessionGoal lifecycle', () => {
+  it('validates options and set() input', () => {
+    expect(() => createSessionGoal({ maxBlocks: 0 })).toThrow(ConfigurationError);
+    expect(() => createSessionGoal({ transcriptTailBytes: 0 })).toThrow(ConfigurationError);
+    expect(() => createSessionGoal().set('  ')).toThrow(ConfigurationError);
+  });
+
+  it('set / clear round-trip with events', () => {
+    const events: SessionGoalEvent[] = [];
+    const goal = createSessionGoal({ onEvent: (e) => events.push(e) });
+    expect(goal.condition).toBeNull();
+    goal.set('CI is green');
+    expect(goal.condition).toBe('CI is green');
+    goal.clear();
+    expect(goal.condition).toBeNull();
+    goal.clear(); // no-op, no duplicate event
+    expect(events).toEqual([
+      { kind: 'set', condition: 'CI is green' },
+      { kind: 'cleared', condition: 'CI is green' },
+    ]);
+  });
+
+  it('handleCommand is the one-call bridge', () => {
+    const goal = createSessionGoal();
+    expect(goal.handleCommand('ordinary prompt')).toEqual({ handled: false });
+
+    const bad = goal.handleCommand('/goal');
+    expect(bad.handled && !bad.ok && bad.error).toMatch(/requires a goal condition/);
+
+    const set = goal.handleCommand('/goal ship it');
+    expect(set.handled && set.ok && set.message).toBe('Goal set: ship it');
+    expect(goal.condition).toBe('ship it');
+
+    const cleared = goal.handleCommand('/goal clear');
+    expect(cleared.handled && cleared.ok && cleared.message).toBe('Goal cleared');
+    expect(goal.condition).toBeNull();
+
+    const nothing = goal.handleCommand('/goal clear');
+    expect(nothing.handled && nothing.ok && nothing.message).toBe('No active goal to clear');
+  });
+});
+
+describe('Stop matcher verdicts', () => {
+  it('is inert with no armed goal (zero model calls)', async () => {
+    const transport = new MockTransport([]);
+    const goal = createSessionGoal({ utility: { transport } });
+    expect(await fireStop(goal, stopInput(transcriptFile('x')))).toEqual({});
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  it('blocks the stop on a "not met" verdict and counts blocks', async () => {
+    const events: SessionGoalEvent[] = [];
+    const transport = new MockTransport([
+      textReplyEvents('{"ok":false,"reason":"tests still red"}'),
+    ]);
+    const goal = createSessionGoal({ utility: { transport }, onEvent: (e) => events.push(e) });
+    goal.set('all tests green');
+    const out = await fireStop(goal, stopInput(transcriptFile('ran tests: 3 failed')));
+    expect(out).toMatchObject({ decision: 'block' });
+    expect(out && 'reason' in out ? out.reason : '').toContain('all tests green');
+    expect(out && 'reason' in out ? out.reason : '').toContain('tests still red');
+    expect(goal.condition).toBe('all tests green'); // stays armed
+    expect(goal.blocks).toBe(1);
+    expect(events.at(-1)).toMatchObject({ kind: 'blocked', blocks: 1 });
+    // The evaluator saw the stop-variant prompt with condition + transcript.
+    expect(transport.requests[0]?.system).toContain('stop-condition hook');
+    const user = transport.requests[0]?.messages[0]?.content;
+    expect(typeof user === 'string' && user.includes('all tests green')).toBe(true);
+    expect(typeof user === 'string' && user.includes('ran tests: 3 failed')).toBe(true);
+  });
+
+  it('auto-clears and allows the stop on a "met" verdict', async () => {
+    const events: SessionGoalEvent[] = [];
+    const transport = new MockTransport([
+      textReplyEvents('{"ok":true,"reason":"all 24 tests passed"}'),
+    ]);
+    const goal = createSessionGoal({ utility: { transport }, onEvent: (e) => events.push(e) });
+    goal.set('all tests green');
+    const out = await fireStop(goal, stopInput(transcriptFile('24 passed')));
+    expect(out).not.toMatchObject({ decision: 'block' });
+    expect(out && 'systemMessage' in out ? out.systemMessage : '').toContain('goal cleared');
+    expect(goal.condition).toBeNull();
+    expect(events.at(-1)).toMatchObject({ kind: 'met' });
+  });
+
+  it('auto-clears and allows the stop on an "impossible" verdict', async () => {
+    const transport = new MockTransport([
+      textReplyEvents('{"ok":false,"impossible":true,"reason":"resource does not exist"}'),
+    ]);
+    const goal = createSessionGoal({ utility: { transport } });
+    goal.set('unreachable thing');
+    const out = await fireStop(goal, stopInput(transcriptFile('tried everything')));
+    expect(out).not.toMatchObject({ decision: 'block' });
+    expect(goal.condition).toBeNull();
+  });
+
+  it('INVERTED failure direction: evaluator error allows the stop, goal stays armed', async () => {
+    const events: SessionGoalEvent[] = [];
+    const throwing = {
+      apiKeySource: () => 'none' as const,
+      // eslint-disable-next-line require-yield
+      async *stream(): AsyncGenerator<never, void> {
+        throw new Error('no credential');
+      },
+    };
+    const goal = createSessionGoal({
+      utility: { transport: throwing },
+      onEvent: (e) => events.push(e),
+    });
+    goal.set('CI green');
+    const out = await fireStop(goal, stopInput(transcriptFile('x')));
+    expect(out).not.toMatchObject({ decision: 'block' });
+    expect(out && 'systemMessage' in out ? out.systemMessage : '').toContain('goal stays armed');
+    expect(goal.condition).toBe('CI green');
+    expect(events.at(-1)).toMatchObject({ kind: 'evaluator_error' });
+  });
+
+  it('INVERTED failure direction: unparseable reply allows the stop, goal stays armed', async () => {
+    const transport = new MockTransport([textReplyEvents('sure, sounds met to me')]);
+    const goal = createSessionGoal({ utility: { transport } });
+    goal.set('CI green');
+    const out = await fireStop(goal, stopInput(transcriptFile('x')));
+    expect(out).not.toMatchObject({ decision: 'block' });
+    expect(goal.condition).toBe('CI green');
+  });
+
+  it('never judges blind: no transcript context -> allow with evaluator_error', async () => {
+    const events: SessionGoalEvent[] = [];
+    const transport = new MockTransport([]);
+    const goal = createSessionGoal({ utility: { transport }, onEvent: (e) => events.push(e) });
+    goal.set('CI green');
+    const out = await fireStop(goal, stopInput()); // no transcript_path at all
+    expect(out).not.toMatchObject({ decision: 'block' });
+    expect(goal.condition).toBe('CI green');
+    expect(transport.requests).toHaveLength(0); // evaluator never called
+    expect(events.at(-1)).toMatchObject({ kind: 'evaluator_error' });
+  });
+
+  it('honors the maxBlocks host-policy cap, keeping the goal armed', async () => {
+    const notMet = () => textReplyEvents('{"ok":false,"reason":"still failing"}');
+    const transport = new MockTransport([notMet(), notMet(), notMet()]);
+    const events: SessionGoalEvent[] = [];
+    const goal = createSessionGoal({
+      utility: { transport },
+      maxBlocks: 2,
+      onEvent: (e) => events.push(e),
+    });
+    goal.set('CI green');
+    const input = stopInput(transcriptFile('red'));
+    expect(await fireStop(goal, input)).toMatchObject({ decision: 'block' });
+    expect(await fireStop(goal, input)).toMatchObject({ decision: 'block' });
+    const third = await fireStop(goal, input);
+    expect(third).not.toMatchObject({ decision: 'block' });
+    expect(third && 'systemMessage' in third ? third.systemMessage : '').toContain('maxBlocks');
+    expect(goal.condition).toBe('CI green');
+    expect(events.at(-1)).toMatchObject({ kind: 'block_limit', blocks: 2 });
+  });
+
+  it('re-arming via set() resets the block counter', async () => {
+    const notMet = () => textReplyEvents('{"ok":false,"reason":"nope"}');
+    const transport = new MockTransport([notMet(), notMet()]);
+    const goal = createSessionGoal({ utility: { transport } });
+    goal.set('goal A');
+    await fireStop(goal, stopInput(transcriptFile('x')));
+    expect(goal.blocks).toBe(1);
+    goal.set('goal B');
+    expect(goal.blocks).toBe(0);
+    await fireStop(goal, stopInput(transcriptFile('x')));
+    expect(goal.blocks).toBe(1);
+  });
+
+  it('a custom context provider replaces the transcript tail', async () => {
+    const transport = new MockTransport([textReplyEvents('{"ok":true,"reason":"done"}')]);
+    const goal = createSessionGoal({
+      utility: { transport },
+      context: () => 'host-assembled summary: everything shipped',
+    });
+    goal.set('ship it');
+    await fireStop(goal, stopInput()); // no transcript_path needed
+    const user = transport.requests[0]?.messages[0]?.content;
+    expect(typeof user === 'string' && user.includes('host-assembled summary')).toBe(true);
+  });
+
+  it('bounds the default transcript read to the tail', async () => {
+    const transport = new MockTransport([textReplyEvents('{"ok":false,"reason":"x"}')]);
+    const goal = createSessionGoal({ utility: { transport }, transcriptTailBytes: 16 });
+    goal.set('g');
+    const path = transcriptFile(`${'A'.repeat(100)}TAIL-MARKER`);
+    await fireStop(goal, stopInput(path));
+    const user = transport.requests[0]?.messages[0]?.content;
+    expect(typeof user === 'string' && user.includes('TAIL-MARKER')).toBe(true);
+    expect(typeof user === 'string' && user.includes('AAAAAAAAAAAAAAAAAAAAA')).toBe(false);
+  });
+
+  it('rethrows on abort (an abort is not a verdict)', async () => {
+    const ctrl = new AbortController();
+    const throwing = {
+      apiKeySource: () => 'none' as const,
+      // eslint-disable-next-line require-yield
+      async *stream(): AsyncGenerator<never, void> {
+        ctrl.abort();
+        throw new Error('aborted mid-call');
+      },
+    };
+    const goal = createSessionGoal({ utility: { transport: throwing } });
+    goal.set('g');
+    await expect(fireStop(goal, stopInput(transcriptFile('x')), ctrl.signal)).rejects.toThrow();
+    expect(goal.condition).toBe('g'); // still armed
+  });
+});


### PR DESCRIPTION
## Background

Companion to the /loop gap (#690, same 2026-07-14 report): the engine's Stop-hook block semantics (v0.39 — `engine/loop.ts` even names it "the /goal goal-gating primitive") and the faithful stop-variant condition evaluator (v0.6, `hooks/condition.ts`) already shipped, but nothing parsed `/goal` — the invocation fell through as a one-shot plain prompt. Keeper dispatch: implement the /goal surface too.

## Changes

- **`src/hooks/session-goal.ts` (BPT-EXTENSION, new)**
  - `parseGoalCommand` — single source of truth for `/goal <condition>` / `/goal clear` (three-way result like `parseLoopCommand`; bare `/goal` errors loudly; `clear <text>` is a condition; multiline preserved).
  - `createSessionGoal` — goal manager producing a Stop matcher via `.hooks()`: a "not met" verdict blocks the stop (reason fed back as a user turn by the existing engine path; `maxTurns`/`maxBudgetUsd` still cap the forced loop), "met" auto-clears, the evaluator's `impossible` escape hatch auto-clears. `handleCommand` one-call host bridge, `onEvent` lifecycle notifications, optional `maxBlocks` host-policy cap, bounded transcript-tail context (32 KiB default, `context` override).
  - **Deliberately INVERTED failure direction** vs the generic hook-condition gate: there the dangerous act is firing a hook (unverified → don't fire); here it is BLOCKING the stop, so an errored / unparseable / context-less evaluation ALLOWS the stop and keeps the goal armed — a broken judge must never trap the agent in a forced loop. Never judges blind (no transcript → no evaluator call).
  - `GOAL_SLASH_COMMAND` menu metadata; NOT an engine built-in (same honesty red line as /loop).
- Module placed under `src/hooks/` so `hooks → generators` is the only cross-module edge (already declared in the import-edges table); `ConfigurationError` whitelist row added to `docs/ARCHITECTURE.md`.
- README "/goal session goals (BPT-EXTENSION)" section with the host bridge example.
- Version 0.59.1 → 0.60.0 (new capability = minor) + CHANGELOG entry (rebased over #691/#692; 0.59.1 entry preserved below); `CONTEXT.md` / `memory/project-status.md` status entries.

## Verification

- `tests/session-goal.test.ts` +20 tests (grammar, lifecycle/events, one-call bridge, and every verdict path: block/met/impossible/evaluator-error/unparseable/blind-context/maxBlocks/re-arm/custom-context/tail-bound/abort).
- Engine chain already locked by `tests/stop-hook-block.test.ts` (block → user-turn feedback → clean pass) and hook-runner aggregation tests (`decision:'block'` → deny + reason).
- Full vitest on the rebased base (includes 0.59.1's `noUnusedLocals` gate): **2423 passed + 2 skipped** (134 files); `tsc` + build exit 0; `check-version-bump` OK.
- Repo pytest: **2923 passed + 12 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJo9pCQWTMd3MrMsfshFVa

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJo9pCQWTMd3MrMsfshFVa)_