### PR TITLE
docs(claude-md): register intel-weekly skill; test: defuse date-bomb fixture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,7 +441,9 @@ MCP 服务端 `biav-sc-memory`（`scripts/mcp_server.py`）对接知识层工具
 
 `.claude/commands/`：`/biav-report` `/daily-news` `/sync-memory` `/validate-data`；
 `.claude/skills/`：`anysearch`（实时网络检索）、`grill`（拷问对齐并落档，user-invoked）、
-`grilling`（核心拷问循环）、`domain-modeling`（术语锐化 + 决策落档）。技能写作审计标尺见
+`grilling`（核心拷问循环）、`domain-modeling`（术语锐化 + 决策落档）、`intel-weekly`
+（社区情报周报生产线：全量档案层取数、固定骨架 + 风险哨兵、移动端 PDF 渲染；
+首期范例 2026-07-12 定稿）。技能写作审计标尺见
 `memory/skill-authoring-standard.md`。详见各自定义文件。
 
 ### §7.6 分支与提交

--- a/tests/test_silent_sources_audit_unit.py
+++ b/tests/test_silent_sources_audit_unit.py
@@ -552,10 +552,17 @@ def test_build_leaf_report_folded_source_leaves(dirs):
 
 
 def test_write_health_embeds_stalled_leaves(dirs):
+    # build_report() 用真实当日（UTC+8）判定，夹具日期必须相对当日生成：
+    # global 写到当日（永不 stalled），jp 固定 2026-06 旧档（永远 stalled）。
+    # 写死 2026-07 固定日期的旧夹具是日期定时炸弹（2026-07-14 起自然变红）。
+    from datetime import datetime, timedelta, timezone
     _, adir, _ = dirs
+    today = datetime.now(timezone.utc) + timedelta(hours=8)
     for d in range(1, 11):
         _write_leaf_day(adir, "appstore/jp", f"2026-06-{d:02d}")
-        _write_leaf_day(adir, "appstore/global", f"2026-07-{d:02d}")
+    for i in range(10):
+        day = (today - timedelta(days=9 - i)).strftime("%Y-%m-%d")
+        _write_leaf_day(adir, "appstore/global", day)
     report = ssa.build_report()
     ssa.write_health(report)
     health = json.loads(ssa.HEALTH_PATH.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Repo-wide audit of CLAUDE.md against the actual repository state (2026-07-16):

- **Audit result**: structure tree (§6), referenced paths, MCP tool roster (11 tools), slash commands (4), archive layout semantics and post-07-12 ruling increments all verified consistent. Single drift found and fixed:
- **CLAUDE.md §7.5**: register the `intel-weekly` skill (weekly community intelligence report pipeline: full-archive-layer sourcing, fixed skeleton + risk sentinels, mobile PDF rendering; first issue finalized 2026-07-12) — it was missing from the skills roster.
- **Test fix (merge-gate unblock)**: `tests/test_silent_sources_audit_unit.py::test_write_health_embeds_stalled_leaves` wrote fixed 2026-07-01..10 fixture dates while `build_report()` judges against the real current date (UTC+8); the test self-reddened from 2026-07-14. Fixture days for `appstore/global` are now generated relative to today; `appstore/jp` keeps fixed 2026-06 days (permanently-stalled is the intended assertion).

## Validation

- CLAUDE.md guard tests (`tests/test_claude_md*.py`): 7 passed.
- Full suite `pytest tests/`: 2925+ passed, 12 skipped; the only remaining local red is `test_kb_governance::test_committed_bundle_structure_matches_sources` (`/sources/weixin.md`) — transient archive drift between the last OKF bundle rebuild (07-16 08:32) and later hourly archive commits; per CLAUDE.md §6.1 content PRs must not rebuild `okf/`, and the drift self-heals via the scheduled rebuild on main. Auto-skipped in CI's sparse checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K71DSSsgmsXjjadsH6Q8cX

---
_Generated by [Claude Code](https://claude.ai/code/session_01K71DSSsgmsXjjadsH6Q8cX)_