### PR TITLE
fix(sdk): T50 batch F — engine compaction/accounting safety net, 8 fixes (0.64.7)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,24 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.64.7 — 2026-07-17
+
+T50 batch F: engine compaction/accounting safety net — 8 fixes from the
+second-pass audit
+(`Public-Info-Pool/Resource/repo-engineering/silver-core-sdk-bug-audit-r2-20260717.md`):
+D1 unmodeled content blocks no longer NaN-poison the history estimate (which
+silently disabled auto-compaction AND the prompt-floor 400 safety net); D2 the
+M5 post-fold overflow check now charges system/tool-defs overhead, so a
+still-oversized view sheds instead of 400ing; D3 a summary API call that fails
+mid-stream books its already-billed partial usage into totals/budget; D4 recap
+truncation is surrogate-safe (no more permanent U+FFFD in folds); D5
+tool-definition overhead estimates are CJK-aware; D6 web_search server-tool
+calls are priced ($10/1k) into estimateCostUsd/maxBudgetUsd; D7
+context-window/output-ceiling tables normalize Bedrock/Vertex model ids; C2
+accumulator seeds omitted start-frame fields as empty strings (no
+"undefinedfoo" / finalize crash). Regression locks in
+`tests/audit-t50-batch-f.test.ts` (20 tests, D2/D3 mutation-checked).
+
 ## 0.64.6 — 2026-07-17
 
 T50 batch G: fs/exec hang & corruption fixes (9 items, P0-availability) from

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-sdk",
-  "version": "0.64.6",
+  "version": "0.64.7",
   "description": "Silver Core SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/accumulator.ts
+++ b/projects/silver-core-sdk/src/engine/accumulator.ts
@@ -8,6 +8,7 @@ import type {
   APIAssistantMessage,
   ContentBlock,
   RawMessageStreamEvent,
+  Usage,
 } from '../types.js';
 
 /**
@@ -91,20 +92,26 @@ export class MessageAccumulator {
         this.requireMessage('content_block_start');
         const cb = event.content_block;
         switch (cb.type) {
+          // C2 (audit r2 2026-07-17): seed fields get the same field-omission
+          // guard the delta handlers already have (`?? ''`). A gateway-rewritten
+          // / non-conformant start frame that omits text/thinking/data would
+          // otherwise seed `undefined`, so the first delta produced the literal
+          // "undefinedfoo" and finalize handed downstream a poisoned block
+          // (signature/input were guarded; these three were not).
           case 'text':
-            this.blocks.set(event.index, { type: 'text', text: cb.text });
+            this.blocks.set(event.index, { type: 'text', text: cb.text ?? '' });
             return;
           case 'thinking':
             this.blocks.set(event.index, {
               type: 'thinking',
-              thinking: cb.thinking,
+              thinking: cb.thinking ?? '',
               signature: cb.signature ?? '',
             });
             return;
           case 'redacted_thinking':
             this.blocks.set(event.index, {
               type: 'redacted_thinking',
-              data: cb.data,
+              data: cb.data ?? '',
             });
             return;
           case 'tool_use':
@@ -248,6 +255,16 @@ export class MessageAccumulator {
         // payloads are surfaced by the transport, never fed here.
         return;
     }
+  }
+
+  /**
+   * Usage reported by the stream so far (message_start seed merged with any
+   * message_delta updates), or undefined when message_start never arrived.
+   * D3 (audit r2 2026-07-17): lets a caller account a billed-but-failed
+   * stream's partial spend instead of silently dropping it.
+   */
+  usageSnapshot(): Usage | undefined {
+    return this.message?.usage;
   }
 
   /** Produce the final assistant message after the stream ends. */

--- a/projects/silver-core-sdk/src/engine/compaction.ts
+++ b/projects/silver-core-sdk/src/engine/compaction.ts
@@ -586,8 +586,8 @@ async function foldViaApi(
       ? await deps.transportForModel(summaryModel, 'compaction')
       : deps.transport;
   const started = Date.now();
+  const acc = new MessageAccumulator();
   try {
-    const acc = new MessageAccumulator();
     for await (const ev of summaryTransport.stream(req)) {
       if (signal.aborted) throw new AbortError();
       acc.feed(ev);
@@ -609,6 +609,16 @@ async function foldViaApi(
       { role: 'assistant', content: [{ type: 'text', text }] },
     ];
   } catch (err) {
+    // D3 (audit r2 2026-07-17): a summary stream that dies AFTER message_start
+    // has already billed its input tokens (~ the whole folded prefix, easily
+    // 100k+), but the sink only fired on the success path — the spend vanished
+    // from totals and maxBudgetUsd. Account whatever usage the stream reported
+    // before failing (message_start seed + any message_delta merges); a
+    // request-phase failure has no message yet and books nothing.
+    const partialUsage = acc.usageSnapshot();
+    if (partialUsage !== undefined) {
+      onSummaryCall?.(summaryModel, normalizeUsage(partialUsage), Date.now() - started);
+    }
     // Never fall back on abort: propagate cancellation as AbortError.
     if (isAbortError(err)) throw err instanceof AbortError ? err : new AbortError();
     deps.debug(
@@ -844,7 +854,14 @@ async function* performCompaction(
       knownPromptFloor !== undefined && preTokens > 0 && knownPromptFloor > preTokens - overheadTokens
         ? knownPromptFloor / Math.max(1, preTokens - overheadTokens)
         : 1;
-    if (Math.round(rawPre * cal) > inputBudget) {
+    // D2 (audit r2 2026-07-17): the next request's prompt is messages PLUS the
+    // system/tool-defs overhead — the trigger (shouldAutoCompact) and preTokens
+    // both add overheadTokens, but this post-fold overflow check compared the
+    // bare message estimate against the full input budget. With a large
+    // system+tools overhead the check believed an overflowing view fit, the
+    // suffix shed never fired, and the next request 400ed "prompt too long" —
+    // the exact failure M5 exists to prevent. Charge the overhead here too.
+    if (Math.round(rawPre * cal) + overheadTokens > inputBudget) {
       const suffixStart = synthetic.length;
       const suffixMsgs = view.messages.slice(suffixStart);
       const shedSuffix = preTierPrefix(suffixMsgs, cfg);
@@ -905,7 +922,7 @@ function buildRecap(prefix: APIMessageParam[]): string {
   }
   const body = lines.join('\n');
   if (body.length <= RECAP_CHAR_CAP) return body;
-  return body.slice(0, RECAP_CHAR_CAP) + '…[truncated]';
+  return sliceSurrogateSafe(body, RECAP_CHAR_CAP) + '…[truncated]';
 }
 
 function recapLines(msg: APIMessageParam): string[] {
@@ -966,5 +983,20 @@ function toolUses(
 }
 
 function firstChars(s: string, n: number): string {
-  return s.length <= n ? s : s.slice(0, n) + '…';
+  return s.length <= n ? s : sliceSurrogateSafe(s, n) + '…';
+}
+
+/**
+ * D4 (audit r2 2026-07-17): truncate to at most n UTF-16 units WITHOUT
+ * splitting a surrogate pair. A bare .slice() cutting an astral codepoint
+ * (emoji, CJK Ext-B) in half writes a lone surrogate into the fold text, which
+ * serializes as U+FFFD on every subsequent wire request — permanently, since
+ * the fold persists. shedToolResultContent is already codepoint-safe; this
+ * closes the recap-cap and per-line paths.
+ */
+function sliceSurrogateSafe(s: string, n: number): string {
+  const cut = s.slice(0, n);
+  const last = cut.charCodeAt(cut.length - 1);
+  // A trailing HIGH surrogate means the cut landed mid-pair: drop it.
+  return last >= 0xd800 && last <= 0xdbff ? cut.slice(0, -1) : cut;
 }

--- a/projects/silver-core-sdk/src/engine/context-window.ts
+++ b/projects/silver-core-sdk/src/engine/context-window.ts
@@ -12,6 +12,8 @@
  * enable it override the window via CompactionOptions.contextWindowTokens.
  */
 
+import { normalizeModelId } from './pricing.js';
+
 /** Returned for any model id not matched by the table below. */
 export const DEFAULT_CONTEXT_WINDOW = 200_000;
 
@@ -50,9 +52,14 @@ const OUTPUT_CEILING_TABLE: readonly WindowEntry[] = [
 
 /** Output-token ceiling for a model id, or undefined when unknown. */
 export function outputCeilingFor(model: string): number | undefined {
+  // D7 (audit r2 2026-07-17): normalize cloud-provider ids (Bedrock
+  // `us.anthropic.claude-…`, Vertex `claude-…@…`) back to canonical form the
+  // same way pricing.ts does — without it those ids never matched a prefix, so
+  // fallback clamping / any non-default window row silently never applied.
+  const normalized = normalizeModelId(model);
   let best: WindowEntry | undefined;
   for (const entry of OUTPUT_CEILING_TABLE) {
-    if (model.startsWith(entry.prefix)) {
+    if (normalized.startsWith(entry.prefix)) {
       if (best === undefined || entry.prefix.length > best.prefix.length) {
         best = entry;
       }
@@ -66,9 +73,14 @@ export function outputCeilingFor(model: string): number | undefined {
  * unknown models return DEFAULT_CONTEXT_WINDOW.
  */
 export function contextWindowFor(model: string): number {
+  // D7: same cloud-id normalization as outputCeilingFor. Today every table row
+  // equals DEFAULT_CONTEXT_WINDOW so the miss was masked; the first non-default
+  // row (e.g. a 1M-window model) would have silently never matched Bedrock /
+  // Vertex ids without this.
+  const normalized = normalizeModelId(model);
   let best: WindowEntry | undefined;
   for (const entry of WINDOW_TABLE) {
-    if (model.startsWith(entry.prefix)) {
+    if (normalized.startsWith(entry.prefix)) {
       if (best === undefined || entry.prefix.length > best.prefix.length) {
         best = entry;
       }

--- a/projects/silver-core-sdk/src/engine/pricing.ts
+++ b/projects/silver-core-sdk/src/engine/pricing.ts
@@ -43,6 +43,17 @@ const PRICE_TABLE: readonly PriceEntry[] = [
 
 const MTOK = 1_000_000;
 
+/**
+ * USD per web_search server-tool call (public pricing: $10 per 1,000 searches,
+ * token costs billed separately and already covered by the table above). Same
+ * estimate-only discipline as the token price table. D6 (audit r2 2026-07-17):
+ * the count was tracked end-to-end (normalizeUsage/addUsage) but never priced,
+ * so web-search-heavy sessions under-reported totalCostUsd and maxBudgetUsd
+ * under-enforced. Model-independent, so it is charged even for model ids the
+ * token table does not know.
+ */
+const WEB_SEARCH_USD_PER_CALL = 10 / 1000;
+
 /** Longest-prefix match over caller overrides (normalized id). */
 function matchOverride(
   normalized: string,
@@ -130,14 +141,19 @@ export function estimateCostUsd(
       }
     }
   }
-  if (best === undefined) return 0;
+  // D6: server-tool (web_search) calls are priced per REQUEST, not per token,
+  // and independently of the model — charge them on both branches below.
+  const serverToolCost =
+    (usage.web_search_requests ?? 0) * WEB_SEARCH_USD_PER_CALL;
+  if (best === undefined) return serverToolCost;
   const cacheWriteRate = cacheTtl === '1h' ? best.input * 2 : best.cacheWrite;
   return (
     (usage.input_tokens * best.input +
       usage.output_tokens * best.output +
       usage.cache_creation_input_tokens * cacheWriteRate +
       usage.cache_read_input_tokens * best.cacheRead) /
-    MTOK
+      MTOK +
+    serverToolCost
   );
 }
 

--- a/projects/silver-core-sdk/src/engine/tokens.ts
+++ b/projects/silver-core-sdk/src/engine/tokens.ts
@@ -107,6 +107,16 @@ function estimateBlockTokens(block: ContentBlockParam): number {
       return estimateToolResultTokens(block.content);
     case 'image':
       return IMAGE_TOKENS;
+    default:
+      // D1 (audit r2 2026-07-17): a block type this switch does not model
+      // (server_tool_use / web_search_tool_result / any future type — the
+      // accumulator deliberately round-trips them verbatim) used to fall out
+      // with `undefined`, and `overhead + undefined` turned the WHOLE history
+      // estimate into NaN. `NaN >= triggerAt` is always false, so one such
+      // block silently disabled auto-compaction, the knownPromptFloor 400
+      // safety net, and the memory flush at once. Estimate the serialized
+      // block instead — conservative but finite.
+      return estimateTextTokens(JSON.stringify(block));
   }
 }
 
@@ -183,8 +193,11 @@ export function estimateMessagesTokens(messages: APIMessageParam[]): number {
   return total;
 }
 
-/** Estimate tokens for the serialized tool-definition schemas. */
+/** Estimate tokens for the serialized tool-definition schemas. D5 (audit r2
+ *  2026-07-17): flat len/4 undercounted CJK tool descriptions ~4x (the same
+ *  blind spot the text estimator fixed); route through the language-aware
+ *  estimator so CJK-described tools charge the overhead they actually cost. */
 export function estimateToolDefsTokens(defs: APIToolDefinitionParam[]): number {
   if (defs.length === 0) return 0;
-  return Math.ceil(JSON.stringify(defs).length / CHARS_PER_TOKEN);
+  return estimateTextTokens(JSON.stringify(defs));
 }

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.64.6';
+export const SDK_VERSION = '0.64.7';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/audit-t50-batch-f.test.ts
+++ b/projects/silver-core-sdk/tests/audit-t50-batch-f.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Regression locks for the T50 batch-F fixes (audit r2 2026-07-17,
+ * silver-core-sdk-bug-audit-r2-20260717.md): the engine compaction /
+ * accounting safety net — D1..D7 + C2. One suite per audit item.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  estimateMessagesTokens,
+  estimateToolDefsTokens,
+} from '../src/engine/tokens.js';
+import {
+  contextWindowFor,
+  outputCeilingFor,
+  DEFAULT_CONTEXT_WINDOW,
+} from '../src/engine/context-window.js';
+import { estimateCostUsd } from '../src/engine/pricing.js';
+import {
+  buildCompactionConfig,
+  foldDeterministic,
+  maybeAutoCompact,
+} from '../src/engine/compaction.js';
+import { MessageAccumulator } from '../src/engine/accumulator.js';
+import { AbortError } from '../src/errors.js';
+import type {
+  CompactionConfig,
+  EngineConfig,
+  EngineDeps,
+} from '../src/internal/contracts.js';
+import type {
+  APIMessageParam,
+  APIToolDefinitionParam,
+  NonNullableUsage,
+  RawMessageStreamEvent,
+  SDKMessage,
+} from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pad(prefix: string, len: number): string {
+  return (prefix + ' ').repeat(Math.ceil(len / (prefix.length + 1))).slice(0, len);
+}
+
+function makeDeps(over: { transport?: EngineDeps['transport'] } = {}): EngineDeps {
+  return {
+    transport:
+      over.transport ??
+      ({
+        apiKeySource: () => 'user',
+        // eslint-disable-next-line require-yield
+        async *stream() {
+          throw new Error('unexpected transport call');
+        },
+      } as EngineDeps['transport']),
+    builtinTools: new Map(),
+    mcp: {} as unknown as EngineDeps['mcp'],
+    permissions: {} as unknown as EngineDeps['permissions'],
+    hooks: { hasHooks: () => false, run: async () => ({ continue: true, systemMessages: [], additionalContext: [] }) },
+    toolContext: {} as unknown as EngineDeps['toolContext'],
+    debug: () => undefined,
+  };
+}
+
+function makeConfig(compaction: CompactionConfig, over: Partial<EngineConfig> = {}): EngineConfig {
+  return {
+    model: 'claude-sonnet-4-5',
+    maxOutputTokens: 500,
+    systemPrompt: '',
+    includePartialMessages: false,
+    sessionId: 'sess-batch-f',
+    cwd: '/work',
+    compaction,
+    ...over,
+  };
+}
+
+async function collect(gen: AsyncGenerator<SDKMessage, boolean>): Promise<SDKMessage[]> {
+  const out: SDKMessage[] = [];
+  for await (const m of gen) out.push(m);
+  return out;
+}
+
+const zeroUsage: NonNullableUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_creation_input_tokens: 0,
+  cache_read_input_tokens: 0,
+};
+
+/** True when `s` contains a lone (unpaired) UTF-16 surrogate. */
+function hasLoneSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i += 1) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : 0;
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      i += 1; // well-formed pair
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      return true; // low surrogate with no preceding high
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// D1 — unmodeled content block must not NaN-poison the history estimate
+// ---------------------------------------------------------------------------
+
+describe('D1: estimateBlockTokens default branch (NaN poisoning)', () => {
+  it('returns a finite positive estimate for an unmodeled block type', () => {
+    const messages = [
+      { role: 'user' as const, content: 'hello world' },
+      {
+        role: 'assistant' as const,
+        content: [
+          { type: 'text' as const, text: 'searching…' },
+          // The accumulator round-trips unmodeled blocks (finding M1) verbatim,
+          // so shapes like server_tool_use reach the estimator.
+          {
+            type: 'server_tool_use',
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            input: { query: 'morimens release date' },
+          } as unknown as APIMessageParam['content'] extends string ? never : object,
+        ],
+      },
+    ] as unknown as APIMessageParam[];
+    const total = estimateMessagesTokens(messages);
+    expect(Number.isFinite(total)).toBe(true);
+    expect(Number.isNaN(total)).toBe(false);
+    expect(total).toBeGreaterThan(0);
+  });
+
+  it('an unmodeled block does not zero out the rest of the history', () => {
+    const withoutOpaque = estimateMessagesTokens([
+      { role: 'user', content: pad('context', 4000) },
+    ]);
+    const withOpaque = estimateMessagesTokens([
+      { role: 'user', content: pad('context', 4000) },
+      {
+        role: 'assistant',
+        content: [{ type: 'web_search_tool_result', tool_use_id: 'x', content: [] }],
+      } as unknown as APIMessageParam,
+    ]);
+    expect(withOpaque).toBeGreaterThanOrEqual(withoutOpaque);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D5 — CJK-aware tool-definition overhead estimate
+// ---------------------------------------------------------------------------
+
+describe('D5: estimateToolDefsTokens is CJK-aware', () => {
+  it('charges CJK descriptions ~1 token per codepoint, not len/4', () => {
+    const cjkDescription = '检索社区档案层的全量数据并按平台聚合统计'.repeat(20); // 400 CJK chars
+    const defs: APIToolDefinitionParam[] = [
+      {
+        name: 'kb_search',
+        description: cjkDescription,
+        input_schema: { type: 'object', properties: {} },
+      } as unknown as APIToolDefinitionParam,
+    ];
+    const estimate = estimateToolDefsTokens(defs);
+    const flat = Math.ceil(JSON.stringify(defs).length / 4);
+    // The CJK-aware estimate must charge the 400 CJK codepoints ~1 each; the
+    // old flat len/4 sat far below that.
+    expect(estimate).toBeGreaterThan(flat);
+    expect(estimate).toBeGreaterThanOrEqual(400);
+  });
+
+  it('still returns 0 for an empty def list', () => {
+    expect(estimateToolDefsTokens([])).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D2 — post-fold suffix-overflow check must charge overheadTokens
+// ---------------------------------------------------------------------------
+
+describe('D2: M5 post-fold overflow check includes overheadTokens', () => {
+  it('sheds the retained suffix when messages fit but messages+overhead overflow', async () => {
+    // window 10000 / maxOutput 500 -> input budget 9500. overhead 8800 forces
+    // the trigger and — POST-fold — pushes the retained view (~1400 message
+    // tokens) over budget even though the bare message estimate sits well
+    // under 9500. Without charging overhead here the shed never fired and the
+    // next request 400ed.
+    const cfg = buildCompactionConfig({ contextWindowTokens: 10_000 });
+    const config = makeConfig(cfg);
+    const bigResult = pad('tool output line', 4400); // > preTier budget of 4000
+    const view = {
+      messages: [
+        { role: 'user', content: 'q0 ' + pad('alpha', 2000) },
+        { role: 'assistant', content: [{ type: 'text', text: pad('beta', 2000) }] },
+        { role: 'user', content: 'q1 ' + pad('gamma', 2000) },
+        { role: 'assistant', content: [{ type: 'text', text: pad('delta', 500) }] },
+        { role: 'user', content: 'q2 keep me' },
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 't1', name: 'Read', input: { p: 'x' } }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 't1', content: bigResult }],
+        },
+        { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+        { role: 'user', content: 'q3' },
+        { role: 'assistant', content: [{ type: 'text', text: 'ans' }] },
+      ] as APIMessageParam[],
+    };
+    const msgs = await collect(
+      maybeAutoCompact(view, makeDeps(), config, 8800, new AbortController().signal),
+    );
+    expect(msgs.some((m) => m.type === 'system' && m.subtype === 'compact_boundary')).toBe(true);
+    // The oversized tool_result retained in the suffix must have been shed.
+    const flat = JSON.stringify(view.messages);
+    expect(flat).toContain('chars elided');
+    expect(flat).not.toContain(bigResult);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D3 — failed summary API call still accounts its billed usage
+// ---------------------------------------------------------------------------
+
+function bigHistory(): APIMessageParam[] {
+  return [
+    { role: 'user', content: 'q0 ' + pad('alpha', 2000) },
+    { role: 'assistant', content: [{ type: 'text', text: pad('beta', 2000) }] },
+    { role: 'user', content: 'q1 ' + pad('gamma', 2000) },
+    { role: 'assistant', content: [{ type: 'text', text: pad('delta', 2000) }] },
+    { role: 'user', content: 'q2 ' + pad('epsilon', 2000) },
+    { role: 'assistant', content: [{ type: 'text', text: pad('zeta', 2000) }] },
+    { role: 'user', content: 'q3' },
+    { role: 'assistant', content: [{ type: 'text', text: 'fin' }] },
+  ];
+}
+
+function messageStartEvent(inputTokens: number): RawMessageStreamEvent {
+  return {
+    type: 'message_start',
+    message: {
+      id: 'msg_partial_1',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: {
+        input_tokens: inputTokens,
+        output_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  } as unknown as RawMessageStreamEvent;
+}
+
+describe('D3: failed summary call books its partial usage', () => {
+  const cfg = buildCompactionConfig({ contextWindowTokens: 2000, useApiSummary: true });
+
+  it('fires the summary sink with the billed input when the stream dies mid-flight', async () => {
+    const transport: EngineDeps['transport'] = {
+      apiKeySource: () => 'user',
+      async *stream() {
+        yield messageStartEvent(12_345);
+        throw new Error('mid-stream boom');
+      },
+    };
+    const config = makeConfig(cfg);
+    const view = { messages: bigHistory() };
+    const seen: Array<{ model: string; input: number }> = [];
+    const msgs = await collect(
+      maybeAutoCompact(view, makeDeps({ transport }), config, 0, new AbortController().signal, (m, u) =>
+        seen.push({ model: m, input: u.input_tokens }),
+      ),
+    );
+    // The failure degraded to the deterministic fold — but the spend is booked.
+    expect(seen).toEqual([{ model: 'claude-sonnet-4-5', input: 12_345 }]);
+    expect(msgs.some((m) => m.type === 'system' && m.subtype === 'compact_boundary')).toBe(true);
+    const text = (view.messages[1]!.content as Array<{ text: string }>)[0]!.text;
+    expect(text).toContain('[Conversation summary');
+  });
+
+  it('books partial usage before rethrowing an abort', async () => {
+    const transport: EngineDeps['transport'] = {
+      apiKeySource: () => 'user',
+      async *stream() {
+        yield messageStartEvent(777);
+        throw new AbortError();
+      },
+    };
+    const config = makeConfig(cfg);
+    const view = { messages: bigHistory() };
+    const seen: number[] = [];
+    await expect(
+      collect(
+        maybeAutoCompact(view, makeDeps({ transport }), config, 0, new AbortController().signal, (_m, u) =>
+          seen.push(u.input_tokens),
+        ),
+      ),
+    ).rejects.toBeInstanceOf(AbortError);
+    expect(seen).toEqual([777]);
+  });
+
+  it('books nothing when the stream fails before message_start', async () => {
+    const transport: EngineDeps['transport'] = {
+      apiKeySource: () => 'user',
+      // eslint-disable-next-line require-yield
+      async *stream() {
+        throw new Error('request-phase failure');
+      },
+    };
+    const config = makeConfig(cfg);
+    const view = { messages: bigHistory() };
+    const seen: number[] = [];
+    await collect(
+      maybeAutoCompact(view, makeDeps({ transport }), config, 0, new AbortController().signal, (_m, u) =>
+        seen.push(u.input_tokens),
+      ),
+    );
+    expect(seen).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D4 — recap truncation never emits a lone surrogate
+// ---------------------------------------------------------------------------
+
+describe('D4: recap truncation is surrogate-safe', () => {
+  it('per-line cap cutting through an astral codepoint drops the split pair', () => {
+    // 199 ASCII chars + an astral emoji: the 200-unit line cap lands exactly
+    // between the surrogate halves.
+    const text = 'a'.repeat(199) + '😀 tail';
+    const fold = foldDeterministic([{ role: 'user', content: text }], null);
+    const recap = (fold[1]!.content as Array<{ text: string }>)[0]!.text;
+    expect(hasLoneSurrogate(recap)).toBe(false);
+  });
+
+  it('recap body cap stays surrogate-safe across boundary parities', () => {
+    // Sweep the cap offset across parities/line positions so at least one pad
+    // forces the 4000-char body cap to land inside an emoji run.
+    for (let padLen = 0; padLen < 14; padLen += 1) {
+      const prefix: APIMessageParam[] = [
+        { role: 'user', content: 'x'.repeat(padLen + 1) },
+      ];
+      for (let i = 0; i < 25; i += 1) {
+        prefix.push({
+          role: 'assistant',
+          content: [{ type: 'text', text: '😀'.repeat(150) }],
+        });
+      }
+      const fold = foldDeterministic(prefix, null);
+      const recap = (fold[1]!.content as Array<{ text: string }>)[0]!.text;
+      expect(recap).toContain('…[truncated]');
+      expect(hasLoneSurrogate(recap)).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D6 — web_search server-tool calls are priced
+// ---------------------------------------------------------------------------
+
+describe('D6: estimateCostUsd charges web_search requests', () => {
+  it('adds $10 per 1k searches on a priced model', () => {
+    const cost = estimateCostUsd('claude-sonnet-4-5', {
+      ...zeroUsage,
+      web_search_requests: 500,
+    });
+    expect(cost).toBeCloseTo(5.0, 10);
+  });
+
+  it('charges web searches even for a model the token table does not know', () => {
+    const cost = estimateCostUsd('gpt-4o', {
+      ...zeroUsage,
+      web_search_requests: 1000,
+    });
+    expect(cost).toBeCloseTo(10.0, 10);
+  });
+
+  it('keeps token-only estimates unchanged when no searches ran', () => {
+    const cost = estimateCostUsd('claude-sonnet-4-5', {
+      input_tokens: 1_000_000,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    });
+    expect(cost).toBeCloseTo(3.0, 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D7 — context-window/output-ceiling tables normalize cloud model ids
+// ---------------------------------------------------------------------------
+
+describe('D7: window tables normalize Bedrock/Vertex model ids', () => {
+  it('outputCeilingFor matches a Bedrock-form id', () => {
+    expect(outputCeilingFor('us.anthropic.claude-opus-4-8-v1:0')).toBe(32_000);
+    expect(outputCeilingFor('apac.anthropic.claude-3-5-haiku-20241022-v1:0')).toBe(8_192);
+  });
+
+  it('outputCeilingFor matches a Vertex-form id', () => {
+    expect(outputCeilingFor('claude-opus-4-8@20260101')).toBe(32_000);
+  });
+
+  it('contextWindowFor resolves cloud ids to the canonical row', () => {
+    expect(contextWindowFor('us.anthropic.claude-sonnet-4-5-v1:0')).toBe(
+      contextWindowFor('claude-sonnet-4-5'),
+    );
+    expect(contextWindowFor('utterly-unknown-model')).toBe(DEFAULT_CONTEXT_WINDOW);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C2 — content_block_start seed fields guard field omission
+// ---------------------------------------------------------------------------
+
+describe('C2: accumulator seeds omitted start-frame fields as empty strings', () => {
+  function feedAll(acc: MessageAccumulator, events: unknown[]): void {
+    for (const ev of events) acc.feed(ev as RawMessageStreamEvent);
+  }
+
+  it('text block with an omitted seed does not become "undefinedfoo"', () => {
+    const acc = new MessageAccumulator();
+    feedAll(acc, [
+      messageStartEvent(10),
+      { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'foo' } },
+      { type: 'content_block_stop', index: 0 },
+    ]);
+    const msg = acc.finalize();
+    expect(msg.content[0]).toEqual({ type: 'text', text: 'foo' });
+  });
+
+  it('thinking block with omitted seed fields accumulates cleanly', () => {
+    const acc = new MessageAccumulator();
+    feedAll(acc, [
+      messageStartEvent(10),
+      { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'th' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'sig' } },
+      { type: 'content_block_stop', index: 0 },
+    ]);
+    const msg = acc.finalize();
+    expect(msg.content[0]).toEqual({ type: 'thinking', thinking: 'th', signature: 'sig' });
+  });
+
+  it('redacted_thinking block with an omitted data seed finalizes as empty string', () => {
+    const acc = new MessageAccumulator();
+    feedAll(acc, [
+      messageStartEvent(10),
+      { type: 'content_block_start', index: 0, content_block: { type: 'redacted_thinking' } },
+      { type: 'content_block_stop', index: 0 },
+    ]);
+    const msg = acc.finalize();
+    expect(msg.content[0]).toEqual({ type: 'redacted_thinking', data: '' });
+  });
+
+  it('usageSnapshot exposes the partial usage after message_start (D3 support)', () => {
+    const acc = new MessageAccumulator();
+    expect(acc.usageSnapshot()).toBeUndefined();
+    acc.feed(messageStartEvent(4242));
+    expect(acc.usageSnapshot()?.input_tokens).toBe(4242);
+  });
+});


### PR DESCRIPTION
## 概述

T50 第二轮审计批 F「引擎压缩/记账安全网（P0-防400/防超支）」8 项全部修复：D1–D7 + C2（明细权威 `Public-Info-Pool/Resource/repo-engineering/silver-core-sdk-bug-audit-r2-20260717.md`）。silver-core-sdk 0.64.6。

- **D1** `engine/tokens.ts` — estimateBlockTokens 补 default 分支：未建模内容块（server_tool_use 等）不再产 undefined→NaN 毒化整个历史估算（该 NaN 曾同时废掉自动压缩、knownPromptFloor 400 安全网与记忆 flush）
- **D2** `engine/compaction.ts` — M5 折后溢窗检查补记 overheadTokens（与触发端/preTokens 口径一致）：大 system+tools 开销下溢窗视图不再被误判「能装下」而跳过 shed
- **D3** `engine/compaction.ts` + `engine/accumulator.ts` — summary API 调用 message_start 后失败时，经新增 `MessageAccumulator.usageSnapshot()` 把已计费部分用量回灌 summary sink（此前 ~100k+ 折叠前缀的花费从 totalCostUsd / maxBudgetUsd 蒸发）
- **D4** `engine/compaction.ts` — buildRecap 帽 / firstChars 截断改 surrogate 安全：折叠文本不再写入孤 surrogate（曾致后续每次 wire 请求永久 U+FFFD）
- **D5** `engine/tokens.ts` — estimateToolDefsTokens 走 CJK 感知估算（平 len/4 对 CJK 工具描述欠估 ~4x）
- **D6** `engine/pricing.ts` — estimateCostUsd 计入 web_search 服务端工具费（$10/1k，模型无关），补齐 totalCostUsd / maxBudgetUsd 缺口
- **D7** `engine/context-window.ts` — contextWindowFor / outputCeilingFor 经 normalizeModelId 归一 Bedrock/Vertex 形态 id（fallback 输出钳制曾对云形态 id 静默失效）
- **C2** `engine/accumulator.ts` — content_block_start 种子字段（text/thinking/data）补 `?? ''` 守卫（与 delta 侧同款）：网关改写帧不再产 "undefinedfoo" / finalize 抛错

## 变更类型

- [x] Bug 修复
- [ ] 其他

## 来源声明

- [x] 不涉及游戏数据；全部为 silver-core-sdk 工程代码变更，缺陷来源为公开仓内审计档案

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不涉及游戏图片 / 数据 / 文本。**
- [x] **同意按 MIT License 提交贡献。**

## 验证清单

- [x] 回归锁 `projects/silver-core-sdk/tests/audit-t50-batch-f.test.ts` 20 项全绿；D2/D3 经变异反证（撤销修复行→对应测试即红）
- [x] SDK 全量 vitest：2581 passed / 3 skipped；`tsc --noEmit` 干净
- [x] 仓库级 pytest：2969 passed / 4 skipped
- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

## 关联 Issue

- Refs `memory/todo.md` T50（批 F）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LHKp5q3FzFoa6j1VehBjS

---
_Generated by [Claude Code](https://claude.ai/code/session_012LHKp5q3FzFoa6j1VehBjS)_