### PR TITLE
chore(lockfile): 锁文件 workspace 版本对齐 0.76.0（PR #799 残留）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4204,7 +4204,7 @@
       }
     },
     "projects/silver-core-maestro-sdk": {
-      "version": "0.75.0",
+      "version": "0.76.0",
       "license": "MIT",
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",
@@ -4224,7 +4224,7 @@
     },
     "projects/silver-core-sdk": {
       "name": "silver-core-agent-sdk",
-      "version": "0.75.0",
+      "version": "0.76.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",


### PR DESCRIPTION
## 概述

派发任务「应用 BIAV-SC-DATA `claude/maestro-cancelled-state-rhmaf6` 下 `docs/maestro/patches/` 两补丁」核实后为**重复派发**：两补丁已于 2026-07-22 经 [PR #799](https://github.com/lightproud/BIAV-SC-CODE/pull/799)（commit `6f3398a`）合并落盘，反向套用检查（`git apply --check -R`）两档均零冲突通过，即工作树内容与补丁后状态逐字节一致。故本 PR **不含任何补丁内容**。

本 PR 仅修一处在核实过程中暴露的残留：PR #799 把双包 `package.json` bump 到 0.76.0，但根 `package-lock.json` 的两个 workspace 版本字段仍停在 0.75.0。

---

## 变更类型

- [x] 其他：构建元数据卫生（workspace 锁文件版本对齐）

---

## 来源声明

不适用（无数据变更，仅工程构建元数据）。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 变更为银芯自有工程产物的锁文件版本字段，方向与 §1.1-HC 防火墙一致。
- [x] **不含任何游戏图片 / 解包原始文件 / 未公开文本。**
- [x] **同意按 MIT License 提交。**

---

## 变更内容

`package-lock.json`，+2 / −2：

| workspace | 变更 |
|---|---|
| `projects/silver-core-maestro-sdk` | `0.75.0` → `0.76.0` |
| `projects/silver-core-sdk`（npm 名 `silver-core-agent-sdk`） | `0.75.0` → `0.76.0` |

**非 CI 故障**：对未修正的锁文件跑 `npm ci --dry-run` 退出码为 0（npm 仅对依赖树不一致硬报错，不校验 workspace 版本字段），故 main 上 18 处 `npm ci` 一直正常。修的是「锁文件对已发布版本说谎」+「任何人在 workspace 跑 `npm install` 就会凭空脏出这两行」。

---

## 验证清单

- [x] `silver-core-maestro-sdk` 单测：**362 passed / 29 files**（`npx vitest run`，双包 `npm run build` 后）
- [x] 双包 `tsc -p tsconfig.json` 构建通过
- [x] `npm ci --dry-run` 退出码 0（修正前后均通过）
- [x] 不引入 emoji（CLAUDE.md 硬约束）
- [x] 未改 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联

- Refs [#799](https://github.com/lightproud/BIAV-SC-CODE/pull/799)（cancelled 封闭终局语义 0.76.0，BPT P0-D1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7YErthJAKUeXwA7rQVNaW

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7YErthJAKUeXwA7rQVNaW)_