### PR TITLE
silver-core-sdk 0.64.6: T50 batch G — fs/exec hang & corruption fixes (F1-F8 + C3)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,54 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.64.6 — 2026-07-17
+
+T50 batch G: fs/exec hang & corruption fixes (9 items, P0-availability) from
+the second-round audit
+(`Public-Info-Pool/Resource/repo-engineering/silver-core-sdk-bug-audit-r2-20260717.md`).
+No new surfaces; pure bug fixes + regression suite `tests/batch-g-fs-exec.test.ts`.
+(The MultiEdit fixes below land on a tool that 0.64.4 soft-deprecated — it
+still ships and works, so it still must not corrupt.)
+
+- **F1** Glob/Grep no longer follow directory symlinks (`followSymbolicLinks:
+  false`, ripgrep default parity): a self-referential or sibling-pair loop
+  symlink used to blow enumeration up to 2^depth — an uninterruptible
+  measured hang.
+- **F2** CRLF files are editable again: Edit/MultiEdit adapt an LF-authored
+  multi-line `old_string` (the only form the model can produce from Read's
+  CR-stripped view) to the file's `\r\n` style, preserving its line endings
+  (`fsutil.adaptEditToLineEndings`). Before, every multi-line edit of a CRLF
+  file failed identically and unrecoverably.
+- **F3** Read/Edit/MultiEdit/Write now require a REGULAR file: a FIFO passed
+  the directory-only stat gate and `readFile` blocked forever (abort could
+  not settle it); size-0 char devices (`/dev/zero`) bypassed the byte cap.
+- **F4** BashOutput with a `filter` holds back the trailing partial line of a
+  running shell's window, so the line-anchored regex never tests a chunk
+  fragment ("ERR" + "OR: x" both failing `/^ERROR/` — the line was dropped
+  forever). Terminal/truncated streams still drain fully.
+- **F5** Background launches (Bash `run_in_background`, Monitor) now replay
+  the persistent cwd/env state (`withStateReplay`, replay-only — no EXIT-trap
+  capture-back, which would clobber foreground state at arbitrary later
+  times). Before, a prior foreground `cd`/`export` silently did not apply,
+  contradicting the tool descriptions.
+- **F6** Grep multiline detection and `-o` extraction now scan the SAME
+  CRLF-normalized text: a pattern crossing a CRLF boundary was detected but
+  extracted zero matches (file silently absent from output), and `$`-anchor
+  behavior flipped between phases.
+- **F7** A `CLAUDE_CODE_GIT_BASH_PATH` override containing a path separator
+  is existence-probed and pinned absolute (spawn does no PATH resolution for
+  separator-bearing names — the old exemption of all non-absolute overrides
+  handed spawn a doomed relative path).
+- **F8** Write is atomic: sibling tmp file + rename (mode preserved, symlink
+  targets resolved so the write still lands through the link). The old
+  direct O_TRUNC open destroyed the previous content the moment the file was
+  opened — an abort/crash mid-write left it empty with no pre-image.
+- **C3** tool-dispatch decides `sandboxEscape` from the FINAL input: a
+  PreToolUse/canUseTool rewrite that added `dangerouslyDisableSandbox: true`
+  AFTER the permission check used to run the command outside the sandbox
+  without the dedicated escape ask; the smuggled flag is now stripped
+  (trusted-side rewrite) and logged.
+
 ## 0.64.5 — 2026-07-17
 
 T50 batch H: memory-tool correctness, all 6 defects from the second-pass audit
@@ -52,7 +100,6 @@ exported mount helpers.
 - Adjacent hardening: the single replacement is spliced by index instead of
   `String.replace`, so `$&`-style replacement patterns in `new_str` are
   written literally instead of expanding.
-
 ## 0.64.4 — 2026-07-17
 
 MultiEdit DEPRECATED — align with upstream (keeper 2026-07-17). Official Claude

--- a/projects/silver-core-sdk/package-lock.json
+++ b/projects/silver-core-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.64.5",
+  "version": "0.64.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silver-core-sdk",
-      "version": "0.64.5",
+      "version": "0.64.6",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.64.5",
+  "version": "0.64.6",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/tool-dispatch.ts
+++ b/projects/silver-core-sdk/src/engine/tool-dispatch.ts
@@ -372,6 +372,29 @@ export function createToolDispatcher(cfg: ToolDispatcherConfig): {
     }
     input = check.updatedInput; // union now narrows to {decision:'allow'; updatedInput}
 
+    // C3 (audit 2026-07-17): the sandboxEscape ask above was decided from the
+    // PRE-rewrite input. A PreToolUse hook / canUseTool rewrite that ADDS
+    // `dangerouslyDisableSandbox: true` in its updatedInput lands here AFTER
+    // the gate ran without the dedicated escape ask — the command would run
+    // outside the sandbox with no escape-specific authorization. Trusted-side
+    // rewrite: strip the smuggled flag (the rewriter can re-issue the call
+    // with the flag set up front to get the proper ask). The reverse rewrite
+    // (removing the flag after an escape ask) only over-asks and is safe.
+    if (
+      toolName === 'Bash' &&
+      !sandboxEscape &&
+      input['dangerouslyDisableSandbox'] === true &&
+      sbx !== undefined &&
+      sbx.allowEscape
+    ) {
+      input = { ...input };
+      delete input['dangerouslyDisableSandbox'];
+      deps.debug(
+        'tool-dispatch: dropped dangerouslyDisableSandbox added by an input ' +
+          'rewrite after the sandbox-escape check (escape requires its own ask)',
+      );
+    }
+
     // 3. Execute: builtin -> MCP. Existence was verified at step 0, so exactly
     //    one branch runs; the final else is an unreachable safety net.
     const execStart = Date.now();

--- a/projects/silver-core-sdk/src/tools/bash.ts
+++ b/projects/silver-core-sdk/src/tools/bash.ts
@@ -266,11 +266,8 @@ function formatStreams(stdout: string, stderr: string): string {
  * No-op on POSIX (mkdtemp paths have no backslashes there).
  */
 export function withPersistentState(command: string, stateDir: string): string {
-  const bashStateDir = stateDir.replace(/\\/g, '/');
   return [
-    `__bpt_state='${bashStateDir}'`,
-    'if [ -f "$__bpt_state/cwd" ]; then cd -- "$(cat "$__bpt_state/cwd")" 2>/dev/null || true; fi',
-    'if [ -f "$__bpt_state/env" ]; then { . "$__bpt_state/env"; } 2>/dev/null || true; fi',
+    ...stateReplayPrologue(stateDir),
     '__bpt_persist() {',
     '  pwd > "$__bpt_state/cwd" 2>/dev/null || true',
     '  export -p > "$__bpt_state/env" 2>/dev/null || true',
@@ -278,6 +275,30 @@ export function withPersistentState(command: string, stateDir: string): string {
     'trap __bpt_persist EXIT',
     command,
   ].join('\n');
+}
+
+/** Shared replay prologue: restore the previous foreground call's cwd + env. */
+function stateReplayPrologue(stateDir: string): string[] {
+  const bashStateDir = stateDir.replace(/\\/g, '/');
+  return [
+    `__bpt_state='${bashStateDir}'`,
+    'if [ -f "$__bpt_state/cwd" ]; then cd -- "$(cat "$__bpt_state/cwd")" 2>/dev/null || true; fi',
+    'if [ -f "$__bpt_state/env" ]; then { . "$__bpt_state/env"; } 2>/dev/null || true; fi',
+  ];
+}
+
+/**
+ * Replay-ONLY variant for background launches (F5, audit 2026-07-17). A
+ * background command used to run with no persistent-state wrapper at all, so
+ * a prior foreground `cd`/`export` silently did not apply — directly
+ * contradicting the tool description ("working directory persists") and
+ * Monitor's "same shell environment". Background shells now REPLAY the state
+ * snapshot at launch but never capture back: a background process exits at an
+ * arbitrary later time, and an EXIT trap there would clobber state persisted
+ * by foreground commands that ran in between.
+ */
+export function withStateReplay(command: string, stateDir: string): string {
+  return [...stateReplayPrologue(stateDir), command].join('\n');
 }
 
 /**
@@ -466,6 +487,12 @@ async function execute(
           isError: true,
         };
       }
+      // F5: background commands see the persistent cwd/env state too —
+      // replay-only (no capture-back; see withStateReplay).
+      const bgCommand =
+        ctx.shells.stateDir !== ''
+          ? withStateReplay(command, ctx.shells.stateDir)
+          : command;
       // Windows-aware shell resolution (see shell-resolve.ts): candidates are
       // tried in order; an empty list means no POSIX shell on this host.
       const bgShells = resolvePosixShells(ctx.env as Record<string, string | undefined>);
@@ -473,7 +500,7 @@ async function execute(
         error: SHELL_NOT_FOUND_GUIDANCE,
       };
       for (const shell of bgShells) {
-        launched = await ctx.shells.spawnBackground(shell, command, ctx, disableSandbox);
+        launched = await ctx.shells.spawnBackground(shell, bgCommand, ctx, disableSandbox);
         if (!('error' in launched)) break;
       }
       if ('error' in launched) {

--- a/projects/silver-core-sdk/src/tools/edit.ts
+++ b/projects/silver-core-sdk/src/tools/edit.ts
@@ -12,7 +12,13 @@ import type {
   ToolResultPayload,
 } from '../internal/contracts.js';
 import { AbortError, isAbortError } from '../errors.js';
-import { formatCatN, isLossyUtf8, looksBinary, resolveAbs } from './fsutil.js';
+import {
+  adaptEditToLineEndings,
+  formatCatN,
+  isLossyUtf8,
+  looksBinary,
+  resolveAbs,
+} from './fsutil.js';
 import { EDIT_DESCRIPTION } from './descriptions.js';
 
 /** Context lines shown around the first edit site in the success snippet. */
@@ -125,6 +131,14 @@ export const editTool: BuiltinTool = {
         if (st.isDirectory()) {
           return errorResult(`Edit failed: "${abs}" is a directory, not a file.`);
         }
+        // F3 (audit 2026-07-17): a FIFO / device / socket passes the directory
+        // check but readFile on it blocks forever (FIFO with no writer) and
+        // abort cannot settle it. Only regular files are editable.
+        if (!st.isFile()) {
+          return errorResult(
+            `Edit failed: "${abs}" is not a regular file (FIFO/device/socket); editing it is not supported.`,
+          );
+        }
       } catch (e) {
         if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
           return errorResult(`Edit failed: file does not exist: "${abs}".`);
@@ -162,7 +176,15 @@ export const editTool: BuiltinTool = {
       }
       const text = buf.toString('utf8');
 
-      const count = countOccurrences(text, oldString);
+      // F2 (audit 2026-07-17): Read strips `\r` per line, so a multi-line
+      // old_string copied from a Read of a CRLF file can never match the raw
+      // content — adapt both strings to the file's `\r\n` style when the
+      // direct match misses (fsutil.adaptEditToLineEndings).
+      const adapted = adaptEditToLineEndings(text, oldString, newString);
+      const effOld = adapted.oldString;
+      const effNew = adapted.newString;
+
+      const count = countOccurrences(text, effOld);
       if (count === 0) {
         return errorResult(
           `Edit failed: old_string was not found in "${abs}". It must match the file contents exactly, including whitespace and indentation.`,
@@ -176,12 +198,12 @@ export const editTool: BuiltinTool = {
 
       // String-based splicing on purpose: String.prototype.replace would
       // interpret $-patterns in the replacement text.
-      const firstIdx = text.indexOf(oldString);
+      const firstIdx = text.indexOf(effOld);
       const updated = replaceAll
-        ? text.split(oldString).join(newString)
+        ? text.split(effOld).join(effNew)
         : text.slice(0, firstIdx) +
-          newString +
-          text.slice(firstIdx + oldString.length);
+          effNew +
+          text.slice(firstIdx + effOld.length);
 
       // Capture the pre-image BEFORE mutating so Query.rewindFiles() can
       // restore it. `text` is the original content already read for the edit.
@@ -206,7 +228,7 @@ export const editTool: BuiltinTool = {
       // so a follow-up Write is not blocked.
       ctx.readFilePaths?.add(abs);
       ctx.debug(`Edit: ${abs} replaced ${replaced} occurrence(s)`);
-      const snippet = buildSnippet(updated, firstIdx, newString);
+      const snippet = buildSnippet(updated, firstIdx, effNew);
       return {
         content:
           `Replaced ${replaced} occurrence${replaced === 1 ? '' : 's'} of old_string in "${abs}".\n` +

--- a/projects/silver-core-sdk/src/tools/fsutil.ts
+++ b/projects/silver-core-sdk/src/tools/fsutil.ts
@@ -71,6 +71,38 @@ export function isLossyUtf8(buf: Buffer): boolean {
   return !isUtf8(buf);
 }
 
+/**
+ * CRLF adaptation for exact-string edits (F2, audit 2026-07-17). Read strips
+ * the `\r` from every displayed line, so a multi-line old_string the model
+ * copied from a Read of a CRLF file carries bare `\n` separators and can NEVER
+ * match the raw `\r\n` content — every retry fails identically. When the
+ * direct match misses on a CRLF file, retry with the needle's newlines
+ * converted to `\r\n` (and the replacement normalized to `\r\n` so the file's
+ * line-ending style is preserved). A needle that already contains `\r\n` was
+ * authored against the raw bytes and is left alone.
+ */
+export function adaptEditToLineEndings(
+  text: string,
+  oldString: string,
+  newString: string,
+): { oldString: string; newString: string } {
+  if (
+    !text.includes(oldString) &&
+    text.includes('\r\n') &&
+    oldString.includes('\n') &&
+    !oldString.includes('\r\n')
+  ) {
+    const crlfOld = oldString.replace(/\n/g, '\r\n');
+    if (text.includes(crlfOld)) {
+      return {
+        oldString: crlfOld,
+        newString: newString.replace(/\r?\n/g, '\r\n'),
+      };
+    }
+  }
+  return { oldString, newString };
+}
+
 /** Heuristic binary sniff: any NUL byte anywhere in the buffer. The old
  *  first-8KB sniff passed files whose NUL bytes sit past the head (text
  *  header + binary tail) and Edit then corrupted the tail (audit 2026-07-17

--- a/projects/silver-core-sdk/src/tools/glob.ts
+++ b/projects/silver-core-sdk/src/tools/glob.ts
@@ -82,6 +82,13 @@ export const globTool: BuiltinTool = {
       ignore: IGNORE_PATTERNS,
       stats: true,
       suppressErrors: true,
+      // F1 (audit 2026-07-17): fast-glob follows directory symlinks by
+      // default with NO cycle guard — a self-referential link returns the
+      // same file dozens of times, and two sibling loop links blow up
+      // enumeration to 2^depth (measured: >20s, and the AbortSignal is only
+      // checked after the await, so the hang is uninterruptible). ripgrep
+      // does not follow symlinks by default either; match that.
+      followSymbolicLinks: false,
     });
     if (ctx.signal.aborted) throw new AbortError();
 

--- a/projects/silver-core-sdk/src/tools/grep.ts
+++ b/projects/silver-core-sdk/src/tools/grep.ts
@@ -118,6 +118,13 @@ function clipLine(s: string): string {
 }
 
 type FileScan = {
+  /** CRLF-normalized file content (`\r\n` -> `\n`) — the single text every
+   *  scan phase runs on (F6, audit 2026-07-17: detection used to scan the RAW
+   *  text while -o extraction scanned a CR-stripped rebuild, so a pattern
+   *  crossing a CRLF boundary was detected yet extracted zero matches — the
+   *  file silently vanished from the output — and `$`-anchor behavior
+   *  flipped between the two phases). */
+  text: string;
   /** File content split into lines (trailing empty line dropped). */
   lines: string[];
   /** Sorted, de-duplicated 0-based indices of matching lines. */
@@ -147,8 +154,12 @@ async function scanFile(
   }
   if (looksBinary(buf)) return null;
 
-  const text = buf.toString('utf8');
-  const lines = text.split(/\r?\n/);
+  // CRLF-normalize ONCE so line splitting, multiline detection and -o
+  // extraction all see the same text (F6). Lone `\r` was never a separator
+  // before and still is not.
+  const raw = buf.toString('utf8');
+  const text = raw.includes('\r') ? raw.replace(/\r\n/g, '\n') : raw;
+  const lines = text.split('\n');
   if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
 
   const matchSet = new Set<number>();
@@ -174,7 +185,7 @@ async function scanFile(
       if (re.test(lines[i] ?? '')) matchSet.add(i);
     }
   }
-  return { lines, matches: [...matchSet].sort((a, b) => a - b) };
+  return { text, lines, matches: [...matchSet].sort((a, b) => a - b) };
 }
 
 type Hunk = { start: number; end: number };
@@ -420,6 +431,10 @@ export const grepTool: BuiltinTool = {
         onlyFiles: true,
         ignore: IGNORE_PATTERNS,
         suppressErrors: true,
+        // F1 (audit 2026-07-17): same symlink-loop guard as Glob — fast-glob
+        // follows directory symlinks with no cycle detection (2^depth blowup
+        // on sibling loop links, uninterruptible). ripgrep default parity.
+        followSymbolicLinks: false,
       });
       if (globPattern && typePatterns) {
         // glob narrowed further by type extensions.
@@ -472,10 +487,11 @@ export const grepTool: BuiltinTool = {
         if (multiline) {
           // A multiline pattern's match can SPAN newlines, so a per-line exec
           // would extract nothing and report "No matches found" for a file the
-          // scanner already flagged as matching. Scan the reconstructed whole
-          // content instead and emit each match with its STARTING line number
-          // (ripgrep -oU semantics).
-          const text = scan.lines.join('\n');
+          // scanner already flagged as matching. Scan the SAME normalized text
+          // the detection pass ran on (F6: a rebuilt approximation diverged
+          // from it on CRLF files) and emit each match with its STARTING line
+          // number (ripgrep -oU semantics).
+          const text = scan.text;
           const offsets = lineStartOffsets(text);
           let m: RegExpExecArray | null;
           while ((m = re.exec(text)) !== null) {

--- a/projects/silver-core-sdk/src/tools/monitor.ts
+++ b/projects/silver-core-sdk/src/tools/monitor.ts
@@ -33,6 +33,7 @@ import type {
 } from '../internal/contracts.js';
 import { AbortError } from '../errors.js';
 import { resolvePosixShells, SHELL_NOT_FOUND_GUIDANCE } from './shell-resolve.js';
+import { withStateReplay } from './bash.js';
 import { MONITOR_DESCRIPTION } from './descriptions.js';
 
 /** Default watch timeout (ms) when `timeout_ms` is omitted (this SDK's default). */
@@ -131,11 +132,15 @@ export const monitorTool: BuiltinTool = {
       };
     }
 
+    // F5: the watch sees the persistent cwd/env state ("same shell
+    // environment"), replay-only — same wrapper as Bash run_in_background.
+    const watchCommand =
+      shellsMgr.stateDir !== '' ? withStateReplay(command, shellsMgr.stateDir) : command;
     // Same Windows-aware shell resolution + launch path as Bash run_in_background.
     const candidates = resolvePosixShells(ctx.env as Record<string, string | undefined>);
     let launched: { id: string } | { error: string } = { error: SHELL_NOT_FOUND_GUIDANCE };
     for (const shell of candidates) {
-      launched = await shellsMgr.spawnBackground(shell, command, ctx);
+      launched = await shellsMgr.spawnBackground(shell, watchCommand, ctx);
       if (!('error' in launched)) break;
     }
     if ('error' in launched) {

--- a/projects/silver-core-sdk/src/tools/multiedit.ts
+++ b/projects/silver-core-sdk/src/tools/multiedit.ts
@@ -28,7 +28,12 @@ import type {
   ToolResultPayload,
 } from '../internal/contracts.js';
 import { AbortError, isAbortError } from '../errors.js';
-import { isLossyUtf8, looksBinary, resolveAbs } from './fsutil.js';
+import {
+  adaptEditToLineEndings,
+  isLossyUtf8,
+  looksBinary,
+  resolveAbs,
+} from './fsutil.js';
 import { MULTIEDIT_DESCRIPTION } from './descriptions.js';
 
 function errorResult(message: string): ToolResultPayload {
@@ -207,6 +212,14 @@ export const multiEditTool: BuiltinTool = {
         if (st.isDirectory()) {
           return errorResult(`MultiEdit failed: "${abs}" is a directory, not a file.`);
         }
+        // F3 (audit 2026-07-17): a FIFO / device / socket passes the directory
+        // check but readFile on it blocks forever. Only regular files are
+        // editable (same gate as Read/Edit).
+        if (!st.isFile()) {
+          return errorResult(
+            `MultiEdit failed: "${abs}" is not a regular file (FIFO/device/socket); editing it is not supported.`,
+          );
+        }
       } catch (e) {
         if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
           return errorResult(`MultiEdit failed: file does not exist: "${abs}".`);
@@ -246,7 +259,12 @@ export const multiEditTool: BuiltinTool = {
       let text = original;
       const perEdit: number[] = [];
       for (let i = 0; i < edits.length; i++) {
-        const edit = edits[i]!;
+        // F2 (audit 2026-07-17): same CRLF adaptation as Edit, applied per
+        // step against the EVOLVING snapshot (a needle authored from Read's
+        // CR-stripped view can never match raw `\r\n` content directly).
+        const raw = edits[i]!;
+        const adapted = adaptEditToLineEndings(text, raw.oldString, raw.newString);
+        const edit: ParsedEdit = { ...raw, ...adapted };
         const label = `edit #${i + 1}`;
         const count = countOccurrences(text, edit.oldString);
         if (count === 0) {

--- a/projects/silver-core-sdk/src/tools/read.ts
+++ b/projects/silver-core-sdk/src/tools/read.ts
@@ -230,6 +230,16 @@ export function createReadTool(limits?: ReadLimits): BuiltinTool {
             `Read failed: "${abs}" is a directory, not a file. Use the Glob tool to list its contents.`,
           );
         }
+        // F3 (audit 2026-07-17): the directory check alone lets special files
+        // through — reading a FIFO with no writer blocks FOREVER (and abort
+        // cannot settle the pending fs read; only SIGKILL frees the process),
+        // and a size-0 char device like /dev/zero slips past the byte-cap
+        // pre-check into an unbounded read. Only regular files are readable.
+        if (!st.isFile()) {
+          return errorResult(
+            `Read failed: "${abs}" is not a regular file (FIFO/device/socket); reading it could block indefinitely.`,
+          );
+        }
         if (st.size > MAX_READ_BYTES) {
           return errorResult(
             `Read failed: "${abs}" is ${st.size} bytes, larger than the ${MAX_READ_BYTES}-byte (${Math.floor(

--- a/projects/silver-core-sdk/src/tools/shell-resolve.ts
+++ b/projects/silver-core-sdk/src/tools/shell-resolve.ts
@@ -20,7 +20,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { isAbsolute } from 'node:path';
+import * as path from 'node:path';
 
 /**
  * Explicit backslash join: these are WINDOWS-ONLY paths, and building them
@@ -65,14 +65,27 @@ export function resolvePosixShells(
   const out: string[] = [];
   const override = env['CLAUDE_CODE_GIT_BASH_PATH'];
   if (typeof override === 'string' && override.length > 0) {
-    // Skip an ABSOLUTE override that does not exist, so the resolver falls
-    // through to the platform defaults (bash/sh, or the Git Bash probes) rather
-    // than handing a doomed path to spawn. This matters most for the BACKGROUND
-    // shell path, which cannot fall back on its own — spawn's ENOENT is async
-    // and fires after spawnBackground has already returned a shell id, so a
-    // misconfigured override there is reported "launched" yet never runs. A
-    // bare-name override (no separator) is kept as-is (PATH-resolved by spawn).
-    if (!isAbsolute(override) || probe(override)) out.push(override);
+    // Probe any override that names a PATH-BEARING location before handing it
+    // to spawn, so the resolver falls through to the platform defaults
+    // (bash/sh, or the Git Bash probes) rather than spawning a doomed path.
+    // F7 (audit 2026-07-17): the old check exempted every non-absolute
+    // override, but spawn does NO PATH resolution for a name containing a
+    // separator (`tools/bash`) — it resolves against the child cwd and fails
+    // ENOENT asynchronously, after the launch was already acked. So: a bare
+    // name (no separator) is kept as-is (genuinely PATH-resolved by spawn);
+    // anything with a separator is resolved to an absolute path (pinning the
+    // ambient-cwd interpretation) and must pass the existence probe.
+    if (!/[/\\]/.test(override)) {
+      out.push(override);
+    } else {
+      // Host-independent absoluteness: a `D:\...` override must stay verbatim
+      // even when this resolver runs on a POSIX host (unit tests, WSL-side
+      // tooling) — path.resolve there would mangle it into a relative name.
+      const isAbs =
+        path.posix.isAbsolute(override) || path.win32.isAbsolute(override);
+      const resolved = isAbs ? override : path.resolve(override);
+      if (probe(resolved)) out.push(resolved);
+    }
   }
   if (platform !== 'win32') {
     out.push('bash', 'sh');

--- a/projects/silver-core-sdk/src/tools/shells.ts
+++ b/projects/silver-core-sdk/src/tools/shells.ts
@@ -336,6 +336,29 @@ function filterLines(chunk: string, filter: string | undefined): string {
     .join('\n');
 }
 
+/**
+ * Consume a stream window for a FILTERED read (F4, audit 2026-07-17). The
+ * cursor is a raw char offset, so a poll can land MID-LINE: the line-anchored
+ * filter then tests both fragments ("ERR" now, "OR: x" next poll) and a line
+ * matching `/^ERROR/` is dropped forever. When a filter is active on a
+ * still-running shell, only complete lines (up to the last '\n') are consumed
+ * — the trailing partial line stays unconsumed and is re-tested whole on the
+ * next poll. Once the shell is terminal (or the stream hit its accumulation
+ * cap, i.e. no more data is coming), everything is consumed.
+ */
+function consumeWindow(
+  data: string,
+  cursor: number,
+  holdPartialTail: boolean,
+): { chunk: string; nextCursor: number } {
+  if (!holdPartialTail) {
+    return { chunk: data.slice(cursor), nextCursor: data.length };
+  }
+  const lastNl = data.lastIndexOf('\n');
+  const end = lastNl >= cursor ? lastNl + 1 : cursor;
+  return { chunk: data.slice(cursor, end), nextCursor: end };
+}
+
 export const bashOutputTool: BuiltinTool = {
   name: 'BashOutput',
   description:
@@ -405,14 +428,25 @@ export const bashOutputTool: BuiltinTool = {
         };
       }
     }
-    const newOut = rec.stdout.slice(rec.cursorOut);
-    const newErr = rec.stderr.slice(rec.cursorErr);
-    rec.cursorOut = rec.stdout.length;
-    rec.cursorErr = rec.stderr.length;
+    // F4: with an active filter on a running shell, hold back the trailing
+    // partial line so the line-anchored regex never tests a chunk fragment.
+    const holding = filter !== undefined && rec.status === 'running';
+    const winOut = consumeWindow(
+      rec.stdout,
+      rec.cursorOut,
+      holding && !rec.stdoutTruncated,
+    );
+    const winErr = consumeWindow(
+      rec.stderr,
+      rec.cursorErr,
+      holding && !rec.stderrTruncated,
+    );
+    rec.cursorOut = winOut.nextCursor;
+    rec.cursorErr = winErr.nextCursor;
 
     const parts: string[] = [describeStatus(rec)];
-    const out = filterLines(newOut, filter);
-    const err = filterLines(newErr, filter);
+    const out = filterLines(winOut.chunk, filter);
+    const err = filterLines(winErr.chunk, filter);
     if (out.length > 0) parts.push(out);
     if (err.length > 0) parts.push(`[stderr]\n${err}`);
     if (out.length === 0 && err.length === 0) parts.push('(no new output)');

--- a/projects/silver-core-sdk/src/tools/write.ts
+++ b/projects/silver-core-sdk/src/tools/write.ts
@@ -7,7 +7,16 @@
  */
 
 import { Buffer } from 'node:buffer';
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import {
+  mkdir,
+  readFile,
+  realpath,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
 import * as path from 'node:path';
 import type {
   BuiltinTool,
@@ -63,6 +72,7 @@ export const writeTool: BuiltinTool = {
 
       // Determine created-vs-overwritten before writing; reject directories.
       let existedBefore = false;
+      let priorMode: number | undefined;
       try {
         const st = await stat(abs);
         if (st.isDirectory()) {
@@ -70,7 +80,16 @@ export const writeTool: BuiltinTool = {
             `Write failed: "${abs}" is a directory; cannot write file content over it.`,
           );
         }
+        // F3/F8 (audit 2026-07-17): writing "over" a FIFO/device/socket either
+        // blocks forever (FIFO with no reader) or clobbers a device node; the
+        // atomic rename below would silently REPLACE the special file. Refuse.
+        if (!st.isFile()) {
+          return errorResult(
+            `Write failed: "${abs}" is not a regular file (FIFO/device/socket); refusing to write over it.`,
+          );
+        }
         existedBefore = true;
+        priorMode = st.mode & 0o7777;
       } catch (e) {
         if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
           throw e;
@@ -130,7 +149,41 @@ export const writeTool: BuiltinTool = {
       }
 
       await mkdir(path.dirname(abs), { recursive: true });
-      await writeFile(abs, content, { encoding: 'utf8', signal: ctx.signal });
+
+      // F8 (audit 2026-07-17): atomic write via tmp + rename. The old direct
+      // O_TRUNC open destroyed the previous content the moment the file was
+      // opened, so an abort/crash between open and write-complete left the
+      // file EMPTY with no result reported (and, without a checkpoint, no
+      // pre-image to recover from). Writing a sibling tmp file and renaming
+      // it over the target makes the swap all-or-nothing: readers see either
+      // the old content or the new, never a torn half. An existing SYMLINK
+      // target is resolved first so the write still lands through the link
+      // (rename would otherwise replace the link itself with a regular file).
+      // Known tradeoff of rename-based atomicity: a multi-hard-link target
+      // gets a fresh inode (the other links keep the old content).
+      let target = abs;
+      if (existedBefore) {
+        try {
+          target = await realpath(abs);
+        } catch {
+          target = abs; // best-effort; fall back to the literal path
+        }
+      }
+      const tmp = path.join(
+        path.dirname(target),
+        `.${path.basename(target)}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`,
+      );
+      try {
+        await writeFile(tmp, content, {
+          encoding: 'utf8',
+          signal: ctx.signal,
+          ...(priorMode !== undefined ? { mode: priorMode } : {}),
+        });
+        await rename(tmp, target);
+      } catch (e) {
+        await unlink(tmp).catch(() => {});
+        throw e;
+      }
 
       const bytes = Buffer.byteLength(content, 'utf8');
       // The session knows the bytes it just wrote: register the path so a

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.64.5';
+export const SDK_VERSION = '0.64.6';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/batch-g-fs-exec.test.ts
+++ b/projects/silver-core-sdk/tests/batch-g-fs-exec.test.ts
@@ -1,0 +1,609 @@
+/**
+ * Batch G regression suite (audit r2 2026-07-17): fs/exec hangs & corruption.
+ *
+ *  - F1 Glob/Grep symlink-loop guard (followSymbolicLinks off, ripgrep parity)
+ *  - F2 CRLF-file multi-line Edit/MultiEdit adaptation
+ *  - F3 special-file (FIFO/device) gates on Read/Edit/MultiEdit/Write
+ *  - F4 BashOutput filter never tests a mid-line chunk fragment
+ *  - F5 background shells replay the persistent cwd/env state
+ *  - F6 Grep multiline detection and -o extraction scan the SAME text
+ *  - F7 separator-bearing CLAUDE_CODE_GIT_BASH_PATH overrides are probed
+ *  - F8 Write is atomic (tmp+rename), preserves mode, writes through symlinks
+ *  - C3 a post-check input rewrite cannot smuggle dangerouslyDisableSandbox
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { globTool } from '../src/tools/glob.js';
+import { grepTool } from '../src/tools/grep.js';
+import { readTool } from '../src/tools/read.js';
+import { editTool } from '../src/tools/edit.js';
+import { multiEditTool } from '../src/tools/multiedit.js';
+import { writeTool } from '../src/tools/write.js';
+import {
+  bashTool,
+  withPersistentState,
+  withStateReplay,
+} from '../src/tools/bash.js';
+import { bashOutputTool, createShellManager } from '../src/tools/shells.js';
+import { resolvePosixShells } from '../src/tools/shell-resolve.js';
+import { createToolDispatcher } from '../src/engine/tool-dispatch.js';
+import type {
+  BackgroundShell,
+  BuiltinTool,
+  ShellManager,
+  ToolContext,
+} from '../src/internal/contracts.js';
+import type { SandboxContext } from '../src/types.js';
+
+const posixIt = it.skipIf(process.platform === 'win32');
+
+let sandboxes: string[] = [];
+
+async function makeSandbox(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'batch-g-test-'));
+  sandboxes.push(dir);
+  return dir;
+}
+
+function makeCtx(cwd: string, extra: Partial<ToolContext> = {}): ToolContext {
+  return {
+    cwd,
+    additionalDirectories: [],
+    env: {},
+    signal: new AbortController().signal,
+    debug: () => {},
+    ...extra,
+  };
+}
+
+/** A ctx whose read-before-write gate is armed and already unlocks `abs`. */
+function gatedCtx(cwd: string, abs: string, extra: Partial<ToolContext> = {}): ToolContext {
+  return makeCtx(cwd, { readFilePaths: new Set([abs]), ...extra });
+}
+
+let sandbox: string;
+
+beforeEach(async () => {
+  sandboxes = [];
+  sandbox = await makeSandbox();
+});
+
+afterEach(async () => {
+  await Promise.all(sandboxes.map((d) => rm(d, { recursive: true, force: true })));
+  sandboxes = [];
+});
+
+// ---------------------------------------------------------------------------
+// F1: symlink loops must not hang or duplicate enumeration
+// ---------------------------------------------------------------------------
+
+describe('F1: Glob/Grep symlink-loop guard', () => {
+  posixIt('Glob returns a file exactly once despite a self-referential dir symlink', async () => {
+    await writeFile(path.join(sandbox, 'a.txt'), 'hello\n', 'utf8');
+    await symlink('.', path.join(sandbox, 'loop'));
+
+    const res = await globTool.execute({ pattern: '**/*.txt' }, makeCtx(sandbox));
+    expect(res.isError).toBeFalsy();
+    const lines = String(res.content).split('\n');
+    expect(lines.filter((l) => l.endsWith('a.txt'))).toHaveLength(1);
+  });
+
+  posixIt('Glob/Grep terminate promptly on two sibling loop symlinks (2^depth blowup before)', async () => {
+    // x/to_y -> ../y and y/to_x -> ../x: with symlink-following this pair
+    // multiplies paths exponentially; the fix must finish within the test
+    // timeout and find the file exactly once.
+    await mkdir(path.join(sandbox, 'x'));
+    await mkdir(path.join(sandbox, 'y'));
+    await writeFile(path.join(sandbox, 'x', 'f.txt'), 'needle-F1\n', 'utf8');
+    await symlink(path.join('..', 'y'), path.join(sandbox, 'x', 'to_y'));
+    await symlink(path.join('..', 'x'), path.join(sandbox, 'y', 'to_x'));
+
+    const g = await globTool.execute({ pattern: '**/*.txt' }, makeCtx(sandbox));
+    expect(String(g.content).split('\n').filter((l) => l.endsWith('f.txt'))).toHaveLength(1);
+
+    const r = await grepTool.execute(
+      { pattern: 'needle-F1', output_mode: 'files_with_matches' },
+      makeCtx(sandbox),
+    );
+    expect(String(r.content).split('\n').filter((l) => l.endsWith('f.txt'))).toHaveLength(1);
+  }, 15_000);
+});
+
+// ---------------------------------------------------------------------------
+// F2: CRLF files must be editable with Read-shaped (LF) old_strings
+// ---------------------------------------------------------------------------
+
+describe('F2: CRLF multi-line edit adaptation', () => {
+  it('Edit matches an LF-authored multi-line old_string against a CRLF file', async () => {
+    const file = path.join(sandbox, 'crlf.txt');
+    await writeFile(file, 'alpha\r\nbeta\r\ngamma\r\n', 'utf8');
+
+    const res = await editTool.execute(
+      { file_path: file, old_string: 'alpha\nbeta', new_string: 'ALPHA\nBETA' },
+      gatedCtx(sandbox, file),
+    );
+    expect(res.isError).toBeFalsy();
+    // The replacement is written in the FILE's line-ending style.
+    expect(await readFile(file, 'utf8')).toBe('ALPHA\r\nBETA\r\ngamma\r\n');
+  });
+
+  it('Edit replace_all adapts every occurrence on a CRLF file', async () => {
+    const file = path.join(sandbox, 'crlf-all.txt');
+    await writeFile(file, 'a\r\nb\r\nz\r\na\r\nb\r\n', 'utf8');
+
+    const res = await editTool.execute(
+      { file_path: file, old_string: 'a\nb', new_string: 'c\nd', replace_all: true },
+      gatedCtx(sandbox, file),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(await readFile(file, 'utf8')).toBe('c\r\nd\r\nz\r\nc\r\nd\r\n');
+  });
+
+  it('a raw CRLF-authored old_string still matches directly (no double conversion)', async () => {
+    const file = path.join(sandbox, 'crlf-raw.txt');
+    await writeFile(file, 'one\r\ntwo\r\n', 'utf8');
+
+    const res = await editTool.execute(
+      { file_path: file, old_string: 'one\r\ntwo', new_string: 'ONE\r\nTWO' },
+      gatedCtx(sandbox, file),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(await readFile(file, 'utf8')).toBe('ONE\r\nTWO\r\n');
+  });
+
+  it('MultiEdit applies an LF-authored chain against a CRLF file', async () => {
+    const file = path.join(sandbox, 'crlf-multi.txt');
+    await writeFile(file, 'alpha\r\nbeta\r\ngamma\r\n', 'utf8');
+
+    const res = await multiEditTool.execute(
+      {
+        file_path: file,
+        edits: [
+          { old_string: 'alpha\nbeta', new_string: 'ALPHA\nbeta' },
+          { old_string: 'beta\ngamma', new_string: 'BETA\nGAMMA' },
+        ],
+      },
+      gatedCtx(sandbox, file),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(await readFile(file, 'utf8')).toBe('ALPHA\r\nBETA\r\nGAMMA\r\n');
+  });
+
+  it('LF files are untouched by the adaptation (exact match still required)', async () => {
+    const file = path.join(sandbox, 'lf.txt');
+    await writeFile(file, 'alpha\nbeta\n', 'utf8');
+
+    const miss = await editTool.execute(
+      { file_path: file, old_string: 'alpha\r\nbeta', new_string: 'x' },
+      gatedCtx(sandbox, file),
+    );
+    expect(miss.isError).toBe(true); // a CRLF needle on an LF file is a real miss
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F3: special files must be refused, not read/edited/overwritten
+// ---------------------------------------------------------------------------
+
+describe('F3: non-regular-file gates', () => {
+  posixIt('Read refuses a FIFO instead of blocking forever', async () => {
+    const fifo = path.join(sandbox, 'pipe');
+    expect(spawnSync('mkfifo', [fifo]).status).toBe(0);
+
+    const res = await readTool.execute({ file_path: fifo }, makeCtx(sandbox));
+    expect(res.isError).toBe(true);
+    expect(String(res.content)).toContain('not a regular file');
+  });
+
+  posixIt('Read refuses a character device (size-0 cap bypass)', async () => {
+    const res = await readTool.execute({ file_path: '/dev/null' }, makeCtx(sandbox));
+    expect(res.isError).toBe(true);
+    expect(String(res.content)).toContain('not a regular file');
+  });
+
+  posixIt('Edit / MultiEdit / Write refuse a FIFO', async () => {
+    const fifo = path.join(sandbox, 'pipe2');
+    expect(spawnSync('mkfifo', [fifo]).status).toBe(0);
+    const ctx = gatedCtx(sandbox, fifo);
+
+    const e = await editTool.execute(
+      { file_path: fifo, old_string: 'a', new_string: 'b' },
+      ctx,
+    );
+    expect(e.isError).toBe(true);
+    expect(String(e.content)).toContain('not a regular file');
+
+    const m = await multiEditTool.execute(
+      { file_path: fifo, edits: [{ old_string: 'a', new_string: 'b' }] },
+      ctx,
+    );
+    expect(m.isError).toBe(true);
+    expect(String(m.content)).toContain('not a regular file');
+
+    const w = await writeTool.execute({ file_path: fifo, content: 'x' }, ctx);
+    expect(w.isError).toBe(true);
+    expect(String(w.content)).toContain('not a regular file');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F4: BashOutput filter vs chunk-boundary line fragments
+// ---------------------------------------------------------------------------
+
+function fakeShellRec(over: Partial<BackgroundShell> = {}): BackgroundShell {
+  return {
+    id: 'bash_1',
+    command: 'test',
+    pid: 1,
+    stdout: '',
+    stdoutTruncated: false,
+    stderr: '',
+    stderrTruncated: false,
+    cursorOut: 0,
+    cursorErr: 0,
+    status: 'running',
+    killRequested: false,
+    exitCode: null,
+    exitSignal: null,
+    kill: () => {},
+    ...over,
+  };
+}
+
+function fakeShellManager(rec: BackgroundShell): ShellManager {
+  return {
+    stateDir: '',
+    spawnBackground: async () => ({ error: 'unused' }),
+    get: (id) => (id === rec.id ? rec : undefined),
+    kill: () => false,
+    dispose: () => {},
+  };
+}
+
+describe('F4: BashOutput filter holds back partial trailing lines', () => {
+  it('a line split across polls is re-tested whole, never dropped', async () => {
+    const rec = fakeShellRec({ stdout: 'ERR' }); // mid-line chunk boundary
+    const ctx = makeCtx('/', { shells: fakeShellManager(rec) });
+
+    const first = await bashOutputTool.execute(
+      { bash_id: 'bash_1', filter: '^ERROR' },
+      ctx,
+    );
+    expect(String(first.content)).toContain('(no new output)');
+    expect(rec.cursorOut).toBe(0); // fragment NOT consumed
+
+    rec.stdout += 'OR: boom\nnext'; // line completes (+ a new partial tail)
+    const second = await bashOutputTool.execute(
+      { bash_id: 'bash_1', filter: '^ERROR' },
+      ctx,
+    );
+    expect(String(second.content)).toContain('ERROR: boom');
+    expect(rec.cursorOut).toBe('ERROR: boom\n'.length); // tail 'next' held
+  });
+
+  it('a terminal shell consumes the unterminated final line', async () => {
+    const rec = fakeShellRec({
+      stdout: 'ERROR: last',
+      status: 'completed',
+      exitCode: 0,
+    });
+    const ctx = makeCtx('/', { shells: fakeShellManager(rec) });
+
+    const res = await bashOutputTool.execute(
+      { bash_id: 'bash_1', filter: '^ERROR' },
+      ctx,
+    );
+    expect(String(res.content)).toContain('ERROR: last');
+    expect(rec.cursorOut).toBe(rec.stdout.length);
+  });
+
+  it('unfiltered reads still consume everything immediately', async () => {
+    const rec = fakeShellRec({ stdout: 'partial' });
+    const ctx = makeCtx('/', { shells: fakeShellManager(rec) });
+
+    const res = await bashOutputTool.execute({ bash_id: 'bash_1' }, ctx);
+    expect(String(res.content)).toContain('partial');
+    expect(rec.cursorOut).toBe(rec.stdout.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F5: background shells see the persistent cwd/env state (replay-only)
+// ---------------------------------------------------------------------------
+
+describe('F5: background persistent-state replay', () => {
+  it('withStateReplay replays cwd/env but never captures back', () => {
+    const wrapped = withStateReplay('echo hi', '/tmp/state');
+    expect(wrapped).toContain('cd -- "$(cat "$__bpt_state/cwd")"');
+    expect(wrapped).toContain('. "$__bpt_state/env"');
+    expect(wrapped).not.toContain('trap'); // no EXIT-trap capture-back
+    expect(wrapped).not.toContain('__bpt_persist');
+    // The foreground wrapper still captures.
+    expect(withPersistentState('echo hi', '/tmp/state')).toContain('trap __bpt_persist EXIT');
+  });
+
+  posixIt('a background command observes a prior foreground cd/export', async () => {
+    const shells = createShellManager(() => {});
+    try {
+      await mkdir(path.join(sandbox, 'sub'));
+      const ctx = makeCtx(sandbox, { shells, env: process.env as Record<string, string> });
+
+      const fg = await bashTool.execute(
+        { command: 'cd sub && export BATCHG_MARK=hello-f5' },
+        ctx,
+      );
+      expect(fg.isError).toBeFalsy();
+
+      const bg = await bashTool.execute(
+        { command: 'echo "$BATCHG_MARK @ $(pwd)"', run_in_background: true },
+        ctx,
+      );
+      expect(bg.isError).toBeFalsy();
+      const id = /id: (bash_\d+)/.exec(String(bg.content))?.[1];
+      expect(id).toBeDefined();
+
+      // Poll until the background shell exits (bounded).
+      const rec = shells.get(id!);
+      expect(rec).toBeDefined();
+      for (let i = 0; i < 100 && rec!.status === 'running'; i++) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(rec!.status).toBe('completed');
+      expect(rec!.stdout).toContain('hello-f5');
+      expect(rec!.stdout).toContain(`${path.join(sandbox, 'sub')}`);
+    } finally {
+      shells.dispose();
+    }
+  }, 15_000);
+});
+
+// ---------------------------------------------------------------------------
+// F6: Grep multiline detection/extraction consistency on CRLF files
+// ---------------------------------------------------------------------------
+
+describe('F6: Grep multiline CRLF consistency', () => {
+  it('an LF-separator pattern matches a CRLF file in multiline mode', async () => {
+    const file = path.join(sandbox, 'ml.txt');
+    await writeFile(file, 'foo\r\nbar\r\ntail\r\n', 'utf8');
+
+    const content = await grepTool.execute(
+      { pattern: 'foo\\nbar', path: file, multiline: true, output_mode: 'content' },
+      makeCtx(sandbox),
+    );
+    expect(content.isError).toBeFalsy();
+    expect(String(content.content)).toContain('foo');
+    expect(String(content.content)).toContain('bar');
+  });
+
+  it('-o extraction agrees with detection (no silent zero-match file)', async () => {
+    const file = path.join(sandbox, 'ml-o.txt');
+    await writeFile(file, 'foo\r\nbar\r\n', 'utf8');
+
+    const res = await grepTool.execute(
+      {
+        pattern: 'foo\\nbar',
+        path: file,
+        multiline: true,
+        output_mode: 'content',
+        '-o': true,
+      },
+      makeCtx(sandbox),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(String(res.content)).not.toBe('No matches found');
+    expect(String(res.content)).toContain('foo\nbar');
+  });
+
+  it('a raw \\r\\n pattern no longer matches (normalized view is authoritative)', async () => {
+    const file = path.join(sandbox, 'ml-raw.txt');
+    await writeFile(file, 'foo\r\nbar\r\n', 'utf8');
+
+    const res = await grepTool.execute(
+      { pattern: 'foo\\r\\nbar', path: file, multiline: true, output_mode: 'content' },
+      makeCtx(sandbox),
+    );
+    expect(String(res.content)).toBe('No matches found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F7: separator-bearing overrides are probed (and pinned absolute)
+// ---------------------------------------------------------------------------
+
+describe('F7: CLAUDE_CODE_GIT_BASH_PATH relative-path probing', () => {
+  it('a relative override WITH a separator is probed, resolved absolute on hit', () => {
+    const resolved = path.resolve('tools/mybash');
+    expect(
+      resolvePosixShells(
+        { CLAUDE_CODE_GIT_BASH_PATH: 'tools/mybash' },
+        'linux',
+        (p) => p === resolved,
+      ),
+    ).toEqual([resolved, 'bash', 'sh']);
+  });
+
+  it('a relative override WITH a separator that does not exist is dropped', () => {
+    expect(
+      resolvePosixShells(
+        { CLAUDE_CODE_GIT_BASH_PATH: 'tools/mybash' },
+        'linux',
+        () => false,
+      ),
+    ).toEqual(['bash', 'sh']);
+  });
+
+  it('a bare-name override is still passed through for PATH resolution', () => {
+    expect(
+      resolvePosixShells({ CLAUDE_CODE_GIT_BASH_PATH: 'mybash' }, 'linux', () => false),
+    ).toEqual(['mybash', 'bash', 'sh']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F8: atomic Write
+// ---------------------------------------------------------------------------
+
+describe('F8: Write atomicity', () => {
+  it('overwrites leave no tmp residue and preserve the file mode', async () => {
+    const file = path.join(sandbox, 'atomic.txt');
+    await writeFile(file, 'old', 'utf8');
+    await chmod(file, 0o750);
+
+    const res = await writeTool.execute(
+      { file_path: file, content: 'new content' },
+      gatedCtx(sandbox, file),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(await readFile(file, 'utf8')).toBe('new content');
+    if (process.platform !== 'win32') {
+      expect(((await stat(file)).mode & 0o777).toString(8)).toBe('750');
+    }
+    const leftovers = (await readdir(sandbox)).filter((n) => n.includes('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  posixIt('writing through a symlink updates the target, keeps the link a link', async () => {
+    const real = path.join(sandbox, 'real.txt');
+    const link = path.join(sandbox, 'link.txt');
+    await writeFile(real, 'original', 'utf8');
+    await symlink(real, link);
+
+    const res = await writeTool.execute(
+      { file_path: link, content: 'via link' },
+      gatedCtx(sandbox, link),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(await readFile(real, 'utf8')).toBe('via link');
+    expect((await lstat(link)).isSymbolicLink()).toBe(true);
+  });
+
+  it('creating a new file still works (and registers as created)', async () => {
+    const file = path.join(sandbox, 'fresh.txt');
+    const res = await writeTool.execute(
+      { file_path: file, content: 'hello' },
+      makeCtx(sandbox),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(String(res.content)).toContain('Created new file');
+    expect(await readFile(file, 'utf8')).toBe('hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C3: sandbox-escape flag smuggled by a post-check input rewrite
+// ---------------------------------------------------------------------------
+
+describe('C3: sandboxEscape decided from the FINAL input', () => {
+  function makeDispatcher(opts: {
+    updatedInput?: (input: Record<string, unknown>) => Record<string, unknown>;
+    onCheck?: (sandboxEscape: boolean | undefined) => void;
+  }) {
+    const seen: Record<string, unknown>[] = [];
+    const echoBash: BuiltinTool = {
+      name: 'Bash',
+      description: 'echo input',
+      inputSchema: { type: 'object', properties: {} },
+      readOnly: false,
+      execute: async (input) => {
+        seen.push(input);
+        return { content: 'ok' };
+      },
+    };
+    const sandboxCtx = {
+      backend: 'bwrap',
+      tmpDir: '/tmp',
+      writablePaths: [],
+      allowNetwork: true,
+      allowEscape: true,
+    } as unknown as SandboxContext;
+    const debugMessages: string[] = [];
+    const dispatcher = createToolDispatcher({
+      deps: {
+        builtinTools: new Map([['Bash', echoBash]]),
+        mcp: {
+          has: () => false,
+          allTools: () => [],
+          call: async () => {
+            throw new Error('no MCP in this test');
+          },
+        } as never,
+        hooks: {
+          hasHooks: () => false,
+          run: async () => {
+            throw new Error('no hooks in this test');
+          },
+        } as never,
+        permissions: {
+          check: async (
+            _name: string,
+            input: Record<string, unknown>,
+            checkOpts: { sandboxEscape?: boolean },
+          ) => {
+            opts.onCheck?.(checkOpts.sandboxEscape);
+            return {
+              decision: 'allow',
+              updatedInput: opts.updatedInput ? opts.updatedInput(input) : input,
+            };
+          },
+        } as never,
+        toolContext: makeCtx('/', { sandbox: sandboxCtx }),
+        debug: (m: string) => debugMessages.push(m),
+      },
+      sessionId: 'test-session',
+      baseHookFields: { session_id: 'test-session', cwd: '/' },
+      signal: new AbortController().signal,
+      recordTool: () => {},
+    });
+    return { dispatcher, seen, debugMessages };
+  }
+
+  it('a rewrite that ADDS dangerouslyDisableSandbox after the check is stripped', async () => {
+    const { dispatcher, seen, debugMessages } = makeDispatcher({
+      updatedInput: (input) => ({ ...input, dangerouslyDisableSandbox: true }),
+    });
+    const outcome = await dispatcher.executeToolUse({
+      type: 'tool_use',
+      id: 'tu_1',
+      name: 'Bash',
+      input: { command: 'true' },
+    });
+    expect(outcome.result.is_error).toBeFalsy();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!['dangerouslyDisableSandbox']).toBeUndefined();
+    expect(debugMessages.some((m) => m.includes('dropped dangerouslyDisableSandbox'))).toBe(true);
+  });
+
+  it('an up-front escape request still flows through as its own ask', async () => {
+    let checkedEscape: boolean | undefined;
+    const { dispatcher, seen } = makeDispatcher({
+      onCheck: (v) => {
+        checkedEscape = v;
+      },
+    });
+    const outcome = await dispatcher.executeToolUse({
+      type: 'tool_use',
+      id: 'tu_2',
+      name: 'Bash',
+      input: { command: 'true', dangerouslyDisableSandbox: true },
+    });
+    expect(outcome.result.is_error).toBeFalsy();
+    expect(checkedEscape).toBe(true); // the gate saw the escape ask
+    expect(seen[0]!['dangerouslyDisableSandbox']).toBe(true); // and it survives
+  });
+});


### PR DESCRIPTION
## 概述

T50 批 G（P0-可用性）：第二轮审计 105 项中的 fs/exec 挂死与损坏簇 9 项（F1-F8 + C3）全部修复，附回归套件 `tests/batch-g-fs-exec.test.ts`（26 例）。明细权威 = `Public-Info-Pool/Resource/repo-engineering/silver-core-sdk-bug-audit-r2-20260717.md`。

- **F1** Glob/Grep `followSymbolicLinks: false`（ripgrep 默认 parity）——符号链接环 2^深度枚举挂死（实测）根除
- **F2** Edit/MultiEdit CRLF 适配：LF 版多行 old_string（Read 去 `\r` 后模型唯一能写出的形态）自动转 `\r\n` 匹配并保留文件行尾风格（`fsutil.adaptEditToLineEndings`）
- **F3** Read/Edit/MultiEdit/Write 加 `isFile()` 门：FIFO 读永久阻塞（abort 不可解）、`/dev/zero` 绕字节帽，一律拒绝
- **F4** BashOutput 带 filter 时扣住运行中 shell 的尾部半行，行锚定正则不再测碎片；终态/截断流照常全量放行
- **F5** 背景启动（Bash run_in_background / Monitor）套 `withStateReplay`（只回放不回写）——先前 foreground 的 cd/export 现对背景命令生效
- **F6** Grep multiline 检测与 `-o` 提取统一扫同一份 CRLF 归一化文本，跨 CRLF 边界模式不再「检测到却零提取」
- **F7** 含分隔符的 `CLAUDE_CODE_GIT_BASH_PATH` override 过存在性探针并钉成绝对路径（spawn 对含分隔符名不做 PATH 解析）
- **F8** Write 原子化：同目录 tmp + rename（保留 mode、先解析 symlink 目标）；旧 O_TRUNC 直开在 abort/crash 时清空文件且无前像
- **C3** tool-dispatch 以 **rewrite 后**输入判 sandboxEscape：PreToolUse/canUseTool 检查后偷加的 `dangerouslyDisableSandbox` 被剥除并记日志（trusted-side rewrite）

版本 **0.64.6**（两次撞号顺延：#716 取 0.64.4、#717 批 H 取 0.64.5；MultiEdit 虽被 0.64.4 软弃用但仍在船，其损坏修复照常有效）。

## 变更类型

- [x] Bug 修复
- [ ] 其他

## 来源声明

- 不适用：纯 SDK 工程代码，不涉及游戏数据 / 翻译。

## 安全声明（强制）

- [x] 本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。
- [x] 不上传内部美术资产、客户端解包原始文件、未公开剧情草稿。
- [x] 同意按 MIT License 提交贡献。

## 验证清单

- [x] `npx tsc --noEmit` 干净；vitest 全量 **2587 passed / 3 skipped**（rebase 批 H 后复跑，含新增 26 例回归）；仓库级 pytest 2933 绿
- [x] 版本守卫 `check-version-bump.mjs` 三方对账 OK（version.ts + package.json + CHANGELOG 0.64.6）
- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

## 关联 Issue

- Refs `memory/todo.md` T50（批 G）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzutATRy5hAgorFMxYwL3T