### PR TITLE
ci(sdk): npm cache + docs-only short-circuit for the required JS checks (CI 轻量化 ①)

### DIFF
--- a/.github/workflows/silver-core-maestro-sdk.yml
+++ b/.github/workflows/silver-core-maestro-sdk.yml
@@ -63,20 +63,53 @@ jobs:
             !/Public-Info-Pool/Record/
             !/Public-Info-Pool/Reference/
           sparse-checkout-cone-mode: false
+      - name: Detect family changes (fail-safe — any doubt runs the full suite)
+        id: changes
+        working-directory: ${{ github.workspace }}
+        run: |
+          # Docs-only PR short-circuit (keeper ruling 2026-07-18 ①): skip the
+          # heavy npm ci + build + test steps when no family path changed. STEP-
+          # level (a skipped required job would deadlock the PR); fail-safe (any
+          # non-PR event / missing SHA / fetch-or-diff error defaults to run=true).
+          set -uo pipefail
+          run=true
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base='${{ github.event.pull_request.base.sha }}'
+            head='${{ github.event.pull_request.head.sha }}'
+            if [ -n "$base" ] && [ -n "$head" ] \
+               && git fetch --no-tags --depth=1 origin "$base" "$head" >/dev/null 2>&1 \
+               && diff="$(git diff --name-only "$base" "$head" 2>/dev/null)"; then
+              if printf '%s\n' "$diff" | grep -qE '^(projects/silver-core-(sdk|maestro-sdk|testbed)/|package(-lock)?\.json|\.github/workflows/silver-core-(sdk|maestro-sdk)\.yml)'; then
+                run=true
+              else
+                run=false
+              fi
+            fi
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          echo "family paths changed -> run=$run"
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
       - name: Install dependencies (workspace root)
+        if: steps.changes.outputs.run == 'true'
         run: npm ci
       - name: Build agent SDK (workspace dependency)
+        if: steps.changes.outputs.run == 'true'
         run: npm run build --workspace silver-core-agent-sdk
       - name: Typecheck
+        if: steps.changes.outputs.run == 'true'
         run: npm run typecheck --workspace silver-core-maestro-sdk
       - name: Build
+        if: steps.changes.outputs.run == 'true'
         run: npm run build --workspace silver-core-maestro-sdk
       - name: Test
+        if: steps.changes.outputs.run == 'true'
         run: npm test --workspace silver-core-maestro-sdk
       - name: Testbed consumer contract (both packages combined, third-party consumer)
+        if: steps.changes.outputs.run == 'true'
         # The family combination gate (keeper ruling 2026-07-18 ①): silver-core-
         # testbed is a non-family third-party consumer that resolves BOTH packages
         # from the workspace (the freshly-built agent + maestro above) and asserts
@@ -84,6 +117,7 @@ jobs:
         # package's own suite cannot see. Fast (~2s, no build — pure .mjs vitest).
         run: npm test --workspace silver-core-testbed
       - name: Publishability (dry-run pack, both packages independently)
+        if: steps.changes.outputs.run == 'true'
         run: |
           npm pack --dry-run --workspace silver-core-agent-sdk
           npm pack --dry-run --workspace silver-core-maestro-sdk

--- a/.github/workflows/silver-core-sdk.yml
+++ b/.github/workflows/silver-core-sdk.yml
@@ -134,18 +134,53 @@ jobs:
           # fetch-depth 2: the version-bump guard diffs HEAD~1 (squash merge =
           # one commit; the guard skips gracefully when no parent exists).
           fetch-depth: 2
+      - name: Detect family changes (fail-safe — any doubt runs the full suite)
+        id: changes
+        working-directory: ${{ github.workspace }}
+        run: |
+          # Docs-only PR short-circuit (keeper ruling 2026-07-18 ①): a PR that
+          # touches NONE of the family packages / lock / these workflows skips the
+          # heavy npm ci + build + test steps below and reports green in seconds.
+          # STEP-level, never job-level `if:` — a SKIPPED required job deadlocks
+          # the PR (counts as not-passed), a job that runs and no-ops does not.
+          # Fail SAFE: a non-PR event, a missing SHA, or any fetch/diff error all
+          # default to run=true, so an SDK change is never skipped on a bad guess.
+          set -uo pipefail
+          run=true
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base='${{ github.event.pull_request.base.sha }}'
+            head='${{ github.event.pull_request.head.sha }}'
+            if [ -n "$base" ] && [ -n "$head" ] \
+               && git fetch --no-tags --depth=1 origin "$base" "$head" >/dev/null 2>&1 \
+               && diff="$(git diff --name-only "$base" "$head" 2>/dev/null)"; then
+              if printf '%s\n' "$diff" | grep -qE '^(projects/silver-core-(sdk|maestro-sdk|testbed)/|package(-lock)?\.json|\.github/workflows/silver-core-(sdk|maestro-sdk)\.yml)'; then
+                run=true
+              else
+                run=false
+              fi
+            fi
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          echo "family paths changed -> run=$run"
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
+        if: steps.changes.outputs.run == 'true'
         run: npm ci
       - name: Typecheck
+        if: steps.changes.outputs.run == 'true'
         run: npm run typecheck
       - name: Build
+        if: steps.changes.outputs.run == 'true'
         run: npm run build
       - name: Test (keyless, includes emulator e2e)
+        if: steps.changes.outputs.run == 'true'
         run: npm test
       - name: Version-bump guard (BPT tarball pinning, 2026-07-05)
+        if: steps.changes.outputs.run == 'true'
         run: node scripts/check-version-bump.mjs
 
   conformance:
@@ -173,33 +208,68 @@ jobs:
             !/Public-Info-Pool/Record/
             !/Public-Info-Pool/Reference/
           sparse-checkout-cone-mode: false
+      - name: Detect family changes (fail-safe — any doubt runs the full suite)
+        id: changes
+        working-directory: ${{ github.workspace }}
+        run: |
+          # Docs-only short-circuit — see the SDK unit job for the rationale
+          # (step-level, fail-safe: any doubt -> run=true).
+          set -uo pipefail
+          run=true
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base='${{ github.event.pull_request.base.sha }}'
+            head='${{ github.event.pull_request.head.sha }}'
+            if [ -n "$base" ] && [ -n "$head" ] \
+               && git fetch --no-tags --depth=1 origin "$base" "$head" >/dev/null 2>&1 \
+               && diff="$(git diff --name-only "$base" "$head" 2>/dev/null)"; then
+              if printf '%s\n' "$diff" | grep -qE '^(projects/silver-core-(sdk|maestro-sdk|testbed)/|package(-lock)?\.json|\.github/workflows/silver-core-(sdk|maestro-sdk)\.yml)'; then
+                run=true
+              else
+                run=false
+              fi
+            fi
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          echo "family paths changed -> run=$run"
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
       - name: Install dependencies
+        if: steps.changes.outputs.run == 'true'
         run: npm ci
       - name: Build
+        if: steps.changes.outputs.run == 'true'
         run: npm run build
       - name: Install pinned official arm (transient, --no-save, never a repo dep)
+        if: steps.changes.outputs.run == 'true'
         run: |
           PINS=$(node -e "const p=require('./tests/conformance/pins.json');process.stdout.write('@anthropic-ai/claude-agent-sdk@'+p.agentSdk+' @anthropic-ai/claude-code@'+p.claudeCode)")
           npm i --no-save $PINS
       - name: L1 stream-grammar differential (content-blind emulator)
+        if: steps.changes.outputs.run == 'true'
         run: node tests/conformance/run-l1.mjs --out=conformance-l1.json
       - name: L2 options-semantics differential
+        if: steps.changes.outputs.run == 'true'
         run: node tests/conformance/run-l2.mjs --out=conformance-l2.json
       - name: L3 tool-behavior differential
+        if: steps.changes.outputs.run == 'true'
         run: node tests/conformance/run-l3.mjs --out=conformance-l3.json
       - name: L4 fault-injection differential
+        if: steps.changes.outputs.run == 'true'
         run: node tests/conformance/run-l4.mjs --out=conformance-l4.json
       - name: L3.5 subagent-lifecycle vocabulary differential (report-only — KD-L35 triage, never a gate; wired 2026-07-11, todo T16)
+        if: steps.changes.outputs.run == 'true'
         run: node tests/conformance/run-l35.mjs --arm=both --out=conformance-l35.json
       - name: Scoreboard ratchet (M3 GATE — green only grows vs committed baseline.json)
+        if: steps.changes.outputs.run == 'true'
         run: node tests/conformance/ratchet.mjs conformance-l1.json conformance-l2.json conformance-l3.json conformance-l4.json
       - name: L5 harness smoke (keyless — scripted emulator round proves the M4 harness end-to-end)
+        if: steps.changes.outputs.run == 'true'
         run: node tests/conformance/run-l5.mjs --smoke
       - uses: actions/upload-artifact@v7
-        if: always()
+        if: always() && steps.changes.outputs.run == 'true'
         with:
           name: conformance-matrix
           path: |


### PR DESCRIPTION
## 概述

守密人裁①「缓存 + docs 短路」落地：砍掉每 PR 的 CI 负担，**零 Ruleset 重动**（你刚勾的四个检查名原样保留，只是变聪明了）。

## 变更

**1. npm 缓存**
- 三个 npm-ci job 的 `setup-node` 加 `cache: 'npm'` + `cache-dependency-path: package-lock.json`（根 lock）。热缓存下 npm ci 省掉下载那一半。

**2. docs-only 短路（关键）**
- 每个必跑 job 加一步 fail-safe 变更探测：PR 若没碰 `projects/silver-core-{sdk,maestro-sdk,testbed}/`、lock、或这两个工作流，则 **npm ci + build + test 全跳过**、job 秒级报绿。
- **步骤级跳**（不是 job 级 `if:`）——被 skip 掉的 required job 会让 PR 卡死（视为未过），报绿的 no-op job 不会。
- **fail-safe**：非 PR 事件 / 缺 base·head SHA / fetch 或 diff 出错，**一律默认 run=true**，真 SDK 改动绝不因误判被跳过。
- 探测 grep 用 `^` 锚定，仅「以家族前缀开头」才触发（`docs/projects/silver-core-sdk/…` 这类不误触）。本地 9 例验证（docs-only / 归档 / 各包 / lock / 工作流 / 混合 / 非锚诱饵）全对。

## 验证

- [x] 两工作流 YAML 解析通过
- [x] 变更探测 bash 逻辑 + grep 锚定 9 例本地全绿
- [x] 本 PR 触碰工作流文件（模式匹配）→ 全套在本 PR 上真跑一遍，端到端验证新逻辑
- [x] live-budget job 仍 `if: event_name` 门控
- [x] CI-only → 无需版本 bump

**效果**：docs-PR 几乎免费（~20s 报绿），SDK-PR 靠缓存提速。

## 更激进选项（未做）

合并成单一 family-ci 检查（每 PR 一次 npm ci）需重勾 Ruleset，缓存后收益边际，按裁①不做。

- Refs: T61（本优化为其 ① 分支落地）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwZdj9zLtVfA7tVSeEr5MR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwZdj9zLtVfA7tVSeEr5MR)_