### PR TITLE
fix(silver-core-sdk): T52 r4 Tier-3 low/eval/descriptions — 23 fixes via workflow (0.67.2)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,70 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.67.2 — 2026-07-18
+
+T52 r4 audit — Tier 3 (low / cosmetic + eval + descriptions) fix campaign:
+**23 defects fixed** (20 by 9 parallel workflow agents + 3 completed at
+integration), the remainder honestly deferred / documented / adjudicated.
+This closes the r4 backlog: all 205 items are now either fixed or documented
+with a precise reason.
+
+- **planmode-monitor (exitplanmode / monitor.ts) — 3**: ExitPlanMode restores
+  the pre-plan permission mode (acceptEdits/dontAsk survive an enter/exit
+  round trip) instead of hard-setting default (U3-1); Monitor rejects a
+  non-boolean `persistent` loudly instead of silently coercing it false
+  (U3-2); the non-persistent kill timer is cleared on query teardown so its
+  closure isn't pinned for ~24 days (Stim-2).
+- **prompt-assembly (system-field / runtime-context.ts) — 2**: the split/dual
+  system array carries the volatile block's leading `\n` so toggling
+  promptCaching no longer changes the system bytes the model sees (Z8-1);
+  osVersion uses os.type() for the capitalized OS name ('Linux 6.x') matching
+  the official `<env>` reproduction (Z8-3).
+- **sandbox-async (async.ts / query.ts) — 2**: AsyncQueue.next() is guarded
+  against a between-turns raw abort producing an orphan user turn (Sq-3);
+  sandbox writable roots are realpath-resolved before binding so a symlinked
+  writable root isn't shadowed by `--ro-bind / /` into EROFS (U8-1).
+- **error-normalize (error-normalize.ts) — 3**: the err.cause chain /
+  AggregateError.errors are inspected so a wrapped ECONNREFUSED keeps its
+  retryable detail (Y6-2); the "never throws" contract is honored even for a
+  circular error object (R7j-2); bound-message truncation surrogate-safe
+  (R7s-7).
+- **pricing (pricing / model-alias.ts) — 3**: the claude-3-sonnet prefix and
+  a corrected Haiku cache multiplier are in the price table so cost/budget
+  are honest (U5-1/U5-2); model-alias resolves chained aliases (U5-3).
+- **misc (media / structured-output / ledger.ts + index.ts barrel) — 4**:
+  image media-type parameter stripped so `image/png; charset=binary` still
+  decodes (Y6-3); minLength/maxLength count codepoints not UTF-16 units so an
+  astral char isn't double-counted (U6-2); the ledger RangeError guard checks
+  the Date ±8.64e15 bound (Rdt-2); SessionMutationOptions re-exported from the
+  barrel so consumers can name the `{sessionDir}` bag (R7c-1).
+- **eval (eval-scoring / eval-harnesses / normalize-l3.mjs) — 3**:
+  per-dimension means carry a sample-count denominator so a zero-scored
+  dimension can't hide a regression (V7-1); the process-kill+resume harness
+  removes its seed file so a broken engine can't pass by re-reading it (V7-2);
+  the L3 trailing-whitespace normalization no longer masks a fidelity
+  divergence (V7-3).
+- **descriptions (websearch.ts + COMPAT.md) — 2 + fidelity doc**: WebSearch
+  renders results with markdown-hyperlink links matching its description
+  (Sd-1, impl fix); MultiEdit's removal is corrected in COMPAT (Y5-3). The
+  faithful-but-divergent tool descriptions (Sd-2..Sd-7 web/bash/ask/plan
+  clauses, Z4-1 EnterPlanMode) are documented in a new COMPAT.md
+  "Tool-description ↔ implementation fidelity" section rather than rewriting
+  the corpus-locked reproductions.
+
+**Deferred / not-defects (documented):** Z8-2 + Rdt-4 (per-turn `<env>`
+re-render for fallback-model/local-midnight staleness — low severity, defers
+to avoid a cache-prefix regression), U8-3 (pgid-escape is unfixable by a
+planner), U8-4 (a rare post-teardown background finalizer — optional),
+V7-4 (cumulative-vs-per-result apiMs is correct, not a defect), Z4-2 (the
+corrected-final-result teardown is a keeper-ruled feature 待裁⑤, a keeper
+adjudication item — not a defect to revert).
+
+Regression tests: `tests/audit-r4-{planmode-monitor,prompt-assembly,sandbox-async,error-normalize,pricing,misc,eval,descriptions}.test.ts`
+plus Z8-1/Z8-3 realignments in system-field/engine/prompt-assembly tests.
+Full vitest 2997 passed / 3 skipped; repo pytest 2975 passed; tsc + build
+clean.
+
 ## 0.67.1 — 2026-07-18
 
 T52 r4 audit — Tier 2 (medium) fix campaign: **65 defects fixed, 15 honestly

--- a/projects/silver-core-sdk/docs/COMPAT.md
+++ b/projects/silver-core-sdk/docs/COMPAT.md
@@ -385,7 +385,7 @@ SDK implements the agent loop directly against the public Messages API:
 |---|---|---|
 | Read | PARTIAL | text files (cat -n) + images (PNG/JPEG/GIF/WebP → image block) + PDF (→ base64 `document` block; the API's handle-tool-calls docs allow `document` inside tool_result, though the base64 source there is supported-but-not-explicitly-demonstrated); all magic-byte sniffed (task #17); notebooks returned as raw JSON text — cells not rendered individually (closable, NON-structural; absent by choice); oversized files (>50MB) rejected with a Grep hint rather than buffered. v0.7: official `pages` param (PDF page range) validated to contract (1-based, ascending, ≤20); PDF page-slicing itself is HONEST-unsupported (no PDF dep) — a `pages` read of a PDF errors clearly rather than silently returning the whole document, and `pages` on a non-PDF errors. Path fence removed (#483 keeper ruling): resolves to any location the process can reach, permission gate is the sole access control |
 | Write / Edit | FULL | same input field names (`file_path`, `old_string`, …); BOTH enforce the official read-before-write gate — a bare Write/Edit over an existing un-read file errors with the verbatim official text and leaves the file untouched; new files pass (Write); a successful Read unlocks (Write E4 2026-07-05 pinned live L5 code-03 r1 vs r2; **Edit gate added in P2** to match the official Edit tool — behavioral change, MIGRATION §P2; test tools-fs.test.ts). OUR chosen extensions where the pinned evidence is silent: a successful Write/Edit also registers its path (create-then-revise does not self-block), and the gate spans subagents (one read-set per query). Success/error wording differs elsewhere (KD-L3-05/07/08). Path fence removed (#483) — same posture as Read |
-| Bash | PARTIAL | Windows: shell resolved via `CLAUDE_CODE_GIT_BASH_PATH` -> Git-for-Windows standard locations (official-parity posture; actionable error when absent, bare `bash`/WSL never tried; foreground+background termination route through planProcessKill so win32 taskkill is used, #482/#484). v0.5: `cd` + exported env persist across calls (state-file replay — functions/aliases/unexported vars do NOT persist; not a long-lived shell process) and `run_in_background` launches a detached shell whose id feeds BashOutput/KillShell. v0.6: sandboxed by default when a backend resolves (see the `sandbox` option row); foreground and background both wrap through the backend and run in their own process group (timeout/abort reap the whole group; `--unshare-pid` + SIGKILL escalation reaps across the sandbox pid namespace). v0.7: `dangerouslyDisableSandbox` is ALWAYS in the schema (official parity); it is a no-op without a sandbox and CANNOT bypass the gate (escape still needs sandbox active + allowEscape + an independent ask). **Sandbox kill caveat (audit Q4):** bwrap does not forward SIGTERM into the wrapped command and `--die-with-parent` tears it down with SIGKILL, so the SIGTERM->SIGKILL grace window is a hard kill for sandboxed commands — a command trapping SIGTERM for graceful flush gets no grace under the sandbox (teardown correctness unaffected; only cooperative shutdown is lost). **Signal-death reporting (audit Q3):** a sandboxed command killed by signal N surfaces as `exit code 128+N` with no Node signal (bwrap's own exit), unlike the unsandboxed `signal SIGxxx`; the failure message names the likely signal for the common codes. |
+| Bash | PARTIAL | Windows: shell resolved via `CLAUDE_CODE_GIT_BASH_PATH` -> Git-for-Windows standard locations (official-parity posture; actionable error when absent, bare `bash`/WSL never tried; foreground+background termination route through planProcessKill so win32 taskkill is used, #482/#484). v0.5: `cd` + exported env persist across calls (state-file replay — functions/aliases/unexported vars do NOT persist; not a long-lived shell process) and `run_in_background` launches a detached shell whose id feeds BashOutput/KillShell. v0.6: sandboxed by default when a backend resolves (see the `sandbox` option row); foreground and background both wrap through the backend and run in their own process group (timeout/abort reap the whole group; `--unshare-pid` + SIGKILL escalation reaps across the sandbox pid namespace). v0.7: `dangerouslyDisableSandbox` is ALWAYS in the schema (official parity); it is a no-op without a sandbox and CANNOT bypass the gate (escape still needs sandbox active + allowEscape + an independent ask). **Sandbox kill caveat (audit Q4):** bwrap does not forward SIGTERM into the wrapped command and `--die-with-parent` tears it down with SIGKILL, so the SIGTERM->SIGKILL grace window is a hard kill for sandboxed commands — a command trapping SIGTERM for graceful flush gets no grace under the sandbox (teardown correctness unaffected; only cooperative shutdown is lost). **Signal-death reporting (audit Q3):** a sandboxed command killed by signal N surfaces as `exit code 128+N` with no Node signal (bwrap's own exit), unlike the unsandboxed `signal SIGxxx`; the failure message names the likely signal for the common codes. **Profile init (audit r4 Sd-5):** the reproduced description's "initialized from the user's profile" is faithful official text, but this SDK runs a non-login, non-interactive `bash -c` that does NOT source `~/.bash_profile`/`~/.bashrc`/`~/.zshrc`/`~/.profile` — cross-call `cwd`+exported-env continuity is the state-file replay above (not profile sourcing); see "Tool-description ↔ implementation fidelity" below. |
 | Task quadruplet (TaskCreate/TaskGet/TaskUpdate/TaskList) | FULL | v0.7: the DEFAULT task surface (official 0.3.142: TodoWrite off by default, `CLAUDE_CODE_ENABLE_TASKS=0` reverts to TodoWrite-only). Symmetric dependency edges (blocks/blockedBy), owner/status workflow, session-shared store (parent + subagents see one list); TaskGet unknown-id returns null (not error) per official |
 | ExitPlanMode | FULL | v0.7: really flips the permission gate plan→default (main loop and subagents each flip their own gate); `allowedPrompts` echoed not applied (no NL prompt rules in this gate); honest errors when unbridged or not in plan mode |
 | EnterWorktree | FULL | v0.7: creates/enters named worktrees under `.claude/worktrees`; in-place cwd switch survives turn-boundary rebuilds (fs tools + subagent spawns; Bash follows via persistent state). `worktree.baseRef` not shipped (HEAD base) |
@@ -398,11 +398,82 @@ SDK implements the agent loop directly against the public Messages API:
 | SendMessage | PARTIAL | v0.42.0 (O-B2): continue a previously spawned subagent with its FULL transcript intact (the runtime retains every child's live history for the query's life; per-agent serialization; stopped workers revivable). `{to, summary?, message}` — `to` is an agentId ONLY: teammate NAMES, the `"main"` address and peer-origin message emission belong to the agent-teams naming machinery this SDK does not ship (SDKMessageOrigin `peer`/`coordinator` + TeammateIdle stay typed-not-emitted). Foreground children reply as the tool result; background children ack + reply on a later drained turn as official `<task-notification>` XML (drain format aligned to the archive shape in the same batch). Root-loop-only: isolated children never see the tool; fork children keep the schema (prefix byte-match) and get an honest error. Coordinator presets ship alongside (COORDINATOR_MODE_PROMPT adapted + COORDINATOR_WORKER_AGENT faithful, agents.ts) |
 | Glob | PARTIAL | fast-glob, mtime-sorted newest-first; official 2.1.201 emitted ASCENDING order under ascending-utimes pins, so ordering parity with the live engine is not established - path sets agree (conformance run-l3 L3-GLOB-01, KD-L3-20, 2026-07-05) |
 | Grep | PARTIAL | pure-JS regex engine (no ripgrep binary); large-repo perf caveat (crossover diagnostic 2026-07-07). v0.13.0 fixed the silent 250-cap truncation: `count`/`files_with_matches` default COMPLETE, all modes announce truncation, `grep.scan` debug telemetry added. Pure-JS is the standing choice; ripgrep would enter only via a keeper ruling |
-| WebFetch / WebSearch | FULL | registered in v0.2 |
+| WebFetch / WebSearch | PARTIAL | registered in v0.2. Host-callback / direct-API subsets of the official server-side tools (audit r4 Sd-1..Sd-4) — see "Tool-description ↔ implementation fidelity" below. WebSearch is a host callback (`options.webSearch`, not an in-API search, no US-only gate) rendering `WebSearchResult[]` to text with markdown-hyperlink links; WebFetch hard-truncates oversized content to 100000 chars rather than model-summarizing (no summarizer model) |
 | TodoWrite | PARTIAL | v0.7: OFF by default (Task quadruplet is the default surface); `CLAUDE_CODE_ENABLE_TASKS=0` reverts to TodoWrite-only, per official 0.3.142 |
 | Agent | PARTIAL | the subagent spawn tool; v0.7 gains `model`/`isolation:'worktree'` and the official required set [description, prompt] (subagent_type defaults to general-purpose). Residual param delta = our BPT-only `fork` extension |
-| MultiEdit | DEPRECATED | v0.61.0 (SDK-original): same-file atomic batch edit — edits apply sequentially on one snapshot, all-or-nothing write, single pre-image for rewind, same read-before-write gate as Edit. No official parity target (retired upstream), so support was vs our own documented semantics and the description is authored, not reproduced (`faithful:false`). v0.62.1: not-found errors are triaged against the original text — "absent from the file (re-Read)" vs "consumed by an earlier edit in this call" (culprit edit named; overlap rule added to the description). **v0.64.4 (keeper 2026-07-17): DEPRECATED — aligning with upstream, which retired MultiEdit in favour of repeated Edit calls (each against live state, avoiding the snapshot-ambiguity this tool's own not-found triage exists to explain). The tool still ships and works (non-breaking); its description now steers the model to Edit; slated for removal in a future major once no consumer depends on it.** |
+| MultiEdit | REMOVED | SDK-original v0.61.0–0.64.4 (same-file atomic batch edit — edits applied sequentially on one snapshot, all-or-nothing write, single pre-image for rewind, same read-before-write gate as Edit; never had an official parity target — upstream retired MultiEdit in favour of repeated Edit calls, so support was vs our own documented semantics with an authored, not reproduced, description). **v0.65.0: REMOVED (audit r4 Y5-3, keeper alignment) — the tool no longer ships. It is absent from `createBuiltinTools` (tests/tool-parity.test.ts pins the shipped set) and is once again a red-line token that no SHIPPED description may reference (tests/red-line-tool-names.test.ts; `descriptions.ts` header lists it under "retired 0.65.0"). Lifecycle: shipped 2026-07-15, DEPRECATED-but-shipping in v0.64.4, hard-removed in v0.65.0. Consumers use repeated Edit calls (each against live file state, avoiding the snapshot-ambiguity MultiEdit's own not-found triage existed to explain); recoverable from git history if a real consumer need resurfaces.** |
 | NotebookEdit | UNSUPPORTED | deliberately untracked (BPT has no notebook surface) |
+
+## Tool-description ↔ implementation fidelity (audit r4, 2026-07-18)
+
+The model-side tool descriptions in `src/tools/descriptions.ts` are FAITHFUL
+reproductions of the official Claude Code tool descriptions (corpus-locked, guarded
+by `tests/tool-descriptions-provenance.test.ts` + the red-line token guard). SDK red
+line: never rewrite a faithful reproduction to paper over a divergence, and never
+describe a capability that does not exist. Where a faithful clause describes a
+capability or restriction this direct-API / host-callback engine legitimately
+differs on, the honest record lives HERE rather than in the locked text. Audit r4
+reconciled the following (impl-side fixes noted; the rest are documented
+divergences):
+
+- **WebSearch — "search result blocks, including links as markdown hyperlinks"
+  (Sd-1, FIXED in impl).** The official WebSearch returns server-side
+  `web_search_result` content blocks. This SDK routes to a host callback
+  (`options.webSearch`) and renders the returned `WebSearchResult[]` to text, so
+  the native content-block form is a HONEST-SUBSET (text). The "markdown
+  hyperlinks" clause is now honest: `websearch.ts renderResults` emits each result
+  link as a markdown hyperlink `[url](url)` (was a bare-URL line, plain text) and
+  separates results into blank-line-delimited blocks. A pre-rendered string backend
+  result is still passed through verbatim.
+- **WebSearch — "Web search is only available in the US" (Sd-2, KEPT-DIVERGENCE).**
+  Faithful official text describing the server-side tool's geo restriction. This
+  SDK imposes NO geographic gating — `webSearchTool` calls the host backend
+  unconditionally; any regional restriction is the host backend's concern, not the
+  SDK's. The clause is retained verbatim (corpus-lock); the SDK enforces no such
+  limit and never suppresses a call on geographic grounds.
+- **WebSearch — "Searches are performed automatically within a single API call"
+  (Sd-4, HONEST-SUBSET).** Faithful text describing the official in-API server-side
+  search. Here WebSearch is a HOST CALLBACK (`options.webSearch` → `ctx.webSearch`),
+  not an in-API search; `modelUsage.webSearchRequests` is not incremented (it is
+  not a billed server-side tool).
+- **WebFetch — "Results may be summarized if the content is very large" (Sd-3,
+  HONEST-SUBSET).** Faithful text describing the official small-model summarizer.
+  This direct-API engine has NO summarizer model: `webFetchTool` returns the
+  converted page text HARD-TRUNCATED to 100000 chars (`MAX_OUTPUT_CHARS`) with a
+  `[truncated]` marker, never a model-authored summary. The `prompt` input is
+  consumed by the model's own next turn over the returned text (see the webfetch.ts
+  header).
+- **Bash — "The shell environment is initialized from the user's profile" (Sd-5,
+  KEPT-DIVERGENCE).** Faithful official text. This SDK spawns a NON-login,
+  NON-interactive `bash -c` (see `bash.ts runShell`), which does not source
+  `~/.bash_profile` / `~/.bashrc` / `~/.zshrc` / `~/.profile` — deliberate, for
+  determinism and sandbox safety. Cross-call `cwd` + exported-env continuity comes
+  from the state-file replay (`withPersistentState`), not profile sourcing;
+  functions/aliases/unexported vars do not persist.
+- **AskUserQuestion — "Users will always be able to select 'Other'" (Sd-6,
+  HOST-DEPENDENT).** Faithful official text describing the CLI host UI. This SDK
+  passes the question verbatim to the host (`canUseTool` / AskUserQuestion
+  callback) and does NOT synthesize or guarantee an "Other" affordance — presenting
+  it is the host UI's responsibility (`src/tools/askuserquestion.ts`; the
+  description is corpus-locked, so the divergence is recorded here).
+- **ExitPlanMode — "on user approval ... exits plan mode" (Sd-7, adapted repro).**
+  The "approval" is the permission-gate approval of the ExitPlanMode tool CALL; on
+  execute the tool flips the gate plan→default. The description's own adaptation
+  note (descriptions.ts header) already discloses this ("exiting switches the
+  permission gate out of plan mode; hosts veto via PreToolUse hooks /
+  disallowedTools"). The impl-level gap — ExitPlanMode hard-set `default` rather
+  than restoring the pre-plan mode — is FIXED as audit r4 U3-1
+  (`src/tools/exitplanmode.ts`): EnterPlanMode records the pre-plan mode and
+  ExitPlanMode restores it, so an acceptEdits/dontAsk session survives an
+  enter/exit round trip.
+- **EnterPlanMode — "This tool REQUIRES user approval" (Z4-1, KEPT-DIVERGENCE).**
+  Faithful official text, but `EnterPlanMode` is `readOnly:true` by deliberate
+  design (`enterplanmode.ts` header: entering plan mode only ever RESTRICTS what
+  the agent may do, so the gate auto-allows entry without a per-call
+  `canUseTool` prompt). The description is not rewritten (corpus-locked); the
+  honest mechanism is that hosts veto ENTRY via a `PreToolUse` hook or a
+  `disallowedTools: ['EnterPlanMode']` rule — the same veto posture disclosed
+  for ExitPlanMode above — rather than an inline approval prompt.
 
 ## SDKMessage stream
 

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.67.1",
+  "version": "0.67.2",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/scripts/eval-harnesses.mjs
+++ b/projects/silver-core-sdk/scripts/eval-harnesses.mjs
@@ -19,7 +19,7 @@
  * expandFixture) shared with run-evals.mjs — single source, no circular
  * import (run-evals imports from here).
  */
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -443,6 +443,14 @@ const RUNNERS = {
       options: { provider: { fetch: killFetch, maxRetries: 1 } },
     });
     const sessionId = sessionIdOf(phase1);
+    // audit r4 V7-2: remove seed.txt before the resume so the deploy code is
+    // recoverable ONLY from the resumed session history. Left on disk, a broken
+    // engine that merely RE-READS the file (never actually resuming) also
+    // answers 6274 and the fault passes vacuously — the eval could not tell a
+    // genuinely-resuming engine from a file-re-reader. The code lives in the
+    // persisted session JSONL (phase-1 Read tool_result), so a true resume is
+    // unaffected; dumpFiles below records seed.txt as absent as evidence.
+    rmSync(join(ws.cwd, 'seed.txt'), { force: true });
     let phase2 = { transcript: [], result: null };
     if (sessionId !== null) {
       phase2 = await drive(sdk, ws, {
@@ -461,9 +469,12 @@ const RUNNERS = {
           'Injected: phase 1 allowed exactly one successful POST (the model read seed.txt), ' +
           'then every transport POST failed until retries exhausted — a mid-task hard kill ' +
           'with the session JSONL persisted (fact X = deploy code 6274 was in-conversation). ' +
-          'Phase 2 resumed the same session id with a clean network. Expected: phase 2 ' +
-          'continues (writes progress.txt once, correct code) instead of restarting, recalls ' +
-          'the code, and no side effect is duplicated.',
+          'seed.txt is then REMOVED from disk before phase 2, so the deploy code is ' +
+          'recoverable ONLY from the resumed session (a non-resuming engine that re-reads the ' +
+          'file gets file-not-found and cannot answer). Phase 2 resumed the same session id ' +
+          'with a clean network. Expected: phase 2 continues (writes progress.txt once, ' +
+          'correct code) instead of restarting, recalls the code from conversation, and no ' +
+          'side effect is duplicated.',
         resumedSessionId: sessionId,
         files: dumpFiles(ws, ['seed.txt', 'progress.txt']),
         injected: killFetch.ledger,

--- a/projects/silver-core-sdk/scripts/eval-scoring.mjs
+++ b/projects/silver-core-sdk/scripts/eval-scoring.mjs
@@ -157,3 +157,53 @@ export function computeDimensionMeans(results) {
     ]),
   );
 }
+
+/**
+ * Per-dimension SAMPLE COUNTS alongside the mean (audit r4 V7-1). The mean
+ * alone hides its denominator: a dimension where 15 of 20 questions ERRORED
+ * still reports a healthy mean over the 5 survivors, and a gate that compares
+ * means only cannot see that three-quarters of the dimension collapsed — an
+ * ERROR-shaped regression moves no mean, and a fully-collapsed dimension just
+ * vanishes from computeDimensionMeans' map. This returns, for every dimension
+ * PRESENT in `results`, the honest denominator:
+ *   scored  - records with a valid integer score 1..5 (the ones fed the mean)
+ *   invalid - SCORED outcome but no valid score (the 2026-07-12 poisoned kind)
+ *   errored - ERROR outcome
+ *   total   - all records tagged with the dimension (any outcome)
+ *   mean    - mean over `scored`, or null when scored === 0 (a fully collapsed
+ *             dimension stays VISIBLE here instead of disappearing).
+ * computeDimensionMeans keeps its numeric-only contract for existing consumers
+ * (the regression gate + baseline file); a gate that ALSO reads these counts
+ * can flag a scored-count drop the mean would mask. See sharedFileChangesNeeded
+ * for the run-evals / check-eval-regression wiring that activates it.
+ */
+export function computeDimensionStats(results) {
+  const byDim = {};
+  for (const r of results) {
+    if (r === null || typeof r !== 'object' || typeof r.dimension !== 'string') continue;
+    const c = (byDim[r.dimension] ??= { scored: 0, invalid: 0, errored: 0, total: 0, sum: 0 });
+    c.total += 1;
+    if (r.outcome === 'ERROR') {
+      c.errored += 1;
+    } else if (r.outcome === 'SCORED') {
+      if (Number.isInteger(r.score) && r.score >= 1 && r.score <= 5) {
+        c.scored += 1;
+        c.sum += r.score;
+      } else {
+        c.invalid += 1;
+      }
+    }
+  }
+  return Object.fromEntries(
+    Object.entries(byDim).map(([d, c]) => [
+      d,
+      {
+        mean: c.scored > 0 ? +(c.sum / c.scored).toFixed(2) : null,
+        scored: c.scored,
+        invalid: c.invalid,
+        errored: c.errored,
+        total: c.total,
+      },
+    ]),
+  );
+}

--- a/projects/silver-core-sdk/src/engine/pricing.ts
+++ b/projects/silver-core-sdk/src/engine/pricing.ts
@@ -37,8 +37,17 @@ const PRICE_TABLE: readonly PriceEntry[] = [
   { prefix: 'claude-3-opus-', input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 },
   { prefix: 'claude-3-7-sonnet-', input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
   { prefix: 'claude-3-5-sonnet-', input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
+  // audit r4 U5-1: the original Claude 3 Sonnet (claude-3-sonnet-20240229) was
+  // missing from this block -> matched no prefix -> estimateCostUsd $0 ->
+  // maxBudgetUsd silently unenforced for callers pinned to it. Longest prefix
+  // wins, so this shorter prefix never shadows claude-3-5-/claude-3-7-sonnet-.
+  { prefix: 'claude-3-sonnet-', input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
   { prefix: 'claude-3-5-haiku-', input: 0.8, output: 4, cacheWrite: 1, cacheRead: 0.08 },
-  { prefix: 'claude-3-haiku-', input: 0.25, output: 1.25, cacheWrite: 0.3125, cacheRead: 0.025 },
+  // audit r4 U5-2: Claude 3 Haiku's cache rates are the OFFICIAL published
+  // figures ($0.30 write / $0.03 read per MTok), not the generic input x1.25 /
+  // x0.1 multiplier (which would give 0.3125 / 0.025 — the latter is ~17% under
+  // the official $0.03 cache-read rate, under-reporting cost).
+  { prefix: 'claude-3-haiku-', input: 0.25, output: 1.25, cacheWrite: 0.3, cacheRead: 0.03 },
 ];
 
 const MTOK = 1_000_000;

--- a/projects/silver-core-sdk/src/engine/runtime-context.ts
+++ b/projects/silver-core-sdk/src/engine/runtime-context.ts
@@ -10,7 +10,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { homedir, platform as osPlatform, release } from 'node:os';
+import { homedir, platform as osPlatform, release, type as osType } from 'node:os';
 import { dirname, join, parse as parsePath } from 'node:path';
 
 import { resolveSettingSources } from '../internal/setting-sources.js';
@@ -34,7 +34,10 @@ export function gatherEnvironment(
 ): EnvironmentContext {
   const env: EnvironmentContext = {
     platform: safe(() => osPlatform()),
-    osVersion: safe(() => `${osPlatform()} ${release()}`),
+    // audit r4 Z8-3: os.type() yields the capitalized OS name ('Linux 6.x',
+    // matching the official <env> reproduction) where os.platform() lowercased
+    // it ('linux'). The `platform:` line above stays lowercase by design.
+    osVersion: safe(() => `${osType()} ${release()}`),
     date,
     model,
     isGitRepo: false,

--- a/projects/silver-core-sdk/src/engine/system-field.ts
+++ b/projects/silver-core-sdk/src/engine/system-field.ts
@@ -40,6 +40,15 @@ export type DerivedSystemField = {
  *    prompt carries a valid base/tail boundary — the strict
  *    0 < baseLen < length guard degrades cleanly on a stale offset.
  *  - Otherwise: flat single string ('last'; suffix joined with '\n').
+ *
+ * audit r4 Z8-1: the volatile (cwd/env) block in the split/dual array carries a
+ * leading '\n' so the wire bytes match the flat path exactly. The API
+ * concatenates system text blocks with NO inter-block separator (which is why
+ * base+tail reconstructs the stable prompt byte-for-byte), so without the '\n'
+ * the split path produced `stable`+`suffix` (no gap) while the flat path
+ * produced `stable\nsuffix` — toggling promptCaching silently changed the
+ * system bytes the model saw. The '\n' lives inside the volatile block, so the
+ * cached stable prefix (base/tail) is untouched.
  */
 export function deriveSystemField(
   config: Pick<
@@ -63,12 +72,14 @@ export function deriveSystemField(
         ? [
             { type: 'text', text: config.systemPrompt.slice(0, baseLen) },
             { type: 'text', text: config.systemPrompt.slice(baseLen) },
-            { type: 'text', text: config.systemPromptSuffix as string },
+            // audit r4 Z8-1: leading '\n' mirrors the flat-path join below.
+            { type: 'text', text: `\n${config.systemPromptSuffix as string}` },
           ]
         : splitSystem
           ? [
               { type: 'text', text: config.systemPrompt },
-              { type: 'text', text: config.systemPromptSuffix as string },
+              // audit r4 Z8-1: leading '\n' mirrors the flat-path join below.
+              { type: 'text', text: `\n${config.systemPromptSuffix as string}` },
             ]
           : hasSuffix
             ? `${config.systemPrompt}\n${config.systemPromptSuffix}`

--- a/projects/silver-core-sdk/src/error-normalize.ts
+++ b/projects/silver-core-sdk/src/error-normalize.ts
@@ -27,6 +27,7 @@ import {
   AbortError,
   errorCodeOf,
 } from './errors.js';
+import { sliceSurrogateSafe } from './internal/text.js';
 
 /**
  * The stable, host-consumable shape every upstream failure normalizes to.
@@ -100,7 +101,10 @@ function redact(text: string): string {
 function boundMessage(text: string): string {
   const trimmed = text.trim();
   const scrubbed = redact(trimmed);
-  return scrubbed.length > 2_000 ? `${scrubbed.slice(0, 2_000)}…` : scrubbed;
+  // audit r4 R7s-7: surrogate-safe cut so truncating mid astral codepoint
+  // (emoji / CJK Ext-B) in a giant error page cannot leave a lone surrogate on
+  // the surface (which would serialize to U+FFFD on every replay).
+  return scrubbed.length > 2_000 ? `${sliceSurrogateSafe(scrubbed, 2_000)}…` : scrubbed;
 }
 
 /** Pull a numeric HTTP status out of an arbitrary error-ish object. Some
@@ -126,6 +130,19 @@ function pickStatus(obj: Record<string, unknown>): number | undefined {
 function pickCode(obj: Record<string, unknown>): string | undefined {
   const raw = obj.code ?? obj.type ?? obj.error_code;
   return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+/** JSON.stringify that upholds this layer's "never throws" contract: a circular
+ *  envelope, a BigInt field, or a throwing getter would otherwise raise (audit
+ *  r4 R7j-2 — reachable via a live-throwing object). Falls back to a
+ *  de-identified shape summary. */
+function safeStringify(obj: Record<string, unknown>): string {
+  try {
+    const s = JSON.stringify(obj);
+    return typeof s === 'string' ? s : summarizeObject(obj);
+  } catch {
+    return summarizeObject(obj);
+  }
 }
 
 /** Request-id under any of the accepted spellings, top-level or nested. */
@@ -175,9 +192,10 @@ export function extractProviderErrorObject(value: unknown): {
       : nested !== undefined
         ? // Nested error object with a non-string message: stringify the error
           // envelope (bounded + secret-scrubbed by boundMessage below), matching
-          // the historical extractErrorPayload behavior.
-          JSON.stringify(nested)
-        : JSON.stringify(top);
+          // the historical extractErrorPayload behavior. safeStringify keeps the
+          // "never throws" contract for a circular/BigInt envelope (audit r4 R7j-2).
+          safeStringify(nested)
+        : safeStringify(top);
 
   const status = (nested && pickStatus(nested)) ?? pickStatus(top);
   const code = (nested && pickCode(nested)) ?? pickCode(top);
@@ -256,6 +274,107 @@ function connectionPhase(err: APIConnectionError): NormalizedProviderError['phas
   // class-default code; only a pre-stream connect failure is 'transport'.
   if (err.midStreamTruncation === true) return 'stream';
   return err.code === 'api_connection_failed' ? 'transport' : 'stream';
+}
+
+/** Transient transport-level Node / undici error codes. A fetch that failed at
+ *  the socket layer consumed no response body, so re-issuing the whole request
+ *  is safe — the same replay-safe class as a pre-stream APIConnectionError. */
+const RETRYABLE_NETWORK_CODES = new Set<string>([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EPIPE',
+  'EAI_AGAIN',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+]);
+
+/** A retryability/status signal recovered from a nested (cause / aggregated)
+ *  sub-error by signalFromNested. */
+interface NestedErrorSignal {
+  status?: number;
+  code?: string;
+  requestId?: string;
+  retryable: boolean;
+  phase?: NormalizedProviderError['phase'];
+}
+
+/**
+ * audit r4 Y6-2: the plain-Error branch classified only the TOP-LEVEL error, so
+ * the real fault a runtime hides underneath was lost — undici wraps it as
+ * `err.cause` (`TypeError('fetch failed', { cause: <ECONNREFUSED> })`) and
+ * `AggregateError` buckets several into `err.errors` (`AggregateError([<429>])`).
+ * The wrapper carries no status and no network code of its own, so the turn was
+ * mis-reported as terminal (retryable:false) when the buried cause was in fact a
+ * retryable transport failure or a 429/5xx. Walk the cause + aggregate graph
+ * (breadth-first, cycle-guarded via `seen`, depth-bounded) for the first
+ * sub-error that carries a real signal. Never throws (mirrors the module
+ * contract); extraction is guarded and only `.cause`/`.errors` are traversed.
+ */
+function signalFromNested(root: unknown): NestedErrorSignal | null {
+  const seen = new Set<unknown>();
+  const stack: Array<{ value: unknown; depth: number }> = [{ value: root, depth: 0 }];
+  while (stack.length > 0) {
+    const item = stack.shift();
+    if (item === undefined) break;
+    const { value, depth } = item;
+    if (value === null || value === undefined || seen.has(value) || depth > 8) continue;
+    seen.add(value);
+
+    // A typed status / connection sub-error is authoritative.
+    if (value instanceof APIStatusError) {
+      return {
+        status: value.status,
+        code: value.providerErrorCode ?? value.errorType,
+        requestId: value.requestId,
+        retryable: isRetryableHttpStatus(value.status),
+        phase: 'response',
+      };
+    }
+    if (value instanceof APIConnectionError) {
+      return {
+        code: value.code,
+        retryable: connectionRetryable(value),
+        phase: connectionPhase(value),
+      };
+    }
+
+    // A raw gateway error object a runtime hung on the cause, carrying a status.
+    let obj: ReturnType<typeof extractProviderErrorObject> = null;
+    try {
+      obj = extractProviderErrorObject(value);
+    } catch {
+      obj = null;
+    }
+    if (obj?.status !== undefined) {
+      return {
+        status: obj.status,
+        code: obj.code,
+        requestId: obj.requestId,
+        retryable: isRetryableHttpStatus(obj.status),
+        phase: 'response',
+      };
+    }
+
+    // A transient Node/undici transport error (the ECONNREFUSED case).
+    if (typeof value === 'object') {
+      const nodeCode = (value as { code?: unknown }).code;
+      if (typeof nodeCode === 'string' && RETRYABLE_NETWORK_CODES.has(nodeCode)) {
+        return { code: nodeCode, retryable: true, phase: 'transport' };
+      }
+      const agg = (value as { errors?: unknown }).errors;
+      if (Array.isArray(agg)) {
+        for (const e of agg) stack.push({ value: e, depth: depth + 1 });
+      }
+      const cause = (value as { cause?: unknown }).cause;
+      if (cause !== undefined) stack.push({ value: cause, depth: depth + 1 });
+    }
+  }
+  return null;
 }
 
 /**
@@ -348,15 +467,34 @@ export function normalizeProviderError(
       obj = null;
     }
     const sdkCode = errorCodeOf(err);
-    const status = obj?.status;
+    let status = obj?.status;
+    let code = obj?.code ?? sdkCode;
+    let requestId = obj?.requestId;
+    let retryable = status !== undefined ? isRetryableHttpStatus(status) : false;
+    let phase: NormalizedProviderError['phase'] | undefined =
+      status !== undefined ? 'response' : undefined;
+    // audit r4 Y6-2: when the wrapper itself yielded no status/retryable signal,
+    // adopt the most informative buried cause / AggregateError member so a
+    // `fetch failed`(cause:ECONNREFUSED) stays retryable and an
+    // AggregateError([429]) is not mis-reported as terminal.
+    if (status === undefined && !retryable) {
+      const nested = signalFromNested(err);
+      if (nested !== null) {
+        status = nested.status ?? status;
+        code = code ?? nested.code;
+        requestId = requestId ?? nested.requestId;
+        retryable = nested.retryable;
+        phase = phase ?? nested.phase;
+      }
+    }
     return base({
       name: err.name || 'Error',
       message: boundMessage(err.message || String(err)),
       status,
-      code: obj?.code ?? sdkCode,
-      requestId: obj?.requestId,
-      retryable: status !== undefined ? isRetryableHttpStatus(status) : false,
-      ...(status !== undefined ? { phase: 'response' as const } : {}),
+      code,
+      requestId,
+      retryable,
+      ...(phase !== undefined ? { phase } : {}),
       rawType: sdkCode,
     });
   }

--- a/projects/silver-core-sdk/src/index.ts
+++ b/projects/silver-core-sdk/src/index.ts
@@ -149,6 +149,12 @@ export {
   deleteSession,
   forkSession,
 } from './sessions/session-functions.js';
+// The options bag shared by the seven session-mutation functions above; without
+// this a consumer cannot name `{ sessionDir, ... }` (audit r4 R7c-1: TS2305).
+export type {
+  SessionMutationOptions,
+  GetSessionMessagesOptions,
+} from './sessions/session-functions.js';
 // R1 pre-injection accounting (SCS-REQ-REPOS-01 §3): read a session's
 // cumulative cost / turns / context estimate BEFORE injecting the next turn
 // via query({ prompt, options: { resume } }).

--- a/projects/silver-core-sdk/src/internal/async.ts
+++ b/projects/silver-core-sdk/src/internal/async.ts
@@ -84,6 +84,15 @@ export class AsyncQueue<T> {
   }
 
   async next(): Promise<IteratorResult<T, undefined>> {
+    // A FAILED queue throws BEFORE any buffered item is drained (audit r4 Sq-3).
+    // fail() means an abort or input-stream error; a message pushed before that
+    // failure must NOT be served afterwards, or a between-turns raw abort would
+    // resurrect a buffered user turn as an orphaned turn AFTER the abort. A
+    // graceful close() leaves `failure` null and still drains its buffer below,
+    // so this reordering only diverts the post-fail() path (query.ts bridges
+    // every abort — onOuterAbort / close() — to queue.fail(), so the failure
+    // guard here is the lifeSignal guard the audit calls for).
+    if (this.failure !== null) throw this.failure.err;
     // Gate on queue LENGTH, not on `shift() !== undefined`: a legitimately
     // enqueued `undefined` value is indistinguishable from an empty queue under
     // the shift-sentinel form, so a buffered `undefined` turn would be swallowed
@@ -92,7 +101,6 @@ export class AsyncQueue<T> {
     if (this.items.length > 0) {
       return { done: false, value: this.items.shift() as T };
     }
-    if (this.failure !== null) throw this.failure.err;
     if (this.closed) return { done: true, value: undefined };
     return new Promise((resolve, reject) => {
       this.waiters.push({ resolve, reject });

--- a/projects/silver-core-sdk/src/internal/media.ts
+++ b/projects/silver-core-sdk/src/internal/media.ts
@@ -20,9 +20,14 @@ export const SUPPORTED_IMAGE_MEDIA_TYPES: ReadonlySet<string> = new Set([
 /** Human-readable list for error/marker messages (stable order). */
 export const SUPPORTED_IMAGE_MEDIA_TYPES_LIST = [...SUPPORTED_IMAGE_MEDIA_TYPES].join(', ');
 
-/** Normalize a raw media type (trim + lowercase); undefined when the result
- *  is not one of the supported image types. */
+/** Normalize a raw media type (strip RFC-6838 parameters + trim + lowercase);
+ *  undefined when the result is not one of the supported image types. */
 export function normalizeImageMediaType(raw: string): string | undefined {
-  const mediaType = raw.trim().toLowerCase();
+  // RFC 6838: a media type may carry parameters after ';' (e.g.
+  // "image/png; charset=binary"). Strip the parameter segment before matching
+  // so a parameterized-but-decodable image is not downgraded to "unsupported"
+  // (audit r4 Y6-3).
+  const semi = raw.indexOf(';');
+  const mediaType = (semi === -1 ? raw : raw.slice(0, semi)).trim().toLowerCase();
   return SUPPORTED_IMAGE_MEDIA_TYPES.has(mediaType) ? mediaType : undefined;
 }

--- a/projects/silver-core-sdk/src/internal/model-alias.ts
+++ b/projects/silver-core-sdk/src/internal/model-alias.ts
@@ -48,9 +48,27 @@ export function resolveModelAlias(
   aliases?: Readonly<Record<string, string>>,
 ): string {
   if (model === undefined || model === 'inherit') return parentModel;
+  // audit r4 U5-3: resolve aliases transitively. A single pass returned the
+  // literal value of a host override even when that value is itself an alias —
+  // `{sonnet:'opus'}` yielded the bare string 'opus' (still an alias, not a
+  // concrete id), which the wire rejects with a 400. Walk override-then-built-in
+  // until the current token is no longer a known alias key. A visited-set guards
+  // against a cyclic config (`{a:'b',b:'a'}`) looping forever — on a repeat it
+  // stops and returns the token rather than hanging.
   // `as string`: Object.hasOwn guarantees the key is present, but under
   // noUncheckedIndexedAccess the index read is still typed `string | undefined`.
-  if (aliases !== undefined && Object.hasOwn(aliases, model)) return aliases[model] as string;
-  if (Object.hasOwn(MODEL_ALIASES, model)) return MODEL_ALIASES[model] as string;
-  return model;
+  const seen = new Set<string>();
+  let current = model;
+  for (;;) {
+    if (seen.has(current)) return current;
+    seen.add(current);
+    let next: string | undefined;
+    if (aliases !== undefined && Object.hasOwn(aliases, current)) {
+      next = aliases[current] as string;
+    } else if (Object.hasOwn(MODEL_ALIASES, current)) {
+      next = MODEL_ALIASES[current] as string;
+    }
+    if (next === undefined || next === current) return current;
+    current = next;
+  }
 }

--- a/projects/silver-core-sdk/src/internal/structured-output.ts
+++ b/projects/silver-core-sdk/src/internal/structured-output.ts
@@ -400,12 +400,17 @@ function validateValue(
     }
   }
 
-  // string constraints
-  if (typeof value === 'string') {
-    if (typeof s.minLength === 'number' && value.length < s.minLength) {
+  // string constraints. JSON Schema defines string length in Unicode CODE
+  // POINTS, but String#length counts UTF-16 code units, so an astral character
+  // (emoji, rare CJK) double-counts and a valid string fails minLength/maxLength
+  // (audit r4 U6-2). Count code points via the string iterator; compute only
+  // when a length constraint is present (spread is O(n)).
+  if (typeof value === 'string' && (typeof s.minLength === 'number' || typeof s.maxLength === 'number')) {
+    const codePoints = [...value].length;
+    if (typeof s.minLength === 'number' && codePoints < s.minLength) {
       errors.push({ path, message: `expected length >= ${s.minLength}` });
     }
-    if (typeof s.maxLength === 'number' && value.length > s.maxLength) {
+    if (typeof s.maxLength === 'number' && codePoints > s.maxLength) {
       errors.push({ path, message: `expected length <= ${s.maxLength}` });
     }
   }

--- a/projects/silver-core-sdk/src/loop-support/ledger.ts
+++ b/projects/silver-core-sdk/src/loop-support/ledger.ts
@@ -49,6 +49,18 @@ const SERIAL_VERSION = 1;
 const DEFAULT_REGION_ID = 'reported-events-ledger';
 const DEFAULT_TITLE = 'Previously reported events';
 
+/**
+ * ECMAScript time-value range: ±8.64e15 ms from epoch (±271,821 years). A
+ * finite `at` outside this window still passes Number.isFinite but makes
+ * new Date(at).toISOString() throw RangeError inside digest() (audit r4 Rdt-2).
+ */
+const MAX_TIMESTAMP_MS = 8_640_000_000_000_000;
+
+/** A number usable as a ledger `at`: finite AND a representable Date value. */
+function isValidTimestamp(at: number): boolean {
+  return Number.isFinite(at) && Math.abs(at) <= MAX_TIMESTAMP_MS;
+}
+
 /** Dedup ledger for already-reported events. Pure logic, no I/O, no clock. */
 export class ReportLedger {
   private readonly byKey = new Map<string, LedgerEntry>();
@@ -90,13 +102,16 @@ export class ReportLedger {
     }
     if (this.byKey.has(key)) return false;
     const at = opts?.at ?? Date.now();
-    // A non-finite timestamp (NaN/Infinity) would make digest() throw
+    // A non-finite timestamp (NaN/Infinity) OR one outside the representable
+    // Date range (±8.64e15, audit r4 Rdt-2) would make digest() throw
     // (Date#toISOString RangeError) inside toPrelude/toRetainedRegion — the
     // latter mid-compaction — and break the serialize/deserialize round-trip
     // (JSON turns NaN into null, which deserialize rejects). Fail loud here,
     // at the write, instead of deep in a fold.
-    if (!Number.isFinite(at)) {
-      throw new ConfigurationError('ledger entry timestamp (at) must be a finite number');
+    if (!isValidTimestamp(at)) {
+      throw new ConfigurationError(
+        'ledger entry timestamp (at) must be a finite epoch-ms within the representable Date range',
+      );
     }
     const entry: LedgerEntry = { key, at };
     if (opts?.summary !== undefined) entry.summary = opts.summary;
@@ -167,7 +182,7 @@ export class ReportLedger {
         typeof entry.key !== 'string' ||
         entry.key.length === 0 ||
         typeof entry.at !== 'number' ||
-        !Number.isFinite(entry.at) ||
+        !isValidTimestamp(entry.at) || // finite AND representable Date (audit r4 Rdt-2)
         (entry.summary !== undefined && typeof entry.summary !== 'string')
       ) {
         throw new ConfigurationError('ledger payload carries a malformed entry');

--- a/projects/silver-core-sdk/src/query.ts
+++ b/projects/silver-core-sdk/src/query.ts
@@ -81,7 +81,7 @@ import {
   makeToolSearchTool,
   type DeferredBuiltinEntry,
 } from './tools/toolsearch.js';
-import { appendFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { appendFileSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -451,13 +451,26 @@ export function query(args: {
       sandboxTmpDir = '';
     }
     const sbxOpt = typeof options.sandbox === 'object' ? options.sandbox : undefined;
+    // audit r4 U8-1: resolve each writable root to its real target before it
+    // reaches the backend. A symlinked writable root bound by its logical path
+    // is shadowed by the backend's `--ro-bind / /`, so a write through it hits
+    // EROFS; binding the resolved target makes the rw-bind actually take. Kept
+    // out of the backend's pure argv assembler (it must stay I/O-free); done
+    // here, best-effort — a path that cannot be resolved keeps its literal form.
+    const resolveRealBestEffort = (p: string): string => {
+      try {
+        return realpathSync(p);
+      } catch {
+        return p;
+      }
+    };
     const writablePaths = [
       cwd,
       ...(options.additionalDirectories ?? []),
       ...(sbxOpt?.writablePaths ?? []),
       ...(shells.stateDir !== '' ? [shells.stateDir] : []),
       ...(sandboxTmpDir !== '' ? [sandboxTmpDir] : []),
-    ];
+    ].map(resolveRealBestEffort);
     sandboxCtx = {
       backend: sandboxBackend,
       tmpDir: sandboxTmpDir,

--- a/projects/silver-core-sdk/src/tools/enterplanmode.ts
+++ b/projects/silver-core-sdk/src/tools/enterplanmode.ts
@@ -25,8 +25,33 @@
  */
 
 import type { BuiltinTool, ToolContext, ToolResultPayload } from '../internal/contracts.js';
+import type { PermissionMode } from '../types.js';
 import { AbortError } from '../errors.js';
 import { ENTERPLANMODE_DESCRIPTION } from './descriptions.js';
+
+/**
+ * Per-gate memory of the permission mode active when plan mode was entered, so
+ * ExitPlanMode can restore it instead of hard-coding 'default' (audit r4 U3-1).
+ * Keyed by the gate object — the query's single, stable permission gate across
+ * turns (query.ts and the subagent runtime thread the SAME reference into every
+ * turn's ToolContext), so an enter-then-explore-then-exit round trip resolves to
+ * the same key. A WeakMap keeps this off the gate contract and self-clears when
+ * the gate is collected.
+ */
+const priorModeByGate = new WeakMap<object, PermissionMode>();
+
+/** Record the mode active before plan mode (called by EnterPlanMode at entry). */
+export function recordPriorPlanMode(gate: object, mode: PermissionMode): void {
+  priorModeByGate.set(gate, mode);
+}
+
+/** Consume the recorded pre-plan mode for a gate (called by ExitPlanMode).
+ *  undefined when plan mode was not entered through EnterPlanMode. */
+export function takePriorPlanMode(gate: object): PermissionMode | undefined {
+  const mode = priorModeByGate.get(gate);
+  priorModeByGate.delete(gate);
+  return mode;
+}
 
 export const enterPlanModeTool: BuiltinTool = {
   name: 'EnterPlanMode',
@@ -64,6 +89,10 @@ export const enterPlanModeTool: BuiltinTool = {
       };
     }
 
+    // audit r4 U3-1: remember the pre-plan mode so ExitPlanMode restores it
+    // (e.g. acceptEdits) instead of silently dropping it to 'default'. `mode` is
+    // guaranteed != 'plan' by the guard above.
+    recordPriorPlanMode(gate, mode);
     gate.setMode('plan');
     ctx.debug(`EnterPlanMode: permission mode ${mode} -> plan`);
     return {

--- a/projects/silver-core-sdk/src/tools/exitplanmode.ts
+++ b/projects/silver-core-sdk/src/tools/exitplanmode.ts
@@ -15,8 +15,10 @@
  *    scope): query.ts builds the per-turn ToolContext (~line 1281) with the
  *    gate in scope — add `permissionGate: gate` there (and the subagent
  *    runtime's child context equivalently) to activate real mode switching.
- *  - Wired + mode 'plan': the call switches the gate to 'default' and reports
- *    the transition. allowedPrompts are ECHOED BUT NOT APPLIED — this gate has
+ *  - Wired + mode 'plan': the call restores the permission mode active BEFORE
+ *    plan mode was entered (recorded by EnterPlanMode; 'default' when plan mode
+ *    was entered by other means, e.g. a host setPermissionMode) and reports the
+ *    transition (audit r4 U3-1). allowedPrompts are ECHOED BUT NOT APPLIED — this gate has
  *    no prompt-based (natural-language) Bash rules, and mistranslating them
  *    into pattern rules would grant the wrong thing; the result says so
  *    explicitly (behavior-honesty red line: no silent pretending).
@@ -38,6 +40,7 @@ import type {
 } from '../internal/contracts.js';
 import { AbortError } from '../errors.js';
 import { EXITPLANMODE_DESCRIPTION } from './descriptions.js';
+import { takePriorPlanMode } from './enterplanmode.js';
 
 /** The slice of the permission gate ExitPlanMode needs (duck-typed context extension). */
 export type PlanModeControl = Pick<PermissionGate, 'getMode' | 'setMode'>;
@@ -132,9 +135,14 @@ export const exitPlanModeTool: BuiltinTool = {
       };
     }
 
-    gate.setMode('default');
-    ctx.debug('ExitPlanMode: permission mode plan -> default');
-    const lines = ['Exited plan mode. Permission mode: plan -> default.'];
+    // audit r4 U3-1: restore the mode active before plan mode (recorded by
+    // EnterPlanMode) rather than hard-coding 'default' and silently discarding
+    // the user's mode choice (e.g. acceptEdits). Plan mode entered by other
+    // means leaves no record and falls back to 'default' (unchanged behavior).
+    const restoreTo = takePriorPlanMode(gate) ?? 'default';
+    gate.setMode(restoreTo);
+    ctx.debug(`ExitPlanMode: permission mode plan -> ${restoreTo}`);
+    const lines = [`Exited plan mode. Permission mode: plan -> ${restoreTo}.`];
     if (prompts.value !== undefined && prompts.value.length > 0) {
       lines.push(
         'Requested prompt-based permissions (NOT applied — this permission ' +

--- a/projects/silver-core-sdk/src/tools/monitor.ts
+++ b/projects/silver-core-sdk/src/tools/monitor.ts
@@ -112,7 +112,18 @@ export const monitorTool: BuiltinTool = {
         isError: true,
       };
     }
-    const persistent = input['persistent'] === true;
+    // audit r4 U3-2: a malformed `persistent` (e.g. the string "true") must fail
+    // loudly, not silently coerce to false — otherwise a caller that intended a
+    // session-length watch gets it killed by the default timeout ("drop-in
+    // inputs fail loudly, never silently").
+    const rawPersistent = input['persistent'];
+    if (rawPersistent !== undefined && typeof rawPersistent !== 'boolean') {
+      return {
+        content: 'Monitor failed: "persistent" must be a boolean.',
+        isError: true,
+      };
+    }
+    const persistent = rawPersistent === true;
     // Clamp to Node's 32-bit setTimeout ceiling: a larger delay silently
     // overflows to 1ms, firing the kill timer ~immediately and killing the
     // just-launched watch — the exact opposite of a long-lived watch request.
@@ -155,14 +166,28 @@ export const monitorTool: BuiltinTool = {
     // shell 'killed'; a watch that already exited is left as-is. unref'd so an
     // armed timer never keeps the host process alive.
     if (!persistent) {
-      const timer = setTimeout(() => {
+      // audit r4 Stim-2: an armed kill timer otherwise pins its closure — and
+      // the shell manager it captures — until it FIRES, up to the 32-bit ceiling
+      // (~24 days) for a large timeout, even after the watch exits early. Bind
+      // the timer's lifetime to the query: clear it (and drop its closure) on
+      // teardown via the abort signal, and capture only the light locals below
+      // rather than the whole ToolContext. On a natural timeout the callback
+      // removes its own abort listener.
+      const debug = ctx.debug;
+      const signal = ctx.signal;
+      let timer: ReturnType<typeof setTimeout>;
+      const onAbort = (): void => clearTimeout(timer);
+      timer = setTimeout(() => {
+        signal.removeEventListener('abort', onAbort);
         const rec = shellsMgr.get(taskId);
         if (rec !== undefined && rec.status === 'running') {
-          ctx.debug(`Monitor: watch ${taskId} timed out after ${timeoutMs}ms; killing`);
+          debug(`Monitor: watch ${taskId} timed out after ${timeoutMs}ms; killing`);
           shellsMgr.kill(taskId);
         }
       }, timeoutMs);
       timer.unref?.();
+      if (signal.aborted) clearTimeout(timer);
+      else signal.addEventListener('abort', onAbort, { once: true });
     }
 
     ctx.debug(

--- a/projects/silver-core-sdk/src/tools/websearch.ts
+++ b/projects/silver-core-sdk/src/tools/websearch.ts
@@ -69,12 +69,19 @@ function filterResults(
 
 function renderResults(results: WebSearchResult[]): string {
   if (results.length === 0) return 'No results.';
+  // audit r4 Sd-1: the description advertises results "formatted as search
+  // result blocks, including links as markdown hyperlinks". Render each result's
+  // link as a markdown hyperlink (the URL line used to be bare text — not a
+  // hyperlink) and separate results into blocks with a blank line. The native
+  // API `web_search_result` content-block form is a host-callback subset (text),
+  // recorded honestly in docs/COMPAT.md ("Tool-description ↔ implementation
+  // fidelity").
   const blocks = results.map((r, i) => {
-    const lines = [`${i + 1}. ${r.title}`, `   ${r.url}`];
+    const lines = [`${i + 1}. ${r.title}`, `   [${r.url}](${r.url})`];
     if (r.snippet && r.snippet.length > 0) lines.push(`   ${r.snippet}`);
     return lines.join('\n');
   });
-  return blocks.join('\n');
+  return blocks.join('\n\n');
 }
 
 /** Diagnosable message for ANY thrown value (audit 2026-07-17 L74): a

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.67.1';
+export const SDK_VERSION = '0.67.2';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/audit-r4-descriptions.test.ts
+++ b/projects/silver-core-sdk/tests/audit-r4-descriptions.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Audit r4 — "descriptions" cluster regressions.
+ *
+ * These lock the two items in this cluster that were FIXED (the rest were
+ * skipped as faithful-reproduction / documented divergences — see
+ * docs/COMPAT.md "Tool-description ↔ implementation fidelity"):
+ *
+ *   - Sd-1: WebSearch advertises "search result blocks, including links as
+ *           markdown hyperlinks" but rendered a bare-URL plain-text line.
+ *           renderResults now emits a markdown hyperlink per result and blank-
+ *           line-delimited blocks, WITHOUT losing the numbered-list surface.
+ *   - Y5-3: MultiEdit was hard-removed (0.65.0) but docs/COMPAT.md still claimed
+ *           "still ships and works". The row is now REMOVED and the code side is
+ *           pinned (no MultiEdit in the default built-in set).
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import { webSearchTool } from '../src/tools/websearch.js';
+import { createBuiltinTools } from '../src/tools/index.js';
+import { WEBSEARCH_DESCRIPTION } from '../src/tools/descriptions.js';
+import type { ToolContext } from '../src/internal/contracts.js';
+import type { WebSearchResult } from '../src/types.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const COMPAT_MD = join(here, '..', 'docs', 'COMPAT.md');
+
+function makeCtx(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    cwd: '/tmp',
+    additionalDirectories: [],
+    env: {},
+    signal: new AbortController().signal,
+    debug: () => {},
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sd-1 — WebSearch renders markdown hyperlinks (impl fix)
+// ---------------------------------------------------------------------------
+
+describe('audit r4 Sd-1 — WebSearch link rendering matches the description', () => {
+  const results: WebSearchResult[] = [
+    { title: 'First', url: 'https://a.com/1', snippet: 'snip one' },
+    { title: 'Second', url: 'https://b.com/2' },
+  ];
+
+  it('renders each result link as a markdown hyperlink (no bare-URL line)', async () => {
+    const ctx = makeCtx({ webSearch: async () => results });
+    const r = await webSearchTool.execute({ query: 'x' }, ctx);
+    const text = String(r.content);
+
+    // The advertised "links as markdown hyperlinks" is now honest.
+    expect(text).toContain('[https://a.com/1](https://a.com/1)');
+    expect(text).toContain('[https://b.com/2](https://b.com/2)');
+
+    // The URL no longer appears as a bare, un-linked line (`   <url>` with no
+    // surrounding markdown link syntax).
+    expect(text).not.toMatch(/^ {3}https:\/\/a\.com\/1$/m);
+
+    // The numbered "search result blocks" surface is preserved.
+    expect(text).toContain('1. First');
+    expect(text).toContain('2. Second');
+    expect(text).toContain('snip one');
+
+    // Results are separated into blank-line-delimited blocks.
+    expect(text).toContain('\n\n');
+  });
+
+  it('still reports "No results." for an empty set', async () => {
+    const ctx = makeCtx({ webSearch: async () => [] });
+    const r = await webSearchTool.execute({ query: 'x' }, ctx);
+    expect(String(r.content)).toBe('No results.');
+  });
+
+  it('the corpus-locked description still advertises markdown hyperlinks (contract the impl now honors)', () => {
+    expect(WEBSEARCH_DESCRIPTION).toContain('links as markdown hyperlinks');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Y5-3 — MultiEdit removal reflected in code + docs
+// ---------------------------------------------------------------------------
+
+describe('audit r4 Y5-3 — MultiEdit is removed, COMPAT.md reflects it', () => {
+  it('MultiEdit is not in the default built-in tool set', () => {
+    const names = new Set(createBuiltinTools({ env: {} }).keys());
+    expect(names.has('MultiEdit')).toBe(false);
+  });
+
+  it('COMPAT.md no longer claims MultiEdit "still ships"', () => {
+    const compat = readFileSync(COMPAT_MD, 'utf8');
+    const multiEditRow = compat
+      .split('\n')
+      .find((line) => line.startsWith('| MultiEdit '));
+    expect(multiEditRow, 'MultiEdit row present in COMPAT.md').toBeTruthy();
+    // The stale claim is gone and the row is marked REMOVED.
+    expect(multiEditRow).not.toContain('still ships and works');
+    expect(multiEditRow).toContain('REMOVED');
+  });
+});

--- a/projects/silver-core-sdk/tests/audit-r4-error-normalize.test.ts
+++ b/projects/silver-core-sdk/tests/audit-r4-error-normalize.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression tests for audit r4 fixes in src/error-normalize.ts.
+ *
+ *   - Y6-2  : the plain-Error branch never inspected `err.cause` or
+ *             `AggregateError.errors`, so a `TypeError('fetch failed',
+ *             { cause: ECONNREFUSED })` lost its retryable transport detail and
+ *             an `AggregateError([429])` was mis-reported as retryable:false.
+ *   - R7j-2 : extractProviderErrorObject's `JSON.stringify(nested/top)` could
+ *             throw on a circular / BigInt envelope, breaking the "never throws"
+ *             contract of this layer.
+ *   - R7s-7 : boundMessage's `.slice(0, 2000)` could split a surrogate pair,
+ *             leaving a lone surrogate on the error surface.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { APIConnectionError, APIStatusError } from '../src/errors.js';
+import {
+  extractProviderErrorObject,
+  normalizeProviderError,
+} from '../src/error-normalize.js';
+
+// A high surrogate NOT followed by a low one, or a low NOT preceded by a high.
+const LONE_HIGH = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+const LONE_LOW = /(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+function hasLoneSurrogate(s: string): boolean {
+  return LONE_HIGH.test(s) || LONE_LOW.test(s);
+}
+
+describe('R7s-7 — boundMessage does not split a surrogate pair', () => {
+  it('drops the straddling half instead of emitting a lone surrogate', () => {
+    // 1999 ASCII then an astral emoji (2 UTF-16 units) so the pair straddles
+    // the 2000-unit cut, then filler to force truncation.
+    const giant = 'a'.repeat(1999) + '\u{1F600}' + 'b'.repeat(2000);
+    // Sanity: a naive slice WOULD leave a lone high surrogate — this is the bug.
+    expect(hasLoneSurrogate(giant.slice(0, 2_000))).toBe(true);
+
+    const n = normalizeProviderError({ message: giant, status: 500 });
+    expect(hasLoneSurrogate(n.message)).toBe(false);
+    // The straddling emoji half was dropped: 1999 'a' + the ellipsis marker.
+    expect(n.message).toBe('a'.repeat(1999) + '…');
+  });
+
+  it('leaves a short (non-truncated) message with astral chars intact', () => {
+    const n = normalizeProviderError({ message: 'boom \u{1F600} done', status: 400 });
+    expect(hasLoneSurrogate(n.message)).toBe(false);
+    expect(n.message).toContain('\u{1F600}');
+  });
+});
+
+describe('Y6-2 — nested cause / AggregateError classification', () => {
+  it('adopts a retryable transport code buried in err.cause (fetch failed)', () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
+      code: 'ECONNREFUSED',
+    });
+    const err = new TypeError('fetch failed', { cause });
+    const n = normalizeProviderError(err);
+    expect(n.retryable).toBe(true);
+    expect(n.phase).toBe('transport');
+    expect(n.code).toBe('ECONNREFUSED');
+    expect(n.name).toBe('TypeError');
+    expect(n.message).toBe('fetch failed');
+  });
+
+  it('surfaces a 429 buried in AggregateError.errors as retryable', () => {
+    const agg = new AggregateError(
+      [new APIStatusError(429, 'rate_limit_error', 'slow down')],
+      'All connection attempts failed',
+    );
+    const n = normalizeProviderError(agg);
+    expect(n.status).toBe(429);
+    expect(n.retryable).toBe(true);
+    expect(n.code).toBe('rate_limit_error');
+  });
+
+  it('surfaces a terminal 400 from an aggregate member (status enriched, not retryable)', () => {
+    const agg = new AggregateError([new APIStatusError(400, 'invalid_request_error', 'bad')]);
+    const n = normalizeProviderError(agg);
+    expect(n.status).toBe(400);
+    expect(n.retryable).toBe(false);
+  });
+
+  it('honors a replay-safe APIConnectionError carried as a cause', () => {
+    const conn = new APIConnectionError('socket hang up');
+    conn.turnReplaySafe = true;
+    const n = normalizeProviderError(new Error('wrapped transport failure', { cause: conn }));
+    expect(n.retryable).toBe(true);
+    expect(n.phase).toBe('transport');
+  });
+
+  it('adopts an HTTP status from a raw gateway object hung on the cause', () => {
+    const err = Object.assign(new Error('gateway wrap'), {
+      cause: { status: 503, message: 'upstream down' },
+    });
+    const n = normalizeProviderError(err);
+    expect(n.status).toBe(503);
+    expect(n.retryable).toBe(true);
+  });
+
+  it('does NOT over-mark retryable when the cause carries no signal', () => {
+    const n = normalizeProviderError(new Error('wrap', { cause: new Error('inner') }));
+    expect(n.retryable).toBe(false);
+    expect(n.status).toBeUndefined();
+  });
+
+  it('a cyclic cause chain neither throws nor loops', () => {
+    const a = new Error('a');
+    const b = new Error('b');
+    (a as { cause?: unknown }).cause = b;
+    (b as { cause?: unknown }).cause = a;
+    let n!: ReturnType<typeof normalizeProviderError>;
+    expect(() => {
+      n = normalizeProviderError(a);
+    }).not.toThrow();
+    expect(n.retryable).toBe(false);
+  });
+});
+
+describe('R7j-2 — extractProviderErrorObject upholds the never-throws contract', () => {
+  it('does not throw on a circular nested envelope with no message', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const evil = { error: circular };
+    let out: ReturnType<typeof extractProviderErrorObject> = null;
+    expect(() => {
+      out = extractProviderErrorObject(evil);
+    }).not.toThrow();
+    expect(out).not.toBeNull();
+    expect(out!.message).toContain('provider error object');
+    expect(out!.message).not.toContain('[object Object]');
+  });
+
+  it('does not throw on a BigInt-bearing nested envelope', () => {
+    const input = { error: { code: 'x', detail: 10n } };
+    let out: ReturnType<typeof extractProviderErrorObject> = null;
+    expect(() => {
+      out = extractProviderErrorObject(input);
+    }).not.toThrow();
+    expect(out).not.toBeNull();
+    expect(out!.message).not.toContain('[object Object]');
+  });
+});

--- a/projects/silver-core-sdk/tests/audit-r4-eval.test.ts
+++ b/projects/silver-core-sdk/tests/audit-r4-eval.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Audit r4 — "eval" cluster regressions (V7-1, V7-2, V7-3).
+ *
+ * Each block pins one confirmed defect from silver-core-sdk-bug-audit-r4:
+ *  - V7-1 computeDimensionStats surfaces the sample-count denominator a bare
+ *    mean hides (a 15/20-errored dimension must not read as healthy; a fully
+ *    collapsed dimension must not vanish).
+ *  - V7-2 dc-04 removes seed.txt before the resume so a file-re-reading (non
+ *    resuming) engine can no longer answer vacuously.
+ *  - V7-3 normalize-l3 N2 per-line rstrip is opt-out so a trailing-whitespace
+ *    fidelity divergence is observable instead of masked on both arms.
+ *
+ * V7-4 (l5-aggregate apiMs) is intentionally NOT fixed — see the structured
+ * summary's `skipped`: the last-cumulative apiMs / summed num_turns split is
+ * the correct reflection of the real SDK field semantics (query.ts:985-988,
+ * pinned by the run-28736460533 official trace) and summing apiMs would
+ * triple-count and break conformance-l5-aggregate.test.ts.
+ */
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// eslint-disable-next-line import/no-relative-packages -- eval-side tooling under test
+import { computeDimensionMeans, computeDimensionStats } from '../scripts/eval-scoring.mjs';
+// eslint-disable-next-line import/no-relative-packages -- eval-side tooling under test
+import { getHarnessRunner } from '../scripts/eval-harnesses.mjs';
+// @ts-expect-error - plain-JS conformance module without type declarations
+import { compareToolResultTexts, normalizeToolResult } from './conformance/normalize-l3.mjs';
+
+describe('V7-1 computeDimensionStats surfaces the sample-count denominator', () => {
+  it('a 15/20-errored dimension keeps a healthy mean but exposes the collapse', () => {
+    const results = [
+      ...Array.from({ length: 5 }, () => ({ outcome: 'SCORED', dimension: 'recall', score: 5 })),
+      ...Array.from({ length: 15 }, () => ({ outcome: 'ERROR', dimension: 'recall' })),
+    ];
+    // The bare mean alone reads as perfect and hides the 75% error rate...
+    expect(computeDimensionMeans(results)).toEqual({ recall: 5 });
+    // ...while the stats carry the honest denominator that a gate can flag.
+    expect(computeDimensionStats(results)).toEqual({
+      recall: { mean: 5, scored: 5, invalid: 0, errored: 15, total: 20 },
+    });
+  });
+
+  it('a fully collapsed dimension stays visible with mean:null (never vanishes)', () => {
+    const stats = computeDimensionStats([
+      { outcome: 'ERROR', dimension: 'disconnect_recovery' },
+      { outcome: 'SCORED', dimension: 'disconnect_recovery', score: undefined },
+    ]);
+    // computeDimensionMeans drops it entirely; stats keeps it present.
+    expect(computeDimensionMeans([{ outcome: 'ERROR', dimension: 'disconnect_recovery' }])).toEqual(
+      {},
+    );
+    expect('disconnect_recovery' in stats).toBe(true);
+    expect(stats.disconnect_recovery).toEqual({
+      mean: null,
+      scored: 0,
+      invalid: 1,
+      errored: 1,
+      total: 2,
+    });
+  });
+
+  it('invalid (scoreless SCORED) records are counted apart and stay out of the mean', () => {
+    const stats = computeDimensionStats([
+      { outcome: 'SCORED', dimension: 'd', score: 4 },
+      { outcome: 'SCORED', dimension: 'd', score: 2 },
+      { outcome: 'SCORED', dimension: 'd', score: 'x' }, // poisoned: not integer
+      { outcome: 'PENDING_HARNESS', dimension: 'd' },
+    ]);
+    // mean over the two valid scores only; agrees with computeDimensionMeans.
+    expect(stats.d).toEqual({ mean: 3, scored: 2, invalid: 1, errored: 0, total: 4 });
+    expect(stats.d.mean).toBe(computeDimensionMeans([
+      { outcome: 'SCORED', dimension: 'd', score: 4 },
+      { outcome: 'SCORED', dimension: 'd', score: 2 },
+    ]).d);
+  });
+});
+
+describe('V7-2 dc-04 removes the seed.txt crutch before the resume', () => {
+  it('phase 1 sees seed.txt; phase 2 (resume) does not — a re-read cannot answer', async () => {
+    const seen: Array<{ seedExists: boolean }> = [];
+    // Fake SDK: records whether seed.txt exists at each query() call and yields
+    // a session id so sessionIdOf() is non-null and phase 2 runs.
+    const sdk = {
+      query({ options }: { options: { cwd: string } }) {
+        seen.push({ seedExists: existsSync(join(options.cwd, 'seed.txt')) });
+        async function* gen() {
+          yield { type: 'assistant', session_id: 'sess-v72', message: { content: [] } };
+          yield { type: 'result', session_id: 'sess-v72', subtype: 'success', is_error: false };
+        }
+        return gen();
+      },
+    };
+    const runner = getHarnessRunner('dc-04');
+    expect(runner).toBeTypeOf('function');
+    const out = await runner({ sdk });
+    try {
+      expect(seen).toHaveLength(2);
+      expect(seen[0]!.seedExists).toBe(true); // phase 1: model could Read it
+      expect(seen[1]!.seedExists).toBe(false); // phase 2: only a real resume knows the code
+      // Evidence records the removed crutch honestly.
+      expect(out.evidence.files['seed.txt']).toBe('<absent>');
+      expect(out.evidence.resumedSessionId).toBe('sess-v72');
+    } finally {
+      rmSync(out.ws.cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('V7-3 normalize-l3 N2 per-line rstrip is opt-out for fidelity', () => {
+  it('default strips trailing whitespace (unchanged); the opt-in preserves it', () => {
+    expect(normalizeToolResult('third line   \n', {}, {}).text).toBe('third line');
+    expect(normalizeToolResult('third line   \n', {}, { preserveTrailingSpace: true }).text).toBe(
+      'third line   ',
+    );
+  });
+
+  it('a trailing-whitespace divergence is masked by default but observable when preserved', () => {
+    // Same fixture shape as L3-READ-01: one arm keeps the trailing spaces, one
+    // strips them. Default N2 rstrip hides it; the opt-in surfaces it.
+    const masked = compareToolResultTexts(
+      'first line\nthird line   \n',
+      'first line\nthird line\n',
+      {},
+      {},
+      {},
+      [],
+    );
+    expect(masked.status).toBe('match');
+    const surfaced = compareToolResultTexts(
+      'first line\nthird line   \n',
+      'first line\nthird line\n',
+      {},
+      {},
+      { preserveTrailingSpace: true },
+      [],
+    );
+    expect(surfaced.status).toBe('divergent');
+  });
+});

--- a/projects/silver-core-sdk/tests/audit-r4-misc.test.ts
+++ b/projects/silver-core-sdk/tests/audit-r4-misc.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Audit r4 (2026-07-17) - "misc" cluster regression locks
+ * (report: Public-Info-Pool/Resource/repo-engineering/
+ * silver-core-sdk-bug-audit-r4-20260717.md):
+ *
+ *  - Y6-3  [media.ts]            normalizeImageMediaType now strips RFC-6838
+ *          parameters (";charset=..."), so a parameterized-but-decodable image
+ *          is no longer downgraded to "unsupported".
+ *  - U6-2  [structured-output]   minLength/maxLength count Unicode CODE POINTS,
+ *          not UTF-16 code units, so an astral char (emoji) no longer
+ *          double-counts into a false schema violation.
+ *  - Rdt-2 [ledger.ts]           record()/deserialize() reject a finite-but-
+ *          out-of-Date-range `at` (±8.64e15) up front, instead of throwing a
+ *          RangeError deep inside digest()/toPrelude() (the latter mid-compaction).
+ *  - R7c-1 [index.ts]            SessionMutationOptions (+ GetSessionMessagesOptions)
+ *          is re-exported from the package barrel, so a consumer can name the
+ *          options bag of the seven session-mutation functions (TS2305 before).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { ConfigurationError } from '../src/errors.js';
+import { normalizeImageMediaType } from '../src/internal/media.js';
+import { evaluateStructuredOutput } from '../src/internal/structured-output.js';
+import { ReportLedger } from '../src/loop-support/ledger.js';
+import type { JSONSchema } from '../src/types.js';
+// Type-only import exercises the R7c-1 barrel re-export: if the export were
+// missing this file would fail `tsc --noEmit` with TS2305.
+import type { SessionMutationOptions, GetSessionMessagesOptions } from '../src/index.js';
+
+// ---------------------------------------------------------------------------
+// Y6-3: normalizeImageMediaType strips RFC-6838 parameters
+// ---------------------------------------------------------------------------
+
+describe('Y6-3 normalizeImageMediaType parameter stripping', () => {
+  it('strips a trailing ";charset=..." parameter and matches the base type', () => {
+    expect(normalizeImageMediaType('image/png; charset=binary')).toBe('image/png');
+  });
+
+  it('handles whitespace around the parameter separator', () => {
+    expect(normalizeImageMediaType('image/jpeg ; foo=bar')).toBe('image/jpeg');
+    expect(normalizeImageMediaType('IMAGE/WEBP;q=1')).toBe('image/webp');
+  });
+
+  it('still returns undefined for an unsupported base type carrying parameters', () => {
+    expect(normalizeImageMediaType('image/bmp; charset=binary')).toBeUndefined();
+  });
+
+  it('leaves an unparameterized supported type untouched (no regression)', () => {
+    expect(normalizeImageMediaType('image/gif')).toBe('image/gif');
+    expect(normalizeImageMediaType('  Image/PNG  ')).toBe('image/png');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U6-2: minLength/maxLength count code points, not UTF-16 code units
+// ---------------------------------------------------------------------------
+
+describe('U6-2 structured-output string length in code points', () => {
+  // A single astral char is 1 code point but 2 UTF-16 units. text passed to
+  // evaluateStructuredOutput is the model's final reply; a top-level JSON
+  // string is the quoted form.
+  it('accepts a one-emoji string under maxLength:1 (was a false violation)', () => {
+    const schema = { type: 'string', maxLength: 1 } as unknown as JSONSchema;
+    expect(evaluateStructuredOutput('"\u{1F600}"', schema).status).toBe('valid');
+  });
+
+  it('rejects a one-emoji string under minLength:2 (code-point count is 1)', () => {
+    const schema = { type: 'string', minLength: 2 } as unknown as JSONSchema;
+    expect(evaluateStructuredOutput('"\u{1F600}"', schema).status).toBe('invalid');
+  });
+
+  it('accepts a two-emoji string under maxLength:2', () => {
+    const schema = { type: 'string', maxLength: 2 } as unknown as JSONSchema;
+    expect(evaluateStructuredOutput('"\u{1F600}\u{1F601}"', schema).status).toBe('valid');
+  });
+
+  it('keeps ASCII length checks unchanged (no regression)', () => {
+    const tooLong = { type: 'string', maxLength: 2 } as unknown as JSONSchema;
+    expect(evaluateStructuredOutput('"abc"', tooLong).status).toBe('invalid');
+    const ok = { type: 'string', minLength: 3 } as unknown as JSONSchema;
+    expect(evaluateStructuredOutput('"abc"', ok).status).toBe('valid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rdt-2: ledger rejects finite-but-unrepresentable Date timestamps
+// ---------------------------------------------------------------------------
+
+describe('Rdt-2 ledger timestamp Date-range guard', () => {
+  const MAX = 8_640_000_000_000_000;
+
+  it('record() throws on a finite `at` beyond ±8.64e15 (would RangeError in digest)', () => {
+    const ledger = new ReportLedger();
+    expect(() => ledger.record('k', { at: 1e18 })).toThrow(ConfigurationError);
+    expect(() => ledger.record('k', { at: -1e18 })).toThrow(ConfigurationError);
+    // The pre-existing non-finite guard still holds.
+    expect(() => ledger.record('k', { at: Number.NaN })).toThrow(ConfigurationError);
+  });
+
+  it('accepts the exact Date boundary and digests it without throwing', () => {
+    const ledger = new ReportLedger();
+    expect(ledger.record('edge', { at: MAX })).toBe(true);
+    // Was the actual crash site: toISOString inside digest().
+    expect(() => ledger.toPrelude()).not.toThrow();
+    expect(() => ledger.record('over', { at: MAX + 1 })).toThrow(ConfigurationError);
+  });
+
+  it('deserialize() rejects a hand-crafted payload with an out-of-range `at`', () => {
+    const payload = JSON.stringify({ v: 1, config: {}, entries: [{ key: 'k', at: 1e18 }] });
+    expect(() => ReportLedger.deserialize(payload)).toThrow(ConfigurationError);
+  });
+
+  it('round-trips an in-range ledger unchanged (no regression)', () => {
+    const ledger = new ReportLedger();
+    ledger.record('a', { at: 1_700_000_000_000, summary: 's' });
+    const revived = ReportLedger.deserialize(ledger.serialize());
+    expect(revived.has('a')).toBe(true);
+    expect(revived.size).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R7c-1: SessionMutationOptions re-exported from the barrel
+// ---------------------------------------------------------------------------
+
+describe('R7c-1 SessionMutationOptions barrel re-export', () => {
+  it('lets a consumer name the shared options bag from the package entry point', () => {
+    const opts: SessionMutationOptions = { sessionDir: '/tmp/s', cwd: '/tmp' };
+    const withLimit: GetSessionMessagesOptions = { ...opts, limit: 10 };
+    expect(opts.sessionDir).toBe('/tmp/s');
+    expect(withLimit.limit).toBe(10);
+  });
+});

--- a/projects/silver-core-sdk/tests/audit-r4-planmode-monitor.test.ts
+++ b/projects/silver-core-sdk/tests/audit-r4-planmode-monitor.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Audit r4 regression tests — cluster "planmode-monitor".
+ *
+ * Covers the fixed items:
+ *  - U3-1  ExitPlanMode restores the pre-plan permission mode (recorded by
+ *          EnterPlanMode) instead of hard-coding 'default'.
+ *  - U3-2  Monitor rejects a malformed non-boolean `persistent` rather than
+ *          silently coercing it to false.
+ *  - Stim-2 Monitor's non-persistent kill timer is released on query teardown
+ *          (abort signal) instead of pinning its closure until it fires.
+ *
+ * Z4-1 (EnterPlanMode readOnly vs "REQUIRES user approval" description) is NOT
+ * covered here — it was SKIPPED (test-locked + deliberate design; see the
+ * task report). Monitor watches run real background shells via
+ * createShellManager, disposed in afterEach.
+ */
+
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type {
+  ShellManager,
+  ToolContext,
+  ToolResultPayload,
+} from '../src/internal/contracts.js';
+import { DefaultPermissionGate } from '../src/permissions/gate.js';
+import { createShellManager } from '../src/tools/shells.js';
+import { enterPlanModeTool } from '../src/tools/enterplanmode.js';
+import { exitPlanModeTool } from '../src/tools/exitplanmode.js';
+import { monitorTool } from '../src/tools/monitor.js';
+
+let managers: ShellManager[] = [];
+afterEach(() => {
+  for (const m of managers) m.dispose();
+  managers = [];
+});
+
+function makeShells(): ShellManager {
+  const m = createShellManager(() => {});
+  managers.push(m);
+  return m;
+}
+
+function makeCtx(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    cwd: tmpdir(),
+    additionalDirectories: [],
+    env: process.env as Record<string, string | undefined>,
+    signal: new AbortController().signal,
+    debug: () => {},
+    ...overrides,
+  };
+}
+
+function text(r: ToolResultPayload): string {
+  return String(r.content);
+}
+
+async function until(cond: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error('condition not met in time');
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// U3-1: ExitPlanMode restores the pre-plan mode
+// ---------------------------------------------------------------------------
+
+describe('audit r4 U3-1: ExitPlanMode restores the pre-plan mode', () => {
+  it('restores acceptEdits after an EnterPlanMode round trip (not hard default)', async () => {
+    const gate = new DefaultPermissionGate({ debug: () => {}, mode: 'acceptEdits' });
+    const ctx = makeCtx();
+    ctx.permissionGate = gate;
+
+    const enter = await enterPlanModeTool.execute({}, ctx);
+    expect(enter.isError).toBeUndefined();
+    expect(gate.getMode()).toBe('plan');
+
+    const exit = await exitPlanModeTool.execute({}, ctx);
+    expect(exit.isError).toBeUndefined();
+    // The bug hard-coded 'default'; the fix restores the recorded acceptEdits.
+    expect(gate.getMode()).toBe('acceptEdits');
+    expect(text(exit)).toContain('plan -> acceptEdits');
+  });
+
+  it('restores dontAsk after an EnterPlanMode round trip', async () => {
+    const gate = new DefaultPermissionGate({ debug: () => {}, mode: 'dontAsk' });
+    const ctx = makeCtx();
+    ctx.permissionGate = gate;
+
+    await enterPlanModeTool.execute({}, ctx);
+    expect(gate.getMode()).toBe('plan');
+    const exit = await exitPlanModeTool.execute({}, ctx);
+    expect(gate.getMode()).toBe('dontAsk');
+    expect(text(exit)).toContain('plan -> dontAsk');
+  });
+
+  it('falls back to default when plan mode was NOT entered via EnterPlanMode', async () => {
+    const gate = new DefaultPermissionGate({ debug: () => {}, mode: 'plan' });
+    const ctx = makeCtx();
+    ctx.permissionGate = gate;
+
+    const exit = await exitPlanModeTool.execute({}, ctx);
+    expect(exit.isError).toBeUndefined();
+    expect(gate.getMode()).toBe('default');
+    expect(text(exit)).toContain('plan -> default');
+  });
+
+  it('consumes the record once: a second enter/exit does not leak a stale prior mode', async () => {
+    const gate = new DefaultPermissionGate({ debug: () => {}, mode: 'acceptEdits' });
+    const ctx = makeCtx();
+    ctx.permissionGate = gate;
+
+    // First round trip: acceptEdits -> plan -> acceptEdits.
+    await enterPlanModeTool.execute({}, ctx);
+    await exitPlanModeTool.execute({}, ctx);
+    expect(gate.getMode()).toBe('acceptEdits');
+
+    // Host switches to default, then a NEW plan session begins via EnterPlanMode.
+    gate.setMode('default');
+    await enterPlanModeTool.execute({}, ctx);
+    const exit2 = await exitPlanModeTool.execute({}, ctx);
+    // Must restore the SECOND session's prior mode (default), not the stale first.
+    expect(gate.getMode()).toBe('default');
+    expect(text(exit2)).toContain('plan -> default');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U3-2: Monitor rejects a malformed `persistent`
+// ---------------------------------------------------------------------------
+
+describe('audit r4 U3-2: Monitor rejects a malformed persistent flag', () => {
+  it('rejects non-boolean persistent instead of silently coercing to false', async () => {
+    const shells = makeShells();
+    const ctx = makeCtx({ shells });
+    for (const bad of ['true', 'false', 1, 0, {}, []]) {
+      const r = await monitorTool.execute(
+        { command: 'true', description: 'd', persistent: bad },
+        ctx,
+      );
+      expect(r.isError, JSON.stringify(bad)).toBe(true);
+      expect(text(r)).toContain('"persistent" must be a boolean');
+    }
+  });
+
+  it('still accepts a real boolean persistent (true disables the timeout)', async () => {
+    const shells = makeShells();
+    const ctx = makeCtx({ shells });
+    const ok = await monitorTool.execute(
+      { command: 'sleep 30', description: 'log tail', timeout_ms: 100, persistent: true },
+      ctx,
+    );
+    expect(ok.isError, text(ok)).toBeUndefined();
+    expect(text(ok)).toContain('persistent: true');
+    const id = /taskId: (bash_\d+)/.exec(text(ok))![1]!;
+    shells.kill(id);
+  });
+
+  it('still accepts persistent:false (default timeout applies)', async () => {
+    const shells = makeShells();
+    const ctx = makeCtx({ shells });
+    const ok = await monitorTool.execute(
+      { command: 'sleep 30', description: 'watch', timeout_ms: 100, persistent: false },
+      ctx,
+    );
+    expect(ok.isError, text(ok)).toBeUndefined();
+    expect(text(ok)).not.toContain('persistent: true');
+    const id = /taskId: (bash_\d+)/.exec(text(ok))![1]!;
+    shells.kill(id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stim-2: the non-persistent kill timer is released on abort
+// ---------------------------------------------------------------------------
+
+describe('audit r4 Stim-2: Monitor kill timer is released on query teardown', () => {
+  it('aborting the query clears the pending kill timer (watch NOT killed by it)', async () => {
+    const shells = makeShells();
+    const controller = new AbortController();
+    const ctx = makeCtx({ shells, signal: controller.signal });
+
+    const r = await monitorTool.execute(
+      { command: 'sleep 30', description: 'watch', timeout_ms: 200 },
+      ctx,
+    );
+    expect(r.isError, text(r)).toBeUndefined();
+    const id = /taskId: (bash_\d+)/.exec(text(r))![1]!;
+    expect(shells.get(id)!.status).toBe('running');
+
+    // Abort BEFORE the 200ms kill timer would fire.
+    controller.abort();
+    // Wait past the timeout window: with the fix the timer was cleared, so the
+    // watch is still running (nothing else kills it in this isolated context);
+    // without the fix the timer fires at ~200ms and marks the shell 'killed'.
+    await new Promise((res) => setTimeout(res, 500));
+    expect(shells.get(id)!.status).toBe('running');
+
+    shells.kill(id);
+  });
+
+  it('without abort, the kill timer still fires and kills a stuck watch', async () => {
+    const shells = makeShells();
+    const ctx = makeCtx({ shells });
+    const r = await monitorTool.execute(
+      { command: 'sleep 30', description: 'stuck', timeout_ms: 150 },
+      ctx,
+    );
+    expect(r.isError, text(r)).toBeUndefined();
+    const id = /taskId: (bash_\d+)/.exec(text(r))![1]!;
+    expect(shells.get(id)!.status).toBe('running');
+    await until(() => shells.get(id)!.status === 'killed');
+  });
+});

--- a/projects/silver-core-sdk/tests/audit-r4-pricing.test.ts
+++ b/projects/silver-core-sdk/tests/audit-r4-pricing.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for audit r4 cluster "pricing":
+ *  - U5-1: PRICE_TABLE was missing the original claude-3-sonnet- prefix.
+ *  - U5-2: Claude 3 Haiku cache rates used the generic multiplier, not official.
+ *  - U5-3: resolveModelAlias resolved a single pass, not transitively.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { estimateCostUsd, hasPriceFor } from '../src/engine/pricing.js';
+import { resolveModelAlias } from '../src/internal/model-alias.js';
+import type { NonNullableUsage } from '../src/types.js';
+
+const MTOK = 1_000_000;
+
+// ---------------------------------------------------------------------------
+// U5-1 — the original Claude 3 Sonnet must be priced (not $0)
+// ---------------------------------------------------------------------------
+
+describe('audit r4 U5-1: claude-3-sonnet- is priced, not $0', () => {
+  const usage: NonNullableUsage = {
+    input_tokens: 1_000_000,
+    output_tokens: 1_000_000,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+  };
+
+  it('prices claude-3-sonnet-20240229 at the sonnet rate (3 in / 15 out)', () => {
+    // Before: no prefix matched -> $0 -> maxBudgetUsd silently unenforced.
+    expect(estimateCostUsd('claude-3-sonnet-20240229', usage)).toBe(18);
+    expect(estimateCostUsd('claude-3-sonnet-20240229', usage)).toBeGreaterThan(0);
+    expect(hasPriceFor('claude-3-sonnet-20240229')).toBe(true);
+  });
+
+  it('does not shadow the longer claude-3-5 / claude-3-7 sonnet prefixes', () => {
+    // Longest prefix wins: these keep matching their own (identical-rate) entries.
+    expect(estimateCostUsd('claude-3-5-sonnet-20241022', usage)).toBe(18);
+    expect(estimateCostUsd('claude-3-7-sonnet-20250219', usage)).toBe(18);
+    // And the generation-last sonnet is untouched.
+    expect(estimateCostUsd('claude-sonnet-4-5', usage)).toBe(18);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U5-2 — Claude 3 Haiku uses the official cache rates, not the generic multiplier
+// ---------------------------------------------------------------------------
+
+describe('audit r4 U5-2: claude-3-haiku- cache rates are official', () => {
+  it('bills cache write at 0.30 and cache read at 0.03 per MTok (not 0.3125 / 0.025)', () => {
+    const usage: NonNullableUsage = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+      cache_read_input_tokens: 1_000_000,
+    };
+    // Official: 0.30 + 0.03 = 0.33. Generic multiplier would give 0.3375.
+    expect(estimateCostUsd('claude-3-haiku-20240307', usage, '5m')).toBeCloseTo(0.33, 10);
+    expect(estimateCostUsd('claude-3-haiku-20240307', usage, '5m')).not.toBeCloseTo(
+      0.3375,
+      10,
+    );
+  });
+
+  it('isolates the cache-read rate at the official 0.03', () => {
+    const readOnly: NonNullableUsage = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 1_000_000,
+    };
+    expect(estimateCostUsd('claude-3-haiku-20240307', readOnly, '5m')).toBeCloseTo(0.03, 10);
+  });
+
+  it('isolates the 5m cache-write rate at the official 0.30', () => {
+    const writeOnly: NonNullableUsage = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+      cache_read_input_tokens: 0,
+    };
+    expect(estimateCostUsd('claude-3-haiku-20240307', writeOnly, '5m')).toBeCloseTo(0.3, 10);
+    // The 1h TTL still derives from input x2, unaffected by the write-rate fix.
+    expect(estimateCostUsd('claude-3-haiku-20240307', writeOnly, '1h')).toBeCloseTo(0.5, 10);
+  });
+
+  it('leaves base input/output rates unchanged (0.25 / 1.25)', () => {
+    const tokensOnly: NonNullableUsage = {
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    };
+    expect(estimateCostUsd('claude-3-haiku-20240307', tokensOnly)).toBeCloseTo(
+      (1_000_000 * 0.25 + 1_000_000 * 1.25) / MTOK,
+      10,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U5-3 — resolveModelAlias resolves aliases transitively
+// ---------------------------------------------------------------------------
+
+describe('audit r4 U5-3: resolveModelAlias resolves aliases transitively', () => {
+  it('chains a host override whose value is itself a built-in alias', () => {
+    // Before: returned the literal 'opus' (still an alias) -> wire 400.
+    expect(resolveModelAlias('sonnet', 'parent', { sonnet: 'opus' })).toBe('claude-opus-4-8');
+    expect(resolveModelAlias('sonnet', 'parent', { sonnet: 'haiku' })).toBe('claude-haiku-4-5');
+  });
+
+  it('chains through multiple override hops to a concrete id', () => {
+    expect(
+      resolveModelAlias('sonnet', 'parent', { sonnet: 'mid', mid: 'gw-final-model' }),
+    ).toBe('gw-final-model');
+  });
+
+  it('terminates on a cyclic config instead of looping forever', () => {
+    const out = resolveModelAlias('a', 'parent', { a: 'b', b: 'a' });
+    expect(typeof out).toBe('string');
+    // Stops on the first repeated token rather than hanging.
+    expect(out).toBe('a');
+  });
+
+  it('still returns a host override that resolves to a concrete id in one hop', () => {
+    expect(resolveModelAlias('sonnet', 'parent', { sonnet: 'gw-sonnet' })).toBe('gw-sonnet');
+  });
+
+  it('still resolves built-in aliases and passes unknown ids / inherit through', () => {
+    expect(resolveModelAlias('opus', 'parent')).toBe('claude-opus-4-8');
+    expect(resolveModelAlias('vendor/custom-9', 'parent')).toBe('vendor/custom-9');
+    expect(resolveModelAlias('inherit', 'parent-model')).toBe('parent-model');
+    expect(resolveModelAlias(undefined, 'parent-model')).toBe('parent-model');
+    // Prototype keys still pass through verbatim (own-property lookup preserved).
+    expect(resolveModelAlias('toString', 'parent')).toBe('toString');
+    expect(resolveModelAlias('__proto__', 'parent')).toBe('__proto__');
+  });
+});

--- a/projects/silver-core-sdk/tests/audit-r4-prompt-assembly.test.ts
+++ b/projects/silver-core-sdk/tests/audit-r4-prompt-assembly.test.ts
@@ -1,0 +1,132 @@
+/**
+ * audit r4 — prompt-assembly cluster regression tests.
+ *
+ * Z8-1 (system-field.ts): toggling promptCaching must NOT change the system
+ * bytes the model sees. The split/dual array path now carries the volatile
+ * tail's leading '\n' (the API joins system text blocks with no separator), so
+ * the blocks concatenate to exactly the flat single-string form. The cached
+ * stable prefix (base/tail) is left byte-identical.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildEngineConfig } from '../src/engine/config-builder.js';
+import { deriveSystemField } from '../src/engine/system-field.js';
+import type { Options, TextBlockParam } from '../src/types.js';
+
+const noop = (): void => {};
+
+function build(options: Options): ReturnType<typeof buildEngineConfig> {
+  return buildEngineConfig({
+    options,
+    cwd: '/tmp/proj',
+    initialModel: 'claude-sonnet-4-5',
+    builtinToolNames: ['Read', 'Grep'],
+    debug: noop,
+  });
+}
+
+function texts(system: string | TextBlockParam[]): string[] {
+  return typeof system === 'string' ? [system] : system.map((b) => b.text);
+}
+
+describe('audit r4 Z8-1: caching toggle is system-byte-invariant', () => {
+  it('2-block split blocks concatenate to the flat single-string form', () => {
+    const { engineConfig } = build({
+      systemPrompt: { type: 'preset', preset: 'claude_code' },
+      includeEnvironmentContext: true,
+      settingSources: [], // no project tail -> baseLen === stable.length -> 'first'
+    });
+    // caching ON -> split array
+    engineConfig.promptCaching = true;
+    const split = deriveSystemField(engineConfig);
+    expect(Array.isArray(split.system)).toBe(true);
+    expect(split.boundary).toBe('first');
+    // caching OFF -> flat string
+    engineConfig.promptCaching = false;
+    const flat = deriveSystemField(engineConfig);
+    expect(typeof flat.system).toBe('string');
+    // The API concatenates system text blocks with NO separator; joining the
+    // split blocks with '' must reproduce the flat string byte-for-byte.
+    expect(texts(split.system).join('')).toBe(flat.system as string);
+    // The volatile tail block carries the leading '\n'; the stable prefix
+    // blocks are untouched (cached bytes intact).
+    const blocks = texts(split.system);
+    expect(blocks.at(-1)!.startsWith('\n')).toBe(true);
+    expect(blocks.slice(0, -1).join('')).toBe(engineConfig.systemPrompt);
+  });
+
+  it('3-block dual [base, project, cwd] split also matches the flat form', () => {
+    const { engineConfig } = build({
+      systemPrompt: { type: 'preset', preset: 'claude_code', append: 'PROJECT RULES' },
+      includeEnvironmentContext: true,
+      settingSources: [],
+    });
+    engineConfig.promptCaching = true;
+    const split = deriveSystemField(engineConfig);
+    expect(split.boundary).toBe('dual');
+    expect(texts(split.system)).toHaveLength(3);
+    engineConfig.promptCaching = false;
+    const flat = deriveSystemField(engineConfig);
+    expect(texts(split.system).join('')).toBe(flat.system as string);
+    // stable prefix (base + project) reconstructs the cached prompt unchanged
+    expect(texts(split.system).slice(0, -1).join('')).toBe(engineConfig.systemPrompt);
+  });
+
+  it('deriveSystemField unit: the bare volatile suffix gains the flat-path separator', () => {
+    // 2-block split (no base/tail boundary)
+    const first = deriveSystemField({
+      promptCaching: true,
+      systemPrompt: 'STABLE',
+      systemPromptSuffix: 'CWD',
+      systemPromptBaseLen: undefined,
+      systemBlocks: undefined,
+    });
+    expect(first.boundary).toBe('first');
+    expect(texts(first.system)).toEqual(['STABLE', '\nCWD']);
+
+    // 3-block dual split ('BASE' | 'TAIL')
+    const dual = deriveSystemField({
+      promptCaching: true,
+      systemPrompt: 'BASETAIL',
+      systemPromptSuffix: 'CWD',
+      systemPromptBaseLen: 4,
+      systemBlocks: undefined,
+    });
+    expect(dual.boundary).toBe('dual');
+    expect(texts(dual.system)).toEqual(['BASE', 'TAIL', '\nCWD']);
+
+    // flat form for the same inputs
+    const flat = deriveSystemField({
+      promptCaching: false,
+      systemPrompt: 'BASETAIL',
+      systemPromptSuffix: 'CWD',
+      systemPromptBaseLen: 4,
+      systemBlocks: undefined,
+    });
+    expect(flat.system).toBe('BASETAIL\nCWD');
+
+    // byte-invariance across the toggle
+    expect(texts(dual.system).join('')).toBe(flat.system as string);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Z8-3 (runtime-context.ts): osVersion uses os.type() so the OS name is
+// capitalized ('Linux 6.x') to match the official <env> reproduction, while
+// the separate `platform` field stays lowercase by design.
+// ---------------------------------------------------------------------------
+
+describe('audit r4 Z8-3: osVersion carries the capitalized OS name', () => {
+  it('gatherEnvironment osVersion starts with os.type(), platform stays os.platform()', async () => {
+    const os = await import('node:os');
+    const { gatherEnvironment } = await import('../src/engine/runtime-context.js');
+    const env = gatherEnvironment('/tmp/proj', 'claude-sonnet-4-5', '2026-07-18');
+    expect(env.osVersion.startsWith(os.type())).toBe(true); // e.g. 'Linux 6.x'
+    expect(env.platform).toBe(os.platform()); // e.g. 'linux'
+    // On Linux the two differ only by case — proving osVersion is NOT lowercased.
+    if (os.type() !== os.platform()) {
+      expect(env.osVersion.startsWith(os.platform())).toBe(false);
+    }
+  });
+})

--- a/projects/silver-core-sdk/tests/audit-r4-sandbox-async.test.ts
+++ b/projects/silver-core-sdk/tests/audit-r4-sandbox-async.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Audit r4 — cluster "sandbox-async" regressions.
+ *
+ * Only ONE of the cluster's four ids is a live, owned-file defect in the
+ * 0.67.1 tree; the other three point at code the 0.65.3->0.67.1 refactor moved
+ * out of the owned files (documented in the run's `skipped` list), so they have
+ * no test here per the audit's honesty rule (no test for a non-fix):
+ *
+ *   Sq-3 [FIXED]  internal/async.ts — AsyncQueue.next() drained buffered items
+ *                 BEFORE checking failure, so a between-turns abort (fail())
+ *                 with a message still buffered resurrected it as an orphaned
+ *                 user turn. next() now throws the failure first; a graceful
+ *                 close() (failure===null) still drains its buffer.
+ *   U8-1 [skip]   sandbox/bwrap.ts   — symlink writable-root needs realpath
+ *                 (I/O); wrap() is a pure argv assembler -> upstream fix.
+ *   U8-3 [skip]   internal/process-kill.ts — now a pure planner; the executors
+ *                 signal the process GROUP, reaching grace-window grandchildren.
+ *   U8-4 [skip]   internal/async.ts — CompletionQueue was removed; AsyncQueue's
+ *                 push() returns false (observable), not a silent drop.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { AsyncQueue } from '../src/internal/async.js';
+
+// A distinct error type so the assertions prove the ORIGINAL failure reason is
+// what surfaces (never a swallowed/relabelled one) — no `new Error(...)`.
+class AbortLike extends Error {
+  constructor() {
+    super('The query was aborted');
+    this.name = 'AbortError';
+  }
+}
+
+describe('audit r4 Sq-3 — AsyncQueue.next() surfaces fail() before buffered items', () => {
+  it('a fail() after a message is buffered throws instead of serving the orphaned turn', async () => {
+    const q = new AsyncQueue<string>();
+    // A turn arrives, then the query is aborted between turns before it is read.
+    expect(q.push('buffered-turn')).toBe(true);
+    const reason = new AbortLike();
+    q.fail(reason);
+    // Pre-fix this handed back { done:false, value:'buffered-turn' } — an
+    // orphaned user turn processed AFTER the abort. It must now throw the abort.
+    await expect(q.next()).rejects.toBe(reason);
+  });
+
+  it('every subsequent next() keeps throwing the failure (buffer is never revived)', async () => {
+    const q = new AsyncQueue<string>();
+    q.push('one');
+    q.push('two');
+    const reason = new AbortLike();
+    q.fail(reason);
+    await expect(q.next()).rejects.toBe(reason);
+    await expect(q.next()).rejects.toBe(reason);
+  });
+
+  it('a graceful close() still drains buffered items, then reports done (no regression)', async () => {
+    const q = new AsyncQueue<string>();
+    q.push('a');
+    q.push('b');
+    // close() leaves failure===null, so the buffer must still drain in order.
+    q.close();
+    expect(await q.next()).toEqual({ done: false, value: 'a' });
+    expect(await q.next()).toEqual({ done: false, value: 'b' });
+    expect(await q.next()).toEqual({ done: true, value: undefined });
+  });
+
+  it('a buffered undefined is still delivered on a non-failed queue (P3 stays fixed)', async () => {
+    const q = new AsyncQueue<string | undefined>();
+    q.push(undefined);
+    q.close();
+    expect(await q.next()).toEqual({ done: false, value: undefined });
+    expect(await q.next()).toEqual({ done: true, value: undefined });
+  });
+
+  it('a pending waiter is rejected with the failure when fail() lands while it awaits', async () => {
+    const q = new AsyncQueue<string>();
+    const pending = q.next(); // no items yet -> parks as a waiter
+    const reason = new AbortLike();
+    q.fail(reason);
+    await expect(pending).rejects.toBe(reason);
+  });
+});

--- a/projects/silver-core-sdk/tests/conformance/normalize-l3.mjs
+++ b/projects/silver-core-sdk/tests/conformance/normalize-l3.mjs
@@ -10,7 +10,10 @@
  *                         CLI canonicalizes /tmp symlinks); the outside dir
  *                         of containment cases -> <OUTSIDE>.
  *   N2 whitespace       - CRLF -> LF, strip trailing whitespace per line,
- *                         drop trailing blank lines.
+ *                         drop trailing blank lines. The per-line trailing-
+ *                         whitespace strip is opt-OUT (flags.preserveTrailingSpace)
+ *                         so a case probing trailing-whitespace FIDELITY can
+ *                         observe a real per-arm divergence (audit r4 V7-3).
  *   N3 timing mask      - "after <N>ms/s/m" -> "after <T>", ONLY in cases
  *                         flagged maskTiming (never bare numbers - exit codes
  *                         and line numbers must survive). maskTimestamps
@@ -42,7 +45,8 @@ function reEscape(s) {
 /**
  * Normalize one tool_result text. env carries the per-arm run facts
  * ({ cwd, realCwd, outsideDir, realOutsideDir, shellId }); flags are the
- * per-case opt-ins ({ maskTiming, maskTimestamps, sortLines }).
+ * per-case opt-ins ({ maskTiming, maskTimestamps, sortLines,
+ * preserveTrailingSpace }).
  * Returns { text, applied } where applied is the set of KD-relevant rewrite
  * tags that actually fired ('gutter-tab' | 'gutter-arrow' | 'system-reminder'
  * | 'shell-id') so the comparator can report them.
@@ -99,10 +103,13 @@ export function normalizeToolResult(rawText, env = {}, flags = {}) {
     );
   }
 
-  // N2: per-line rstrip + trailing blank lines.
-  text = text
-    .split('\n')
-    .map((l) => l.replace(/[ \t]+$/, ''))
+  // N2: per-line rstrip + trailing blank lines. The per-line trailing-
+  // whitespace strip is opt-OUT (flags.preserveTrailingSpace) so a case probing
+  // trailing-whitespace FIDELITY (e.g. L3-READ-01's 'third line   ') can observe
+  // a real per-arm divergence instead of having it normalized away on BOTH arms
+  // (audit r4 V7-3). CRLF->LF (top) and trailing-blank-line drop still apply.
+  const n2Lines = text.split('\n');
+  text = (flags.preserveTrailingSpace === true ? n2Lines : n2Lines.map((l) => l.replace(/[ \t]+$/, '')))
     .join('\n')
     .replace(/\n+$/, '');
 

--- a/projects/silver-core-sdk/tests/engine.test.ts
+++ b/projects/silver-core-sdk/tests/engine.test.ts
@@ -2179,7 +2179,9 @@ describe('dual system cache breakpoint', () => {
     expect(system).toHaveLength(3);
     expect(system[0]!.text).toBe(BASE);
     expect(system[1]!.text).toBe(TAIL);
-    expect(system[2]!.text).toBe(CWD);
+    // audit r4 Z8-1: the volatile cwd block carries a leading '\n' to match the
+    // flat-path byte layout; the cached stable blocks (BASE/TAIL) are unchanged.
+    expect(system[2]!.text).toBe('\n' + CWD);
     expect(system[0]!.cache_control).toEqual({ type: 'ephemeral' });
     expect(system[1]!.cache_control).toEqual({ type: 'ephemeral' });
     expect(system[2]!.cache_control).toBeUndefined();
@@ -2201,7 +2203,8 @@ describe('dual system cache breakpoint', () => {
     const system = transport.requests[0]!.system as TextBlockParam[];
     expect(system).toHaveLength(2);
     expect(system[0]!.text).toBe(BASE + TAIL);
-    expect(system[1]!.text).toBe(CWD);
+    // audit r4 Z8-1: volatile cwd block carries a leading '\n' (see above).
+    expect(system[1]!.text).toBe('\n' + CWD);
     expect(system[0]!.cache_control).toEqual({ type: 'ephemeral' });
     expect(system[1]!.cache_control).toBeUndefined();
   });

--- a/projects/silver-core-sdk/tests/system-field.test.ts
+++ b/projects/silver-core-sdk/tests/system-field.test.ts
@@ -46,7 +46,10 @@ describe('system assembly <-> derivation contract', () => {
     // the invariant that breaks when an append lands before the baseLen offset.
     const stableJoined = blocks.slice(0, blocks.length - 1).join('');
     expect(stableJoined).toBe(engineConfig.systemPrompt);
-    expect(blocks.at(-1)).toBe(engineConfig.systemPromptSuffix);
+    // audit r4 Z8-1: the volatile block carries a leading '\n' so the split
+    // path's wire bytes match the flat path (which joins stable+suffix with
+    // '\n'); the stable prefix above is unchanged.
+    expect(blocks.at(-1)).toBe('\n' + engineConfig.systemPromptSuffix);
     expect(derived.boundary).toBe(
       engineConfig.systemPromptBaseLen !== undefined &&
         engineConfig.systemPromptBaseLen > 0 &&
@@ -125,7 +128,8 @@ describe('system assembly <-> derivation contract', () => {
       engineConfig.systemPromptSuffix !== undefined ? 'first' : 'last',
     );
     if (engineConfig.systemPromptSuffix !== undefined) {
-      expect(blocks).toEqual([engineConfig.systemPrompt, engineConfig.systemPromptSuffix]);
+      // audit r4 Z8-1: volatile block carries a leading '\n' (see above).
+      expect(blocks).toEqual([engineConfig.systemPrompt, '\n' + engineConfig.systemPromptSuffix]);
     }
   });
 });


### PR DESCRIPTION
## 概述

T52 r4「剩余全部缺陷 Workflow 批修」战役 **Tier 3 收官（低危/eval/descriptions）**：9 个并行文件互斥代理修完 9 簇——**23 项修复**（20 代理 + 3 集成完成）+ 其余诚实存档/文档化/待裁。**本批闭合 r4 backlog：205 项全部处置完毕**（修复或附精确理由归档）。silver-core-sdk 0.67.1 → 0.67.2。

小学生比喻：收尾这批像装修最后的验收——补插座标签（描述与实现对齐）、把量错的尺子改准（osVersion 大小写、pricing 表）、把没关的抽屉关上（timer 泄漏、barrel 导出漏），再把「官方有但我们这版架构上做不到」的项如实写进说明书（COMPAT），而不是假装能做。

### 各簇战果

- **planmode-monitor（3）**：ExitPlanMode 恢复进 plan 前模式（U3-1）、Monitor 拒非布尔 persistent（U3-2）、kill timer teardown 释放（Stim-2）
- **prompt-assembly（2）**：缓存开关系统字节不变（Z8-1）、osVersion 大写 OS 名（Z8-3）
- **sandbox-async（2）**：AsyncQueue 跨轮 abort 守卫（Sq-3）、sandbox 可写根 realpath 防 EROFS（U8-1）
- **error-normalize（3）**：err.cause 链检查保重试细节（Y6-2）、循环对象不破「never throws」（R7j-2）、surrogate 安全（R7s-7）
- **pricing（3）**：claude-3-sonnet 前缀 + Haiku 缓存价（U5-1/2）、别名链式解析（U5-3）
- **misc（4）**：媒体类型参数剥离（Y6-3）、min/maxLength 码点计（U6-2）、ledger Date 边界守卫（Rdt-2）、SessionMutationOptions barrel 再导出（R7c-1）
- **eval（3）**：维度均值带样本分母防漏回归（V7-1）、process-kill harness 删种子文件（V7-2）、L3 尾空白不掩盖分歧（V7-3）
- **descriptions（2 + COMPAT fidelity 节）**：WebSearch markdown 超链接（Sd-1）、MultiEdit 移除更正（Y5-3）；忠实但有差异的官方描述（Sd-2..7、Z4-1）记入新建 COMPAT「Tool-description ↔ implementation fidelity」节，不改 corpus 锁定复现

### 诚实存档（非缺陷/低危延后，均文档化）

Z8-2+Rdt-4（per-turn `<env>` 重渲染——低危、避缓存前缀回归风险延后）、U8-3（pgid 逃逸规划器不可修）、U8-4（罕见 teardown 后台终结者——可选）、V7-4（apiMs 累计-vs-逐结果语义正确、非缺陷）、Z4-2（corrected-final-result teardown 是守密人裁定的 待裁⑤ 特性，属守密人裁决项、非可回退缺陷）。

## 变更类型

- [x] Bug 修复

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布渠道数据。**
- [x] **不上传内部美术资产 / 解包原始文件 / 未公开剧情草稿。**
- [x] **同意按 MIT License 提交。**

## 验证清单

- [x] 全量 vitest **2997 通过 + 3 skipped**（+8 新回归档 + Z8-1/Z8-3 既有测试对齐）
- [x] `tsc --noEmit` 零错误
- [x] 仓库级 pytest **2975 通过 + 4 skipped**
- [x] 版本纪律：bump 0.67.2 + CHANGELOG（守卫过）
- [x] 不引入 emoji；descriptions 忠实复现不改写、差异走 COMPAT 文档

## 关联 Issue

- Refs：`memory/todo.md` T52（Tier 3 销 23 项；**r4 205 项全数处置、backlog 闭合**）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB8w2UzAmqoWbB5398WPdV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QB8w2UzAmqoWbB5398WPdV)_