### PR TITLE
fix(silver-core-sdk): Z8-2/Rdt-4 — per-turn &lt;env&gt; refresh for live model + date (0.68.2)

### DIFF
--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,38 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.68.2 — 2026-07-18
+
+Z8-2 / Rdt-4 (audit r4, keeper ruling 2026-07-18 「剩下一个低危站岗也要修」):
+the volatile `<env>` block is now rebuilt PER TURN from the live model and a
+freshly-computed local calendar day, instead of being baked once at query
+construction. A fallback-model switch no longer tells the model it is the
+primary model (`You are powered by the model named …`), and a session
+spanning local midnight no longer serves a stale `Today's date`.
+
+**Cache-safe by design** (this was the earlier over-stated "risk", corrected):
+the volatile tail rides AFTER the cache breakpoint and carries no
+`cache_control`, so refreshing it never touches the cached stable prefix —
+the whole point of the v0.5+ stable/volatile split was to let cwd-class facts
+change freely. The prior deferral was a cluster-ownership boundary (the
+prompt-assembly fix needed a change in loop.ts), not a real cache hazard.
+
+- **prompts.ts**: `renderVolatileTail(cwd, environment?)` exported; the
+  internal `volatileTail` delegates to it, so the baked and rebuilt tails are
+  byte-identical for equal inputs.
+- **config-builder.ts**: captures the base `<env>` facts + cwd into a
+  `rebuildVolatileSuffix(liveModel)` closure on the engine config (present only
+  when an `<env>` block exists); the local calendar day is recomputed per
+  rebuild.
+- **loop.ts**: each streaming attempt refreshes `systemPromptSuffix` via that
+  closure (with the live `useModel`) just before deriving the wire system
+  field. An unchanged model + day reproduces the exact same suffix bytes, so a
+  steady-state turn keeps the cache prefix stable.
+
++4 regression tests (rebuild reflects a fallback model / same-model byte
+identity / absent when `<env>` disabled). Full vitest 3001 passed / 3 skipped;
+tsc + build clean.
+
 ## 0.68.1 — 2026-07-18
 
 Result accounting contract — clarified, single-mechanism (keeper ruling

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.68.1",
+  "version": "0.68.2",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/config-builder.ts
+++ b/projects/silver-core-sdk/src/engine/config-builder.ts
@@ -25,7 +25,7 @@ import type {
   SystemCompositionPart,
 } from '../internal/contracts.js';
 import { buildCompactionConfig } from './compaction.js';
-import { buildSystemPromptParts } from './prompts.js';
+import { buildSystemPromptParts, renderVolatileTail } from './prompts.js';
 import { estimateTextTokens } from './tokens.js';
 import { gatherEnvironment, loadProjectInstructions } from './runtime-context.js';
 import {
@@ -80,6 +80,10 @@ export function buildEngineConfig(args: {
   let systemBlocks: TextBlockParam[] | undefined;
   let systemPromptStable = '';
   let systemPromptVolatile = '';
+  // audit r4 Z8-2/Rdt-4: per-turn rebuild of the volatile <env> tail for the
+  // live model + current date (set on the runtime-assembly path when an <env>
+  // block exists; undefined otherwise). The loop calls it each turn.
+  let rebuildVolatileSuffix: ((liveModel: string) => string) | undefined;
   // Git branch of cwd at query construction, reused from the runtime-context
   // probe below (no second git call) and persisted into the session meta line
   // so listSessions/getSessionInfo report SDKSessionInfo.gitBranch. Absent on
@@ -163,11 +167,14 @@ export function buildEngineConfig(args: {
     const includeEnv = options.includeEnvironmentContext !== false;
     // E6 (audit r2): "Today's date" must be the HOST'S calendar day, not the
     // UTC one — toISOString() told a UTC+8 host yesterday's date every day
-    // from 00:00 to 08:00 local.
-    const now = new Date();
-    const localToday = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    // from 00:00 to 08:00 local. audit r4 Rdt-4: recomputed per rebuild so a
+    // session spanning local midnight refreshes the date, not just at build.
+    const localCalendarDay = (): string => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    };
     const environment = includeEnv
-      ? gatherEnvironment(cwd, initialModel, localToday)
+      ? gatherEnvironment(cwd, initialModel, localCalendarDay())
       : undefined;
     sessionGitBranch = environment?.gitBranch;
     const projectInstructions = loadProjectInstructions(cwd, options.settingSources);
@@ -205,6 +212,16 @@ export function buildEngineConfig(args: {
         label: 'environment',
         estTokens: estimateTextTokens(systemPromptVolatile),
       });
+    }
+    // audit r4 Z8-2/Rdt-4: capture the base <env> facts so the loop can rebuild
+    // the tail per turn with the live model and a freshly-computed calendar day.
+    // Only when an <env> block is actually present (otherwise the tail is the
+    // bare working-directory line — nothing per-run to refresh). Byte-identical
+    // to the baked tail for equal inputs (renderVolatileTail is the same code
+    // buildSystemPromptParts used above).
+    if (environment !== undefined && systemPromptVolatile.length > 0) {
+      rebuildVolatileSuffix = (liveModel: string): string =>
+        renderVolatileTail(cwd, { ...environment, model: liveModel, date: localCalendarDay() });
     }
     systemComposition = { parts: compositionParts };
   }
@@ -261,6 +278,8 @@ export function buildEngineConfig(args: {
     ...(systemPromptVolatile.length > 0
       ? { systemPromptSuffix: systemPromptVolatile }
       : {}),
+    // audit r4 Z8-2/Rdt-4: per-turn <env> tail refresh (live model + date).
+    ...(rebuildVolatileSuffix !== undefined ? { rebuildVolatileSuffix } : {}),
     // Base/tail split offset for the 2nd system cache breakpoint (string/preset
     // path only; the loop guards 0 < baseLen < systemPrompt.length so it
     // degrades to a single breakpoint when there is no appended tail).

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -836,6 +836,15 @@ export async function* runAgentLoop(
     // (audit 2026-07-10 P2-2) — the assembly side lives in config-builder and
     // the pairing is pinned by tests/system-field.test.ts.
     const cachingOn = config.promptCaching === true;
+    // audit r4 Z8-2/Rdt-4: refresh the volatile <env> tail for the LIVE model
+    // and the current calendar day before deriving the wire system field, so a
+    // fallback-model switch or a session spanning local midnight no longer
+    // serves the construction-time model name / date. Cache-safe: the tail
+    // rides after the breakpoint (deriveSystemField reads systemPromptSuffix),
+    // so refreshing it never touches the cached stable prefix.
+    if (config.rebuildVolatileSuffix !== undefined) {
+      config.systemPromptSuffix = config.rebuildVolatileSuffix(useModel);
+    }
     const derived = deriveSystemField(config);
     // Re-clamp max_tokens for the LIVE model: a fallback switch to a model
     // with a lower output ceiling (e.g. sonnet 64k cap -> opus 32k) would

--- a/projects/silver-core-sdk/src/engine/prompts.ts
+++ b/projects/silver-core-sdk/src/engine/prompts.ts
@@ -121,14 +121,22 @@ function environmentBlock(cwd: string, env: EnvironmentContext): string {
 /**
  * The per-run volatile tail: the `<env>` context block when environment facts
  * are supplied, else the bare working directory. Either way the cwd is present
- * so relative-path guidance stays valid.
+ * so relative-path guidance stays valid. Exported so the engine loop can
+ * REBUILD it per turn from the live model + current date (audit r4 Z8-2/Rdt-4)
+ * without re-running the whole prompt assembly; the internal volatileTail
+ * delegates here so the baked and rebuilt tails are byte-identical for equal
+ * inputs.
  */
-function volatileTail(ctx: PromptContext): string {
-  const lines = ctx.environment
-    ? [environmentBlock(ctx.cwd, ctx.environment)]
-    : [`Working directory: ${ctx.cwd}`];
+export function renderVolatileTail(cwd: string, environment?: EnvironmentContext): string {
+  const lines = environment
+    ? [environmentBlock(cwd, environment)]
+    : [`Working directory: ${cwd}`];
   lines.push('Treat relative paths as relative to this directory and prefer absolute paths in tool calls.');
   return lines.join('\n');
+}
+
+function volatileTail(ctx: PromptContext): string {
+  return renderVolatileTail(ctx.cwd, ctx.environment);
 }
 
 /**

--- a/projects/silver-core-sdk/src/internal/contracts.ts
+++ b/projects/silver-core-sdk/src/internal/contracts.ts
@@ -581,6 +581,14 @@ export type EngineConfig = {
    *  so it never invalidates the cached stable prefix. Absent -> systemPrompt
    *  is sent as a single string (original behavior). */
   systemPromptSuffix?: string;
+  /** Rebuild the volatile <env> tail for the LIVE model + current calendar day
+   *  (audit r4 Z8-2/Rdt-4). The loop calls this each turn and refreshes
+   *  systemPromptSuffix before deriving the wire system field, so a fallback-
+   *  model switch or a session spanning local midnight no longer serves the
+   *  construction-time model name / date. Absent when there is no <env> block
+   *  (nothing per-run to refresh). Cache-safe: the tail rides after the
+   *  breakpoint, so a refresh never touches the cached stable prefix. */
+  rebuildVolatileSuffix?: (liveModel: string) => string;
   /** Char offset in systemPrompt where the base harness ends and the appended
    *  stable tail (project instructions / append / structured-output) begins;
    *  enables a 2nd system cache breakpoint so the shared base and the

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.68.1';
+export const SDK_VERSION = '0.68.2';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/audit-r4-prompt-assembly.test.ts
+++ b/projects/silver-core-sdk/tests/audit-r4-prompt-assembly.test.ts
@@ -130,3 +130,44 @@ describe('audit r4 Z8-3: osVersion carries the capitalized OS name', () => {
     }
   });
 })
+
+// ---------------------------------------------------------------------------
+// Z8-2 / Rdt-4 (config-builder + loop): the volatile <env> tail is rebuilt per
+// turn for the LIVE model (and a freshly-computed calendar day), so a fallback-
+// model switch no longer serves the construction-time model name.
+// ---------------------------------------------------------------------------
+
+describe('audit r4 Z8-2/Rdt-4: <env> model line tracks the live model', () => {
+  it('config exposes a rebuild closure; the baked suffix names the initial model', () => {
+    const { engineConfig } = build({ systemPrompt: { type: 'preset', preset: 'claude_code' } });
+    expect(engineConfig.rebuildVolatileSuffix).toBeTypeOf('function');
+    // Baked at construction from initialModel.
+    expect(engineConfig.systemPromptSuffix).toContain(
+      'You are powered by the model named claude-sonnet-4-5.',
+    );
+  });
+
+  it('rebuilding with a fallback model reflects THAT model, not the initial one', () => {
+    const { engineConfig } = build({ systemPrompt: { type: 'preset', preset: 'claude_code' } });
+    const refreshed = engineConfig.rebuildVolatileSuffix!('claude-opus-4-8');
+    expect(refreshed).toContain('You are powered by the model named claude-opus-4-8.');
+    expect(refreshed).not.toContain('claude-sonnet-4-5');
+  });
+
+  it('rebuilding with the SAME model reproduces the baked tail byte-for-byte', () => {
+    const { engineConfig } = build({ systemPrompt: { type: 'preset', preset: 'claude_code' } });
+    // Same model + same calendar day => identical bytes (cache-safe: an unchanged
+    // turn refreshes to the exact same suffix, so the wire prefix is stable).
+    expect(engineConfig.rebuildVolatileSuffix!('claude-sonnet-4-5')).toBe(
+      engineConfig.systemPromptSuffix,
+    );
+  });
+
+  it('no rebuild closure when the <env> block is disabled', () => {
+    const { engineConfig } = build({
+      systemPrompt: { type: 'preset', preset: 'claude_code' },
+      includeEnvironmentContext: false,
+    });
+    expect(engineConfig.rebuildVolatileSuffix).toBeUndefined();
+  });
+})


### PR DESCRIPTION
## 概述

r4 最后一个低危站岗(守密人 2026-07-18「剩下一个低危站岗也要修,按你的建议修」):`<env>` 系统块改为**每轮从实时模型 + 当前日期重渲染**,不再在会话构造期烘焙一次。fallback 换模型后不再告诉模型「你是 primary 模型」;会话跨本地午夜后不再供陈旧日期。silver-core-sdk 0.68.1 → 0.68.2。

**缓存安全**(订正此前高估的「缓存回归风险」):volatile 尾块架构上就在缓存断点**之后**、自身不带 `cache_control`,重渲染它绝不触及缓存的 stable 前缀——v0.5+ stable/volatile 拆分的全部目的正是让 cwd 这类每次都变的事实自由变化。当初延后只是簇所有权边界(prompt-assembly 的修复需改 loop.ts),不是真实缓存风险。

- **`prompts.ts`**:导出 `renderVolatileTail(cwd, environment?)`,内部 `volatileTail` 复用它——保证烘焙态与重建态对相同输入**字节一致**。
- **`config-builder.ts`**:把 `<env>` 基础事实 + cwd 捕获进 engine config 上的 `rebuildVolatileSuffix(liveModel)` 闭包(仅当有 `<env>` 块时存在);本地日期每次重建重新计算。
- **`loop.ts`**:每个流式尝试在推导 wire system 前,用实时 `useModel` 经该闭包刷新 `systemPromptSuffix`。模型 + 日期不变时重建出**完全相同的字节**,故稳态轮次的缓存前缀纹丝不动。

小学生比喻:教室门口「今日模型 / 日期」的牌子原来开学挂一次就不换,中途换值日生、到第二天都还是旧的。现在改成**每节课自动刷一次牌子**;而牌子本来就挂在公告栏外面的活动挂钩上(缓存断点之后),天天刷都碰不到公告栏(缓存前缀)——刷牌子和不刷,内容一样时连字节都一样。

## 变更类型

- [x] Bug 修复

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布渠道数据。**
- [x] **同意按 MIT License 提交。**

## 验证清单

- [x] 全量 vitest **3001 通过 + 3 skipped**（+4 新回归:fallback 模型反映 / 同模型字节一致 / `<env>` 禁用时无闭包）
- [x] `tsc --noEmit` 零错误
- [x] 仓库级 pytest **2975 通过 + 4 skipped**
- [x] 版本纪律：bump 0.68.2 + CHANGELOG（守卫过）
- [x] 不引入 emoji

## 关联 Issue

- Refs：`memory/todo.md` T52 站岗项 Z8-2/Rdt-4（r4 最后一个低危站岗结清）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB8w2UzAmqoWbB5398WPdV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QB8w2UzAmqoWbB5398WPdV)_