### PR TITLE
test: formalize the priced-model fixture (pricedReplyEvents)

### DIFF
--- a/projects/silver-core-sdk/tests/helpers/mock-transport.ts
+++ b/projects/silver-core-sdk/tests/helpers/mock-transport.ts
@@ -72,6 +72,26 @@ export function textReplyEvents(
   ];
 }
 
+/**
+ * A PRICED text reply: a response model the pricing table charges for, plus real
+ * input-token usage, so ACCOUNTING-class assertions (total_cost_usd / usage
+ * deltas) are actually exercised. The default `textReplyEvents` model
+ * (`claude-test-1`) is unpriced, so cost stays 0 and under-reporting bugs are
+ * invisible — the exact blind spot behind the 0.62.2 `webSearchRequests`=0 and
+ * 0.62.7 session-end-usage defects (the fixes were only observable once a test
+ * used a priced model). Reach for this in any test that asserts cost/usage.
+ */
+export function pricedReplyEvents(
+  text: string,
+  opts: { inputTokens?: number; model?: string; stopReason?: StopReason } = {},
+): RawMessageStreamEvent[] {
+  return textReplyEvents(text, {
+    model: opts.model ?? 'claude-sonnet-4-5',
+    usage: { input_tokens: opts.inputTokens ?? 100 },
+    ...(opts.stopReason !== undefined ? { stopReason: opts.stopReason } : {}),
+  });
+}
+
 /** Build the event sequence for a reply containing one tool_use block. */
 export function toolUseReplyEvents(
   toolName: string,

--- a/projects/silver-core-sdk/tests/memory-m2.test.ts
+++ b/projects/silver-core-sdk/tests/memory-m2.test.ts
@@ -43,7 +43,12 @@ import type {
   ToolContext,
   APIMessageParam,
 } from '../src/internal/contracts.js';
-import { MockTransport, textReplyEvents, toolUseReplyEvents } from './helpers/mock-transport.js';
+import {
+  MockTransport,
+  pricedReplyEvents,
+  textReplyEvents,
+  toolUseReplyEvents,
+} from './helpers/mock-transport.js';
 import { makeSSEFetch, type SSEFetchStub } from './helpers/sse-fetch.js';
 
 // ---------------------------------------------------------------------------
@@ -349,8 +354,8 @@ describe('R7: session-end progress-card round (query level)', () => {
     // own (already-yielded) result reported — so a corrected final result is
     // emitted carrying the COMPLETE cumulative cost (keeper 2026-07-16 完整修).
     const stub = makeSSEFetch([
-      textReplyEvents('the answer', { model: 'claude-sonnet-4-5', usage: { input_tokens: 100 } }),
-      textReplyEvents('progress saved', { model: 'claude-sonnet-4-5', usage: { input_tokens: 900 } }),
+      pricedReplyEvents('the answer', { inputTokens: 100 }),
+      pricedReplyEvents('progress saved', { inputTokens: 900 }),
     ]);
     const messages = await collectQuery('do the task', baseOptions(stub, { memory: {} }));
     const results = messages.filter((m): m is SDKResultMessage => m.type === 'result');
@@ -358,6 +363,9 @@ describe('R7: session-end progress-card round (query level)', () => {
     const [first, corrected] = results;
     expect(first!.subtype).toBe('success');
     if (first!.subtype === 'success') expect(first!.result).toBe('the answer');
+    // The fixture is genuinely PRICED — if it silently reverted to an unpriced
+    // model, cost would be 0 and this whole accounting assertion would be vacuous.
+    expect(first!.total_cost_usd).toBeGreaterThan(0);
     // Complete cumulative cost (round's spend now included), no new per-turn usage.
     expect(corrected!.total_cost_usd).toBeGreaterThan(first!.total_cost_usd);
     expect(corrected!.num_turns).toBe(0);


### PR DESCRIPTION
## 概述

补齐测试硬化最后一件(根因③:不计价 mock 让记账测试悄悄跑在成本 0、掩盖漏计——正是 webSearchRequests=0 与会话末轮用量漏计的盲区)。把「计价 fixture」从「⑤回归里内联演示」正式抽成命名 helper。纯测试,无 shipped 变更。

## 变更类型

- [x] 其他:测试硬化(计价 fixture)

## 变更详情

- `tests/helpers/mock-transport.ts`:新增 `pricedReplyEvents()`——计价响应模型 + 真实 input-token 用量,附文档注:凡断言 cost/usage 的测试都该用它,别用默认不计价的 `claude-test-1`。
- `tests/memory-m2.test.ts`:⑤ 的「补正最终 result」回归改用该 fixture,并加 `expect(first.total_cost_usd).toBeGreaterThan(0)`——**fixture 一旦被悄悄改回不计价,该断言立即报错**,杜绝「空跑成本 0 却看着绿」。

## 来源声明

不适用:纯 SDK 测试代码。

## 安全声明（强制）

- [x] 不含任何内网 / 黑池 / 未发布数据。

## 验证清单

- [x] vitest 全量 **2484 passed / 3 skipped**
- [x] `tsc` typecheck + version-bump 守门通过(纯测试、无需 bump)
- [x] 不引入 emoji;未改 `memory/decisions.md` / `memory/lessons-learned.md`

## 关联 Issue

- 承接 #702(属性测试);本 PR 补齐测试硬化「计价 fixture」一件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYoWq3akS66ZMajA4BYCME

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYoWq3akS66ZMajA4BYCME)_