### PR TITLE
fix(memory): align record_lesson output with 2026-07-12 lesson format

### DIFF
--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -141,19 +141,25 @@ def record_decision(summary: str, scope: str, rationale: str = "") -> str:
 
 
 @mcp.tool()
-def record_lesson(summary: str, context: str = "") -> str:
+def record_lesson(summary: str, context: str = "",
+                  principle: str = "", guard: str = "") -> str:
     """追加教训条目到 memory/lessons-learned.md 末尾。
 
+    格式为守密人 2026-07-12 裁定的「准则清单体」：坑 / 准则 / 防护。
+
     Args:
-        summary: 教训摘要
-        context: 触发场景（可选）
+        summary:   坑本质（教训摘要一句）
+        context:   触发场景（可选，折进坑句）
+        principle: 准则（触发信号 → 动作，可选）
+        guard:     防护 / 案卷指针（可选）
 
     Returns:
         JSON: {"status": "ok|error", "lesson_id": "..."}
     """
     from silver_memory_tools import record_lesson as _rl
 
-    return json.dumps(_rl(summary, context), ensure_ascii=False, indent=2)
+    return json.dumps(_rl(summary, context, principle, guard),
+                      ensure_ascii=False, indent=2)
 
 
 @mcp.tool()

--- a/scripts/silver_memory_tools.py
+++ b/scripts/silver_memory_tools.py
@@ -202,19 +202,23 @@ def record_decision(summary: str, scope: str, rationale: str = "") -> dict:
 _LESSON_HEADING_RE = re.compile(r"^##\s+(\d+)\.\s+")
 
 
-def record_lesson(summary: str, context: str = "") -> dict:
+def record_lesson(summary: str, context: str = "",
+                  principle: str = "", guard: str = "") -> dict:
     """档案写入 —— 追加一条教训到 memory/lessons-learned.md 末尾。
 
     编号策略：扫描现有 `## <N>. <title>` 条目，取最大 N + 1 作为新教训 ID。
     插入位置：文件末尾的「维护说明」引言之前（若存在），否则文件末尾。
 
-    教训格式遵循现有约定：Context / Problem / Fix / Impact 四段。本函数仅填
-    Context 与 Problem（由 summary / context 提供），Fix 与 Impact 由守密人
-    日后手动补全。
+    教训格式遵循守密人 2026-07-12 裁定的「准则清单体」：每条 = **坑**（本质一句）
+    + **准则**（触发信号 → 动作）+ **防护/案卷**（指针，如有）。summary 落坑句，
+    context（触发场景，可选）折进坑句，principle / guard（可选）直填准则 / 防护行；
+    principle 缺省时留「（待守密人补充）」，guard 缺省时不落该行。
 
     Args:
-        summary: 教训标题 + 问题陈述
-        context: 触发场景描述，可选
+        summary:   坑本质（教训标题 + 问题陈述一句）
+        context:   触发场景描述，可选；给出则折进坑句
+        principle: 准则（触发信号 → 动作），可选；缺省留待守密人补充
+        guard:     防护措施 / 案卷指针，可选；缺省不落该行
 
     Returns:
         {
@@ -252,18 +256,23 @@ def record_lesson(summary: str, context: str = "") -> dict:
     new_id = max_id + 1
 
     title_line = f"## {new_id}. {summary.strip()}"
-    context_block = context.strip() if context.strip() else "（待守密人补充）"
+
+    # 守密人 2026-07-12 格式裁定：坑 / 准则 / 防护（防护行仅在给出时落）。
+    trap_line = summary.strip()
+    if context.strip():
+        trap_line = f"{trap_line}（触发场景：{context.strip()}）"
+    principle_line = principle.strip() if principle.strip() else "（待守密人补充）"
 
     block = [
         "",
         title_line,
         "",
-        f"- **Context**：{context_block}",
-        f"- **Problem**：{summary.strip()}",
-        "- **Fix**：（待补充）",
-        "- **Impact**：（待补充）",
-        "",
+        f"- **坑**：{trap_line}",
+        f"- **准则**：{principle_line}",
     ]
+    if guard.strip():
+        block.append(f"- **防护/案卷**：{guard.strip()}")
+    block.append("")
 
     # 定位「维护说明」引言块（以 `> **维护说明**` 开头）
     insert_at = len(lines)

--- a/tests/test_silver_memory_tools_unit.py
+++ b/tests/test_silver_memory_tools_unit.py
@@ -238,8 +238,12 @@ def test_record_lesson_increments_id_before_maintenance(sandbox):
     assert out["lesson_id"] == "31"
     text = smt.LESSONS_FILE.read_text(encoding="utf-8")
     assert "## 31. 抽样率失真" in text
-    assert "- **Context**：把输出层当全量" in text
-    assert "- **Problem**：抽样率失真" in text
+    # 守密人 2026-07-12 格式：坑句含 summary + 折入的触发场景；准则缺省待补
+    assert "- **坑**：抽样率失真（触发场景：把输出层当全量）" in text
+    assert "- **准则**：（待守密人补充）" in text
+    # 新条目不再产出旧四段字段（fixture 既有旧条目不算）
+    assert "- **Fix**" not in text
+    assert "- **Problem**：抽样率失真" not in text
     # Inserted before the maintenance block / separator
     lines = text.splitlines()
     new_idx = lines.index("## 31. 抽样率失真")
@@ -254,6 +258,30 @@ def test_record_lesson_default_context(sandbox):
     assert out["lesson_id"] == "6"
     text = smt.LESSONS_FILE.read_text(encoding="utf-8")
     assert "（待守密人补充）" in text
+
+
+def test_record_lesson_principle_and_guard(sandbox):
+    smt.LESSONS_FILE.write_text(LESSONS_NO_MAINTENANCE, encoding="utf-8")
+    out = smt.record_lesson(
+        "空跑无人察觉",
+        context="脚本重构后产出 0 条",
+        principle="数据脚本必带空结果守卫——0 条不覆盖、非零退出",
+        guard="已毕业迁 tests/test_aggregator.py",
+    )
+    assert out["status"] == "ok"
+    text = smt.LESSONS_FILE.read_text(encoding="utf-8")
+    assert "- **坑**：空跑无人察觉（触发场景：脚本重构后产出 0 条）" in text
+    assert "- **准则**：数据脚本必带空结果守卫——0 条不覆盖、非零退出" in text
+    assert "- **防护/案卷**：已毕业迁 tests/test_aggregator.py" in text
+
+
+def test_record_lesson_guard_omitted_when_empty(sandbox):
+    smt.LESSONS_FILE.write_text(LESSONS_NO_MAINTENANCE, encoding="utf-8")
+    smt.record_lesson("无防护条", principle="随手补的准则")
+    text = smt.LESSONS_FILE.read_text(encoding="utf-8")
+    assert "- **准则**：随手补的准则" in text
+    # guard 缺省时不落该行
+    assert "- **防护/案卷**" not in text
 
 
 def test_record_lesson_empty_file_starts_at_one(sandbox):


### PR DESCRIPTION
## 概述

修正 MCP 记忆工具 `record_lesson`：其仍产出已退役的四段骨架（Context/Problem/Fix/Impact，Fix/Impact 硬编码「（待补充）」），落后于守密人 2026-07-12「准则清单体」格式裁定（每条 = 坑 / 准则 / 防护（案卷））。工具改为产出现行格式，并补齐使其能产出合规条目所需的可选参数。

---

## 变更类型

- [x] Bug 修复

---

## 来源声明

- 不涉及数据补全 / 翻译，纯工程修正，无外部数据来源。

---

## 安全声明（强制）

- [x] 本变更不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。
- [x] 不涉及游戏图片 / 内部美术资产 / 解包原始文件。
- [x] 同意按 MIT License 提交。

---

## 变更明细

- `scripts/silver_memory_tools.py`：`record_lesson` 产出「坑 / 准则 / 防护」格式（防护行仅在给出时落）；新增可选参数 `principle`（准则）/ `guard`（防护/案卷），向后兼容旧签名，`context`（触发场景）折进坑句。
- `scripts/mcp_server.py`：MCP 包装器镜像新签名并透传。
- `tests/test_silver_memory_tools_unit.py`：单测断言更新为新格式 + 新增两参数覆盖。

## 验证清单

- [x] 对话内跑全量 `pytest tests/`：2949 passed / 12 skipped
- [x] 记忆 + MCP 相关测试 45 项全绿（含新增 2 项）
- [x] CLAUDE.md 对账三卫 7 项全绿
- [x] 不引入 emoji
- [x] 未改 `memory/decisions.md` / `memory/lessons-learned.md`（仅改工具向该档写入的格式）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjXC3exQB5o6QLgoWNH1r7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjXC3exQB5o6QLgoWNH1r7)_