### PR TITLE
feat(sdk): R7 session-end write-back observability (0.75.0 lockstep)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4204,7 +4204,7 @@
       }
     },
     "projects/silver-core-maestro-sdk": {
-      "version": "0.72.1",
+      "version": "0.75.0",
       "license": "MIT",
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",
@@ -4224,7 +4224,7 @@
     },
     "projects/silver-core-sdk": {
       "name": "silver-core-agent-sdk",
-      "version": "0.72.1",
+      "version": "0.75.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,6 +12,14 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
+## 0.75.0 — 2026-07-20
+
+Lockstep alignment only — no maestro-SDK code change. The agent SDK added R7
+session-end write-back observability (`SDKMemoryHealth.sessionEndUpdate` +
+`Query.memoryHealthSnapshot()`), giving ledger-driven hosts the signal to
+detect a session that ended without updating its progress card. See the
+agent CHANGELOG 0.75.0.
+
 ## 0.74.0 — 2026-07-18
 
 Audit round 5 of the 500-bug campaign (T56): three lenses over the NEW r4

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.74.0';
+export const MAESTRO_SDK_VERSION = '0.75.0';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,40 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.75.0 — 2026-07-20
+
+R7 session-end write-back observability (keeper ruling 2026-07-20, from the
+BPT memory-rot diagnosis: ledger-driven sessions that end at a cap / driver
+timeout silently skip the session-end progress-card round, the card goes
+stale, and every resume re-verifies the world from an outdated recovery
+point — with no programmatic signal that the write-back was starved):
+
+- `SDKMemoryHealth.sessionEndUpdate` — what happened to the R7 round
+  (`pending` / `ran` / `failed` / `disabled` / `skipped-no-turns` /
+  `skipped-abort` / `skipped-budget` / `skipped-turns` /
+  `skipped-interrupt`), stamped on every exit path incl. the pre-turn
+  budget/turns cap returns and string-mode interrupts;
+- `Query.memoryHealthSnapshot()` — live counters snapshot, readable at any
+  time incl. after the stream ended or threw (the only channel on abort/cap
+  paths, where no result can carry the final value); the SessionManager
+  supervised wrapper delegates it to the current inner query;
+- the corrected final result now refreshes `metrics.memoryHealth` instead of
+  re-reporting the pre-round snapshot (which missed the round's own writes
+  and showed a stale `pending`);
+- docs/MEMORY.md "Session-end write-back observability" section with the
+  host compensation contract; 5 new tests (31 in memory-m2).
+
+Also in this build — upstream corpus re-sync (latent break shipped by the
+2026-07-20 automated snapshot refresh, `[skip ci]` so the guards never ran):
+
+- coordinator-worker preset synced to ccVersion 2.1.213: upstream flipped
+  "Do not spawn subagents" to bounded fan-out ("You may use the Agent tool
+  to fan out … bounded by the same depth cap as every other caller");
+- context-tip prompt set: upstream RETIRED the source files at 2.1.213; the
+  SDK keeps its adapted prompts pinned at last-seen 2.1.182, and the
+  corpus-sync guards now gate on the individual archive file (skip honestly
+  on a retired source, re-arm automatically if it returns).
+
 ## 0.74.0 — 2026-07-18
 
 Lockstep alignment only — no agent-SDK code change. The maestro SDK landed

--- a/projects/silver-core-sdk/docs/MEMORY.md
+++ b/projects/silver-core-sdk/docs/MEMORY.md
@@ -35,9 +35,11 @@ M2 surface summary:
   enforced in the store engine and re-checked at the tool layer (view
   truncation + create size + create cards) so directly-implemented stores are
   covered too; `metrics.memoryHealth` reports operations / reads / writes /
-  errors / bytesRead / bytesWritten / indexInjectionTokens per run. For the
-  deep on-demand store scan (waterlines / rot / capacity / supersede chains
-  / read-write ratio) see "Store health assessment" below.
+  errors / bytesRead / bytesWritten / indexInjectionTokens /
+  sessionEndUpdate per run. For the deep on-demand store scan (waterlines /
+  rot / capacity / supersede chains / read-write ratio) see "Store health
+  assessment" below; for the sessionEndUpdate write-back signal see
+  "Session-end write-back observability" below.
 - **R9 cards mode** — `schema: 'cards'` + `memory.cards` (defaults 500
   chars/card, 50 cards/file): every written file must be `## <title>` cards
   with 结论 / 依据 / 过期条件 fields (half- or full-width colons, multi-line
@@ -147,6 +149,51 @@ contract (keeper ruling 2026-07-18: no new machinery). Both guarantees are
 executable — the contract suite's two `concurrency:` checks
 (`src/tools/memory/contract-suite.ts`) drive parallel writes and a stale
 replace against any implementation.
+
+## Session-end write-back observability (keeper 2026-07-20)
+
+The R7 session-end progress-card round runs ONLY on the normal end of input
+— an abort (driver timeout), a spent `maxBudgetUsd` / `maxTurns` cap, or a
+string-mode interrupt all skip it. That is correct per-session (a progress
+card is never worth breaching the budget contract), but silently fatal for a
+ledger-driven host whose sessions routinely end at their caps: the card
+never updates, every resume works from a stale recovery point, re-verifies
+the world, hits the cap again — the memory-rot loop the BPT deploy-rollback
+incident exposed (each retry round re-read the stale "one rollback failure"
+card and re-ran the whole verification).
+
+`memoryHealth.sessionEndUpdate` makes the skip programmatically visible:
+
+- `'ran'` — the round completed; nothing to do.
+- `'failed'` — the round started but errored/aborted mid-way (non-fatal to
+  the query); the card may still be stale — check `writes`.
+- `'disabled'` / `'skipped-no-turns'` — deliberate or vacuous; no action.
+- `'skipped-abort'` / `'skipped-budget'` / `'skipped-turns'` /
+  `'skipped-interrupt'` — the card was NOT updated; compensate.
+- `'pending'` — the run never reached the decision point at all (abort or
+  error threw past it, or the input was blocked); treat like a skip.
+
+Two read paths, because not every exit can carry the value on a result:
+
+```ts
+const q = query({ prompt, options: { memory: {} } });
+try {
+  for await (const m of q) { /* ... */ }
+} catch (err) { /* aborted / errored — no final result carries the value */ }
+
+const wb = q.memoryHealthSnapshot();       // null when memory is not enabled
+if (wb !== null && wb.sessionEndUpdate !== 'ran' && wb.sessionEndUpdate !== 'disabled') {
+  // write-back starved: dispatch a dedicated card-update session, or raise
+  // the caps for this task — otherwise the next resume works from a stale card
+}
+```
+
+On a normal completion where the round ran, the corrected final result (the
+one re-emitted with complete accounting) carries the refreshed snapshot in
+`metrics.memoryHealth` — earlier results honestly report `'pending'` because
+they predate the decision point. `Query.memoryHealthSnapshot()` is readable
+at any time, including after the stream ended or threw, and is the ONLY
+channel on abort/cap paths.
 
 ## Store health assessment (keeper memo 2026-07-18 §2)
 

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/query.ts
+++ b/projects/silver-core-sdk/src/query.ts
@@ -23,6 +23,7 @@ import type {
   RewindFilesResult,
   SDKControlInitializeResponse,
   SDKControlInterruptResponse,
+  SDKMemoryHealth,
   SDKMessage,
   SDKMirrorErrorMessage,
   SDKResultMessage,
@@ -1638,7 +1639,12 @@ export function query(args: {
           sess.pendingTurnRef ?? randomUUID(),
           sess.pendingTurnUuid,
         );
-        if (outcome === 'stop') return;
+        if (outcome === 'stop') {
+          // R7 write-back observability: a string-mode interrupt ends the run
+          // before the session-end round can fire.
+          if (memory !== null) memory.health.sessionEndUpdate = 'skipped-interrupt';
+          return;
+        }
       }
 
       // 3. Consume user turns until the input queue closes.
@@ -1784,6 +1790,10 @@ export function query(args: {
         }
         if (options.maxBudgetUsd !== undefined) {
           if (acct.cost >= options.maxBudgetUsd) {
+            // R7 write-back observability (keeper 2026-07-20): this exit
+            // bypasses the session-end round entirely — stamp the reason so
+            // the host can see the progress card was not updated.
+            if (memory !== null) memory.health.sessionEndUpdate = 'skipped-budget';
             yield terminalResult(
               'error_max_budget_usd',
               sess.sessionId,
@@ -1799,6 +1809,8 @@ export function query(args: {
         }
         if (options.maxTurns !== undefined) {
           if (acct.turns >= options.maxTurns) {
+            // R7 write-back observability: same bypass as the budget exit above.
+            if (memory !== null) memory.health.sessionEndUpdate = 'skipped-turns';
             yield terminalResult(
               'error_max_turns',
               sess.sessionId,
@@ -1821,7 +1833,12 @@ export function query(args: {
         // interrupt) ends the run; anything else falls through to the next
         // input (streaming-mode interrupt or normal completion).
         const outcome = yield* driveTurn(userUuid);
-        if (outcome === 'stop') return;
+        if (outcome === 'stop') {
+          // R7 write-back observability: same interrupt bypass as the
+          // redrive path above.
+          if (memory !== null) memory.health.sessionEndUpdate = 'skipped-interrupt';
+          return;
+        }
       }
 
       // Memory spec R7: session-end progress-card round. Runs ONLY on the
@@ -1846,20 +1863,39 @@ export function query(args: {
       // real remaining turns and skip the round entirely once none are left.
       const sessionEndRemainingTurns =
         options.maxTurns !== undefined ? options.maxTurns - acct.turns : undefined;
-      if (
-        memory !== null &&
-        memory.sessionEndUpdate &&
-        acct.turns > 0 &&
-        !lifeSignal.aborted &&
-        (sessionEndRemainingUsd === undefined || sessionEndRemainingUsd > 0) &&
-        (sessionEndRemainingTurns === undefined || sessionEndRemainingTurns > 0)
-      ) {
+      // R7 write-back observability (keeper 2026-07-20, BPT memory-rot
+      // diagnosis): stamp WHY the round does or does not run, so a
+      // ledger-driven host can detect a session that ended without updating
+      // its progress card (capped sessions silently skipped the round, the
+      // card went stale, and every resume re-verified the world from an
+      // outdated recovery point). 'pending' here ⇔ every gate below passes;
+      // the stamp then advances to 'failed' at round start and 'ran' on
+      // clean completion. It rides later metrics snapshots and
+      // q.memoryHealthSnapshot().
+      if (memory !== null) {
+        memory.health.sessionEndUpdate = !memory.sessionEndUpdate
+          ? 'disabled'
+          : acct.turns === 0
+            ? 'skipped-no-turns'
+            : lifeSignal.aborted
+              ? 'skipped-abort'
+              : sessionEndRemainingUsd !== undefined && sessionEndRemainingUsd <= 0
+                ? 'skipped-budget'
+                : sessionEndRemainingTurns !== undefined && sessionEndRemainingTurns <= 0
+                  ? 'skipped-turns'
+                  : 'pending';
+      }
+      if (memory !== null && memory.health.sessionEndUpdate === 'pending') {
         // The round's own result is ABSORBED (below), so it must not count as
         // the last consumer-visible result — driveTurn sets lastYieldedResult
         // via its internal yield regardless. Save the pre-round pointer and
         // restore it after, so the corrected final result (待裁⑤) still sees
         // that acct grew past what the consumer last actually received.
         const preRoundResult = lastYieldedResult;
+        // Committed to the round: 'failed' until the drive completes cleanly,
+        // so any error/abort mid-round leaves an honest "started but did not
+        // finish" — the card may still be stale (writes counter tells).
+        memory.health.sessionEndUpdate = 'failed';
         // L2-2 (audit 2026-07-17): this round hand-drives driveTurn, so the
         // iterator-protocol duties the for-await sugar normally covers are
         // explicit here. Two rules: (1) only errors thrown BY the round
@@ -1909,7 +1945,10 @@ export function query(args: {
                 );
                 break;
               }
-              if (it.done === true) break;
+              if (it.done === true) {
+                memory.health.sessionEndUpdate = 'ran';
+                break;
+              }
               const msg = it.value;
               // A consumer-injected throw()/return() resumes AT this yield and
               // propagates out of the round (through the finally below).
@@ -2055,7 +2094,22 @@ export function query(args: {
           // now carry the whole session (incl. the session-end memory round and
           // any late background-subagent settle). The A-contract is documented in
           // docs/COMPAT.md ("Result accounting contract").
-          yield { ...lastYieldedResult, ...resultCommon() };
+          yield {
+            ...lastYieldedResult,
+            ...resultCommon(),
+            // R7 write-back observability: this emission happens AFTER the
+            // session-end round, so refresh the memoryHealth snapshot —
+            // re-spreading the pre-round metrics would re-report a stale
+            // sessionEndUpdate ('pending') and miss the round's own writes.
+            ...(memory !== null && lastYieldedResult.metrics !== undefined
+              ? {
+                  metrics: {
+                    ...lastYieldedResult.metrics,
+                    memoryHealth: { ...memory.health },
+                  },
+                }
+              : {}),
+          };
         }
       }
     }
@@ -2127,6 +2181,13 @@ export function query(args: {
     },
     [Symbol.asyncIterator](): Query {
       return q;
+    },
+
+    memoryHealthSnapshot(): SDKMemoryHealth | null {
+      // R7 write-back observability: live-object snapshot, readable on every
+      // exit path (incl. after an abort threw — no result carries the final
+      // sessionEndUpdate value there).
+      return memory !== null ? { ...memory.health } : null;
     },
 
     async interrupt(): Promise<SDKControlInterruptResponse> {

--- a/projects/silver-core-sdk/src/session-manager.ts
+++ b/projects/silver-core-sdk/src/session-manager.ts
@@ -732,6 +732,9 @@ export function createBptSession(options: SessionManagerOptions = {}): SessionMa
       setMcpServers: (servers) => q.setMcpServers(servers),
       rewindFiles: (id, opts) => q.rewindFiles(id, opts),
       stopTask: (taskId) => q.stopTask(taskId),
+      // R7 write-back observability: delegate to the CURRENT inner query (q is
+      // reassigned on resume), so the snapshot always reflects the live run.
+      memoryHealthSnapshot: () => q.memoryHealthSnapshot(),
       setRetainedRegion: (region) => {
         // Region carries its own id; a re-set overwrites, matching the query's
         // own last-write-wins semantics for a given region id.

--- a/projects/silver-core-sdk/src/subagents/agents.ts
+++ b/projects/silver-core-sdk/src/subagents/agents.ts
@@ -428,9 +428,10 @@ export const COORDINATOR_MODE_PROMPT_PROVENANCE = {
 /**
  * Coordinator worker instructions — a faithful OPEN reproduction of the
  * official coordinator-assigned-worker prompt (archive slug
- * system-prompt-coordinator-worker-instructions, ccVersion 2.1.182), with the
- * single \`\${AGENT_TOOL_NAME}\` variable resolved to Agent. Corpus-sync
- * guard: tests/subagents.test.ts.
+ * system-prompt-coordinator-worker-instructions, ccVersion 2.1.213 — synced
+ * 2026-07-20 when upstream flipped the no-subagents rule to bounded fan-out),
+ * with the single \`\${AGENT_TOOL_NAME}\` variable resolved to Agent.
+ * Corpus-sync guard: tests/subagents.test.ts.
  */
 export const COORDINATOR_WORKER_INSTRUCTIONS = `You are a worker agent executing a task assigned by the coordinator.
 
@@ -442,7 +443,7 @@ export const COORDINATOR_WORKER_INSTRUCTIONS = `You are a worker agent executing
 
 Complete exactly what was asked. Don't fix unrelated issues you discover — suggest them as follow-ups instead.
 - If you changed any files, commit your changes when done. Use a clear, descriptive commit message. Only stage files you actually changed — never use \`git add .\` or \`git add -A\`. Report the commit hash in your summary.
-- Do not spawn subagents (Agent tool)
+- You may use the Agent tool to fan out (e.g. \`/simplify\`, \`/code-review\`, or your own parallel research/verification) — bounded by the same depth cap as every other caller
 - Limit changes to what your task requires
 
 ## Resumed Tasks

--- a/projects/silver-core-sdk/src/tips/prompts.ts
+++ b/projects/silver-core-sdk/src/tips/prompts.ts
@@ -98,7 +98,11 @@ Output: {"has_tip":true,"tip":"We've been going back and forth on this. Starting
 export const CONTEXT_TIP_SELECTOR_OUTPUT_CONTRACT =
   'Respond with ONLY this JSON, no code fences:\n{"has_tip":<true|false>,"tip":"<the 1-2 sentence tip; omit when has_tip is false>","feature_id":"<an id from eligible_ids; omit when has_tip is false>","action":"<the command/shortcut; omit when has_tip is false>"}';
 
-/** Provenance for the context-tip selector surface. */
+/** Provenance for the context-tip selector surface. NOTE: upstream retired
+ *  the whole context-tip prompt set at ccVersion 2.1.213 (archive refresh
+ *  2026-07-20); the SDK keeps this surface PINNED at the last-seen version
+ *  (2.1.182). `faithful` describes fidelity to that pinned source; the
+ *  corpus-sync guards re-arm automatically if the archive file returns. */
 export const CONTEXT_TIP_SELECTOR_PROVENANCE: TipProvenance = {
   slug: 'agent-prompt-context-tip-selector',
   faithful: true,

--- a/projects/silver-core-sdk/src/tools/memory/memory-tool.ts
+++ b/projects/silver-core-sdk/src/tools/memory/memory-tool.ts
@@ -166,6 +166,7 @@ export function createMemoryHealth(): SDKMemoryHealth {
     bytesRead: 0,
     bytesWritten: 0,
     indexInjectionTokens: 0,
+    sessionEndUpdate: 'pending',
   };
 }
 

--- a/projects/silver-core-sdk/src/types.ts
+++ b/projects/silver-core-sdk/src/types.ts
@@ -1765,6 +1765,40 @@ export type MemoryOptions = {
 };
 
 /**
+ * Outcome of the session-end progress-card round (memory spec R7) for one
+ * run — the write-back observability signal (keeper 2026-07-20, BPT
+ * memory-rot diagnosis). The failure mode this exposes: a ledger-driven host
+ * whose sessions routinely end at a cap / driver timeout never gets the
+ * round, the progress card goes stale, and every resume re-verifies the
+ * world from an outdated recovery point. Contract for hosts: any final value
+ * other than 'ran' means the progress card was NOT updated this run —
+ * compensate (e.g. dispatch a dedicated card-update session) or the next
+ * resume works from a stale card.
+ *
+ *  - 'pending'           — the run never reached the session-end decision
+ *                          point (abort / thrown error / blocked input);
+ *  - 'ran'               — the round was driven to completion;
+ *  - 'failed'            — the round started but did not complete (error or
+ *                          abort mid-round; non-fatal to the query);
+ *  - 'disabled'          — sessionEndUpdate: false, or an incognito session;
+ *  - 'skipped-no-turns'  — zero turns ran, nothing to record;
+ *  - 'skipped-abort'     — the life signal was aborted at the decision point;
+ *  - 'skipped-budget'    — maxBudgetUsd was already spent;
+ *  - 'skipped-turns'     — maxTurns was already spent;
+ *  - 'skipped-interrupt' — a string-mode interrupt ended the run.
+ */
+export type SDKMemorySessionEndUpdate =
+  | 'pending'
+  | 'ran'
+  | 'failed'
+  | 'disabled'
+  | 'skipped-no-turns'
+  | 'skipped-abort'
+  | 'skipped-budget'
+  | 'skipped-turns'
+  | 'skipped-interrupt';
+
+/**
  * Memory-operation counters for one run (spec R8 observability; rides
  * SDKRunMetrics.memoryHealth when the memory system is enabled). All-zero
  * means the model never touched memory. For the on-demand DEEP health scan
@@ -1790,6 +1824,12 @@ export type SDKMemoryHealth = {
   /** Estimated tokens of the resident memory-index injection (R6), so the
    *  read-side residency cost shows up on the bill. */
   indexInjectionTokens: number;
+  /** R7 write-back observability: what happened to the session-end
+   *  progress-card round. Advances during the run ('pending' until the
+   *  decision point); the final value is authoritative once the query has
+   *  finished — read it via the last result's metrics or, on paths where no
+   *  result can carry it (abort / cap), via `Query.memoryHealthSnapshot()`. */
+  sessionEndUpdate: SDKMemorySessionEndUpdate;
 };
 
 /**
@@ -3602,6 +3642,15 @@ export interface Query extends AsyncGenerator<SDKMessage, void> {
   rewindFiles(userMessageId: string, options?: { dryRun?: boolean }): Promise<RewindFilesResult>;
   /** Stop a background subagent task by id (no-op + debug warn when unknown). */
   stopTask(taskId: string): Promise<void>;
+  /**
+   * Snapshot of the run's live memory counters (SDKMemoryHealth), or null
+   * when the memory system is not enabled for this query. Readable at any
+   * time — including AFTER the stream ended or threw — so a host can check
+   * `sessionEndUpdate` even on abort/cap paths where no result could carry
+   * the final value, and compensate for a missed write-back (keeper
+   * 2026-07-20, BPT memory-rot diagnosis).
+   */
+  memoryHealthSnapshot(): SDKMemoryHealth | null;
   /**
    * Declare (or replace, by id) a compaction retained region (R3): its content
    * survives every automatic compaction verbatim. Throws `ConfigurationError`

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.74.0';
+export const SDK_VERSION = '0.75.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/memory-m2.test.ts
+++ b/projects/silver-core-sdk/tests/memory-m2.test.ts
@@ -31,7 +31,13 @@ import {
   truncateViewBody,
   validateCardsContent,
 } from '../src/tools/memory/index.js';
-import type { MemoryStore, Options, SDKMessage, SDKResultMessage } from '../src/types.js';
+import type {
+  MemoryStore,
+  Options,
+  SDKMessage,
+  SDKResultMessage,
+  SDKUserMessage,
+} from '../src/types.js';
 import type {
   AggregatedHookResult,
   BuiltinTool,
@@ -410,6 +416,86 @@ describe('R7: session-end progress-card round (query level)', () => {
     expect(last.subtype).toBe('error_max_turns');
     // No turn ran, no session-end round fired.
     expect(stub.requests).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R7 write-back observability: memoryHealth.sessionEndUpdate (keeper
+// 2026-07-20, BPT memory-rot diagnosis) — a host must be able to detect a
+// session that ended WITHOUT updating its progress card, on every exit path.
+// ---------------------------------------------------------------------------
+
+describe('R7 observability: sessionEndUpdate stamp + memoryHealthSnapshot()', () => {
+  async function collectWithHandle(
+    prompt: string | AsyncIterable<SDKUserMessage>,
+    options: Options,
+  ) {
+    const q = query({ prompt, options });
+    const messages: SDKMessage[] = [];
+    for await (const m of q) messages.push(m);
+    return { q, messages };
+  }
+
+  it("a completed round stamps 'ran'; the corrected final result carries the REFRESHED snapshot", async () => {
+    const stub = makeSSEFetch([
+      pricedReplyEvents('the answer', { inputTokens: 100 }),
+      pricedReplyEvents('progress saved', { inputTokens: 900 }),
+    ]);
+    const { q, messages } = await collectWithHandle(
+      'do the task',
+      baseOptions(stub, { memory: {} }),
+    );
+    expect(q.memoryHealthSnapshot()?.sessionEndUpdate).toBe('ran');
+    const results = messages.filter((m): m is SDKResultMessage => m.type === 'result');
+    expect(results).toHaveLength(2);
+    // The task's own result predates the decision point -> its snapshot is
+    // honest 'pending'; the corrected final result is emitted AFTER the round
+    // and must NOT re-report that stale snapshot.
+    expect(results[0]!.metrics?.memoryHealth?.sessionEndUpdate).toBe('pending');
+    expect(results[1]!.metrics?.memoryHealth?.sessionEndUpdate).toBe('ran');
+  });
+
+  it("sessionEndUpdate: false stamps 'disabled'; no memory system -> snapshot is null", async () => {
+    const stub = makeSSEFetch([textReplyEvents('answer')]);
+    const { q } = await collectWithHandle(
+      'hi',
+      baseOptions(stub, { memory: { sessionEndUpdate: false } }),
+    );
+    expect(q.memoryHealthSnapshot()?.sessionEndUpdate).toBe('disabled');
+
+    const bare = makeSSEFetch([textReplyEvents('answer')]);
+    const { q: q2 } = await collectWithHandle('hi', baseOptions(bare));
+    expect(q2.memoryHealthSnapshot()).toBeNull();
+  });
+
+  it("a maxTurns-capped run stamps 'skipped-turns' (the round is silently starved without it)", async () => {
+    const stub = makeSSEFetch([]);
+    const { q, messages } = await collectWithHandle(
+      'hi',
+      baseOptions(stub, { memory: {}, maxTurns: 0 }),
+    );
+    expect((messages.at(-1) as SDKResultMessage).subtype).toBe('error_max_turns');
+    expect(q.memoryHealthSnapshot()?.sessionEndUpdate).toBe('skipped-turns');
+  });
+
+  it("a maxBudgetUsd-exhausted run stamps 'skipped-budget' and never drives the round", async () => {
+    // The single priced turn spends past the (tiny) session cap, so the
+    // decision point finds no budget left: exactly one request, no round.
+    const stub = makeSSEFetch([pricedReplyEvents('the answer', { inputTokens: 5000 })]);
+    const { q } = await collectWithHandle(
+      'do the task',
+      baseOptions(stub, { memory: {}, maxBudgetUsd: 0.000001 }),
+    );
+    expect(stub.requests).toHaveLength(1);
+    expect(q.memoryHealthSnapshot()?.sessionEndUpdate).toBe('skipped-budget');
+  });
+
+  it("a zero-turn run (input closes with no items) stamps 'skipped-no-turns'", async () => {
+    const stub = makeSSEFetch([]);
+    const empty = (async function* (): AsyncGenerator<SDKUserMessage> {})();
+    const { q } = await collectWithHandle(empty, baseOptions(stub, { memory: {} }));
+    expect(stub.requests).toHaveLength(0);
+    expect(q.memoryHealthSnapshot()?.sessionEndUpdate).toBe('skipped-no-turns');
   });
 });
 

--- a/projects/silver-core-sdk/tests/tips.test.ts
+++ b/projects/silver-core-sdk/tests/tips.test.ts
@@ -206,17 +206,25 @@ describe('context-tip prompt provenance (corpus-sync guard, Track B parity)', ()
       .filter((s) => !body.includes(s.slice(0, 60)));
   };
 
+  // Upstream RETIRED the context-tip prompt set at ccVersion 2.1.213 (snapshot
+  // refresh 2026-07-20 deleted the archived files). The SDK keeps its adapted
+  // prompts PINNED at the last-seen upstream version (2.1.182); each guard
+  // below re-arms automatically if upstream resurrects its source file —
+  // gating on the individual file, not the archive directory, so a retired
+  // source skips honestly instead of red-ing on ENOENT forever.
+  const archived = (slug: string) => existsSync(join(archive, `${slug}.md`));
+
   it('the provenance table has 2 faithful entries', () => {
     expect(Object.keys(TIP_PROVENANCE)).toHaveLength(2);
     for (const p of Object.values(TIP_PROVENANCE)) expect(p.faithful).toBe(true);
   });
-  it.runIf(existsSync(archive))('selector is faithful to its archive', () => {
+  it.runIf(archived(CONTEXT_TIP_SELECTOR_PROVENANCE.slug))('selector is faithful to its archive', () => {
     expect(faithful(CONTEXT_TIP_SELECTOR_SYSTEM, CONTEXT_TIP_SELECTOR_PROVENANCE.slug)).toEqual([]);
   });
-  it.runIf(existsSync(archive))('reception evaluator is faithful to its archive', () => {
+  it.runIf(archived(TIP_RECEPTION_PROVENANCE.slug))('reception evaluator is faithful to its archive', () => {
     expect(faithful(TIP_RECEPTION_SYSTEM, TIP_RECEPTION_PROVENANCE.slug)).toEqual([]);
   });
-  it.runIf(existsSync(archive))('catalog situations are faithful to their archive', () => {
+  it.runIf(archived('data-context-tip-situation-persistent-memory'))('catalog situations are faithful to their archive', () => {
     expect(faithful(SITUATION_PERSISTENT_MEMORY, 'data-context-tip-situation-persistent-memory')).toEqual([]);
   });
 });


### PR DESCRIPTION
## 概述

BPT「记忆腐烂」诊断的银芯侧根治（守密人 2026-07-20 裁定「先落观测信号」）：agent SDK 在会话顶帽 / 超时结束时静默跳过 R7 收尾写卡轮，进度卡停在旧状态、每次续跑照过期恢复点全量重验证。本 PR 为每条退出路径落 `sessionEndUpdate` 结果戳，并保证戳值可送达宿主；双包锁步 bump 0.75.0。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [ ] 文档完善（CLAUDE.md / BIAV-SC.md / README.md / 子项目 CONTEXT.md）
- [ ] Bug 修复
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 其他（请说明）：silver-core-sdk / silver-core-maestro-sdk 工程产物（使命#2）

变更明细：

- `SDKMemoryHealth.sessionEndUpdate`：9 取值结果戳（ran / failed / disabled / pending / 5 种 skipped-*），覆盖预算帽、回合帽、中断、R7 裁定点全部退出路径
- `Query.memoryHealthSnapshot()`：流结束或抛出后仍可读的活体快照（abort / 顶帽路径唯一送达通道）；SessionManager 监督包装层转发
- corrected final result 刷新 `metrics.memoryHealth`（原样重报轮前过期快照的既有暗伤一并修正）
- docs/MEMORY.md 新增「Session-end write-back observability」节（宿主补偿契约）；memory-m2 测试 26 → 31
- 存量暗伤修复：2026-07-20 `[skip ci]` 快照刷新带进的 4 处测试失败——coordinator-worker 预设同步上游 ccVersion 2.1.213（worker 有界扇出）；context-tip 三档钉住 2.1.182、守卫改单档案在位对账（自动复武）
- 双包锁步 0.75.0（maestro 为对齐 bump + CHANGELOG 锁步注）

---

## 来源声明

- [x] 本 PR 不涉及游戏数据；仅工程产物与上游公开仓库（Claude Code 系统提示词公开快照）对账

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 所有引用素材均来自公开可查阅来源。
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**；不上传内部美术资产、客户端解包原始文件、未公开的剧情草稿等。
- [x] **同意按 [MIT License](../LICENSE) 提交贡献。**

---

## 验证清单

- [x] 对话内全量验证四套全绿：agent SDK vitest 3081 过、maestro vitest 335 过、testbed 30 过、pytest 2963 过 12 跳过
- [x] 双包 `tsc --noEmit` 通过；三方版本对账（CHANGELOG / package.json / version 常量）绿
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案

---

## 关联 Issue

- Refs：无（会话派发任务，源起守密人 BPT 症状报告 2026-07-20）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6ZVmaiYDNT2iSXaCCWUZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6ZVmaiYDNT2iSXaCCWUZA)_