### PR TITLE
feat: 死手开关（招三施工）+ 状态档事实块生成（招一点火）

### DIFF
--- a/.github/workflows/dead-man-switch.yml
+++ b/.github/workflows/dead-man-switch.yml
@@ -1,0 +1,79 @@
+name: Dead Man Switch
+
+# 只数空座位，不听课（设计档 Public-Info-Pool/Resource/proposal/
+# dead-man-switch-design-20260726.md，守密人 2026-07-26 裁定「按建议推进」）。
+#
+# 靶：不是「机制报错时告诉我」（工作流失败会红，已有），而是**「机制该出声却没出声时
+# 告诉我」**——2026-07-26 前全仓为零，于是 store-patrol 连红 7 天、
+# community-platform-backup 建成次日即坏且从未触发，都无人知晓。
+#
+# 拉模式：本作业查 Actions API 覆盖**全部**带 cron 的工作流，阈值由各自的 cron 推导
+# （清单只有一份，就是工作流文件本身）。加新定时工作流零改动即被纳入监控。
+#
+# 互看：本工作流被 testbed 巡检的 ci-status 名单列入（projects/silver-core-testbed/
+# targets/inspect.targets.json），而本工作流反过来监控 testbed-patrol——两个不同宿主
+# 互看，任一哑掉由另一方报。最后一道是人：status.json 自带 generated_at，
+# 月检档扫一眼（memory/methodology.md）。
+
+on:
+  schedule:
+    - cron: '50 7 * * *' # 每日北京 15:50，排在 store-patrol(15:15)/testbed(15:20) 之后
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dead-man-switch
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Ruleset 挡 GITHUB_TOKEN 推 main（todo T31）——机器提交走部署密钥。
+          # 这条是 2026-07-26 store-patrol 连红 7 天的直接教训，新工作流照此配。
+          ssh-key: ${{ secrets.BOT_DEPLOY_KEY }}
+          sparse-checkout: |
+            /*
+            !/Public-Info-Pool/Record/
+            !/Public-Info-Pool/Reference/
+            /Public-Info-Pool/Record/heartbeat/
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      # 发现沉默要让作业变红（可见），但状态文件必须先落库——否则「有发现」等于
+      # 「没记录」，与 store-patrol 审计 H5 同一教训。
+      - name: Sweep for silent workflows
+        id: sweep
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/dead_man_switch.py
+      - name: Commit status
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Public-Info-Pool/Record/heartbeat/
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: dead man switch status [skip ci]"
+            for i in 1 2 3 4; do
+              if git pull --rebase origin main && git push origin main; then exit 0; fi
+              echo "Push attempt $i failed, retrying in ${i}s..."
+              sleep $i
+            done
+            echo "All push attempts failed"
+            exit 1
+          fi
+      - name: Fail if any workflow went silent
+        if: steps.sweep.outcome == 'failure'
+        run: |
+          echo "死手开关有发现（STALE / NEVER），详见上方日志与 Public-Info-Pool/Record/heartbeat/status.json"
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,6 +424,8 @@ wiki 旧结构化层的 6 个占位 JSON（2026-06-15 裁定清空者）。**守
 | wiki 构建产出 | `cd projects/wiki && npm run docs:build` |
 | 数据校验（wiki JSON）| slash `/validate-data` 或 `python scripts/...`（见 schema 目录）|
 | 跨档案检索 | `rg "<关键词>" memory/ assets/`（ripgrep） |
+| 死手开关（沉默检测）| `python3 scripts/dead_man_switch.py [--dry-run]`（**只数空座位**：查全部带 cron 工作流的最近一次成功，超阈值报 `STALE`、从无成功报 `NEVER`；阈值由各自 cron 推导 ×2 + 宽限，状态落 `Public-Info-Pool/Record/heartbeat/status.json`，CI `dead-man-switch.yml` 每日北京 15:50；设计档见 `Public-Info-Pool/Resource/proposal/dead-man-switch-design-20260726.md`，单测 `tests/test_dead_man_switch.py`）|
+| 状态档事实块重算 | `python3 scripts/build_status_facts.py [--check]`（`memory/project-status.md` 的版本 / 规模 / 台账数字由权威源生成，**勿手抄**；同步守卫 `tests/test_status_facts.py`）|
 | 记忆保鲜巡检 | `python3 scripts/memory_freshness.py`（lessons 指针/编号不变量门禁见 `tests/test_memory_freshness.py`；月检例程与 `/sync-memory` 手册共用一套流程）|
 | 知识库有效性记分卡 | `python3 scripts/kb_eval.py`（黄金问题集 hit@k + MRR；需求侧有效性回归见 `tests/test_kb_golden.py`）|
 | 知识库使用遥测报告 | `python3 scripts/kb_telemetry.py`（借阅记录：调用分布 / 死概念 / 零命中查询；日志按日落 git 内 `Public-Info-Pool/Record/kb-usage/{date}.jsonl` **跨会话累计**，2026-07-11 方案甲裁定，路径唯一源 = `kb_telemetry.KB_USAGE_DIR`）；`--harvest` 把零命中查询回流成 held-out 难题候选（闭合评判 #1↔#2）|

--- a/Public-Info-Pool/Record/heartbeat/status.json
+++ b/Public-Info-Pool/Record/heartbeat/status.json
@@ -1,0 +1,283 @@
+{
+  "generated_at": "2026-07-26T08:38:00+00:00",
+  "threshold_factor": 2.0,
+  "grace_hours": 2.0,
+  "watched": 25,
+  "findings": 3,
+  "entries": [
+    {
+      "workflow": "backfill-media.yml",
+      "cron": [
+        "40 * * * *"
+      ],
+      "expected_interval_h": 1.0,
+      "created_at": "2026-06-02T20:53:02.000Z",
+      "state": "stale",
+      "last_success": "2026-06-21T11:53:23Z",
+      "note": "最近一次成功在 836.7h 前，超阈值 4.0h"
+    },
+    {
+      "workflow": "backfill-news.yml",
+      "cron": [
+        "20 * * * *"
+      ],
+      "expected_interval_h": 1.0,
+      "created_at": "2026-04-05T05:18:19.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T07:07:18Z",
+      "note": "最近一次成功在 1.5h 前（阈值 4.0h）"
+    },
+    {
+      "workflow": "build-analysis-index.yml",
+      "cron": [
+        "17 4 * * 1"
+      ],
+      "expected_interval_h": 168.0,
+      "created_at": "2026-06-21T08:25:44.000Z",
+      "state": "ok",
+      "last_success": "2026-07-20T07:31:18Z",
+      "note": "最近一次成功在 145.1h 前（阈值 338.0h）"
+    },
+    {
+      "workflow": "build-okf-bundle.yml",
+      "cron": [
+        "17 6 * * *"
+      ],
+      "expected_interval_h": 24.0,
+      "created_at": "2026-06-21T06:32:39.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T08:38:33Z",
+      "note": "最近一次成功在 -0.0h 前（阈值 50.0h）"
+    },
+    {
+      "workflow": "check-version.yml",
+      "cron": [
+        "0 6 * * 1"
+      ],
+      "expected_interval_h": 168.0,
+      "created_at": "2026-03-29T09:46:17.000Z",
+      "state": "stale",
+      "last_success": "2026-06-15T12:09:42Z",
+      "note": "最近一次成功在 980.5h 前，超阈值 338.0h"
+    },
+    {
+      "workflow": "cleanup-stale-branches.yml",
+      "cron": [
+        "0 2 * * 1"
+      ],
+      "expected_interval_h": 168.0,
+      "created_at": "2026-04-26T14:46:41.000Z",
+      "state": "ok",
+      "last_success": "2026-07-20T05:35:30Z",
+      "note": "最近一次成功在 147.0h 前（阈值 338.0h）"
+    },
+    {
+      "workflow": "collect-comments.yml",
+      "cron": [
+        "5 7 * * *"
+      ],
+      "expected_interval_h": 24.0,
+      "created_at": "2026-06-03T05:00:03.000Z",
+      "state": "ok",
+      "last_success": "2026-07-25T09:07:37Z",
+      "note": "最近一次成功在 23.5h 前（阈值 50.0h）"
+    },
+    {
+      "workflow": "collect-fanart.yml",
+      "cron": [
+        "10 7 * * *"
+      ],
+      "expected_interval_h": 24.0,
+      "created_at": "2026-06-11T00:45:07.000Z",
+      "state": "stale",
+      "last_success": "2026-07-20T10:20:13Z",
+      "note": "最近一次成功在 142.3h 前，超阈值 50.0h"
+    },
+    {
+      "workflow": "community-cold-compress.yml",
+      "cron": [
+        "23 3 2 * *"
+      ],
+      "expected_interval_h": 744.0,
+      "created_at": "2026-07-12T13:14:54.000Z",
+      "state": "ok",
+      "last_success": "2026-07-20T04:11:35Z",
+      "note": "最近一次成功在 148.4h 前（阈值 1490.0h）"
+    },
+    {
+      "workflow": "community-platform-backup.yml",
+      "cron": [
+        "23 4 3 * *"
+      ],
+      "expected_interval_h": 744.0,
+      "created_at": "2026-07-19T07:27:35.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T07:21:44Z",
+      "note": "最近一次成功在 1.3h 前（阈值 1490.0h）"
+    },
+    {
+      "workflow": "conformance-drift.yml",
+      "cron": [
+        "7 5 * * 1"
+      ],
+      "expected_interval_h": 168.0,
+      "created_at": "2026-07-05T09:13:33.000Z",
+      "state": "ok",
+      "last_success": "2026-07-20T09:33:24Z",
+      "note": "最近一次成功在 143.1h 前（阈值 338.0h）"
+    },
+    {
+      "workflow": "dead-man-switch.yml",
+      "cron": [
+        "50 7 * * *"
+      ],
+      "expected_interval_h": 24.0,
+      "state": "unknown",
+      "note": "API 查询失败: HTTP Error 404: Not Found"
+    },
+    {
+      "workflow": "discord-archive-jp.yml",
+      "cron": [
+        "45 */3 * * *"
+      ],
+      "expected_interval_h": 3.0,
+      "created_at": "2026-06-17T07:24:44.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T04:18:13Z",
+      "note": "最近一次成功在 4.3h 前（阈值 8.0h）"
+    },
+    {
+      "workflow": "discord-archive-volunteer.yml",
+      "cron": [
+        "15 */3 * * *"
+      ],
+      "expected_interval_h": 3.0,
+      "created_at": "2026-06-16T14:02:26.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T03:54:52Z",
+      "note": "最近一次成功在 4.7h 前（阈值 8.0h）"
+    },
+    {
+      "workflow": "discord-archive.yml",
+      "cron": [
+        "0 7 * * *",
+        "0 6 1 * *"
+      ],
+      "expected_interval_h": 24.0,
+      "created_at": "2026-03-29T09:08:30.000Z",
+      "state": "ok",
+      "last_success": "2026-07-25T09:02:54Z",
+      "note": "最近一次成功在 23.6h 前（阈值 50.0h）"
+    },
+    {
+      "workflow": "discord-cold-compress.yml",
+      "cron": [
+        "23 3 2 * *"
+      ],
+      "expected_interval_h": 744.0,
+      "created_at": "2026-07-12T12:49:23.000Z",
+      "state": "ok",
+      "last_success": null,
+      "note": "新工作流，尚在首跑宽限内（至 2026-09-12T14:49:23+00:00）"
+    },
+    {
+      "workflow": "discord-history-backfill.yml",
+      "cron": [
+        "30 */3 * * *"
+      ],
+      "expected_interval_h": 3.0,
+      "created_at": "2026-04-05T05:49:21.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T04:07:30Z",
+      "note": "最近一次成功在 4.5h 前（阈值 8.0h）"
+    },
+    {
+      "workflow": "refresh-claude-code-prompts.yml",
+      "cron": [
+        "0 3 * * 1"
+      ],
+      "expected_interval_h": 168.0,
+      "created_at": "2026-07-04T22:31:56.000Z",
+      "state": "ok",
+      "last_success": "2026-07-20T06:22:53Z",
+      "note": "最近一次成功在 146.3h 前（阈值 338.0h）"
+    },
+    {
+      "workflow": "sdk-mutation-ratchet.yml",
+      "cron": [
+        "43 5 * * 1"
+      ],
+      "expected_interval_h": 168.0,
+      "created_at": "2026-07-13T04:54:38.000Z",
+      "state": "ok",
+      "last_success": "2026-07-13T09:01:51Z",
+      "note": "最近一次成功在 311.6h 前（阈值 338.0h）"
+    },
+    {
+      "workflow": "secret-scan.yml",
+      "cron": [
+        "17 3 * * 1"
+      ],
+      "expected_interval_h": 168.0,
+      "created_at": "2026-07-19T02:53:46.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T08:03:12Z",
+      "note": "最近一次成功在 0.6h 前（阈值 338.0h）"
+    },
+    {
+      "workflow": "silver-core-sdk.yml",
+      "cron": [
+        "17 6 1 * *"
+      ],
+      "expected_interval_h": 744.0,
+      "created_at": "2026-07-10T17:53:49.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T08:02:12Z",
+      "note": "最近一次成功在 0.6h 前（阈值 1490.0h）"
+    },
+    {
+      "workflow": "store-patrol.yml",
+      "cron": [
+        "15 7 * * *"
+      ],
+      "expected_interval_h": 24.0,
+      "created_at": "2026-07-18T06:59:41.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T02:46:48Z",
+      "note": "最近一次成功在 5.9h 前（阈值 50.0h）"
+    },
+    {
+      "workflow": "testbed-patrol.yml",
+      "cron": [
+        "20 7 * * *"
+      ],
+      "expected_interval_h": 24.0,
+      "created_at": "2026-07-18T11:53:26.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T02:47:31Z",
+      "note": "最近一次成功在 5.8h 前（阈值 50.0h）"
+    },
+    {
+      "workflow": "update-news.yml",
+      "cron": [
+        "0 */3 * * *"
+      ],
+      "expected_interval_h": 3.0,
+      "created_at": "2026-03-24T06:13:31.000Z",
+      "state": "ok",
+      "last_success": "2026-07-26T08:38:41Z",
+      "note": "最近一次成功在 -0.0h 前（阈值 8.0h）"
+    },
+    {
+      "workflow": "weekly-heavy-deps-test.yml",
+      "cron": [
+        "30 7 * * 1"
+      ],
+      "expected_interval_h": 168.0,
+      "created_at": "2026-07-12T03:38:17.000Z",
+      "state": "ok",
+      "last_success": "2026-07-20T10:24:08Z",
+      "note": "最近一次成功在 142.2h 前（阈值 338.0h）"
+    }
+  ]
+}

--- a/memory/methodology.md
+++ b/memory/methodology.md
@@ -303,6 +303,13 @@ Light 当前在 L3.5。L3→L4 是最难的跳跃，需要同时完成三件事�
   记录（死概念 / 零命中回流候选，遥测已落 git 内 `Public-Info-Pool/Record/kb-usage/`
   跨会话累计）——CI 测试只守「不回归」，趋势要人看
 
+### 月检加一眼：死手开关的状态戳（2026-07-26 起）
+
+看 `Public-Info-Pool/Record/heartbeat/status.json` 的 **`generated_at`**。它若停在上个月，
+说明死手开关自己哑了——**人是最后一道不会哑的开关**（设计档 `Public-Info-Pool/Resource/
+proposal/dead-man-switch-design-20260726.md` §3 选择四）。`findings` 非零即有工作流
+「该出声却没出声」，`entries` 里 `stale`（曾成功、超阈值）与 `never`（从未成功）分列。
+
 ### 数据增长触发线（命中任一即重开冷热分层议题，只定何时重议、不预设结论）
 | 触发条件 | 定标基准（2026-07-02 实测） |
 |----------|---------------------------|

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -72,6 +72,28 @@
 - ⏳ **守密人本地待执行**：批量删除 37 个 stale 分支（含 13 个安全 + 24 个审计后决定删 + 本会话清理分支）
 - ⏳ **5 个 dependabot PR 待批量升级**（#136-140）— 已派任务给 Code-news（参 batch dependency update 文字派单）
 
+<!-- STATUS-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
+
+### 机器生成事实（版本 / 规模 / 台账）
+
+> 本块由 `scripts/build_status_facts.py` 从权威源生成，`tests/test_status_facts.py` 守同步。
+> **勿手抄这些数字到别处**——要引用就指这里（2026-07-26 抗漂移裁定，提案招一）。
+> 测试**通过数**不在此列：那要真跑才知道，属实测记录、随文注明日期，不是静态事实。
+
+| 事实 | 值 | 权威源 |
+|------|----|--------|
+| Silver Core Agent SDK 版本 | `0.76.0` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.76.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
+| agent SDK 源文件 / 测试档 | 122 / 197 | 磁盘实况 |
+| maestro SDK 源文件 / 测试档 | 16 / 29 | 磁盘实况 |
+| testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
+| Python 测试档 | 127 | 磁盘实况 |
+| CI 工作流 / 其中定时 | 43 / 25 | `.github/workflows/` |
+| 挂账台账 开 / 已清 | 19 / 53 | `memory/todo.md` |
+
+<!-- STATUS-FACTS:END -->
+
 ## 子项目状态
 
 | 子项目 | 状态 | 负责会话 | 下一步 |
@@ -279,7 +301,7 @@
   （`SDKMemoryHealth.sessionEndUpdate` 九态 + `Query.memoryHealthSnapshot()`）+ 上游 corpus
   重同步 ccVersion 2.1.213。
   **实测复核（2026-07-26 本地现跑）**：三处版本常量一致 · `tsc --noEmit` 零错误 · vitest
-  **3215 通过 + 6 skipped / 196 文件**（原记 3017，**+198**）· tarball 1640 KB / 解包 5.85 MB ·
+  **3215 通过 + 6 skipped / 196 文件**（原记 3017，**+198**）（**同日复测订正 2026-07-26**：本会话再跑得 **3216 通过 + 5 skipped / 197 文件**，总数同为 3221——差异 = 一条**条件跳过**的用例在两次环境下归属不同 + 文件计数口径（顶层 glob 196 vs 递归 197，vitest 报 197）。两处均为**手抄实测数**，正是`memory/project-status.md` 机器生成事实块要消灭的那一类：静态口径以块内为准，实测通过数留在正文但须带日期。）· tarball 1640 KB / 解包 5.85 MB ·
   `npm audit` 0 漏洞 · 家族锁步 agent = maestro = 0.76.0 · maestro 362 绿 / testbed 33 绿 ·
   依赖方向守卫 + 版本纪律守卫均 OK。
 - **v0.69.0（2026-07-18，守密人待办批 SDK 侧 1–3 项）**：① 迁移文档刷新

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -82,7 +82,7 @@ src/
 > 诊断）+ 上游 corpus 重同步（ccVersion 2.1.213）。
 >
 > **实测复核（2026-07-26 本地现跑，非引用）**：版本 **0.76.0**（`package.json` / `src/version.ts` /
-> `CHANGELOG.md` 三处一致）· `tsc --noEmit` 零错误 · vitest **3215 通过 + 6 skipped / 196 文件**
+> `CHANGELOG.md` 三处一致）· `tsc --noEmit` 零错误 · vitest **3215 通过 + 6 skipped / 196 文件**（**同日复测订正 2026-07-26**：本会话再跑得 **3216 通过 + 5 skipped / 197 文件**，总数同为 3221——差异 = 一条**条件跳过**的用例在两次环境下归属不同 + 文件计数口径（顶层 glob 196 vs 递归 197，vitest 报 197）。两处均为**手抄实测数**，正是`memory/project-status.md` 机器生成事实块要消灭的那一类：静态口径以块内为准，实测通过数留在正文但须带日期。）
 > （原记 3017，**+198**）· `npm pack` 614 文件 / 解包 5.85 MB / tarball 1640 KB · `npm audit` 0 漏洞 ·
 > 家族锁步 agent 0.76.0 = maestro 0.76.0 · maestro 362 测试全绿 · testbed 33 测试全绿 ·
 > 依赖方向守卫与版本纪律守卫均 OK。

--- a/projects/silver-core-testbed/targets/inspect.targets.json
+++ b/projects/silver-core-testbed/targets/inspect.targets.json
@@ -3,7 +3,7 @@
     "what": "热层目标清单 (hot layer): what the four inspectors watch. Editing this file changes patrol coverage with ZERO code changes — same registry discipline as store-patrol.targets.json and archive_sources.json.",
     "keys": "repo: owner/name used by GitHub API inspectors; ci-status.workflows: workflow files whose latest completed run is checked; doc-links.roots: files/dirs swept for internal markdown links; lockstep.packages: package dirs that must carry the same family version; ratchet: mutation-ratchet floor files + the weekly workflow that re-measures them."
   },
-  "repo": "lightproud/brain-in-a-vat",
+  "repo": "lightproud/BIAV-SC-CODE",
   "ci-status": {
     "workflows": [
       "test.yml",
@@ -15,7 +15,9 @@
       "update-news.yml",
       "build-okf-bundle.yml",
       "discord-archive.yml",
-      "collect-comments.yml"
+      "collect-comments.yml",
+      "dead-man-switch.yml",
+      "collect-fanart.yml"
     ]
   },
   "doc-links": {

--- a/scripts/build_status_facts.py
+++ b/scripts/build_status_facts.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""状态档机器生成事实块 —— 「会变的数字不许手抄」。
+
+2026-07-26 审视会话实测：`memory/project-status.md` 自称「状态唯一权威」，SDK 行却写着
+v0.63.1 而实际已是 0.76.0——滞后 13 个次版本、9 天；同日回填的一处变异地板数字在写下时
+就已过期。两处同因：**会变的事实被手抄进档案**（抗漂移提案 §1 第一因）。
+
+本脚本把这类事实改为**从权威源生成**（提案 §2 招一）：版本取 `package.json`、
+规模取磁盘实况、台账条数取 `todo.md`。人只写判断，不写数字。
+
+纪律：块内**不含时间戳**——它是仓库当前状态的纯函数，故守卫测试可以重算逐字比对；
+掺入 `generated_at` 会让块每次重算都变，反而没法比。「这份状态多旧」由 git 记录回答。
+
+用法：
+    python3 scripts/build_status_facts.py            # 就地更新块
+    python3 scripts/build_status_facts.py --check    # 只比对，不写（CI / 测试用）
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+STATUS_DOC = REPO / "memory" / "project-status.md"
+BEGIN = "<!-- STATUS-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->"
+END = "<!-- STATUS-FACTS:END -->"
+
+PACKAGES = {
+    "silver-core-agent-sdk": REPO / "projects" / "silver-core-sdk",
+    "silver-core-maestro-sdk": REPO / "projects" / "silver-core-maestro-sdk",
+    "silver-core-testbed": REPO / "projects" / "silver-core-testbed",
+}
+
+
+def _pkg(path: Path) -> dict:
+    return json.loads((path / "package.json").read_text(encoding="utf-8"))
+
+
+def _count(pattern: str, root: Path) -> int:
+    return sum(1 for _ in root.glob(pattern))
+
+
+def _ledger_counts() -> tuple[int, int]:
+    text = (REPO / "memory" / "todo.md").read_text(encoding="utf-8")
+    body = text.split("## 开账", 1)[1]
+    open_part, closed_part = body.split("## 已清", 1)
+    row = re.compile(r"^\|\s*[TC]\d+\s*\|", re.M)
+    return len(row.findall(open_part)), len(row.findall(closed_part))
+
+
+def render() -> str:
+    versions = {name: _pkg(path)["version"] for name, path in PACKAGES.items()}
+    agent, maestro, testbed = (PACKAGES[k] for k in PACKAGES)
+    workflows = sorted((REPO / ".github" / "workflows").glob("*.yml"))
+    scheduled = [p for p in workflows if re.search(r"^\s*-\s*cron:", p.read_text(encoding="utf-8"), re.M)]
+    open_rows, closed_rows = _ledger_counts()
+
+    lines = [
+        BEGIN,
+        "",
+        "### 机器生成事实（版本 / 规模 / 台账）",
+        "",
+        "> 本块由 `scripts/build_status_facts.py` 从权威源生成，`tests/test_status_facts.py` 守同步。",
+        "> **勿手抄这些数字到别处**——要引用就指这里（2026-07-26 抗漂移裁定，提案招一）。",
+        "> 测试**通过数**不在此列：那要真跑才知道，属实测记录、随文注明日期，不是静态事实。",
+        "",
+        "| 事实 | 值 | 权威源 |",
+        "|------|----|--------|",
+        f"| Silver Core Agent SDK 版本 | `{versions['silver-core-agent-sdk']}` | `projects/silver-core-sdk/package.json` |",
+        f"| Silver Core Maestro SDK 版本 | `{versions['silver-core-maestro-sdk']}` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|",
+        f"| testbed 试金石 | `{versions['silver-core-testbed']}`（private，永不发布）| `projects/silver-core-testbed/package.json` |",
+        f"| agent SDK 源文件 / 测试档 | {_count('src/**/*.ts', agent)} / {_count('tests/**/*.test.ts', agent)} | 磁盘实况 |",
+        f"| maestro SDK 源文件 / 测试档 | {_count('src/**/*.ts', maestro)} / {_count('tests/**/*.test.ts', maestro)} | 磁盘实况 |",
+        f"| testbed 源文件 / 测试档 | {_count('src/*.mjs', testbed)} / {_count('tests/*.test.mjs', testbed)} | 磁盘实况 |",
+        f"| Python 测试档 | {_count('tests/test_*.py', REPO)} | 磁盘实况 |",
+        f"| CI 工作流 / 其中定时 | {len(workflows)} / {len(scheduled)} | `.github/workflows/` |",
+        f"| 挂账台账 开 / 已清 | {open_rows} / {closed_rows} | `memory/todo.md` |",
+        "",
+        END,
+    ]
+    return "\n".join(lines)
+
+
+def apply(check_only: bool = False) -> int:
+    doc = STATUS_DOC.read_text(encoding="utf-8")
+    block = render()
+    if BEGIN in doc and END in doc:
+        start, tail = doc.split(BEGIN, 1)
+        _, rest = tail.split(END, 1)
+        updated = start + block + rest
+    else:
+        # 首次落块：插在「## 子项目状态」之前——读者看表之前先看到硬数字
+        anchor = "## 子项目状态"
+        if anchor not in doc:
+            print("未找到锚点「## 子项目状态」，无法插入", file=sys.stderr)
+            return 2
+        updated = doc.replace(anchor, block + "\n\n" + anchor, 1)
+
+    if updated == doc:
+        print("状态事实块已是最新")
+        return 0
+    if check_only:
+        print("状态事实块与权威源不同步：跑 `python3 scripts/build_status_facts.py` 重算", file=sys.stderr)
+        return 1
+    STATUS_DOC.write_text(updated, encoding="utf-8")
+    print(f"已更新 {STATUS_DOC.relative_to(REPO)} 的机器生成事实块")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="生成 project-status.md 的机器事实块")
+    parser.add_argument("--check", action="store_true", help="只比对不写，不同步则非零退出")
+    args = parser.parse_args(argv)
+    return apply(check_only=args.check)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dead_man_switch.py
+++ b/scripts/dead_man_switch.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""死手开关 —— 只数空座位，不听课。
+
+靶（设计档 `Public-Info-Pool/Resource/proposal/dead-man-switch-design-20260726.md`）：
+**不是「机制报错时告诉我」（工作流失败会红，已有），而是「机制该出声却没出声时告诉我」**
+（2026-07-26 前全仓为零）。两种沉默分开报，因为病因不同：
+
+- `STALE` —— 曾经成功过，最近一次成功超出阈值（2026-07-26 的 store-patrol：连红 7 天）；
+- `NEVER` —— 从来没成功过（同日的 community-platform-backup：建成次日即坏、从未触发，
+  首个 cron 还在一周之后，「坏了」这个事件根本还没发生）。
+
+三条设计取舍（守密人 2026-07-26 裁定「按建议推进」）：
+1. **拉模式**：一个作业查 Actions API 覆盖全部定时工作流，不必改 N 个文件、不指望下一个
+   作者记得加心跳——漏网面是推模式的死穴。
+2. **阈值由 cron 自己推导**：期望间隔 = 该工作流全部 cron 的**最大相邻间隔**，阈值 =
+   期望间隔 × `THRESHOLD_FACTOR` + `GRACE_HOURS`。清单只有一份，就是工作流文件本身。
+3. **NEVER 宽限** = 工作流创建时刻 + 一个期望间隔（首个 cron 到期）+ 再一个间隔，
+   新建工作流不会一落地就红。
+
+克制（守卫的信誉是一次性的）：禁用的工作流跳过；无 cron 的（纯 workflow_dispatch）不纳入；
+只报状态、不猜原因——它一分析就会变复杂，而元规则要求**守卫必须比它守的东西简单**。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = REPO / ".github" / "workflows"
+STATUS_PATH = REPO / "Public-Info-Pool" / "Record" / "heartbeat" / "status.json"
+
+THRESHOLD_FACTOR = 2.0
+GRACE_HOURS = 2.0
+#  cron 采样窗口：要能覆盖到月度 cron 的两次触发（每月 3 日 → 需 > 31 天）
+SAMPLE_DAYS = 400
+
+CRON_BOUNDS = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 6)]
+
+
+def parse_field(spec: str, lo: int, hi: int) -> set[int]:
+    """展开单个 cron 字段。支持 `*` / `a` / `a-b` / `a,b` / `*/n` / `a-b/n`。"""
+    values: set[int] = set()
+    for part in spec.split(","):
+        step = 1
+        if "/" in part:
+            part, step_s = part.split("/", 1)
+            step = int(step_s)
+            if step <= 0:
+                raise ValueError(f"步长必须为正: {spec}")
+        if part in ("*", "?"):
+            start, end = lo, hi
+        elif "-" in part.lstrip("-"):
+            start_s, end_s = part.split("-", 1)
+            start, end = int(start_s), int(end_s)
+        else:
+            start = end = int(part)
+        if start < lo or end > hi or start > end:
+            raise ValueError(f"字段越界: {part} 不在 [{lo},{hi}]")
+        values.update(range(start, end + 1, step))
+    return values
+
+
+def _matches_day(dom_spec: str, dow_spec: str, dom: set[int], dow: set[int], when: datetime) -> bool:
+    """cron 的日/周语义：两者都被限定时取「或」，否则取「与」。"""
+    # cron 的 dow：0/7 = 周日；Python weekday(): 周一=0
+    cron_dow = (when.weekday() + 1) % 7
+    dom_hit = when.day in dom
+    dow_hit = cron_dow in dow or (7 in dow and cron_dow == 0)
+    if dom_spec.strip() not in ("*", "?") and dow_spec.strip() not in ("*", "?"):
+        return dom_hit or dow_hit
+    return dom_hit and dow_hit
+
+
+def fire_times(cron: str, start: datetime, days: int = SAMPLE_DAYS) -> list[datetime]:
+    """窗口内的全部触发时刻。只遍历 minute/hour 集合，不逐分钟扫。"""
+    fields = cron.split()
+    if len(fields) != 5:
+        raise ValueError(f"cron 须为 5 段: {cron!r}")
+    minutes, hours, doms, months, dows = (
+        parse_field(f, lo, hi) for f, (lo, hi) in zip(fields, CRON_BOUNDS)
+    )
+    out: list[datetime] = []
+    for offset in range(days):
+        day = (start + timedelta(days=offset)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        if day.month not in months:
+            continue
+        if not _matches_day(fields[2], fields[4], doms, dows, day):
+            continue
+        for hour in sorted(hours):
+            for minute in sorted(minutes):
+                out.append(day.replace(hour=hour, minute=minute))
+    return sorted(out)
+
+
+def expected_interval_hours(crons: Iterable[str], reference: datetime) -> float:
+    """期望间隔 = 全部 cron 触发时刻**并集**的最大相邻间隔。
+
+    取最大而非平均：`discord-archive.yml` 同时有每日与每月两条 cron，按平均会得出一个
+    没有任何一条 cron 真正满足的阈值。最大间隔才是「多久没动静算不对劲」的诚实answer。
+    """
+    stamps: list[datetime] = []
+    for cron in crons:
+        stamps.extend(fire_times(cron, reference))
+    stamps = sorted(set(stamps))
+    if len(stamps) < 2:
+        raise ValueError("采样窗口内触发次数不足，无法推导间隔")
+    gaps = [
+        (b - a).total_seconds() / 3600.0 for a, b in zip(stamps, stamps[1:])
+    ]
+    return max(gaps)
+
+
+def scheduled_workflows(workflow_dir: Path = WORKFLOW_DIR) -> dict[str, list[str]]:
+    """{工作流文件名: [cron...]}，只收带 schedule 的。纯 dispatch 的本就不该定期出声。"""
+    import re
+
+    found: dict[str, list[str]] = {}
+    for path in sorted(workflow_dir.glob("*.yml")):
+        crons = re.findall(r"^\s*-\s*cron:\s*'([^']+)'", path.read_text(encoding="utf-8"), re.M)
+        if crons:
+            found[path.name] = crons
+    return found
+
+
+def _api(url: str, token: str | None) -> dict:
+    request = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - 固定 api.github.com
+        return json.loads(response.read().decode("utf-8"))
+
+
+def github_fetcher(repo: str, token: str | None) -> Callable[[str], dict]:
+    """返回 fetch(workflow_file) -> {created_at, state, last_success}；失败向上抛。"""
+
+    def fetch(workflow_file: str) -> dict:
+        base = f"https://api.github.com/repos/{repo}/actions/workflows/{workflow_file}"
+        meta = _api(base, token)
+        runs = _api(f"{base}/runs?status=success&per_page=1", token)
+        items = runs.get("workflow_runs") or []
+        return {
+            "created_at": meta.get("created_at"),
+            "state": meta.get("state", "active"),
+            "last_success": items[0].get("updated_at") if items else None,
+        }
+
+    return fetch
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def classify(entry: dict, now: datetime) -> tuple[str, str]:
+    """(state, note)。state ∈ ok / stale / never / skipped / unknown。"""
+    if entry.get("state") not in (None, "active"):
+        return "skipped", f"工作流非 active（{entry.get('state')}），不计沉默"
+    interval = entry["expected_interval_h"]
+    threshold = interval * THRESHOLD_FACTOR + GRACE_HOURS
+    last = _parse_ts(entry.get("last_success"))
+    if last is not None:
+        age = (now - last).total_seconds() / 3600.0
+        if age > threshold:
+            return "stale", f"最近一次成功在 {age:.1f}h 前，超阈值 {threshold:.1f}h"
+        return "ok", f"最近一次成功在 {age:.1f}h 前（阈值 {threshold:.1f}h）"
+    created = _parse_ts(entry.get("created_at"))
+    if created is None:
+        return "unknown", "无成功记录且无创建时间，无法判定"
+    # NEVER 宽限：首个 cron 到期（+1 间隔）再给一个间隔，新工作流不会一落地就红
+    grace_deadline = created + timedelta(hours=interval * 2 + GRACE_HOURS)
+    if now < grace_deadline:
+        return "ok", f"新工作流，尚在首跑宽限内（至 {grace_deadline.isoformat()}）"
+    return "never", f"创建于 {created.isoformat()}，至今从无一次成功"
+
+
+def build_status(
+    fetch: Callable[[str], dict],
+    now: datetime,
+    workflow_dir: Path = WORKFLOW_DIR,
+) -> dict:
+    entries = []
+    for name, crons in scheduled_workflows(workflow_dir).items():
+        record: dict = {"workflow": name, "cron": crons}
+        try:
+            record["expected_interval_h"] = round(expected_interval_hours(crons, now), 2)
+        except ValueError as exc:
+            record.update(state="unknown", note=f"cron 间隔无法推导: {exc}")
+            entries.append(record)
+            continue
+        try:
+            record.update(fetch(name))
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
+            record.update(state="unknown", note=f"API 查询失败: {exc}")
+            entries.append(record)
+            continue
+        state, note = classify(record, now)
+        record["state"] = state
+        record["note"] = note
+        entries.append(record)
+    findings = [e for e in entries if e.get("state") in ("stale", "never")]
+    return {
+        "generated_at": now.isoformat(),
+        "threshold_factor": THRESHOLD_FACTOR,
+        "grace_hours": GRACE_HOURS,
+        "watched": len(entries),
+        "findings": len(findings),
+        "entries": entries,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="死手开关：报告该出声却没出声的定时工作流")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "lightproud/BIAV-SC-CODE"))
+    parser.add_argument("--out", type=Path, default=STATUS_PATH)
+    parser.add_argument("--dry-run", action="store_true", help="只打印，不写文件")
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+    status = build_status(github_fetcher(args.repo, token), now)
+
+    for entry in status["entries"]:
+        if entry.get("state") in ("stale", "never", "unknown"):
+            print(f"  [{entry['state'].upper():7}] {entry['workflow']}: {entry.get('note')}")
+    print(f"死手开关：watched={status['watched']} findings={status['findings']}")
+
+    if not args.dry_run:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(status, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+        print(f"状态已写入 {args.out}")
+    return 1 if status["findings"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dead_man_switch.py
+++ b/tests/test_dead_man_switch.py
@@ -1,0 +1,151 @@
+"""死手开关单测 —— 守卫自己也得被守。
+
+覆盖三块：cron 字段展开与期望间隔推导（阈值的唯一来源，算错则全盘误报）、
+沉默判定（ok / stale / never / skipped 四态与两道宽限）、状态产出形态。
+
+全部注入式：不碰网络、不读真 Actions API——守卫必须能在无凭据环境下跑（元规则之二）。
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import dead_man_switch as dms  # noqa: E402
+
+NOW = datetime(2026, 7, 26, 0, 0, tzinfo=timezone.utc)
+
+
+class TestCronFields:
+    def test_star_expands_to_full_range(self):
+        assert dms.parse_field("*", 0, 5) == {0, 1, 2, 3, 4, 5}
+
+    def test_step_and_list_and_range(self):
+        assert dms.parse_field("*/3", 0, 23) == {0, 3, 6, 9, 12, 15, 18, 21}
+        assert dms.parse_field("1,5", 0, 59) == {1, 5}
+        assert dms.parse_field("2-4", 0, 59) == {2, 3, 4}
+        assert dms.parse_field("0-6/2", 0, 6) == {0, 2, 4, 6}
+
+    @pytest.mark.parametrize("bad", ["*/0", "99", "5-1", "60"])
+    def test_illegal_specs_raise(self, bad):
+        with pytest.raises(ValueError):
+            dms.parse_field(bad, 0, 59)
+
+
+class TestExpectedInterval:
+    """真实节拍必须算对——这些正是仓内在用的 cron。"""
+
+    @pytest.mark.parametrize(
+        "cron,hours",
+        [
+            ("0 */3 * * *", 3.0),      # update-news
+            ("40 * * * *", 1.0),       # backfill-media
+            ("15 7 * * *", 24.0),      # store-patrol
+            ("43 5 * * 1", 168.0),     # sdk-mutation-ratchet
+            ("23 4 3 * *", 744.0),     # community-platform-backup（月度，需 >31 天采样窗）
+        ],
+    )
+    def test_single_cron(self, cron, hours):
+        assert dms.expected_interval_hours([cron], NOW) == pytest.approx(hours, abs=1.0)
+
+    def test_multi_cron_takes_the_widest_gap_of_the_union(self):
+        """discord-archive 同时有每日与每月两条：并集的最大间隔仍是 24h。
+
+        取最大而非平均——平均会得出一个没有任何一条 cron 真正满足的阈值。
+        """
+        assert dms.expected_interval_hours(["0 7 * * *", "0 6 1 * *"], NOW) == pytest.approx(24.0)
+
+    def test_five_fields_required(self):
+        with pytest.raises(ValueError):
+            dms.expected_interval_hours(["0 7 * *"], NOW)
+
+
+class TestClassify:
+    def _entry(self, **over):
+        base = {"expected_interval_h": 24.0, "state": "active"}
+        base.update(over)
+        return base
+
+    def test_recent_success_is_ok(self):
+        entry = self._entry(last_success=(NOW - timedelta(hours=20)).isoformat())
+        assert dms.classify(entry, NOW)[0] == "ok"
+
+    def test_silence_beyond_threshold_is_stale(self):
+        """store-patrol 的形态：日更工作流，最近一次成功在 8 天前。"""
+        entry = self._entry(last_success=(NOW - timedelta(days=8)).isoformat())
+        state, note = dms.classify(entry, NOW)
+        assert state == "stale"
+        assert "超阈值" in note
+
+    def test_within_factor_two_is_still_ok(self):
+        """×2 + 宽限：日更工作流漏一轮不报，漏两轮才报——GitHub 定时本就会延迟。"""
+        entry = self._entry(last_success=(NOW - timedelta(hours=40)).isoformat())
+        assert dms.classify(entry, NOW)[0] == "ok"
+
+    def test_never_succeeded_past_grace_is_never(self):
+        """community-platform-backup 的形态：建好即坏、从未成功过。"""
+        entry = self._entry(created_at=(NOW - timedelta(days=30)).isoformat(), last_success=None)
+        state, note = dms.classify(entry, NOW)
+        assert state == "never"
+        assert "从无一次成功" in note
+
+    def test_brand_new_workflow_is_not_reported(self):
+        """新建工作流在首个 cron 到期 + 一个周期内不报——否则每加一个新件就红一次。"""
+        entry = self._entry(created_at=(NOW - timedelta(hours=6)).isoformat(), last_success=None)
+        assert dms.classify(entry, NOW)[0] == "ok"
+
+    def test_disabled_workflow_is_skipped_not_accused(self):
+        entry = self._entry(state="disabled_manually", last_success=None)
+        assert dms.classify(entry, NOW)[0] == "skipped"
+
+    def test_unknown_when_no_evidence_at_all(self):
+        assert dms.classify(self._entry(last_success=None, created_at=None), NOW)[0] == "unknown"
+
+
+class TestBuildStatus:
+    def test_status_shape_and_findings_count(self, tmp_path):
+        wf = tmp_path / "workflows"
+        wf.mkdir()
+        (wf / "daily.yml").write_text("on:\n  schedule:\n    - cron: '0 7 * * *'\n", encoding="utf-8")
+        (wf / "manual.yml").write_text("on:\n  workflow_dispatch:\n", encoding="utf-8")
+
+        def fetch(name):
+            return {
+                "created_at": (NOW - timedelta(days=90)).isoformat(),
+                "state": "active",
+                "last_success": (NOW - timedelta(days=9)).isoformat(),
+            }
+
+        status = dms.build_status(fetch, NOW, workflow_dir=wf)
+        # 纯 dispatch 的不纳入：它本就不该定期出声
+        assert status["watched"] == 1
+        assert status["findings"] == 1
+        assert status["entries"][0]["workflow"] == "daily.yml"
+        assert status["entries"][0]["state"] == "stale"
+        assert status["generated_at"] == NOW.isoformat()
+
+    def test_api_failure_degrades_to_unknown_not_to_silence(self, tmp_path):
+        """查不到 ≠ 没事：降级为 unknown 并留痕，绝不悄悄算作 ok。"""
+        wf = tmp_path / "workflows"
+        wf.mkdir()
+        (wf / "daily.yml").write_text("on:\n  schedule:\n    - cron: '0 7 * * *'\n", encoding="utf-8")
+
+        def boom(name):
+            raise OSError("network down")
+
+        status = dms.build_status(boom, NOW, workflow_dir=wf)
+        assert status["entries"][0]["state"] == "unknown"
+        assert status["findings"] == 0
+
+
+def test_real_workflows_all_yield_a_threshold():
+    """仓内 24 个带 cron 的工作流必须条条能推导出间隔——推不出即阈值缺失、静默漏守。"""
+    found = dms.scheduled_workflows()
+    assert len(found) >= 20, f"带 cron 工作流仅 {len(found)} 个，疑似解析失效"
+    for name, crons in found.items():
+        assert dms.expected_interval_hours(crons, NOW) > 0, f"{name} 无法推导期望间隔"

--- a/tests/test_status_facts.py
+++ b/tests/test_status_facts.py
@@ -1,0 +1,56 @@
+"""状态档机器事实块守卫 —— 「会变的数字不许手抄」的执行层。
+
+对应 `scripts/build_status_facts.py`。守两件事：块存在且与权威源同步（不同步即红并给出
+重算命令），以及块内数字确实来自权威源而非被人手改。
+
+本组的存在理由是当天的实测：`memory/project-status.md` 的 SDK 行曾停在 v0.63.1 而包已
+0.76.0（滞后 13 个次版本）；同日两个会话各自手抄一遍本地实测数，得出 3216+5/197 与
+3215+6/196 两组不同数字。手抄多少遍就会分叉多少次——所以静态事实一律生成。
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import build_status_facts as bsf  # noqa: E402
+
+
+def _doc() -> str:
+    return bsf.STATUS_DOC.read_text(encoding="utf-8")
+
+
+def test_block_is_present() -> None:
+    doc = _doc()
+    assert bsf.BEGIN in doc and bsf.END in doc, (
+        "project-status.md 缺机器生成事实块：跑 `python3 scripts/build_status_facts.py`"
+    )
+
+
+def test_block_is_in_sync_with_the_authoritative_sources() -> None:
+    """块必须是仓库当前状态的纯函数——不同步说明有人手改了数字，或权威源变了没重算。"""
+    assert bsf.apply(check_only=True) == 0, (
+        "机器事实块与权威源不同步：跑 `python3 scripts/build_status_facts.py` 重算后提交"
+    )
+
+
+def test_versions_in_the_block_match_package_json() -> None:
+    """独立复核一遍（不经生成器）：守卫自身若跟生成器同错，就什么也没守住。"""
+    doc = _doc()
+    block = doc.split(bsf.BEGIN, 1)[1].split(bsf.END, 1)[0]
+    for path in (REPO / "projects" / "silver-core-sdk", REPO / "projects" / "silver-core-maestro-sdk"):
+        version = json.loads((path / "package.json").read_text(encoding="utf-8"))["version"]
+        assert f"`{version}`" in block, f"块内缺 {path.name} 的真实版本 {version}"
+
+
+def test_family_lockstep_holds() -> None:
+    """两包锁步同号是 2026-07-18 裁定的家族纪律；号不同则块里的「锁步」是假话。"""
+    versions = {
+        name: json.loads((path / "package.json").read_text(encoding="utf-8"))["version"]
+        for name, path in bsf.PACKAGES.items()
+        if name != "silver-core-testbed"
+    }
+    assert len(set(versions.values())) == 1, f"家族版本钟脱锁: {versions}"


### PR DESCRIPTION
## 概述

守密人 2026-07-26 两项裁定：死手开关**按艾瑞卡建议推进**（设计档 §6 三点由艾瑞卡定），状态档版本数字**点火改生成**。

**首跑即抓出三条无人看守的真故障**——这正是它存在的理由。

---

## 变更类型

- [x] Bug 修复（发现三条真故障，本 PR 只诊断不修）
- [x] 文档完善（CLAUDE.md / methodology / 状态档）
- [ ] 数据补全
- [ ] 翻译贡献
- [ ] 视觉/前端改进

---

## 来源声明

不涉及游戏数据。事实依据：仓内文件 + GitHub Actions API 实查 + 本地三次实测。

```
死手开关首跑：watched=25 findings=3（产物已提交 Public-Info-Pool/Record/heartbeat/status.json）
collect-fanart run 30152342537 日志：FileNotFoundError .../discord/global/channel_index.json
vitest 第三次实测：197 文件 / 3216 通过 / 5 skipped
```

---

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布渠道数据。**
- [x] **不含内部美术资产 / 解包原始文件 / 未公开草稿。**
- [x] **同意按 MIT License 提交。**

---

## 变更内容

### 一、死手开关（招三施工）

设计档 §6 三点，艾瑞卡取：**阈值 = 期望间隔 ×2 + 2h 宽限** · **NEVER 宽限 = 首个 cron 到期再加一个周期** · **双宿主互看**（代价仅目标档一行，换一层自动兜底）。

**阈值全部由各工作流自己的 cron 推导**，实证覆盖既有 24 条：`*/3` → 3h、weekly → 168h、monthly → 744h；`discord-archive.yml` 两条 cron 取**并集最大间隔** 24h——取平均会得出一个**没有任何一条 cron 真正满足**的阈值。

新工作流**从第一天就挂 `BOT_DEPLOY_KEY`**：这是今晨 store-patrol 连红 7 天的教训被应用，而不是被重复。

### 二、首跑抓到的三条（只诊断，未修 —— 超出本次委托范围）

| 工作流 | 沉默时长 | 根因 |
|---|---|---|
| `collect-fanart.yml` | 失败 5 天（07-21 起）| `collect_fanart.py` 把 `ROOT = "Public-Info-Pool/Record/Community"` 写成模块常量而非问 `archive_layout`，§7甲 搬走数据湖后读不到 `discord/global/channel_index.json`。**与平台备份同一类**，是 T62 读侧桥接的漏网 |
| `check-version.yml` | 失败 ≥5 周（06-22 起）| 尚未诊断；wiki 已冻结，可能该退役而非修 |
| `backfill-media.yml` | 最近一次成功在 **836 小时前** | 每小时 cron 撞 90 分钟超时——排队比排空快，新 run 顶掉待跑 run，`cancelled` 循环。注释自陈「清积压期」，积压期恐已过 |

比喻：点名册第一次翻开就发现三个空座位，而且其中一个空了 35 天——之前没人点过名。

### 三、状态档事实块生成（招一点火）

版本 / 源文件数 / 测试档数 / 工作流数 / 台账条数，全部由 `package.json` 与磁盘生成进标记块；守卫测试重算比对，手改即红（**负控实证**：把块内版本改回 0.63.1 立刻转红）。

**块内刻意不含时间戳**——它是仓库状态的纯函数，掺时间戳就没法逐字比对。**实测通过数不进块**（那要真跑才知道），留在正文但必须带日期。

**今日恰好证明了为什么**：两个会话数小时内各自手抄同一套件，得出 **3216+5/197 档** 与 **3215+6/196 档**。第三次实测定案为 **197 档 / 3216 通过 / 5 跳过**，差异 = 一条条件跳过的用例 + 文件计数口径（顶层 glob vs 递归）。两处数字均已补订正注。

### 四、顺带

testbed 目标档仍写着改名前的 `lightproud/brain-in-a-vat`，靠 GitHub 重定向侥幸能用——已订正，并把死手开关与 collect-fanart 纳入 ci-status 监控。

---

## 验证清单

- [x] `pytest tests/` — **2971 通过 / 51 跳过**（2944 + 新增 27）
- [x] 负控实证 ×2：手改块内版本转红；死手开关四态判定逐条覆盖
- [x] **首跑实证**：死手开关对真 API 跑通，产物已提交（自己遵守自己刚立的纪律）
- [x] 对账三卫在提交前拦下两次（新脚本未进 CLAUDE.md、引用了尚不存在的 status.json），均已补正
- [x] 不引入 emoji

---

## 关联

- 提案 `drift-resistant-architecture-20260726.md` 招一 / 招三；设计档 `dead-man-switch-design-20260726.md`
- 本会话前序：#804 / #805 / #810 / #811 / #812 / #813 / #814 / #816

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3PTjiaJAMbzSoEV45XZkk)_