### PR TITLE
silver-core-sdk 0.62.0: close tool-parity gaps (EnterPlanMode, ReadMcpResourceDirTool) + parity backstop

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,35 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.62.0 — 2026-07-15
+
+Tool-parity audit (2026-07-15): closed the remaining clean gaps against the
+official Claude Code CLI tool surface, and added a backstop so future gaps
+red the build.
+
+- **EnterPlanMode** built-in (`src/tools/enterplanmode.ts`) — the mirror of
+  the already-shipped ExitPlanMode. Flips the session permission mode to
+  'plan' through the same `ctx.permissionGate` handle; readOnly (entering
+  plan mode only ever restricts). Faithful description reproduced from the
+  archive fragment. Was a gap: the SDK shipped the "exit" half of the pair
+  but not the "enter" half.
+- **ReadMcpResourceDirTool** built-in (`src/tools/resources.ts`) — lists the
+  direct children of an MCP directory resource (`resources/directory/read`),
+  completing the MCP resource family (List / Read / **ReadDir**). Threaded
+  `readResourceDir` through the whole MCP registry chain (contract, registry,
+  stdio/http/sdk-server connections, and every delegating wrapper). Non-
+  recursive; errors from servers without directory support propagate as an
+  error result.
+- **Tool-parity ledger** (`docs/TOOL-PARITY.md`) + backstop test
+  (`tests/tool-parity.test.ts`): the ledger enumerates official CLI tools ×
+  shipped? × why-not (including deliberate exclusions like LSP/NotebookEdit
+  and host-facing candidates SendUserFile/ListAgents for when the host layer
+  grows); the test pins the default built-in set so adding/removing a tool
+  reds until the ledger is updated. This is the mechanism that would have
+  caught the MultiEdit / EnterPlanMode gaps.
+- Coverage: EnterPlanMode cases in `tests/tools-planmode-worktree-monitor.
+  test.ts`; ReadMcpResourceDirTool cases in `tests/tools-v2.test.ts`.
+
 ## 0.61.0 — 2026-07-15
 
 New capability: **MultiEdit** — several exact-string replacements to ONE file

--- a/projects/silver-core-sdk/docs/TOOL-PARITY.md
+++ b/projects/silver-core-sdk/docs/TOOL-PARITY.md
@@ -1,0 +1,94 @@
+# Tool parity ledger
+
+Why this file exists: the SDK reproduces the **Claude Code CLI agent** tool
+surface. Twice a tool that official Claude Code has went unshipped for no real
+reason — just a coverage gap in the community system-prompt reconstruction the
+SDK cross-references (`Public-Info-Pool/Reference/Claude-Code-System-Prompts/`):
+**MultiEdit** (added 2026-07-15) and **EnterPlanMode** (added 2026-07-15). The
+root cause was that nothing enumerated "official CLI tools × shipped? × why
+not" in one place, so a miss had no backstop.
+
+This ledger is that backstop. `tests/tool-parity.test.ts` pins the shipped
+default-builtin set to the **Shipped** table below: adding or removing a tool
+reds the test until this file is updated, forcing a conscious decision and a
+line here.
+
+Scope note: the reconstruction archive is **multi-product** (claude.ai web,
+Cowork, Claude-in-Chrome, computer-use, remote/scheduling). Only Claude Code
+**CLI agent** tools belong here; other products' tools are listed under
+"Out of scope" so they are not re-flagged as gaps.
+
+---
+
+## Shipped (default built-ins)
+
+Registered by `createBuiltinTools` (`src/tools/index.ts`).
+
+| Tool | Source | Notes |
+|------|--------|-------|
+| Read | `read.ts` | |
+| Write | `write.ts` | |
+| Edit | `edit.ts` | |
+| MultiEdit | `multiedit.ts` | added 2026-07-15 (was a gap); atomic same-file batch |
+| Bash / BashOutput / KillShell | `bash.ts` / `shells.ts` | |
+| Glob | `glob.ts` | |
+| Grep | `grep.ts` | |
+| Read/ListMcpResourcesTool | `resources.ts` | |
+| ReadMcpResourceTool | `resources.ts` | |
+| ReadMcpResourceDirTool | `resources.ts` | added 2026-07-15 (was a gap); `resources/directory/read` |
+| EnterPlanMode | `enterplanmode.ts` | added 2026-07-15 (was a gap); mirror of ExitPlanMode |
+| ExitPlanMode | `exitplanmode.ts` | |
+| EnterWorktree | `enterworktree.ts` | |
+| Monitor | `monitor.ts` | poll model (no event push) |
+| WebFetch | `webfetch.ts` | |
+| WebSearch | `websearch.ts` | |
+| AskUserQuestion | `askuserquestion.ts` | host answers via `onUserQuestion` |
+| TaskCreate / TaskGet / TaskUpdate / TaskList | `tasks` | (TodoWrite legacy, behind `CLAUDE_CODE_ENABLE_TASKS=0`) |
+| TaskOutput / TaskStop | `shells.ts` | background-task read/stop |
+| TodoWrite | legacy | only when `CLAUDE_CODE_ENABLE_TASKS=0` |
+| Workflow | `workflow.ts` | |
+| SendMessage | subagent bridge | continue/stop a spawned subagent |
+
+## Shipped (conditional / deferred — not in `createBuiltinTools`)
+
+| Tool | Source | How it registers |
+|------|--------|------------------|
+| Agent (alias Task) | `subagents/agent-tool.ts` | conditionally registered in `query.ts` |
+| ToolSearch | `tools/toolsearch.ts` | deferred-builtin mechanism |
+
+## Deliberately excluded (documented, NOT gaps)
+
+| Tool | Why not shipped |
+|------|-----------------|
+| NotebookEdit / NotebookRead | need a Jupyter subsystem the SDK has no counterpart for |
+| PowerShell | Windows-shell variant of Bash; out of scope |
+| ExitWorktree | references worktree machinery this SDK does not ship (EnterWorktree adapts around it) |
+| SlashCommand | host routing concern — the command arrives as a user message; engine must not advertise a command it would swallow |
+| Skill / invoke-skill | the SDK has no skill subsystem (see CONTEXT.md) |
+| **LSP** | needs a full Language-Server-Protocol subsystem (per-filetype servers) the SDK has no counterpart for — same class as NotebookEdit. Confirmed a real CLI tool, deliberately deferred as a subsystem, not a one-file tool. Archive: `tool-description-lsp.md`. |
+
+## Open assessment (host-facing; revisit as the host layer grows)
+
+These are real Claude Code surfaces but lean **host responsibility** — the
+headless engine has no delivery channel today. As the consuming host (BPT)
+builds these channels, each could become a host-capability-gated tool surface
+in the SDK (the pattern already used for `askUser` / `mcpResources`: the SDK
+ships the tool, the host wires the capability, absent capability → graceful
+"not configured" error).
+
+| Tool | Archive | Assessment |
+|------|---------|------------|
+| SendUserFile | `tool-description-senduserfile.md` | Pushes a deliverable file to the user (incl. "reach their phone"). Needs a host file-delivery capability. Candidate for a capability-gated surface once the host exposes the channel. |
+| ListAgents | `tool-description-listagents.md` | Lists agents reachable via SendMessage — mostly cross-session / cloud / remote-bridge infra the SDK deliberately does not do (no teammate mode). Revisit only if the host adds that fabric. |
+
+## Out of scope (other products, NOT Claude Code CLI)
+
+Not SDK gaps — belong to other Claude surfaces:
+claude.ai web / Cowork (Artifact, ClaudeDesign, DesignSync, onboarding role
+picker, plugin/skill marketplace: ListConnectors, SuggestConnectors,
+SearchMcpRegistry, SearchPlugins, SearchSkills), Claude-in-Chrome (browser*,
+chrome*), computer-use (computer*, mouse/key/zoom), remote/scheduling
+(CronCreate, ScheduleWakeup, Snooze, RemoteTrigger, PushNotification),
+host session control (EndConversation, SendUserMessage), code-review command
+host tools (ReportFindings), REPL (an alternative JS-orchestration execution
+paradigm, not a standard terminal-agent tool).

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/internal/contracts.ts
+++ b/projects/silver-core-sdk/src/internal/contracts.ts
@@ -172,6 +172,8 @@ export type ToolContext = {
   mcpResources?: {
     list(server: string | undefined, signal: AbortSignal): Promise<McpResource[]>;
     read(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]>;
+    /** List the direct children of a directory resource (resources/directory/read). */
+    readDir(server: string, uri: string, signal: AbortSignal): Promise<McpResource[]>;
   };
   /** v0.2 WebFetch escape hatch for localhost/private hosts (default false). */
   allowPrivateWebFetch?: boolean;
@@ -484,6 +486,8 @@ export interface McpRegistry {
   listResources(server: string | undefined, signal: AbortSignal): Promise<McpResource[]>;
   /** Read one resource's contents from a named server. */
   readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]>;
+  /** List the direct children of a directory resource on a named server. */
+  readResourceDir(server: string, uri: string, signal: AbortSignal): Promise<McpResource[]>;
   reconnect(serverName: string): Promise<void>;
   setEnabled(serverName: string, enabled: boolean): void;
   /** Replace the live server set at runtime; callers read statuses() for

--- a/projects/silver-core-sdk/src/mcp/http.ts
+++ b/projects/silver-core-sdk/src/mcp/http.ts
@@ -166,6 +166,13 @@ export class HttpMcpConnection {
     return parseResourceContents(result);
   }
 
+  /** resources/directory/read: direct children of a directory resource. Errors
+   *  propagate (a server without directory support rejects the request). */
+  async readResourceDir(uri: string, signal?: AbortSignal): Promise<McpResource[]> {
+    const result = await this.rpcRequest('resources/directory/read', { uri }, signal);
+    return parseResourcesList(result);
+  }
+
   /** Cancel all in-flight requests; further calls fail with AbortError. */
   async close(): Promise<void> {
     this.closeController.abort();

--- a/projects/silver-core-sdk/src/mcp/registry.ts
+++ b/projects/silver-core-sdk/src/mcp/registry.ts
@@ -51,6 +51,7 @@ type McpConnectionLike = {
   ): Promise<CallToolResult>;
   listResources(signal?: AbortSignal): Promise<McpResource[]>;
   readResource(uri: string, signal?: AbortSignal): Promise<McpResourceContent[]>;
+  readResourceDir(uri: string, signal?: AbortSignal): Promise<McpResource[]>;
   close(): Promise<void>;
 };
 
@@ -238,6 +239,26 @@ export class DefaultMcpRegistry implements McpRegistry {
       });
     }
     return await entry.connection.readResource(uri, signal);
+  }
+
+  async readResourceDir(
+    server: string,
+    uri: string,
+    signal: AbortSignal,
+  ): Promise<McpResource[]> {
+    const entry = this.entries.find((e) => e.name === server);
+    if (!entry) {
+      throw new McpError('mcp_unknown_server', `No such MCP server: ${server}`, {
+        serverLabel: server,
+      });
+    }
+    if (!entry.enabled || entry.baseStatus !== 'connected' || !entry.connection) {
+      throw new McpError('mcp_not_connected', `MCP server '${server}' is not connected`, {
+        serverLabel: server,
+        phase: 'request',
+      });
+    }
+    return await entry.connection.readResourceDir(uri, signal);
   }
 
   /** Tear down and re-establish one server's connection. Never throws. */

--- a/projects/silver-core-sdk/src/mcp/sdk-server.ts
+++ b/projects/silver-core-sdk/src/mcp/sdk-server.ts
@@ -214,6 +214,10 @@ export class SdkMcpConnection {
     return [];
   }
 
+  async readResourceDir(_uri: string, _signal?: AbortSignal): Promise<McpResource[]> {
+    return [];
+  }
+
   /** In-process: nothing to release. */
   async close(): Promise<void> {
     // Intentionally empty.

--- a/projects/silver-core-sdk/src/mcp/stdio.ts
+++ b/projects/silver-core-sdk/src/mcp/stdio.ts
@@ -239,6 +239,13 @@ export class StdioMcpConnection {
     return parseResourceContents(result);
   }
 
+  /** resources/directory/read: direct children of a directory resource. Errors
+   *  propagate (a server without directory support rejects the request). */
+  async readResourceDir(uri: string, signal?: AbortSignal): Promise<McpResource[]> {
+    const result = await this.request('resources/directory/read', { uri }, signal);
+    return parseResourcesList(result);
+  }
+
   /** Terminate the child: SIGTERM, then SIGKILL after a short grace period. */
   async close(): Promise<void> {
     this.lifeController.abort();

--- a/projects/silver-core-sdk/src/mcp/tool-filter.ts
+++ b/projects/silver-core-sdk/src/mcp/tool-filter.ts
@@ -54,6 +54,9 @@ export class ToolFilterMcpRegistry implements McpRegistry {
   readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]> {
     return this.inner.readResource(server, uri, signal);
   }
+  readResourceDir(server: string, uri: string, signal: AbortSignal): Promise<McpResource[]> {
+    return this.inner.readResourceDir(server, uri, signal);
+  }
   reconnect(serverName: string): Promise<void> {
     return this.inner.reconnect(serverName);
   }

--- a/projects/silver-core-sdk/src/query.ts
+++ b/projects/silver-core-sdk/src/query.ts
@@ -1081,6 +1081,7 @@ export function query(args: {
           mcpResources: {
             list: (server, signal) => mcpEff.listResources(server, signal),
             read: (server, uri, signal) => mcpEff.readResource(server, uri, signal),
+            readDir: (server, uri, signal) => mcpEff.readResourceDir(server, uri, signal),
           },
           allowPrivateWebFetch: options.allowPrivateWebFetch === true,
           recordFileChange: checkpointStore

--- a/projects/silver-core-sdk/src/session-manager.ts
+++ b/projects/silver-core-sdk/src/session-manager.ts
@@ -177,6 +177,9 @@ class SharedMcpRegistry implements McpRegistry {
   readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]> {
     return this.inner.readResource(server, uri, signal);
   }
+  readResourceDir(server: string, uri: string, signal: AbortSignal): Promise<McpResource[]> {
+    return this.inner.readResourceDir(server, uri, signal);
+  }
   reconnect(serverName: string): Promise<void> {
     // Reconnect is shared RECOVERY (a failed server is failed for every
     // borrower; reconnecting fixes it for all), not a per-session preference —

--- a/projects/silver-core-sdk/src/subagents/runtime.ts
+++ b/projects/silver-core-sdk/src/subagents/runtime.ts
@@ -342,6 +342,9 @@ class ChildMcpFilter implements McpRegistry {
   readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]> {
     return this.inner.readResource(server, uri, signal);
   }
+  readResourceDir(server: string, uri: string, signal: AbortSignal): Promise<McpResource[]> {
+    return this.inner.readResourceDir(server, uri, signal);
+  }
   reconnect(serverName: string): Promise<void> {
     // Reconnect is shared RECOVERY (a failed server is failed for every
     // borrower; reconnecting fixes it for all), not a per-session preference —

--- a/projects/silver-core-sdk/src/tools/descriptions.ts
+++ b/projects/silver-core-sdk/src/tools/descriptions.ts
@@ -552,6 +552,34 @@ Usage notes:
 - Use multiSelect: true to allow multiple answers to be selected for a question
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label`;
 
+export const ENTERPLANMODE_DESCRIPTION = `Use this tool proactively when you're about to start a non-trivial implementation task. Getting user sign-off on your approach before writing code prevents wasted effort and ensures alignment. This tool transitions you into plan mode where you can explore the codebase and design an implementation approach for user approval.
+
+## When to Use This Tool
+
+Prefer using EnterPlanMode for implementation tasks unless they're simple. Use it when ANY of these conditions apply:
+
+1. New Feature Implementation: Adding meaningful new functionality.
+2. Multiple Valid Approaches: The task can be solved in several different ways.
+3. Code Modifications: Changes that affect existing behavior or structure.
+4. Architectural Decisions: The task requires choosing between patterns or technologies.
+5. Multi-File Changes: The task will likely touch more than 2-3 files.
+6. Unclear Requirements: You need to explore before understanding the full scope.
+7. User Preferences Matter: The implementation could reasonably go multiple ways. If you would use AskUserQuestion to clarify the approach, use EnterPlanMode instead — plan mode lets you explore first, then present options with context.
+
+## When NOT to Use This Tool
+
+Only skip EnterPlanMode for simple tasks:
+- Single-line or few-line fixes (typos, obvious bugs, small tweaks)
+- Adding a single function with clear requirements
+- Tasks where the user has given very specific, detailed instructions
+- Pure research/exploration tasks (use the Agent tool instead)
+
+## Important Notes
+
+- This tool REQUIRES user approval - they must consent to entering plan mode
+- If unsure whether to use it, err on the side of planning - it's better to get alignment upfront than to redo work
+- Users appreciate being consulted before significant changes are made to their codebase`;
+
 export const EXITPLANMODE_DESCRIPTION = `Use this tool when you are in plan mode and have finished presenting your plan and are ready for user approval to begin implementing.
 
 ## How This Tool Works
@@ -875,6 +903,7 @@ export const TOOL_DESCRIPTION_PROVENANCE: ToolDescriptionProvenance[] = [
   { tool: 'WebFetch', faithful: true, slugs: ['tool-description-webfetch'] },
   { tool: 'WebSearch', faithful: true, slugs: ['tool-description-websearch'] },
   { tool: 'AskUserQuestion', faithful: true, slugs: ['tool-description-askuserquestion'] },
+  { tool: 'EnterPlanMode', faithful: true, slugs: ['tool-description-enterplanmode'] },
   { tool: 'ExitPlanMode', faithful: true, slugs: ['tool-description-exitplanmode'] },
   { tool: 'EnterWorktree', faithful: true, slugs: ['tool-description-enterworktree'] },
   {
@@ -910,6 +939,7 @@ export const TOOL_DESCRIPTION_TEXT: Record<string, string> = {
   WebFetch: WEBFETCH_DESCRIPTION,
   WebSearch: WEBSEARCH_DESCRIPTION,
   AskUserQuestion: ASKUSERQUESTION_DESCRIPTION,
+  EnterPlanMode: ENTERPLANMODE_DESCRIPTION,
   ExitPlanMode: EXITPLANMODE_DESCRIPTION,
   EnterWorktree: ENTERWORKTREE_DESCRIPTION,
   Monitor: MONITOR_DESCRIPTION,

--- a/projects/silver-core-sdk/src/tools/enterplanmode.ts
+++ b/projects/silver-core-sdk/src/tools/enterplanmode.ts
@@ -1,0 +1,76 @@
+/**
+ * EnterPlanMode built-in tool — the mirror of ExitPlanMode (audit 2026-07-15
+ * tool-parity gap: the SDK shipped the "exit" half of the plan-mode pair but
+ * not the "enter" half).
+ *
+ * Semantics in THIS SDK (which has a real `plan` permission mode on the gate —
+ * src/permissions/gate.ts step 6 — but no plan-file machinery):
+ *
+ *  - Like ExitPlanMode, it flips the session's permission MODE through the
+ *    gate handle carried on ToolContext (`permissionGate`, a formal field
+ *    since the 2026-07-10 audit batch). It switches the gate to 'plan' so the
+ *    agent explores read-only and presents a plan for approval; ExitPlanMode
+ *    switches back.
+ *  - Wired + mode is NOT already 'plan': switch to 'plan', report the
+ *    transition.
+ *  - Wired + mode already 'plan': explicit error (nothing to enter).
+ *  - Not wired: explicit error, permission mode untouched (behavior-honesty
+ *    red line — no silent pretending).
+ *
+ * readOnly: true — it only flips session permission-mode state and never
+ * touches files. Entering plan mode only ever RESTRICTS (plan mode denies
+ * non-readOnly tools), so auto-approving the entry is safe; hosts keep a veto
+ * via a PreToolUse hook / disallowedTools rule on 'EnterPlanMode' (gate steps
+ * 1-2 run before the readOnly auto-allow).
+ */
+
+import type { BuiltinTool, ToolContext, ToolResultPayload } from '../internal/contracts.js';
+import { AbortError } from '../errors.js';
+import { ENTERPLANMODE_DESCRIPTION } from './descriptions.js';
+
+export const enterPlanModeTool: BuiltinTool = {
+  name: 'EnterPlanMode',
+  description: ENTERPLANMODE_DESCRIPTION,
+  // Session permission-mode state only; never touches files. See file header
+  // for why readOnly is safe here (entering plan mode only restricts).
+  readOnly: true,
+  inputSchema: {
+    type: 'object',
+    properties: {},
+  },
+  async execute(
+    _input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<ToolResultPayload> {
+    if (ctx.signal.aborted) throw new AbortError();
+
+    const gate = ctx.permissionGate;
+    if (gate === undefined) {
+      return {
+        content:
+          'EnterPlanMode failed: no permission-mode controller is wired on this ' +
+          'tool context (the host must expose the permission gate as ' +
+          '`permissionGate` on the ToolContext). The permission mode was NOT ' +
+          'changed.',
+        isError: true,
+      };
+    }
+
+    const mode = gate.getMode();
+    if (mode === 'plan') {
+      return {
+        content: 'EnterPlanMode failed: the session is already in plan mode.',
+        isError: true,
+      };
+    }
+
+    gate.setMode('plan');
+    ctx.debug(`EnterPlanMode: permission mode ${mode} -> plan`);
+    return {
+      content:
+        `Entered plan mode. Permission mode: ${mode} -> plan. Explore the ` +
+        'codebase read-only and present a plan for approval; call ExitPlanMode ' +
+        'once the user approves to resume implementation.',
+    };
+  },
+};

--- a/projects/silver-core-sdk/src/tools/index.ts
+++ b/projects/silver-core-sdk/src/tools/index.ts
@@ -44,10 +44,11 @@ import { webSearchTool } from './websearch.js';
 import { askUserQuestionTool } from './askuserquestion.js';
 import { todoWriteTool } from './todo.js';
 import { taskTools } from './task.js';
-import { listMcpResourcesTool, readMcpResourceTool } from './resources.js';
+import { listMcpResourcesTool, readMcpResourceTool, readMcpResourceDirTool } from './resources.js';
 import { bashOutputTool, killShellTool, taskOutputTool, taskStopTool } from './shells.js';
 import { monitorTool } from './monitor.js';
 import { exitPlanModeTool } from './exitplanmode.js';
+import { enterPlanModeTool } from './enterplanmode.js';
 import { enterWorktreeTool } from './enterworktree.js';
 import { workflowTool } from './workflow.js';
 import { sendMessageTool } from './sendmessage.js';
@@ -86,6 +87,8 @@ export function createBuiltinTools(cfg?: {
     ...(legacyTodo ? [todoWriteTool] : taskTools),
     listMcpResourcesTool,
     readMcpResourceTool,
+    readMcpResourceDirTool,
+    enterPlanModeTool,
     exitPlanModeTool,
     enterWorktreeTool,
     workflowTool,

--- a/projects/silver-core-sdk/src/tools/resources.ts
+++ b/projects/silver-core-sdk/src/tools/resources.ts
@@ -86,3 +86,44 @@ export const readMcpResourceTool: BuiltinTool = {
     }
   },
 };
+
+export const readMcpResourceDirTool: BuiltinTool = {
+  name: 'ReadMcpResourceDirTool',
+  description:
+    'List the direct children of a directory resource on an MCP server ' +
+    '(resources/directory/read). The listing is NOT recursive: each entry ' +
+    'carries its own uri, and a subdirectory appears with a directory mimeType ' +
+    '— call this tool again on that uri to descend. Only usable against a ' +
+    'server that has declared support for directory listing; others return an ' +
+    'error. Returns the child resource descriptors as JSON.',
+  readOnly: true,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      server: { type: 'string', description: 'The MCP server to read from.' },
+      uri: { type: 'string', description: 'The URI of the directory resource.' },
+    },
+    required: ['server', 'uri'],
+  },
+  async execute(input: Record<string, unknown>, ctx: ToolContext): Promise<ToolResultPayload> {
+    if (ctx.signal.aborted) throw new AbortError();
+    if (!ctx.mcpResources) {
+      return errorResult('ReadMcpResourceDirTool: no MCP servers are configured.');
+    }
+    const server = input['server'];
+    const uri = input['uri'];
+    if (typeof server !== 'string' || server.length === 0) {
+      return errorResult('ReadMcpResourceDirTool: "server" must be a non-empty string.');
+    }
+    if (typeof uri !== 'string' || uri.length === 0) {
+      return errorResult('ReadMcpResourceDirTool: "uri" must be a non-empty string.');
+    }
+    try {
+      const children = await ctx.mcpResources.readDir(server, uri, ctx.signal);
+      return { content: JSON.stringify(children) };
+    } catch (e) {
+      if (isAbortError(e)) throw new AbortError('ReadMcpResourceDirTool was aborted');
+      return errorResult(`ReadMcpResourceDirTool failed: ${(e as Error).message}`);
+    }
+  },
+};

--- a/projects/silver-core-sdk/src/tools/toolsearch.ts
+++ b/projects/silver-core-sdk/src/tools/toolsearch.ts
@@ -120,6 +120,9 @@ export class DeferredMcpRegistry implements McpRegistry {
   readResource(server: string, uri: string, signal: AbortSignal): Promise<McpResourceContent[]> {
     return this.inner.readResource(server, uri, signal);
   }
+  readResourceDir(server: string, uri: string, signal: AbortSignal): Promise<McpResource[]> {
+    return this.inner.readResourceDir(server, uri, signal);
+  }
 
   reconnect(serverName: string): Promise<void> {
     return this.inner.reconnect(serverName);

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.61.0';
+export const SDK_VERSION = '0.62.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/tool-parity.test.ts
+++ b/projects/silver-core-sdk/tests/tool-parity.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tool-parity backstop (audit 2026-07-15): pins the shipped default-builtin
+ * set so adding or removing a tool reds this test until docs/TOOL-PARITY.md is
+ * updated. This is the mechanism that would have caught the MultiEdit /
+ * EnterPlanMode / ReadMcpResourceDirTool gaps. Agent and ToolSearch are shipped
+ * conditionally/deferred (not via createBuiltinTools) and are asserted
+ * separately.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createBuiltinTools } from '../src/tools/index.js';
+import { createAgentTool } from '../src/subagents/agent-tool.js';
+import { TOOL_SEARCH_NAME } from '../src/tools/toolsearch.js';
+
+/** Default env (no CLAUDE_CODE_ENABLE_TASKS override) → the Task-tool family, not TodoWrite. */
+const EXPECTED_DEFAULT = [
+  'AskUserQuestion',
+  'Bash',
+  'BashOutput',
+  'Edit',
+  'EnterPlanMode',
+  'EnterWorktree',
+  'ExitPlanMode',
+  'Glob',
+  'Grep',
+  'KillShell',
+  'ListMcpResourcesTool',
+  'Monitor',
+  'MultiEdit',
+  'Read',
+  'ReadMcpResourceDirTool',
+  'ReadMcpResourceTool',
+  'SendMessage',
+  'TaskCreate',
+  'TaskGet',
+  'TaskList',
+  'TaskOutput',
+  'TaskStop',
+  'TaskUpdate',
+  'WebFetch',
+  'WebSearch',
+  'Workflow',
+  'Write',
+].sort();
+
+describe('tool-parity backstop', () => {
+  it('the default built-in set exactly matches the ledger (update docs/TOOL-PARITY.md on change)', () => {
+    const names = [...createBuiltinTools({ env: {} }).keys()].sort();
+    expect(names).toEqual(EXPECTED_DEFAULT);
+  });
+
+  it('legacy TodoWrite swaps in for the Task-tool family under CLAUDE_CODE_ENABLE_TASKS=0', () => {
+    const names = new Set(createBuiltinTools({ env: { CLAUDE_CODE_ENABLE_TASKS: '0' } }).keys());
+    expect(names.has('TodoWrite')).toBe(true);
+    for (const t of ['TaskCreate', 'TaskGet', 'TaskUpdate', 'TaskList']) {
+      expect(names.has(t), t).toBe(false);
+    }
+  });
+
+  it('Agent and ToolSearch ship conditionally/deferred (outside createBuiltinTools)', () => {
+    const defaults = new Set(createBuiltinTools({ env: {} }).keys());
+    expect(defaults.has('Agent')).toBe(false);
+    expect(defaults.has(TOOL_SEARCH_NAME)).toBe(false);
+    // But they are real, shipped tools registered elsewhere.
+    expect(createAgentTool([]).name).toBe('Agent');
+    expect(TOOL_SEARCH_NAME).toBe('ToolSearch');
+  });
+});

--- a/projects/silver-core-sdk/tests/tools-planmode-worktree-monitor.test.ts
+++ b/projects/silver-core-sdk/tests/tools-planmode-worktree-monitor.test.ts
@@ -23,6 +23,7 @@ import { DefaultPermissionGate } from '../src/permissions/gate.js';
 import { createShellManager } from '../src/tools/shells.js';
 import { createBuiltinTools } from '../src/tools/index.js';
 import { exitPlanModeTool } from '../src/tools/exitplanmode.js';
+import { enterPlanModeTool } from '../src/tools/enterplanmode.js';
 import type { ToolContextWithPermissionGate } from '../src/tools/exitplanmode.js';
 import { enterWorktreeTool, peekWorktreeSession } from '../src/tools/enterworktree.js';
 import { DEFAULT_MONITOR_TIMEOUT_MS, monitorTool } from '../src/tools/monitor.js';
@@ -180,6 +181,57 @@ describe('ExitPlanMode', () => {
     }
     // Invalid input never flips the mode.
     expect(gate.getMode()).toBe('plan');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EnterPlanMode (mirror of ExitPlanMode; audit 2026-07-15 tool-parity gap)
+// ---------------------------------------------------------------------------
+
+describe('EnterPlanMode', () => {
+  function gateCtx(mode: 'plan' | 'default' | 'acceptEdits' = 'default'): {
+    ctx: ToolContext;
+    gate: DefaultPermissionGate;
+  } {
+    const gate = new DefaultPermissionGate({ debug: () => {}, mode });
+    const ctx = makeCtx() as ToolContextWithPermissionGate;
+    ctx.permissionGate = gate;
+    return { ctx, gate };
+  }
+
+  it('registers by default and is readOnly (only ever restricts)', () => {
+    expect(createBuiltinTools({ env: {} }).has('EnterPlanMode')).toBe(true);
+    expect(enterPlanModeTool.readOnly).toBe(true);
+  });
+
+  it('enters plan mode through the wired permission gate', async () => {
+    const { ctx, gate } = gateCtx('default');
+    const r = await enterPlanModeTool.execute({}, ctx);
+    expect(r.isError).toBeUndefined();
+    expect(text(r)).toContain('default -> plan');
+    expect(gate.getMode()).toBe('plan');
+  });
+
+  it('errors (mode untouched) when the session is already in plan mode', async () => {
+    const { ctx, gate } = gateCtx('plan');
+    const r = await enterPlanModeTool.execute({}, ctx);
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/already in plan mode/);
+    expect(gate.getMode()).toBe('plan');
+  });
+
+  it('errors when no permission gate is wired (mode cannot be changed)', async () => {
+    const r = await enterPlanModeTool.execute({}, makeCtx());
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/no permission-mode controller is wired/);
+  });
+
+  it('round-trips with ExitPlanMode (enter from default, exit back to default)', async () => {
+    const { ctx, gate } = gateCtx('default');
+    await enterPlanModeTool.execute({}, ctx);
+    expect(gate.getMode()).toBe('plan');
+    await exitPlanModeTool.execute({}, ctx);
+    expect(gate.getMode()).toBe('default');
   });
 });
 

--- a/projects/silver-core-sdk/tests/tools-v2.test.ts
+++ b/projects/silver-core-sdk/tests/tools-v2.test.ts
@@ -16,7 +16,11 @@ import { webFetchTool, readCappedBody } from '../src/tools/webfetch.js';
 import { webSearchTool } from '../src/tools/websearch.js';
 import { askUserQuestionTool } from '../src/tools/askuserquestion.js';
 import { todoWriteTool } from '../src/tools/todo.js';
-import { listMcpResourcesTool, readMcpResourceTool } from '../src/tools/resources.js';
+import {
+  listMcpResourcesTool,
+  readMcpResourceTool,
+  readMcpResourceDirTool,
+} from '../src/tools/resources.js';
 import {
   resolveElicitation,
   parseElicitationParams,
@@ -820,6 +824,58 @@ describe('ListMcpResourcesTool / ReadMcpResourceTool', () => {
     expect(list.isError).toBe(true);
     const read = await readMcpResourceTool.execute({ server: 's', uri: 'u' }, makeCtx());
     expect(read.isError).toBe(true);
+    const dir = await readMcpResourceDirTool.execute({ server: 's', uri: 'u' }, makeCtx());
+    expect(dir.isError).toBe(true);
+  });
+
+  it('lists a directory resource\'s direct children via ctx.mcpResources.readDir', async () => {
+    const ctx = makeCtx({
+      mcpResources: {
+        list: async () => [],
+        read: async () => [],
+        readDir: async (server, uri) => [
+          { uri: `${uri}child.txt`, name: 'child.txt', server },
+          { uri: `${uri}sub/`, name: 'sub', mimeType: 'inode/directory', server },
+        ],
+      },
+    });
+    const res = await readMcpResourceDirTool.execute(
+      { server: 'srv1', uri: 'file:///dir/' },
+      ctx,
+    );
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content as string)).toEqual([
+      { uri: 'file:///dir/child.txt', name: 'child.txt', server: 'srv1' },
+      { uri: 'file:///dir/sub/', name: 'sub', mimeType: 'inode/directory', server: 'srv1' },
+    ]);
+  });
+
+  it('surfaces a server error (e.g. no directory support) as an error result', async () => {
+    const ctx = makeCtx({
+      mcpResources: {
+        list: async () => [],
+        read: async () => [],
+        readDir: async () => {
+          throw new Error('server does not support directory listing');
+        },
+      },
+    });
+    const res = await readMcpResourceDirTool.execute(
+      { server: 'srv1', uri: 'file:///dir/' },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(String(res.content)).toMatch(/directory listing/);
+  });
+
+  it('validates ReadMcpResourceDirTool required args', async () => {
+    const ctx = makeCtx({
+      mcpResources: { list: async () => [], read: async () => [], readDir: async () => [] },
+    });
+    const noServer = await readMcpResourceDirTool.execute({ uri: 'u' }, ctx);
+    expect(noServer.isError).toBe(true);
+    const noUri = await readMcpResourceDirTool.execute({ server: 's' }, ctx);
+    expect(noUri.isError).toBe(true);
   });
 
   it('validates ReadMcpResourceTool required args', async () => {


### PR DESCRIPTION
## 内容

工具对等审计的收口(守密人裁定 A + 看看 345)。把对照官方 Claude Code CLI 工具表面的**干净缺件**补齐,并新建根因兜底机制。

### 补齐的两个 CONFIRMED 缺件
- **EnterPlanMode**([enterplanmode.ts](https://github.com/lightproud/brain-in-a-vat/blob/main/projects/silver-core-sdk/src/tools/enterplanmode.ts))——已发货 ExitPlanMode 的镜像另一半。经同一 `ctx.permissionGate` 把权限模式翻到 'plan';readOnly(进 plan 模式只会更严)。描述忠实复现归档片段。
- **ReadMcpResourceDirTool**([resources.ts](https://github.com/lightproud/brain-in-a-vat/blob/main/projects/silver-core-sdk/src/tools/resources.ts))——`resources/directory/read`,补全 MCP 资源三件套(List/Read/**ReadDir**)。`readResourceDir` 穿过整条 MCP registry 链(contract → registry → stdio/http/sdk-server 客户端 → 全部委托包装器),设为必需方法靠 typecheck 强制补全每处委托、杜绝静默漏转。非递归;server 不支持目录列举时错误如实上报。

### 根因兜底(A 案要点:堵住「漏了没兜底」)
- **工具对等台账**([docs/TOOL-PARITY.md](https://github.com/lightproud/brain-in-a-vat/blob/main/projects/silver-core-sdk/docs/TOOL-PARITY.md)):官方 CLI 工具 × 是否发货 × 为何不发,一处枚举。含刻意排除(LSP/NotebookEdit 等需子系统)+ **host 面向候选**(SendUserFile/ListAgents,随 host 层做大再评估——按 askUser/mcpResources 的 host-capability 范式)。
- **兜底测试**([tool-parity.test.ts](https://github.com/lightproud/brain-in-a-vat/blob/main/projects/silver-core-sdk/tests/tool-parity.test.ts)):把默认 builtin 集钉死,新增/删除工具即红,逼迫更新台账——正是当初能抓住 MultiEdit/EnterPlanMode 漏项的机制。

### 关于 345(守密人「看看 host 做大」)
- **3 LSP**:确属 CLI 但需完整 LSP 子系统(同 NotebookEdit 类),登记为刻意排除、不实现。
- **4 SendUserFile / 5 ListAgents**:倾向 host 职责——但正如守密人所点,host 层在做大,故台账记为「随 host 通道就位可转为 capability-gated 工具表面」的候选,待守密人决定再实现。

### 验证
- typecheck(含 noUnusedLocals)EXIT 0
- 全量 vitest:**2446 通过 / 3 skipped / 0 失败**(136 文件)
- 版本纪律:0.61.0 → 0.62.0(新能力 minor)+ CHANGELOG;描述 provenance 守护绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZguTH8Msaxa3RP7kGjhkG)_