### PR TITLE
ci(backup): 平台备份改读数据仓（分仓遗漏的断链），为 16 平台补上第二网

### DIFF
--- a/.github/workflows/community-platform-backup.yml
+++ b/.github/workflows/community-platform-backup.yml
@@ -2,10 +2,18 @@ name: Community Platform Backup
 
 # 为非 discord 社区平台建 Release 副本 —— 分仓（T62）硬前置。
 # 门① 盘点发现：discord 有 community-data 桶兜底，但 16 个非 discord 平台
-# （appstore / bilibili / reddit / steam / youtube / weibo / ... ）在 git 里是
-# 唯一正本、零第二份。数据移动（分仓 / 历史动作）前必须先有备份，否则误伤即不可逆丢失。
-# 本工作流每月刷新一次滚动全量副本（--clobber 覆盖同名），并可 workflow_dispatch 在迁移前手动跑一次。
+# （appstore / bilibili / reddit / steam / youtube / weibo / ... ）只有一份正本、零第二份。
+# 本工作流每月刷新一次滚动全量副本（--clobber 覆盖同名），亦可 workflow_dispatch 手动跑。
 # discord 不在此（自有 community-data 桶）；tar 步显式跳过 discord 作正确性兜底。
+#
+# 2026-07-26 修复（守密人裁定「修好并立即跑一轮」）：本工作流建于 2026-07-19，
+# 原从 code 仓 sparse 取 `Public-Info-Pool/Record/Community` —— 而 T62 §7甲（07-20）
+# 已把数据湖迁出 code 仓，该目录不再存在。它建成后一次都没触发过（首次 cron 为 08-03），
+# 所以这个断裂一直没被发现，只是静静等在那里；照原样跑必在自检处响亮失败。
+# 现改为 clone BIAV-SC-DATA 数据仓（同 discord 族 CI 模板，PAT = BIAV_SC_DATA_TOKEN），
+# 数据根经 `BIAV_SC_DATA_ROOT` + `archive_layout.community_root()` 解析 —— 布局真相
+# 只在 archive_layout 一处（CLAUDE.md §7.3），本工作流不再自行拼路径。
+# 前置 secret：BIAV_SC_DATA_TOKEN。Release 仍落 code 仓（与数据仓互为异地副本）。
 
 on:
   schedule:
@@ -23,25 +31,57 @@ concurrency:
 jobs:
   backup:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     if: github.ref == 'refs/heads/main'
+    env:
+      BIAV_SC_DATA_ROOT: ${{ github.workspace }}/data-repo
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout code repo（sparse 脚本，不取数据）
+        uses: actions/checkout@v7
         with:
-          # 只取 Community 下非 discord 平台（~26M）；非 cone 模式支持 discord 子树排除。
-          # 即便排除失效，下方 tar 步仍显式跳过 discord，正确性不依赖 sparse。
           sparse-checkout: |
-            /Public-Info-Pool/Record/Community
-            !/Public-Info-Pool/Record/Community/discord
-          sparse-checkout-cone-mode: false
+            projects/news
+          sparse-checkout-cone-mode: true
 
-      - name: Package non-discord platforms
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Clone BIAV-SC-DATA（PAT，数据根）
+        env:
+          DATA_TOKEN: ${{ secrets.BIAV_SC_DATA_TOKEN }}
         run: |
           set -euo pipefail
-          COMM=Public-Info-Pool/Record/Community
+          if [ -z "${DATA_TOKEN:-}" ]; then
+            echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
+          fi
+          git config --global credential.helper store
+          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
+          chmod 600 ~/.git-credentials
+          # 只读用途，--depth 1 足够（要的是当前全量内容，不是历史）
+          git clone --depth 1 https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+
+      - name: Resolve the community root（单一真相源）
+        id: root
+        run: |
+          set -euo pipefail
+          COMM=$(python3 -c "
+          import sys
+          sys.path.insert(0, 'projects/news/scripts')
+          from archive_layout import community_root
+          print(community_root())
+          ")
+          echo "comm=$COMM" >> "$GITHUB_OUTPUT"
+          echo "community root: $COMM"
+
+      - name: Package non-discord platforms
+        env:
+          COMM: ${{ steps.root.outputs.comm }}
+        run: |
+          set -euo pipefail
           mkdir -p /tmp/platform-backup
           if [ ! -d "$COMM" ]; then
-            echo "::error::$COMM 不存在，checkout 异常"; exit 1
+            echo "::error::$COMM 不存在，数据仓 clone 异常"; exit 1
           fi
           backed=""
           for d in "$COMM"/*/; do
@@ -65,7 +105,7 @@ jobs:
           gh release view community-platforms --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
             || gh release create community-platforms --repo "$GITHUB_REPOSITORY" \
                  --title "Community Platform Archive (non-discord)" \
-                 --notes "非 discord 社区平台全量档案备份（分仓 T62 硬前置）。滚动全量、每月刷新。"
+                 --notes "非 discord 社区平台全量档案备份（T65 三网之一）。源 = BIAV-SC-DATA 数据仓，滚动全量、每月刷新。"
           # --clobber：同名平台资产覆盖为最新全量（滚动副本，非月度版本化）
           gh release upload community-platforms /tmp/platform-backup/*.tar.gz \
             --clobber --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## 概述

`community-platform-backup.yml` 建于 2026-07-19，从 **code 仓** sparse 取 `Public-Info-Pool/Record/Community`；次日 T62 §7甲 就把数据湖迁出 code 仓，该路径不复存在。它**一次都没触发过**（monthly cron 首发为 08-03），所以这条断链自建成次日起一直静静躺着。守密人 2026-07-26 裁定「修好并立即跑一轮」。

---

## 变更类型

- [x] Bug 修复（分仓遗漏的 CI 断链）
- [ ] 文档完善
- [ ] 数据补全
- [ ] 翻译贡献
- [ ] 视觉/前端改进

---

## 来源声明

不涉及游戏数据。事实依据：

```
list_workflow_runs(community-platform-backup.yml) → total_count: 0（从未运行）
.github/workflows/discord-archive.yml（数据仓 clone 模板）
projects/news/scripts/archive_layout.py（归档布局单一真相源）
```

---

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布渠道数据。** 备份对象为银芯自有公开社区档案，方向仍是银芯内部两仓之间，与 §1.1-HC 无涉。
- [x] **不含内部美术资产 / 解包原始文件 / 未公开草稿。**
- [x] **同意按 MIT License 提交。**

---

## 变更内容

- **数据源改 clone BIAV-SC-DATA**（`BIAV_SC_DATA_TOKEN`，同 discord 族 CI 模板）；`--depth 1`——本作业要的是当前全量内容，不是历史。
- **路径不再手拼**：经 `BIAV_SC_DATA_ROOT` + `archive_layout.community_root()` 解析，布局真相仍只在 `archive_layout` 一处（CLAUDE.md §7.3 纪律）。原工作流硬编码在树路径，正是它被分仓改坏而无人知的原因。
- Release 仍落 code 仓——**这正是它的意义**：与数据仓互为异地副本，两处不会同时失手。
- discord 依旧显式跳过（自有 `community-data` 桶）；「无任何平台被打包即报错」的自检保留。

比喻：家里 16 个抽屉只有原件，说好要拍照存档；相机买了、定时器设在 8 月 3 日，但镜头对着的是已经搬空的房间。这次把镜头转向新家，并且不再让人手抄门牌号——直接问那本唯一的地址簿。

---

## 验证清单

- [x] `pytest tests/` — **2932 通过 / 51 跳过**
- [x] 工作流 YAML 解析通过，六步顺序正确
- [x] 解析器实证：设 `BIAV_SC_DATA_ROOT` 后 `community_root()` 返回 `<根>/Record/Community` 并可枚举平台目录
- [ ] **合并后 dispatch 一轮实证**（本 PR 合并即执行，回报 run 链接与产出平台数）
- [x] 不引入 emoji

---

## 关联

- Refs `memory/todo.md` #T65（三网站岗；本 PR 补的正是其中最薄的一张）
- Refs #810（T65 立项）

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3PTjiaJAMbzSoEV45XZkk)_