### PR TITLE
silver-core-sdk 0.60.1: subagent natural end no longer clears the root /goal

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,31 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.60.1 — 2026-07-15
+
+Bug fix — a subagent's natural end no longer clears or pollutes the root
+session goal (the 0.60.0 `/goal` primitive):
+
+- **Stop-hook root-only gate widened to the invocation itself**
+  (`src/engine/loop.ts`). A `/goal` goal-gate is a session-scoped Stop hook,
+  and a subagent's child loop shares the parent HookRunner. Pre-fix, the
+  `isRootLoop` gate guarded only the Stop hook's *block decision*, so a
+  child's natural end still *invoked* the Stop hook against the child's
+  transcript — and `session-goal.onStop` mutates state as a side effect
+  (clears the goal on a "met"/"impossible" verdict, bumps the block counter
+  on "not met", and spends an evaluator LLM call). The result: any subagent
+  finishing could clear the root goal, so the root conversation stopped even
+  though the goal was never actually met (a conversation-loses-stop-state
+  bug). The gate now wraps the whole Stop-hook block — child loops
+  (parentToolUseId set) skip Stop entirely and are governed by SubagentStop
+  at the runtime level, matching the module's documented intent. Also
+  eliminates the wasted evaluator call per subagent.
+- Regression coverage (`tests/stop-hook-block.test.ts`): a child loop never
+  invokes the Stop hook (`stopInputs` empty), and an end-to-end test with the
+  real `createSessionGoal` + a stubbed "met" evaluator confirms a child's
+  natural end leaves an armed root goal intact (both tests fail against the
+  pre-fix engine).
+
 ## 0.60.0 — 2026-07-14
 
 New capability: `/goal` session-goal primitive (`src/hooks/session-goal.ts`,

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -1552,7 +1552,20 @@ export async function* runAgentLoop(
       // assistant message already carried the raw content).
       const naturalEndContent = assistant.content.filter((b) => b.type !== 'tool_use');
       pushAssistant(naturalEndContent, assistant.model);
-      if (deps.hooks.hasHooks('Stop')) {
+      // ROOT LOOP ONLY: the Stop hook fires exclusively for the root loop; a
+      // subagent's natural end is governed by SubagentStop (runtime-level). The
+      // gate wraps the hook's INVOCATION, not merely its 'block' decision
+      // (audit 2026-07-15): a Stop hook such as /goal's onStop MUTATES
+      // session-goal state as a side effect (clears the goal on "met"/
+      // "impossible", bumps the block counter on "not met", and spends an
+      // evaluator LLM call). Running it on a CHILD's transcript would let any
+      // subagent's natural end clear or pollute the ROOT goal — the very
+      // conversation-loses-stop-state bug this gate must prevent. Guarding only
+      // the block branch (the pre-fix shape) stopped children being trapped but
+      // left those side effects leaking. parentToolUseId marks child loops.
+      const isRootLoop =
+        config.parentToolUseId === undefined || config.parentToolUseId === null;
+      if (isRootLoop && deps.hooks.hasHooks('Stop')) {
         const stopAgg = await deps.hooks.run(
           'Stop',
           { ...baseHookFields, hook_event_name: 'Stop', stop_hook_active: stopHookActive },
@@ -1565,12 +1578,8 @@ export async function* runAgentLoop(
         // PREVENTS the stop — the reason is fed back as a user turn and the
         // loop runs another assistant turn (the /goal goal-gating primitive).
         // `continue:false` forces the stop and WINS over block (official
-        // precedence). ROOT LOOP ONLY: a subagent's natural end is governed
-        // by SubagentStop (runtime-level), so a goal-gate registered on Stop
-        // must not capture every child (parentToolUseId marks child loops).
-        const isRootLoop =
-          config.parentToolUseId === undefined || config.parentToolUseId === null;
-        if (isRootLoop && stopAgg.continue && stopAgg.decision === 'deny') {
+        // precedence).
+        if (stopAgg.continue && stopAgg.decision === 'deny') {
           const reason =
             stopAgg.decisionReason ?? 'Stop hook blocked stopping (no reason given)';
           deps.debug(`engine: Stop hook blocked the stop; continuing (${reason})`);

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.60.0';
+export const SDK_VERSION = '0.60.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/stop-hook-block.test.ts
+++ b/projects/silver-core-sdk/tests/stop-hook-block.test.ts
@@ -11,6 +11,8 @@ import { describe, expect, it } from 'vitest';
 
 import { runAgentLoop } from '../src/engine/loop.js';
 import { DefaultPermissionGate } from '../src/permissions/gate.js';
+import { DefaultHookRunner } from '../src/hooks/runner.js';
+import { createSessionGoal } from '../src/hooks/session-goal.js';
 import type {
   AggregatedHookResult,
   EngineConfig,
@@ -192,7 +194,13 @@ describe('Stop-hook block semantics', () => {
     expect(lastResult(messages).subtype).toBe('success');
   });
 
-  it('child loops (parentToolUseId set) ignore Stop-hook blocks', async () => {
+  it('child loops (parentToolUseId set) never INVOKE the Stop hook', async () => {
+    // Regression (audit 2026-07-15): a child's natural end must not fire the
+    // Stop hook AT ALL — not merely have its 'block' decision ignored. A Stop
+    // hook such as /goal's onStop mutates session-goal state as a side effect,
+    // so invoking it on a child's transcript would let the child clear or
+    // pollute the ROOT goal (conversation loses stop state). The gate now
+    // wraps the invocation, so the hook is never consulted for a child.
     const transport = new MockTransport([textReplyEvents('child answer')]);
     const hooks = new ScriptedStopHooks([
       { decision: 'deny', decisionReason: 'goal gate must not capture children' },
@@ -206,6 +214,45 @@ describe('Stop-hook block semantics', () => {
     );
     expect(transport.requests).toHaveLength(1);
     expect(lastResult(messages).subtype).toBe('success');
+    // The heart of the fix: the child never reached the Stop hook, so no
+    // onStop side effect (goal clear / block-counter bump / evaluator call)
+    // could have run against the child's transcript.
+    expect(hooks.stopInputs).toHaveLength(0);
+  });
+
+  it('a child goal-gate that would "clear on met" leaves the armed root goal intact', async () => {
+    // End-to-end shape of the bug: wire the REAL /goal primitive as a
+    // session-scoped Stop hook, arm a root goal, then run a CHILD loop to
+    // natural end. The evaluator is stubbed to return a MET verdict, so if the
+    // child's natural end reached onStop AT ALL it would clear the root goal
+    // (pre-fix behavior). Post-fix the child never invokes Stop, so the goal
+    // stays armed. Discriminating and network-free (injected transport).
+    const metEvaluator = new MockTransport([
+      textReplyEvents('{"ok": true, "reason": "child subtask done"}'),
+    ]);
+    const goal = createSessionGoal({
+      context: () => 'the child finished its subtask',
+      utility: { transport: metEvaluator },
+    });
+    goal.set('the ROOT task is fully complete');
+    const beforeCondition = goal.condition;
+
+    const transport = new MockTransport([textReplyEvents('child answer')]);
+    const hooks = new DefaultHookRunner({ hooks: goal.hooks(), debug: () => {} });
+    const messages = await collect(
+      runAgentLoop(
+        [{ role: 'user', content: 'child subtask' }],
+        makeDeps(transport, hooks),
+        makeConfig({ parentToolUseId: 'toolu_parent_2' }),
+      ),
+    );
+    expect(lastResult(messages).subtype).toBe('success');
+    // The root goal is untouched by the child's natural end; the stubbed
+    // evaluator was never consulted (would have cleared the goal if it had).
+    expect(goal.condition).toBe(beforeCondition);
+    expect(goal.condition).not.toBeNull();
+    expect(goal.blocks).toBe(0);
+    expect(metEvaluator.requests).toHaveLength(0);
   });
 
   it('a stubborn block still honors maxTurns', async () => {


### PR DESCRIPTION
## 内容

修复守密人查证任务坐实的一处 CONFIRMED 缺陷：0.60.0 新上的 `/goal` 会话目标原语，会被任何子代理的自然结束误触发 `onStop` 副作用，清空/污染根目标——导致根对话在目标从未达成时就丢失 stop 状态、提前停止。

### 根因
`/goal` goal-gate 是会话级 Stop 钩子；子代理的子循环与根**共用同一个 HookRunner**（runtime.ts:1309）。原 `isRootLoop` 门控只套住了 Stop 钩子的 **block 决策**（loop.ts:1573），没套住 Stop 钩子的**触发本身**（loop.ts:1555）。于是子代理自然结束时仍会调用 `onStop`，它读子代理转录并产生副作用：判「met/impossible」→ `condition = null`（清空根目标）、判「not met」→ `blocks += 1`（污染计数）、每次白跑一次评审 LLM。

### 修法
把 `isRootLoop` 上提门控整个 Stop 钩子触发块——子代理（parentToolUseId 已设）**根本不触发 Stop**，只走运行时层的 SubagentStop（与 loop.ts:1568-1570 现有注释的既定意图一致）。顺带消除子代理每次白跑评审 LLM 的浪费。

### 回归测试（`tests/stop-hook-block.test.ts`）
- 强化「child loops never INVOKE the Stop hook」：断言子循环后 `hooks.stopInputs` 为空
- 新增端到端：用真 `createSessionGoal` + 注入返回「met」判决的桩评估器，断言子代理自然结束后根 `goal.condition` 存活、`blocks` 为 0、桩评估器零调用
- **两个新测试在 pre-fix 引擎上均变红**（已实测验证 discriminating）

### 验证
- typecheck（含 noUnusedLocals 门禁）EXIT 0
- 全量 vitest：**2423 通过 / 3 skipped / 0 失败**（134 文件）
- 版本纪律：0.60.0 → 0.60.1 + CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG)_