### PR TITLE
silver-core-sdk 0.62.1: triage MultiEdit not-found errors (overlap culprit named)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,35 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.62.1 — 2026-07-15
+
+Bug fix (usability) — MultiEdit's not-found error now diagnoses WHY instead of
+one undifferentiated message. Field report (BPT, same day as 0.61.0): repeated
+`MultiEdit failed at edit #3: old_string was not found` loops — the model
+authors every old_string from one Read of the ORIGINAL file, but edits apply
+sequentially, so an old_string that overlaps an earlier edit's region (usually
+context lines added for uniqueness) no longer exists when its turn comes; the
+generic error gave no way to tell this self-inflicted case from a genuinely
+stale old_string, so retries repeated the same mistake.
+
+- **Not-found triage** (`src/tools/multiedit.ts`): the tool holds the original
+  text, so it now tells the two causes apart. Absent from the original too →
+  "does not appear in the original file either — Re-Read the file". Present in
+  the original but gone at apply time → the already-validated preceding edits
+  are replayed to NAME the culprit ("edit #1 in this call already rewrote that
+  text") and the remedy is stated: merge overlapping edits into one, or author
+  the later old_string against the post-edit text.
+- **Overlap rule in the description** (`src/tools/descriptions.ts`): edits
+  whose regions share any line or text must be merged into a single edit;
+  authoring a later old_string against post-edit text is for intended
+  dependencies only. Preventive guidance so the model stops writing the trap.
+- **COMPAT.md drift fixed**: the tools table still carried the pre-0.61.0
+  `NotebookEdit / MultiEdit | UNSUPPORTED | … retired upstream` row,
+  contradicting this ledger; MultiEdit now has its own FULL row (SDK-original,
+  no official parity target), NotebookEdit stays UNSUPPORTED.
+- Coverage: `tests/multiedit.test.ts` +2 cases (absent-from-original triage;
+  overlap triage naming the culprit edit, atomic rollback intact).
+
 ## 0.62.0 — 2026-07-15
 
 Tool-parity audit (2026-07-15): closed the remaining clean gaps against the

--- a/projects/silver-core-sdk/docs/COMPAT.md
+++ b/projects/silver-core-sdk/docs/COMPAT.md
@@ -373,7 +373,8 @@ SDK implements the agent loop directly against the public Messages API:
 | WebFetch / WebSearch | FULL | registered in v0.2 |
 | TodoWrite | PARTIAL | v0.7: OFF by default (Task quadruplet is the default surface); `CLAUDE_CODE_ENABLE_TASKS=0` reverts to TodoWrite-only, per official 0.3.142 |
 | Agent | PARTIAL | the subagent spawn tool; v0.7 gains `model`/`isolation:'worktree'` and the official required set [description, prompt] (subagent_type defaults to general-purpose). Residual param delta = our BPT-only `fork` extension |
-| NotebookEdit / MultiEdit | UNSUPPORTED | deliberately untracked (BPT has no notebook surface; MultiEdit retired upstream) |
+| MultiEdit | FULL | v0.61.0 (SDK-original): same-file atomic batch edit — edits apply sequentially on one snapshot, all-or-nothing write, single pre-image for rewind, same read-before-write gate as Edit. No official parity target (retired upstream), so FULL is vs our own documented semantics and the description is authored, not reproduced (`faithful:false`). v0.62.1: not-found errors are triaged against the original text — "absent from the file (re-Read)" vs "consumed by an earlier edit in this call" (culprit edit named; overlap rule added to the description) |
+| NotebookEdit | UNSUPPORTED | deliberately untracked (BPT has no notebook surface) |
 
 ## SDKMessage stream
 

--- a/projects/silver-core-sdk/package-lock.json
+++ b/projects/silver-core-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.60.0",
+  "version": "0.62.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silver-core-sdk",
-      "version": "0.60.0",
+      "version": "0.62.1",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/tools/descriptions.ts
+++ b/projects/silver-core-sdk/src/tools/descriptions.ts
@@ -263,6 +263,7 @@ Usage:
 - Provide \`file_path\` and an ordered \`edits\` array; each edit carries \`old_string\`, \`new_string\`, and an optional \`replace_all\` (default false).
 - Edits apply SEQUENTIALLY on one snapshot: each edit matches the file as left by the preceding edits, so you can rename a symbol and then edit a line that now contains the new name — in the same call.
 - ATOMIC: if any edit's \`old_string\` is not found (or is not unique without \`replace_all\`), NOTHING is written and the failing edit is named by index. Order your edits so an earlier one does not break a later one's match.
+- OVERLAP RULE: edits whose regions overlap — share any line or text, including context lines added for uniqueness — must be MERGED into a single edit. An earlier edit rewrites the text a later \`old_string\` was copied from, and the later edit then fails to match. Author a later \`old_string\` against the post-edit text only when the dependency is intended (e.g. rename a symbol, then edit a line that now holds the new name).
 - Each \`old_string\` must be unique in the file at the point it applies unless \`replace_all\` is true. Preserve exact indentation as it appears in the Read output, excluding the line-number prefix.
 - \`new_string\` must differ from \`old_string\`. Only use emojis if the user explicitly requests it.`;
 

--- a/projects/silver-core-sdk/src/tools/multiedit.ts
+++ b/projects/silver-core-sdk/src/tools/multiedit.ts
@@ -96,18 +96,12 @@ function parseEdits(raw: unknown): ParsedEdit[] | string {
   return parsed;
 }
 
-/** Apply one edit to `text`, returning the new text or an error message. */
-function applyOne(text: string, edit: ParsedEdit, label: string): { text: string; replaced: number } | string {
-  const count = countOccurrences(text, edit.oldString);
-  if (count === 0) {
-    return `MultiEdit failed at ${label}: old_string was not found. It must match the current file contents exactly (after the preceding edits in this call), including whitespace and indentation. No changes were written.`;
-  }
-  if (count > 1 && !edit.replaceAll) {
-    return `MultiEdit failed at ${label}: found ${count} occurrences of old_string. The match must be unique — add more surrounding context, or set replace_all: true. No changes were written.`;
-  }
+/** Substitute `edit` into `text` (match already validated by the caller). */
+function substitute(text: string, edit: ParsedEdit): { text: string; replaced: number } {
   if (edit.replaceAll) {
     // String splitting on purpose: String.prototype.replace would interpret
     // $-patterns in the replacement text.
+    const count = countOccurrences(text, edit.oldString);
     return { text: text.split(edit.oldString).join(edit.newString), replaced: count };
   }
   const idx = text.indexOf(edit.oldString);
@@ -115,6 +109,36 @@ function applyOne(text: string, edit: ParsedEdit, label: string): { text: string
     text: text.slice(0, idx) + edit.newString + text.slice(idx + edit.oldString.length),
     replaced: 1,
   };
+}
+
+/**
+ * A not-found old_string has two very different causes with two different
+ * remedies, and the tool can tell them apart because it holds the original
+ * text: either the text never existed in the file (stale memory / whitespace
+ * mismatch — re-Read), or it DID exist and a preceding edit in this same call
+ * rewrote it (overlapping edits — merge them). For the second case, replay the
+ * already-validated preceding edits to name the one that consumed the match.
+ */
+function diagnoseNotFound(
+  original: string,
+  edits: ParsedEdit[],
+  failedIndex: number,
+  label: string,
+): string {
+  const needle = edits[failedIndex]!.oldString;
+  if (!original.includes(needle)) {
+    return `MultiEdit failed at ${label}: old_string was not found — it does not appear in the original file either. Re-Read the file and copy the text exactly, including whitespace and indentation. No changes were written.`;
+  }
+  let text = original;
+  let culprit = 0;
+  for (let j = 0; j < failedIndex; j++) {
+    text = substitute(text, edits[j]!).text;
+    if (!text.includes(needle)) {
+      culprit = j + 1;
+      break;
+    }
+  }
+  return `MultiEdit failed at ${label}: old_string matches the ORIGINAL file, but edit #${culprit} in this call already rewrote that text, so it no longer exists when ${label} applies. Edits whose regions overlap must be MERGED into a single edit (or the later old_string authored against the post-edit text). No changes were written.`;
 }
 
 export const multiEditTool: BuiltinTool = {
@@ -212,10 +236,18 @@ export const multiEditTool: BuiltinTool = {
       let text = original;
       const perEdit: number[] = [];
       for (let i = 0; i < edits.length; i++) {
-        const outcome = applyOne(text, edits[i]!, `edit #${i + 1}`);
-        if (typeof outcome === 'string') {
-          return errorResult(outcome);
+        const edit = edits[i]!;
+        const label = `edit #${i + 1}`;
+        const count = countOccurrences(text, edit.oldString);
+        if (count === 0) {
+          return errorResult(diagnoseNotFound(original, edits, i, label));
         }
+        if (count > 1 && !edit.replaceAll) {
+          return errorResult(
+            `MultiEdit failed at ${label}: found ${count} occurrences of old_string. The match must be unique — add more surrounding context, or set replace_all: true. No changes were written.`,
+          );
+        }
+        const outcome = substitute(text, edit);
         text = outcome.text;
         perEdit.push(outcome.replaced);
       }

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.62.0';
+export const SDK_VERSION = '0.62.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/multiedit.test.ts
+++ b/projects/silver-core-sdk/tests/multiedit.test.ts
@@ -136,6 +136,50 @@ describe('MultiEdit tool', () => {
     expect(await readFile(file, 'utf8')).toBe(original);
   });
 
+  it('triages a not-found old_string that never existed: says so and points at Read', async () => {
+    const file = path.join(sandbox, 'triage-absent.txt');
+    const original = 'one\ntwo\n';
+    await writeFile(file, original, 'utf8');
+
+    const res = await multiEditTool.execute(
+      { file_path: file, edits: [{ old_string: 'NEVER-THERE', new_string: 'x' }] },
+      makeCtx(sandbox),
+    );
+
+    expect(res.isError).toBe(true);
+    expect(String(res.content)).toContain('does not appear in the original file');
+    expect(String(res.content)).toContain('Re-Read');
+    expect(await readFile(file, 'utf8')).toBe(original);
+  });
+
+  it('triages a not-found old_string consumed by an earlier edit: names the culprit', async () => {
+    const file = path.join(sandbox, 'triage-overlap.txt');
+    const original = 'alpha\nbeta\ngamma\n';
+    await writeFile(file, original, 'utf8');
+
+    // Edit #1 rewrites "beta"; edit #3's old_string was authored against the
+    // ORIGINAL file and includes that now-gone line — the classic overlap trap.
+    const res = await multiEditTool.execute(
+      {
+        file_path: file,
+        edits: [
+          { old_string: 'beta', new_string: 'BETA' },
+          { old_string: 'alpha', new_string: 'ALPHA' },
+          { old_string: 'beta\ngamma', new_string: 'X' },
+        ],
+      },
+      makeCtx(sandbox),
+    );
+
+    expect(res.isError).toBe(true);
+    expect(String(res.content)).toContain('edit #3');
+    expect(String(res.content)).toContain('matches the ORIGINAL file');
+    expect(String(res.content)).toContain('edit #1');
+    expect(String(res.content)).toContain('MERGED into a single edit');
+    // Atomic: nothing written despite edits #1 and #2 having applied in memory.
+    expect(await readFile(file, 'utf8')).toBe(original);
+  });
+
   it('is ATOMIC on a non-unique match without replace_all', async () => {
     const file = path.join(sandbox, 'ambiguous.txt');
     const original = 'dup\ndup\n';


### PR DESCRIPTION
## 概述

修正 `MultiEdit` 的 `old_string was not found` 报错——从一句笼统错误升级为「会分诊」的报错，打断「报错→误修→再报错」的死循环。silver-core-sdk 0.62.0 → 0.62.1。

---

## 变更类型

- [x] Bug 修复
- [x] 文档完善（COMPAT.md 工具表漂移修正 / CHANGELOG）

---

## 变更详情

`MultiEdit` 的多个 edit 顺序作用在同一份快照上，但模型通常照同一份原文一次性写完所有 old_string。于是「edit #N 找不到」有两种截然不同的病因，旧报错无法区分：

- **病因 A（文本压根不存在）**：old_string 原文里就没有（记忆过期／空格对不上）→ 新报错明说「原文里也没有，请重新 Read 文件」。
- **病因 B（被前序 edit 吃掉）**：原文有，但某个更早的 edit 已重写了那段（区域重叠）→ 新报错**重放已验证的前序 edit、点名是第几个 edit 吃掉了匹配**，并给出处方「重叠的 edit 必须合并成一个」。

- `src/tools/multiedit.ts`：not-found 分诊逻辑（`diagnoseNotFound`），原子回滚不变。
- `src/tools/descriptions.ts`：MultiEdit 描述加 OVERLAP RULE 预防条款（SDK-original，`faithful:false`）。
- `docs/COMPAT.md`：修正 0.61.0 之前残留的旧行「MultiEdit UNSUPPORTED / 已被上游退役」（与 CHANGELOG 矛盾）；MultiEdit 独立 FULL 行，NotebookEdit 维持 UNSUPPORTED。
- `tests/multiedit.test.ts`：+2 回归（病因 A、病因 B 分诊路径 + 原子回滚）。
- 版本三处同步（package.json / version.ts / lockfile）0.62.0 → 0.62.1。

---

## 安全声明（强制）

- [x] 本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据（纯 SDK 工程产物）。

---

## 验证清单

- [x] vitest 全量 2448 passed / 3 skipped（含新增 2 例）
- [x] pytest 全量 2925 passed
- [x] `tsc` typecheck + version-bump 守门通过
- [x] 不引入 emoji
- [x] 未改 `memory/decisions.md` / `memory/lessons-learned.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYoWq3akS66ZMajA4BYCME

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYoWq3akS66ZMajA4BYCME)_