### PR TITLE
fix(ci,test): 堵 okf/ 测试污染泄漏 + 复活 PR 凭据扫描 + 去 store-patrol e2e 偶发

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,6 +16,9 @@ on:
 
 permissions:
   contents: read
+  # PR 扫描要列 PR commit 范围（GET /pulls/{n}/commits）；仍不给 write，
+  # 评论已由 GITLEAKS_ENABLE_COMMENTS: false 关闭，最小权限不变。
+  pull-requests: read
 
 jobs:
   gitleaks:
@@ -29,6 +32,11 @@ jobs:
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
+          # gitleaks-action v2 扫 pull_request 事件强制要求 GITHUB_TOKEN（用于取 PR
+          # commit 范围）。缺此项时 action 在扫描启动前即 ##[error] 退出——2026-07-19
+          # 本工作流落地起 pull_request 事件 30/30 全红，凭据扫描从未在任何 PR 上
+          # 真正跑过（push / schedule 事件不走该分支，一直有效）。补于 2026-07-25。
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # 个人账户 / 公开仓无需 GITLEAKS_LICENSE。
           # 关闭 PR 评论以维持 contents: read 最小权限（发现即 job 失败，已足够作门）。
           GITLEAKS_ENABLE_COMMENTS: false

--- a/projects/silver-core-maestro-sdk/tests/store-patrol.e2e.test.ts
+++ b/projects/silver-core-maestro-sdk/tests/store-patrol.e2e.test.ts
@@ -101,7 +101,15 @@ const targetsFor = (base: string) => [
   { id: 'steam-review-summary', url: `${base}/reviews`, extract: 'steam-review-summary' },
 ];
 
-const fastOpts = { pollIntervalMs: 20, retryBaseMs: 30, queryTimeoutMs: 400, drainTimeoutMs: 10_000 };
+// queryTimeoutMs is deliberately generous relative to pollIntervalMs/retryBaseMs: a
+// loopback fetch against the in-process fake storefront returns in single-digit ms, so
+// this budget is never reached on a healthy run and the suite stays fast. It is NOT a
+// tuning knob for the assertions — it only has to sit above the worst-case cold-start
+// latency of a loaded CI runner. At 400ms it did not: a runner overshoot timed the
+// attempt out, the driver retried, and the ledger carried 4 query rows where the test
+// asserts 2 (observed 2026-07-25, PR #801). Raising the ceiling removes the false
+// timeout without touching the semantics under test.
+const fastOpts = { pollIntervalMs: 20, retryBaseMs: 30, queryTimeoutMs: 3_000, drainTimeoutMs: 10_000 };
 
 describe('store patrol on the ledger + driver (real HTTP, fake storefront)', () => {
   it('baseline day: snapshots + change log seeded, sessions done, ledger persisted', async () => {

--- a/tests/test_build_okf_bundle_unit.py
+++ b/tests/test_build_okf_bundle_unit.py
@@ -14,7 +14,9 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+import build_kb_index as bki
 import build_okf_bundle as bok
+import okf_pointer_layers as opl
 
 
 # --- _yaml_scalar -----------------------------------------------------------
@@ -278,10 +280,26 @@ def _repo_tmp_bundle():
     return Path(tempfile.mkdtemp(prefix="_unit_okf_", dir=repo)) / "okf"
 
 
+def _redirect_bundle(monkeypatch, b):
+    """Point every module that writes into the bundle at `b`.
+
+    `bok.BUNDLE` alone is not enough: okf_pointer_layers and build_kb_index each
+    hold their own `REPO / "okf"` (deliberately self-contained to avoid a circular
+    import), and `bok.main()` drives both. Patching only `bok.BUNDLE` sent the four
+    native layers to tmp while every pointer layer + kb_index.json was written
+    straight into the tracked okf/ tree — and with the community data lake absent
+    (no BIAV_SC_DATA_ROOT) that rewrite silently dropped 17 platform concepts.
+    """
+    monkeypatch.setattr(bok, "BUNDLE", b)
+    monkeypatch.setattr(opl, "BUNDLE", b)
+    monkeypatch.setattr(bki, "BUNDLE", b)
+    monkeypatch.setattr(bki, "INDEX_PATH", b / "kb_index.json")
+
+
 def test_main_builds_full_bundle(monkeypatch, capsys):
     import shutil
     b = _repo_tmp_bundle()
-    monkeypatch.setattr(bok, "BUNDLE", b)
+    _redirect_bundle(monkeypatch, b)
     monkeypatch.setattr(sys, "argv", ["build_okf_bundle.py"])
     try:
         bok.main()
@@ -297,10 +315,45 @@ def test_main_builds_full_bundle(monkeypatch, capsys):
         shutil.rmtree(b.parent, ignore_errors=True)
 
 
+def test_main_leaves_the_tracked_bundle_untouched(monkeypatch, capsys):
+    """main() under redirection must not write one byte into the tracked okf/.
+
+    Regression guard for the leak this helper closes. Without it the pointer
+    layers landed in the real tree, and running the suite in an environment
+    without the community data lake rewrote them into a lossy state that the
+    stop hook then invited you to commit.
+    """
+    import shutil
+    real = Path(__file__).resolve().parent.parent / "okf"
+    if not real.is_dir():
+        pytest.skip("tracked okf/ absent (sparse checkout) — 无从核验污染")
+
+    def snapshot():
+        return {p: (p.stat().st_mtime_ns, p.stat().st_size)
+                for p in sorted(real.rglob("*")) if p.is_file()}
+
+    before = snapshot()
+    assert before, "tracked okf/ unexpectedly empty — guard would be vacuous"
+
+    b = _repo_tmp_bundle()
+    _redirect_bundle(monkeypatch, b)
+    monkeypatch.setattr(sys, "argv", ["build_okf_bundle.py"])
+    try:
+        bok.main()
+        capsys.readouterr()
+        # The pointer layers really ran — they just landed in the redirected dir.
+        # (Asserting only "real/ unchanged" would also pass if opl never ran.)
+        assert (b / "assets" / "index.md").exists()
+        assert (b / "kb_index.json").exists()
+        assert snapshot() == before, "build_okf_bundle wrote into the tracked okf/"
+    finally:
+        shutil.rmtree(b.parent, ignore_errors=True)
+
+
 def test_main_with_tarball(tmp_path, monkeypatch):
     import shutil
     b = _repo_tmp_bundle()
-    monkeypatch.setattr(bok, "BUNDLE", b)
+    _redirect_bundle(monkeypatch, b)
     tarball = tmp_path / "out.tar.gz"
     monkeypatch.setattr(sys, "argv",
                         ["build_okf_bundle.py", "--tarball", str(tarball)])


### PR DESCRIPTION
## 概述

核实 PR #801 期间暴露三处缺陷，守密人 2026-07-25 逐项裁定（三项皆取推荐案）后一并处置。三者互不相干，共同点是都**长期静默**：没有一条会让 CI 变红，因此都活到了今天。

---

## 变更类型

- [x] Bug 修复（测试隔离泄漏 / CI 工作流配置 / 测试偶发）

---

## 来源声明

不适用（无数据变更，纯工程修复）。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不含任何游戏图片 / 解包原始文件 / 未公开文本。**
- [x] **同意按 MIT License 提交。**

---

## 变更内容

### 一、`tests/test_build_okf_bundle_unit.py` — bundle 写入逃逸进真实仓库树

`test_main_builds_full_bundle` / `test_main_with_tarball` 只 monkeypatch 了 `build_okf_bundle.BUNDLE`，但 `okf_pointer_layers.py:25` 与 `build_kb_index.py:33` **各自持有一份** `REPO / "okf"`（注释写明「刻意自持，避免循环 import」），而 `bok.main()` 两者都驱动。结果：原生四层（characters / sources / memory / story）乖乖落临时目录，**每一个指针层 + `kb_index.json` 全部写进被 git 跟踪的 `okf/`——202 档**。

放大成数据丢失的是第二个条件：本仓数据湖已按 T62 P2-5 迁出 code 仓，容器未设 `BIAV_SC_DATA_ROOT` 时重建看不到档案层，`community/index.md` 从 **19 概念塌成 2 概念，17 个平台概念被整批删除**。而 stop 钩子随即提示「有未提交变更，请提交推送」——离把数据丢失 diff 推上 main 只差一步。

修法：新增 `_redirect_bundle()` 把三个模块的 bundle 绑定（含 `bki.INDEX_PATH`）一起改道；新增守卫用例 `test_main_leaves_the_tracked_bundle_untouched`，断言 `main()` 跑完后真实 `okf/` 逐档 mtime + size 不变。守卫**同时**断言指针层确实落在了重定向目录（否则「opl 根本没跑」也能让守卫通过，成为永绿假门）。已反向验证：退化 `_redirect_bundle` 后该用例立即 `AssertionError`。

> 小学生比喻：让实习生在草稿纸上练习画地图，他草稿纸用了、但顺手把正式挂图也重画了一遍——偏偏画的时候资料柜锁着，17 个地名没抄上去。然后墙上贴了张条：「图改好了记得交上去」。

### 二、`.github/workflows/secret-scan.yml` — PR 侧凭据扫描从未运行

gitleaks-action v2 扫 `pull_request` 事件强制要求 `GITHUB_TOKEN`（用于解析 PR commit 范围），工作流未传，action 在**扫描启动前**即 `##[error]` 退出。实测该工作流 `pull_request` 事件近 30 次运行 **30/30 全部失败**——即自 2026-07-19 落地起，凭据扫描从未在任何 PR 上真正跑过一次。`push` / `schedule` 事件不走该分支，一直有效。

修法：补 `GITHUB_TOKEN` + `pull-requests: read`（列 PR commit 所需）。不给 write 权限，评论仍由 `GITLEAKS_ENABLE_COMMENTS: false` 关闭，最小权限姿态不变。

> 小学生比喻：门口装了安检门也通了电，但没给保安发工牌——保安每天到岗、刷不进门、掉头就走，登记表上只留一行「未能上岗」。三十天没人看那张表，于是所有人都以为安检在查。

### 三、`store-patrol.e2e.test.ts` — 必需检查里的计时偶发

`queryTimeoutMs` 仅 400ms，而该用例走真实 HTTP 打进程内假商店。CI runner 冷启动一旦超出，attempt 被判超时 → driver 重试 → ledger 落 4 条 query 行，而断言期望 2 条（`:127`）。本次为首红（main 此前 28 次运行全绿，重跑一次即转绿）。

修法：提到 3s——高于 runner 最坏冷启动延迟，健康路径永不触及（该档耗时实测不变，~1.0s），**被测语义与断言一字未动**。

> 小学生比喻：考试限时 400 毫秒交卷，平时够用，赶上机房卡一下就算你没答完、罚你重考一遍——然后阅卷老师发现卷子多了两张，判你不及格。把限时放宽到 3 秒，答得快的照样 1 秒交卷，卡一下也不再误判。

---

## 验证清单（对话内全量跑通）

| 检查 | 结果 |
|---|---|
| `pytest tests/` | **2927 passed / 51 skipped**（+1 新守卫用例） |
| 全量 pytest 后 `okf/` 污染档数 | **0**（修前 202） |
| 守卫反向验证（退化 `_redirect_bundle`） | 如期 `AssertionError`，非永绿假门 |
| maestro 单测 | 362 passed (29 files) |
| testbed 消费者契约 | 30 passed (3 files) |
| `store-patrol.e2e` 单档耗时 | 1.04s（加固前后不变） |
| 不引入 emoji | 是 |
| 未改 `memory/decisions.md` / `memory/lessons-learned.md` | 是 |

---

## 关联

- Refs [#801](https://github.com/lightproud/BIAV-SC-CODE/pull/801)（三处缺陷均在核实该 PR 期间暴露）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7YErthJAKUeXwA7rQVNaW

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7YErthJAKUeXwA7rQVNaW)_