### PR TITLE
fix(secret-scan): allowlist historical data-layer paths for the weekly full-history scan

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -32,4 +32,7 @@ jobs:
           # 个人账户 / 公开仓无需 GITLEAKS_LICENSE。
           # 关闭 PR 评论以维持 contents: read 最小权限（发现即 job 失败，已足够作门）。
           GITLEAKS_ENABLE_COMMENTS: false
-          GITLEAKS_ENABLE_SUMMARY: true
+          # 步骤摘要关闭（守密人 2026-07-20 裁定）：全历史扫命中过多时摘要体超
+          # GitHub 1MB 上限反把 job 炸红（2026-07-20 实测 5MB）；报告一律走
+          # SARIF 工件（gitleaks-results.sarif.zip，action 自动上传），不走摘要。
+          GITLEAKS_ENABLE_SUMMARY: false

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,4 +13,16 @@ paths = [
   '''Public-Info-Pool/Record/.*''',
   '''projects/news/output/.*''',
   '''okf/.*''',
+  # ---- 历史路径豁免（2026-07-20 守密人裁定）----
+  # 周一全历史兜底扫会扫到目录迁移前的旧 blob：同一批「数据层非凭据面」内容，
+  # 只是住在旧地址。逐条锚定（^），不误伤同名工程目录；工程面（projects/*/src、
+  # scripts/、.github/ 等）无论历史现今一律照扫。
+  '''^projects/news/data/.*''',                        # 旧社区归档层（2026-06-21 迁入 Public-Info-Pool/Record 前）
+  '''^Public-Info-Pool/Reference/Game-Unpacked/.*''',  # 解包 text 层（2026-07-12 整层删除，历史 blob 仍在）
+  '''^projects/wiki/data/.*''',                        # wiki 解包/基线数据层（游戏数据 JSON）
+  '''^projects/wiki/docs/.*''',                        # wiki 站点内容层（生成角色页/图鉴/图标）
+  '''^wiki/.*''',                                      # 远古根级 wiki 布局（现已迁 projects/wiki）
+  '''^deliverables/.*''',                              # 旧产物目录（已由 Public-Info-Pool 取代）
+  '''^data/.*''',                                      # 远古根级数据布局（历史 blob）
+  '''^news/.*''',                                      # 远古根级 news 布局（历史 blob）
 ]


### PR DESCRIPTION
## 概述

修复 Secret Scan 周一全历史兜底扫的误报风暴（9,162 条疑似泄漏 + 5MB 摘要撑爆 1MB 上限二次炸 job，守密人 2026-07-20 裁定「扩豁免名单后重扫」）：`.gitleaks.toml` 按「数据层非凭据面」原教义补上同批数据层的**历史旧地址**（迁移前旧社区归档 `projects/news/data/`、已删解包 text 层、远古根级 wiki / data / news 布局、旧 `deliverables/`，全部 `^` 锚定防误伤同名工程目录）；报告改走 SARIF 工件、关闭步骤摘要。

---

## 变更类型

- [ ] 数据补全 / 翻译贡献 / 文档完善 / 视觉改进
- [x] Bug 修复
- [ ] 其他

---

## 来源声明

- [x] 不涉及游戏数据；仅 CI 配置与扫描豁免规则

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **仅引用公开素材。**
- [x] **同意按 [MIT License](../LICENSE) 提交贡献。** 豁免面仅扩展到历史数据层路径；工程凭据面（src / scripts / .github / 配置）无论历史现今一律照扫。

---

## 验证清单

- [x] pytest 全量 2963 过 12 跳过
- [x] 本 PR 自身触发的 pull_request 增量扫 = gitleaks 对新 TOML 的解析验证
- [x] 合并后将 workflow_dispatch 触发全历史重扫验证归零（SARIF 工件留档，残余命中逐条核实后另报）
- [x] 不引入 emoji；不动 memory 档案

---

## 关联 Issue

- Refs：无（源起 2026-07-20 定时扫红灯排查）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6ZVmaiYDNT2iSXaCCWUZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6ZVmaiYDNT2iSXaCCWUZA)_