### PR TITLE
fix(ci): fanart 采集接回数据仓 · backfill-media 降为每日（死手开关首跑两条）

### DIFF
--- a/.github/workflows/backfill-media.yml
+++ b/.github/workflows/backfill-media.yml
@@ -10,7 +10,10 @@ name: "🖼️ Backfill & Archive Media"
 
 on:
   schedule:
-    - cron: '40 * * * *'   # 每小时（清积压期；积压补齐后可调回每日）
+    # 2026-07-26 降为每日（守密人裁定）：死手开关首跑抓到本工作流**最近一次成功在
+    # 836 小时前**——每小时 cron 撞 90 分钟超时，排队比排空快，新 run 顶掉待跑 run，
+    # 于是连续 35 天全是 cancelled。注释原写「积压补齐后可调回每日」，此刻兑现。
+    - cron: '40 8 * * *'   # 每日北京 16:40（08:40 UTC），错开 15 点档采集群
   workflow_dispatch:
     inputs:
       no_discord:

--- a/.github/workflows/collect-fanart.yml
+++ b/.github/workflows/collect-fanart.yml
@@ -30,12 +30,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.ref == 'refs/heads/main'
+    env:
+      BIAV_SC_DATA_ROOT: ${{ github.workspace }}/data-repo
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      # 二创附件是从 discord 归档里挑出来的——档案自 T62 §7甲 起住在数据仓。
+      # 本作业只读数据仓（产物直传 release，不回写），故浅克隆即可。
+      - name: Clone BIAV-SC-DATA（PAT，数据根）
+        env:
+          DATA_TOKEN: ${{ secrets.BIAV_SC_DATA_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DATA_TOKEN:-}" ]; then
+            echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
+          fi
+          git config --global credential.helper store
+          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
+          chmod 600 ~/.git-credentials
+          git clone --depth 1 https://github.com/lightproud/BIAV-SC-DATA.git data-repo
 
       - name: Collect fan art
         env:

--- a/projects/news/scripts/collect_fanart.py
+++ b/projects/news/scripts/collect_fanart.py
@@ -19,16 +19,21 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import archive_layout  # discord 布局 SSOT（2026-07-10 方案甲）
 
-# discord 数据迁至 Public-Info-Pool/Record/Community（2026-06-21）；ROOT 仅用于读 discord
-ROOT = "Public-Info-Pool/Record/Community"
+# 归档根**不再硬编码**（2026-07-26 死手开关首跑抓到：T62 §7甲 把数据湖迁出 code 仓后，
+# 本脚本仍按在树路径找 discord/global/channel_index.json，自 07-21 起天天崩）。
+# 一律问 archive_layout 这个单一真相源；env `BIAV_SC_DATA_ROOT` 指向数据仓 checkout，
+# 未设时它自己回落在树默认，故本地与 CI 同一份代码。
+def _community_root() -> Path:
+    """社区档案根。调用期现算——单测 monkeypatch env 即可改根。"""
+    return archive_layout.community_root()
 
 
 def _discord_global_dir() -> Path:
     """主服 global 数据目录（原语义：二创频道只在主服；新旧布局经 SSOT 解析）。
 
-    调用期从 ROOT 现算（可测性：单测 monkeypatch ROOT 即可改根）。
+    调用期经 archive_layout 现算（新旧布局与数据仓 env 根均由 SSOT 解析）。
     """
-    droot = Path(ROOT) / "discord"
+    droot = _community_root() / "discord"
     return archive_layout.discord_region_roots(droot).get("global", droot / "global")
 FANART_CH = ["同人创作", "art-and-memes", "官方素材", "official-materials",
              "fanart", "创作", "二创", "绘"]
@@ -136,7 +141,7 @@ def main():
                         "file": x["fn"] if status == "ok" else None, "status": status})
 
     # ---- Pixiv ----
-    pfp = f"{ROOT}/platforms/pixiv/{a.date}.json"
+    pfp = str(_community_root() / "platforms" / "pixiv" / f"{a.date}.json")
     if os.path.isfile(pfp):
         items = json.load(open(pfp, encoding="utf-8"))
         items = items if isinstance(items, list) else items.get("items", [])

--- a/tests/test_collect_fanart_unit.py
+++ b/tests/test_collect_fanart_unit.py
@@ -99,7 +99,12 @@ class TestRefreshDiscord(unittest.TestCase):
 
 class TestMain(unittest.TestCase):
     def _build_root(self, d, with_token_chan=True):
-        root = Path(d)
+        # 2026-07-26：夹具改建在**数据湖布局**下（<BIAV_SC_DATA_ROOT>/Record/Community/），
+        # 并经真实 env 根解析——原先 monkeypatch 模块常量 ROOT，恰好绕开了
+        # archive_layout 这条真实路径，于是 T62 §7甲 把档案迁出 code 仓后单测照绿、
+        # 线上天天崩（死手开关 2026-07-26 首跑抓到）。测试要走生产同一条解析链。
+        root = Path(d) / "Record" / "Community"
+        root.mkdir(parents=True, exist_ok=True)
         # channel_index.json
         idx = {"c1": {"dir": "11111111", "name": "同人创作"},
                "c2": {"dir": "22222222", "name": "general-chat"}}
@@ -134,8 +139,9 @@ class TestMain(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             self._build_root(d)
             out = str(Path(d) / "out")
-            with mock.patch.object(cf, "ROOT", str(Path(d))):
-                self._run(["prog", "--date", "2026-06-01", "--out", out], {}, out)
+            with mock.patch.dict(cf.os.environ, {"BIAV_SC_DATA_ROOT": d}):
+                self._run(["prog", "--date", "2026-06-01", "--out", out],
+                          {"BIAV_SC_DATA_ROOT": d}, out)
             manifest = json.loads(Path(out, "gallery_manifest.json").read_text())
             sources = {g["source"] for g in manifest}
             self.assertIn("discord", sources)
@@ -146,11 +152,13 @@ class TestMain(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             self._build_root(d)
             out = str(Path(d) / "out")
-            with mock.patch.object(cf, "ROOT", str(Path(d))), \
+            with mock.patch.dict(cf.os.environ, {"BIAV_SC_DATA_ROOT": d}), \
                     mock.patch.object(cf, "refresh_discord",
                                       return_value={"https://d/a.png": "https://d/a.png?new"}) as rd:
                 with mock.patch.object(sys, "argv", ["prog", "--date", "2026-06-01", "--out", out]), \
-                        mock.patch.dict(cf.os.environ, {"DISCORD_BOT_TOKEN": "t"}, clear=True), \
+                        mock.patch.dict(cf.os.environ,
+                                        {"DISCORD_BOT_TOKEN": "t", "BIAV_SC_DATA_ROOT": d},
+                                        clear=True), \
                         mock.patch.object(cf, "fetch", return_value="ok"), \
                         mock.patch.object(cf.time, "sleep"):
                     cf.main()
@@ -159,16 +167,17 @@ class TestMain(unittest.TestCase):
     def test_run_missing_pixiv_and_jsonl(self):
         import tempfile
         with tempfile.TemporaryDirectory() as d:
-            root = Path(d)
+            root = Path(d) / "Record" / "Community"
             ddir = root / "discord" / "global"   # 2026-07-10 方案甲区服布局
             ddir.mkdir(parents=True)
             (ddir / "channels").mkdir()          # 标记新布局根存在
             # channel matches fanart but no jsonl file for the date
             idx = {"c1": {"dir": "11111111", "name": "fanart"}}
             (ddir / "channel_index.json").write_text(json.dumps(idx), encoding="utf-8")
-            out = str(root / "out")
-            with mock.patch.object(cf, "ROOT", str(root)):
-                self._run(["prog", "--date", "2026-06-01", "--out", out], {}, out)
+            out = str(Path(d) / "out")
+            with mock.patch.dict(cf.os.environ, {"BIAV_SC_DATA_ROOT": d}):
+                self._run(["prog", "--date", "2026-06-01", "--out", out],
+                          {"BIAV_SC_DATA_ROOT": d}, out)
             manifest = json.loads(Path(out, "gallery_manifest.json").read_text())
             self.assertEqual(manifest, [])
 


### PR DESCRIPTION
## 概述

死手开关首跑三条发现中的两条，按守密人 2026-07-26 裁定处置：fanart **修并实证 + 排查同类**、backfill-media **降为每日**。第三条 check-version 按裁定**只诊断不动手**，结论见下。

---

## 变更类型

- [x] Bug 修复
- [ ] 文档完善
- [ ] 数据补全
- [ ] 翻译贡献
- [ ] 视觉/前端改进

---

## 来源声明

不涉及游戏数据。依据为 Actions 日志与本地复现：

```
collect-fanart run 30152342537：FileNotFoundError .../discord/global/channel_index.json
backfill-media：最近一次成功 836h 前，其后 run 全为 cancelled
本地复现 check_version.py：FileNotFoundError projects/wiki/data/db/versions.json
```

---

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布渠道数据。**
- [x] **不含内部美术资产 / 解包原始文件 / 未公开草稿。**
- [x] **同意按 MIT License 提交。**

---

## 变更内容

### 一、collect-fanart（失败 5 天）

`collect_fanart.py` 把 `ROOT = "Public-Info-Pool/Record/Community"` 写成模块常量而非问 `archive_layout`，§7甲 搬走数据湖后每晚必崩。现改经 `archive_layout.community_root()` 解析，工作流浅克隆 BIAV-SC-DATA（同平台备份模板）。

**这是同一类的第三例**，故按裁定顺带排查了全仓硬编码归档路径——余下命中均为文档注释、**有意保持逻辑相对**的 OKF 指针字符串、以及 restore 工具，无新漏网。

**单测本身是这条能活下来的原因之一**：它们 monkeypatch 模块常量，等于**测了一条生产早已不走的路**，于是在一个每晚都让线上崩掉的改动下始终绿着。现改为在数据湖布局下建夹具、驱动真实 env 根解析器——**测试要走生产同一条链**。负控实证：还原旧硬编码写法，三例转红。

比喻：消防演习一直在隔壁楼进行，所以本楼起火时演习记录依然全优。

### 二、backfill-media（最近一次成功在 836 小时前）

每小时 cron 撞 90 分钟超时——**排队比排空快**，新 run 顶掉待跑 run，于是连续 35 天全是 `cancelled`。改为每日北京 16:40（错开 15 点档采集群）。工作流注释原本就写着「积压补齐后可调回每日」，此刻兑现，而非另编节拍。

比喻：每小时派一班车，但一趟要开一个半小时——于是每班车还没发车就被下一班顶掉，35 天一个人也没运走。

### 三、check-version（只诊断，未动手）

根因：`check_version.py` 写 `projects/wiki/data/db/versions.json`，而 `data/db/` 整层已于 **2026-06-15 守密人裁定删除**。**读侧优雅降级、写侧硬崩**，故自那以后每周必红。

**决策相关的一条事实**：它的检测逻辑仍然有效——本次复现中它**成功识别出游戏新版本 2.5.3**（来自 Steam news），随后才崩在写盘。修与退役的取舍另呈。

---

## 验证清单

- [x] `pytest tests/` — **2976 通过 / 51 跳过**
- [x] 负控实证：还原 fanart 旧硬编码写法，改后的单测三例转红
- [x] 同类漏网排查完成（无新增）
- [ ] **合并后 dispatch collect-fanart 一轮实证**（按首跑实证纪律，回报 run 与产物）
- [x] 不引入 emoji

---

## 关联

- 死手开关首份状态快照 `Public-Info-Pool/Record/heartbeat/status.json`
- 本会话前序：#804 / #805 / #810 / #811 / #812 / #813 / #814 / #816 / #817

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3PTjiaJAMbzSoEV45XZkk)_