### PR TITLE
fix(secret-scan): fingerprint-level ignores for the 3 triaged residual findings

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,14 @@
+# .gitleaksignore —— 指纹级豁免（残余命中逐条核实档案，守密人 2026-07-20 裁定）
+# 与 .gitleaks.toml 的路径面豁免不同：本档每条对应一个已人工核实的具体命中，
+# 新增条目必须附核实结论注记。
+
+# [核实：合成夹具] SDK 脱敏测试的假密钥（sk-abcdef_LEAK99 等），
+# 该测试断言的正是「密钥须被脱敏」，夹具本身非凭据。
+a04d534896bfa07c3326bff8697c3d734242f1e8:projects/silver-core-sdk/tests/error-normalize.test.ts:generic-api-key:199
+
+# [核实：历史 blob，已单独报守密人] 已退役会话蒸馏子系统（2026-06-20 整删）
+# 2026-04-15 digest 收录了旧泄漏检查器 stdout，回显了其发现并已脱敏的
+# LTAI 形状 AccessKey ID（单 ID 不构成可用凭据，配对 secret 未在扫描中出现；
+# 处置权在守密人：若识别为在用 key 建议阿里侧轮换，历史 blob 无法撤回）。
+0a538928abd697998764bf376710f623391f318e:memory/session-digests/ff59edeb-0742-46f2-8778-114f17d1be09.progress.jsonl:alibaba-access-key-id:3
+24ace9d76f1d35cf7bdb77ad7f7fea4538d0271c:memory/session-digests/ff59edeb-0742-46f2-8778-114f17d1be09.progress.jsonl:alibaba-access-key-id:3


### PR DESCRIPTION
## 概述

全历史重扫 9,162 → 3 后的收尾：3 条残余已逐条人工核实（1 条 SDK 脱敏测试合成夹具误报；2 条为同一历史 blob 行的双提交指纹——已退役会话蒸馏子系统 2026-04-15 收录了旧泄漏检查器回显的 LTAI 形状 AccessKey ID，已单独报守密人）。以 `.gitleaksignore` **指纹级**豁免落档（每条附核实结论注记），不扩大任何路径面豁免，周检门转绿。

---

## 变更类型

- [x] Bug 修复
- [ ] 其他

---

## 来源声明

- [x] 不涉及游戏数据；仅扫描豁免指纹档案

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **仅引用公开素材。** 指纹条目引用的均为本公开仓库自身 git 历史中的已核实命中。
- [x] **同意按 [MIT License](../LICENSE) 提交贡献。**

---

## 验证清单

- [x] 3 条残余命中逐条人工核实（结论注记随档案入库）
- [x] 指纹级豁免（非路径豁免）——工程面扫描范围零收窄
- [x] 合并后 workflow_dispatch 重扫验证归零
- [x] 不引入 emoji；不动 memory 档案

---

## 关联 Issue

- Refs：#788（路径面豁免前置修复）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6ZVmaiYDNT2iSXaCCWUZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6ZVmaiYDNT2iSXaCCWUZA)_