### PR TITLE
fix(silver-core-sdk): result accounting contract — uuid-reuse + explicit doc (0.68.1)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,40 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.68.1 — 2026-07-18
+
+Result accounting contract — clarified, single-mechanism (keeper ruling
+2026-07-18, options 乙+丙; supersedes the deferred/hybrid idea).
+
+Background: a query using `options.memory` (session-end round) or in-flight
+background subagents can spend money AFTER a turn's `result` was yielded, so
+the query emits a trailing corrected result at teardown with the complete
+cumulative accounting (the "待裁⑤" mechanism). We considered deferring the
+single result instead (one-result-per-query), but deferral deadlocks an
+interactive streaming consumer that waits for the result before sending its
+next input — so the correction is the only universal, deadlock-safe
+mechanism, and a second (mode-split) mechanism would be redundant and
+introduce a mode-dependent footgun. Chosen instead: keep the one correction
+mechanism, and make it clean + explicit.
+
+- **丙 (src/query.ts)**: the trailing corrected result now REUSES the original
+  result's `uuid` instead of minting a new one. A consumer that keys/dedupes
+  results by `uuid` collapses the two into one (latest-wins = complete
+  accounting) with no special-casing; a non-deduping consumer still receives
+  both and applies the documented last-wins rule. `num_turns: 0` + zero
+  `usage` still keep the per-result sums from double-counting.
+- **乙 (docs/COMPAT.md)**: new "Result accounting contract" section makes the
+  previously-implicit contract explicit — cumulative fields (`total_cost_usd`,
+  `duration_api_ms`) are last-wins (never sum), per-result fields
+  (`num_turns`, `usage`) are per-turn (sum), when the correction appears, the
+  uuid-reuse behavior, and the deadlock rationale. The `result` row in the
+  SDKMessage stream table points to it.
+
+No behavior change for a plain query (no memory, no background subagents):
+exactly one `result`, matching the official one-result-per-query shape.
+Regression: memory-m2 待裁⑤ test now also asserts the shared uuid. Full
+vitest 2997 passed / 3 skipped; tsc + build clean.
+
 ## 0.68.0 — 2026-07-18
 
 LOCKSTEP versioning begins (keeper ruling 2026-07-18, overriding the
@@ -27,6 +61,7 @@ equality (check-dep-direction section D, red-proven). From here on, a merge
 that changes shipped runtime code in EITHER package bumps BOTH package.json
 versions; the untouched package's changelog gets a one-line lockstep
 alignment note. No agent-side code changes in this release.
+
 
 ## 0.67.2 — 2026-07-18
 

--- a/projects/silver-core-sdk/docs/COMPAT.md
+++ b/projects/silver-core-sdk/docs/COMPAT.md
@@ -483,11 +483,43 @@ divergences):
 | `assistant` | FULL | full `APIAssistantMessage` |
 | `user` (echo + tool results) | FULL | prompt echo and tool_result user turns both yielded and persisted in order |
 | `stream_event` | FULL | behind `includePartialMessages`; **P2**: `SDKPartialAssistantMessage` now carries the official `ttft_ms?` field, attached from the event that latches the first token onward (test engine.test.ts) |
-| `result` success / error_max_turns / error_during_execution / `error_max_budget_usd` / `error_max_structured_output_retries` | PARTIAL | success arm carries ttft_ms + structured_output + deferred_tool_use + v0.3 `metrics`; error arm carries both `errorMessage: string` and the official-parallel `errors: string[]` (v0.4). Mid-stream SSE truncation degrades gracefully like official 2.1.201 (E3, 2026-07-05): the blocks the wire delivered whole are salvaged - partial text becomes the `success` answer, complete tool_use blocks EXECUTE (at either cut depth, with or without stop_reason) and the loop re-requests to deliver the tool_result; the connection error rides `errors` as a non-fatal note on the terminal result (former KD-L4-04 + all three truncation engine findings retired; residual KD-L4-02: official also appends the error as assistant text and throws from the iterator post-result - deliberately not replicated). An UNCLOSED tool_use (mid-transmission input) never executes; nothing salvageable falls back to `error_during_execution`. Remaining fault-path divergence: on a terminal non-retryable 400 ours ends with a clean `result/error_during_execution` where official surfaces the error as assistant text plus `result/success` then throws (KD-L4-01; run-l4 l4-http400-non-retryable, l4-script-exhausted-400-terminal). Reporting semantics on streamed multi-turn input match official (E2, 2026-07-05, KD-L5-04 retired): `num_turns`/`usage` are PER-RESULT (that turn's own figures), `total_cost_usd`/`duration_api_ms` are session-cumulative; `modelUsage` stays session-cumulative (official per-result semantics unobserved - our choice); internal `maxTurns`/`maxBudgetUsd` enforcement remains session-wide. Query-layer synthetic results (hook-block / pre-turn cap stop / interrupt) report `num_turns: 0` + zero `usage` (no engine turn ran for them; official shape unobserved) |
+| `result` success / error_max_turns / error_during_execution / `error_max_budget_usd` / `error_max_structured_output_retries` | PARTIAL | success arm carries ttft_ms + structured_output + deferred_tool_use + v0.3 `metrics`; error arm carries both `errorMessage: string` and the official-parallel `errors: string[]` (v0.4). Mid-stream SSE truncation degrades gracefully like official 2.1.201 (E3, 2026-07-05): the blocks the wire delivered whole are salvaged - partial text becomes the `success` answer, complete tool_use blocks EXECUTE (at either cut depth, with or without stop_reason) and the loop re-requests to deliver the tool_result; the connection error rides `errors` as a non-fatal note on the terminal result (former KD-L4-04 + all three truncation engine findings retired; residual KD-L4-02: official also appends the error as assistant text and throws from the iterator post-result - deliberately not replicated). An UNCLOSED tool_use (mid-transmission input) never executes; nothing salvageable falls back to `error_during_execution`. Remaining fault-path divergence: on a terminal non-retryable 400 ours ends with a clean `result/error_during_execution` where official surfaces the error as assistant text plus `result/success` then throws (KD-L4-01; run-l4 l4-http400-non-retryable, l4-script-exhausted-400-terminal). Reporting semantics on streamed multi-turn input match official (E2, 2026-07-05, KD-L5-04 retired): `num_turns`/`usage` are PER-RESULT (that turn's own figures), `total_cost_usd`/`duration_api_ms` are session-cumulative; `modelUsage` stays session-cumulative (official per-result semantics unobserved - our choice); internal `maxTurns`/`maxBudgetUsd` enforcement remains session-wide. Query-layer synthetic results (hook-block / pre-turn cap stop / interrupt) report `num_turns: 0` + zero `usage` (no engine turn ran for them; official shape unobserved). A query using `options.memory` (session-end round) or with in-flight background subagents may emit a TRAILING corrected result at teardown — same uuid, complete cumulative cost — see "Result accounting contract" below |
 | `system/compact_boundary` | FULL | emitted on auto-compaction (the official manual `/compact` text command has no engine equivalent — slash retirement §4; the `trigger` union keeps `manual` for stream-shape parity) |
 | `system/mirror_error` | FULL | emitted on a session-store mirror failure |
 | `active_goal` | TYPED | NEW-IN-DOCS 0.3.205; no persistent goal/condition loop in a headless engine (`value:null` clears) |
 | `conversation_reset` | TYPED | NEW-IN-DOCS 0.3.205; a new conversation is a new `query()`/session here, not an in-stream boundary |
+
+### Result accounting contract (read this to aggregate cost/usage correctly)
+
+Two SDK-original features — `options.memory` (the session-end progress-card
+round) and in-flight background subagents — can spend money AFTER a turn's
+`result` was already yielded (the round/settle happens at teardown). Rather
+than delay the answer, the query emits a **trailing corrected result** carrying
+the complete cumulative accounting. The contract a consumer must follow:
+
+- **Cumulative fields are last-wins.** `total_cost_usd` and `duration_api_ms`
+  are session-cumulative; **read them from the LAST `result` message**, never by
+  summing across results. Summing double-counts.
+- **Per-result fields are per-turn.** `num_turns` and `usage` are that turn's own
+  figures (**sum** them across results). The trailing correction carries
+  `num_turns: 0` + zero `usage` precisely so summing them stays correct.
+- **The correction reuses the original result's `uuid`** (keeper ruling
+  2026-07-18, 丙). A consumer that keys/dedupes results by `uuid` therefore sees
+  ONE result — the correction is its updated, complete-accounting version
+  (latest-wins) — and needs no special-casing; a consumer that does not dedupe
+  still receives both messages and must apply the last-wins rule above.
+- **When it appears:** only when teardown moved the totals (a priced session-end
+  memory round, or a background subagent that settled cost late). A plain query
+  with no memory and no background subagents emits exactly one `result`, matching
+  the official one-result-per-query shape.
+- **Not emitted** on abort/error (those throw/emit their own terminal result) or
+  to a consumer that already stopped iterating (return()/throw()).
+
+Rationale (keeper 2026-07-16 / 2026-07-18): deferring the single result until
+after teardown would deadlock an interactive streaming consumer that waits for
+the result before sending its next input, so the correction — not deferral — is
+the universal, deadlock-safe mechanism; reusing the uuid removes the "two
+results" ambiguity for deduping consumers without a second code path.
 
 ### Observability arm (v0.3 — task #16)
 

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/query.ts
+++ b/projects/silver-core-sdk/src/query.ts
@@ -2027,7 +2027,17 @@ export function query(args: {
           lastYieldedResult !== undefined &&
           acct.cost > lastYieldedResult.total_cost_usd
         ) {
-          yield { ...lastYieldedResult, uuid: randomUUID(), ...resultCommon() };
+          // 丙 (keeper 2026-07-18): REUSE the original result's uuid (do not mint
+          // a new one). A consumer that dedupes/keys by uuid then sees ONE result
+          // — this emission is the SAME logical result, updated to the complete
+          // accounting — instead of two distinct results; a consumer that does
+          // not dedupe still receives the correction. num_turns:0 / usage:0
+          // (via resultCommon) keep the per-result sums from double-counting (E2),
+          // while the cumulative total_cost_usd / duration_api_ms / modelUsage
+          // now carry the whole session (incl. the session-end memory round and
+          // any late background-subagent settle). The A-contract is documented in
+          // docs/COMPAT.md ("Result accounting contract").
+          yield { ...lastYieldedResult, ...resultCommon() };
         }
       }
     }

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.68.0';
+export const SDK_VERSION = '0.68.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/memory-m2.test.ts
+++ b/projects/silver-core-sdk/tests/memory-m2.test.ts
@@ -372,6 +372,10 @@ describe('R7: session-end progress-card round (query level)', () => {
     expect(corrected!.usage.input_tokens).toBe(0);
     // The corrected result is the LAST message on the stream.
     expect(messages[messages.length - 1]!.type).toBe('result');
+    // 丙 (keeper 2026-07-18): the correction REUSES the first result's uuid, so a
+    // consumer that dedupes by uuid collapses the two into one (latest-wins =
+    // complete accounting), while a non-deduping consumer still sees both.
+    expect(corrected!.uuid).toBe(first!.uuid);
   });
 
   it('a zero-cost session-end round adds NO corrected result (exactly one)', async () => {


### PR DESCRIPTION
## 概述

Result 记账合同——澄清 + 单机制清理(守密人 2026-07-18 裁定「丙」= 乙 + 丙,覆盖此前 B'/延后单条的设想)。silver-core-sdk 0.68.0 → 0.68.1。

### 背景与取舍

一个用 `options.memory`(session-end 记忆轮)或有在飞后台子代理的 query,会在**终结 result 已发之后**产生迟到成本,故末尾补发一条**完整累计**的更正 result(待裁⑤ 机制)。曾考虑改成「延后单条 result」以贴合官方 one-result-per-query——但**延后会死锁交互流式消费方**(它要先看到 result 才发下一轮输入),故更正条是**唯一通用、无死锁**的机制;再加第二套(按模式分叉)机制既多余又引入「行为随模式变」的新坑。守密人裁定:**保留这一套机制,把它做干净 + 讲明白。**

- **丙(`src/query.ts`)**:更正条**复用原 result 的 uuid**(不再新造)。按 uuid 去重的消费方自动合并为一条(latest-wins = 完整记账)、零特判;不去重的仍收到两条并按 last-wins 规则处理。`num_turns:0 + usage:0` 仍防逐结果求和双计。
- **乙(`docs/COMPAT.md`)**:新增「Result accounting contract」节,把此前隐性的合同挑明——累计字段(`total_cost_usd`/`duration_api_ms`)取最后一条(绝不求和)、逐结果字段(`num_turns`/`usage`)求和、更正条何时出现、uuid 复用行为、死锁原理;SDKMessage stream 表的 `result` 行指向它。

**普通 query(无记忆、无后台子代理)行为不变**:恰好一条 result,贴合官方 one-result-per-query。

小学生比喻:餐厅仍「先给小票、加点的补更正票」,但**更正票印上跟原小票同一个单号**——按单号归档的顾客自动只留最新一张(=一张完整票),不归档的也照收更正;再把「累计额看最后一张、别把两张加起来」的规矩写进店堂告示(COMPAT)。既没另起一套规矩,又把老规矩讲透了。

## 变更类型

- [x] Bug 修复 / 契约澄清

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布渠道数据。**
- [x] **同意按 MIT License 提交。**

## 验证清单

- [x] 全量 vitest **2997 通过 + 3 skipped**（memory-m2 待裁⑤ 增断言共享 uuid;uuid-persistence 唯一性锁不受影响——更正条不落盘）
- [x] `tsc --noEmit` 零错误
- [x] 仓库级 pytest **2975 通过 + 4 skipped**
- [x] 版本纪律：bump 0.68.1 + CHANGELOG（守卫过；让号 0.67.3→0.68.1 因 main 已到 0.68.0）
- [x] 不引入 emoji

## 关联 Issue

- Refs：`memory/todo.md` T52 待裁⑤(Z4-2)——由「保留 A vs 退役」升级为「保留单机制 + uuid 复用 + 合同文档化」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB8w2UzAmqoWbB5398WPdV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QB8w2UzAmqoWbB5398WPdV)_