### PR TITLE
governance: 招一射程延伸至 CONTEXT.md · 哨兵收窄为叙述层并加「不被架空」非空控

### DIFF
--- a/.github/workflows/sdk-platform-probe.yml
+++ b/.github/workflows/sdk-platform-probe.yml
@@ -55,6 +55,30 @@ jobs:
         run: npm ci
       - name: Typecheck (agent SDK)
         run: npm run typecheck --workspace silver-core-agent-sdk
+      # Shell-resolver diagnostic (added after round 1, 2026-07-26): the first
+      # probe failed ~24 Bash-path tests with "No POSIX shell found", yet the
+      # runner demonstrably has C:\Program Files\Git\bin\git.exe and the
+      # resolver's probe list covers %ProgramFiles%\Git\bin\bash.exe. Either the
+      # env var is absent/differently cased under the runner shell, or bash.exe
+      # is not where git.exe is — this step tells us which, instead of leaving
+      # the whole cluster classified as "probably environment".
+      # Non-fatal on purpose: it is instrumentation, not a gate.
+      - name: Diagnose the Windows shell resolver
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          Write-Host "ProgramFiles      = $env:ProgramFiles"
+          Write-Host "ProgramFiles(x86) = ${env:ProgramFiles(x86)}"
+          Write-Host "ProgramW6432      = $env:ProgramW6432"
+          Write-Host "LOCALAPPDATA      = $env:LOCALAPPDATA"
+          foreach ($p in @(
+            "$env:ProgramFiles\Git\bin\bash.exe",
+            "$env:ProgramFiles\Git\usr\bin\bash.exe",
+            "${env:ProgramFiles(x86)}\Git\bin\bash.exe",
+            "$env:LOCALAPPDATA\Programs\Git\bin\bash.exe"
+          )) { Write-Host ("exists {0,-5} {1}" -f (Test-Path $p), $p) }
+          node -e "const e=process.env; const s={...e}; console.log('spread keeps ProgramFiles:', 'ProgramFiles' in s, JSON.stringify(s.ProgramFiles ?? null));"
       # The suite is expected to surface platform assumptions here — path
       # separators, shell resolution, process-group kills, and the sandbox
       # backend that only resolves on Linux. A red run is DATA, not a failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,7 +425,7 @@ wiki 旧结构化层的 6 个占位 JSON（2026-06-15 裁定清空者）。**守
 | 数据校验（wiki JSON）| slash `/validate-data` 或 `python scripts/...`（见 schema 目录）|
 | 跨档案检索 | `rg "<关键词>" memory/ assets/`（ripgrep） |
 | 死手开关（沉默检测）| `python3 scripts/dead_man_switch.py [--dry-run]`（**只数空座位**：查全部带 cron 工作流的最近一次成功，超阈值报 `STALE`、从无成功报 `NEVER`；阈值由各自 cron 推导 ×2 + 宽限，状态落 `Public-Info-Pool/Record/heartbeat/status.json`，CI `dead-man-switch.yml` 每日北京 15:50；设计档见 `Public-Info-Pool/Resource/proposal/dead-man-switch-design-20260726.md`，单测 `tests/test_dead_man_switch.py`）|
-| 状态档事实块重算 | `python3 scripts/build_status_facts.py [--check]`（`memory/project-status.md` 的版本 / 规模 / 台账数字由权威源生成，**勿手抄**；同步守卫 `tests/test_status_facts.py`）|
+| 状态档事实块重算 | `python3 scripts/build_status_facts.py [--check]`（`memory/project-status.md` 的版本 / 规模 / 台账数字 **+ 两包 `CONTEXT.md` 的版本标签块**由权威源生成，**勿手抄**；同步守卫 `tests/test_status_facts.py`，叙述新鲜度另由 `tests/test_status_doc_facts.py` 守）|
 | 记忆保鲜巡检 | `python3 scripts/memory_freshness.py`（lessons 指针/编号不变量门禁见 `tests/test_memory_freshness.py`；月检例程与 `/sync-memory` 手册共用一套流程）|
 | 知识库有效性记分卡 | `python3 scripts/kb_eval.py`（黄金问题集 hit@k + MRR；需求侧有效性回归见 `tests/test_kb_golden.py`）|
 | 知识库使用遥测报告 | `python3 scripts/kb_telemetry.py`（借阅记录：调用分布 / 死概念 / 零命中查询；日志按日落 git 内 `Public-Info-Pool/Record/kb-usage/{date}.jsonl` **跨会话累计**，2026-07-11 方案甲裁定，路径唯一源 = `kb_telemetry.KB_USAGE_DIR`）；`--harvest` 把零命中查询回流成 held-out 难题候选（闭合评判 #1↔#2）|

--- a/memory/methodology.md
+++ b/memory/methodology.md
@@ -389,6 +389,26 @@ lessons-learned 的毕业纪律写的是第三个说法：「文字劝告是弱�
 生成块对它一无所知。`tests/test_status_doc_facts.py` 守的正是这一层（发布台账最新一版必须在
 叙述里留下痕迹），与生成块不重叠。
 
+**射程延伸（守密人 2026-07-26「3 推进」）**：哨兵原本要求「最新版本号出现在 CONTEXT.md
+当前状态节」——那实质是**要求人手抄一个会变的数字**，与招一相抵。现已改为生成
+（两包 `CONTEXT.md` 的 CONTEXT-FACTS 块：版本 / 发布日 / 锁步对端），哨兵同步收窄为只看叙述。
+**这是「能生成的先生成」次序的一次实际执行：先扩生成层，再把哨兵让出那一维。**
+
+### 生成层扩射程时的必查项：别把哨兵架空了（2026-07-26 实战教训）
+
+把版本号生成进 CONTEXT.md 的**那一刻**，哨兵「版本号必须出现在当前状态节」就地变成永真——
+生成块自己就带着那个号。**测试照常绿，守的东西却没了，而且它红不了，所以没人会发现它已经死了。**
+
+这不是本次特有的坑，是生成层与检查层共存的通用失效模式。故立两条：
+
+- **搜叙述前先剥生成块**（`_narrative()` 用 `<!-- X:BEGIN … X:END -->` 通配剥除，不是硬编码
+  某个块名——下一个块不会再触发一次同样的事故）；
+- **为「不架空」本身写一条非空控**（`test_narrative_stripping_is_not_vacuous`：构造一份版本号
+  只存在于生成块里的档案，断言叙述检查仍判负）。哨兵的负控证明它会咬，这一条证明**它咬的
+  还是原来那块肉**。
+
+一句话纪律：**生成层每扩一次射程，回头点一遍现有哨兵的判据有没有被自己吃掉。**
+
 ### 两条配套纪律
 
 - **空 allowlist 是目标**。豁免每条须写明理由，且必须是「经核实的哨兵已知盲区」而非「懒得改」。
@@ -400,16 +420,17 @@ lessons-learned 的毕业纪律写的是第三个说法：「文字劝告是弱�
 ### 覆盖现状（新增须在此登记，便于下一个会话知道哪些角落已有岗）
 
 **先看生成层**（漂移不可能，非「被发现」）：`scripts/build_status_facts.py`（版本 / 规模 /
-台账条数生成进 STATUS-FACTS 块，守卫 `tests/test_status_facts.py`）· `sdk-mutation-ratchet.yml`
-矩阵改生成（地板清单即唯一源，不再两份手写）。**生成层盖不到的，才由下表的哨兵站岗。**
+台账条数生成进 `project-status.md` 的 STATUS-FACTS 块 **+ 两包 `CONTEXT.md` 的 CONTEXT-FACTS
+版本标签块**，守卫 `tests/test_status_facts.py`）· `sdk-mutation-ratchet.yml` 矩阵改生成
+（地板清单即唯一源，不再两份手写）。**生成层盖不到的，才由下表的哨兵站岗。**
 
 | 哨兵 | 盯的对应关系 |
 |------|-------------|
 | `tests/test_claude_md.py` | CLAUDE.md 引用的路径 ↔ 磁盘实况（正向） |
 | `tests/test_claude_md_coverage.py` | 核心脚本 ↔ 权威档提及（反向孤儿） |
 | `tests/test_claude_md_dates.py` | CLAUDE.md 裁定日期 ↔ decisions 台账（跨档） |
-| `tests/test_status_facts.py` | 生成块 ↔ 权威源（重算逐字比对，2026-07-26 招一） |
-| `tests/test_status_doc_facts.py` | CHANGELOG 最新版本 ↔ package.json ↔ 状态**叙述层**（生成块够不到的那层，2026-07-26 新增） |
+| `tests/test_status_facts.py` | 生成块 ↔ 权威源（重算逐字比对 + 块存在性，2026-07-26 招一） |
+| `tests/test_status_doc_facts.py` | CHANGELOG 最新版本 ↔ package.json ↔ 状态**叙述层**（剥掉生成块后搜，含「不被架空」非空控，2026-07-26 新增） |
 | `tests/test_memory_freshness.py` | lessons 指针完整性 + 编号不变量 |
 | `tests/test_ledger_discipline.py` | todo 台账编号 / 分节纪律（2026-07-26 招二） |
 | `tests/test_mutation_ratchet_matrix.py` | 变异地板清单 ↔ CI 矩阵腿（双向） |

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -28,6 +28,14 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式:�
 
 ## 当前状态
 
+<!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
+
+**当前版本 `0.76.0`** · 发布日 2026-07-22 · 家族锁步对端 `silver-core-agent-sdk` = `0.76.0`
+
+> 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
+
+<!-- CONTEXT-FACTS:END -->
+
 第零战(monorepo 迁移)+ 第一战(任务台账 + 驱动器,0.2.0)完成:
 
 - 封闭状态机(`pending | running | retrying | failed | done`,定稿回填需求档 §4)

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -67,6 +67,14 @@ src/
 
 ## 当前状态
 
+<!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
+
+**当前版本 `0.76.0`** · 发布日 2026-07-22 · 家族锁步对端 `silver-core-maestro-sdk` = `0.76.0`
+
+> 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
+
+<!-- CONTEXT-FACTS:END -->
+
 > **回写摘要（2026-07-26 审视补记，守密人裁定「补顶部摘要 + 实测数字」）**：本节逐条叙述此前
 > 停在 v0.69.0，其后 **12 个发布（0.70.0 → 0.76.0）未回写**，现以一条摘要合并补齐，逐版全文
 > 见 `CHANGELOG.md`（唯一发布权威，不在此复刻）：

--- a/scripts/build_status_facts.py
+++ b/scripts/build_status_facts.py
@@ -28,15 +28,41 @@ STATUS_DOC = REPO / "memory" / "project-status.md"
 BEGIN = "<!-- STATUS-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->"
 END = "<!-- STATUS-FACTS:END -->"
 
+# 子项目 CONTEXT.md 侧的版本标签块（2026-07-26 守密人「3 推进」裁定：招一射程从状态档
+# 延伸到 CONTEXT）。背景：同日的跨档哨兵 tests/test_status_doc_facts.py 曾要求「最新版本号
+# 必须出现在 CONTEXT.md 当前状态节」——那本质是要求人手抄一个会变的数字，与本脚本立身之本
+# 相抵。改为生成后，该维度的漂移从「会被发现」升级为「不可能」。
+# 块内**只放静态标签**（版本 / 发布日 / 锁步对端），规模数字不复制——要引用就指 project-status
+# 的 STATUS-FACTS 块，同一事实不开第二张手抄表。
+CONTEXT_BEGIN = (
+    "<!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->"
+)
+CONTEXT_END = "<!-- CONTEXT-FACTS:END -->"
+CONTEXT_ANCHOR = "## 当前状态"
+
 PACKAGES = {
     "silver-core-agent-sdk": REPO / "projects" / "silver-core-sdk",
     "silver-core-maestro-sdk": REPO / "projects" / "silver-core-maestro-sdk",
     "silver-core-testbed": REPO / "projects" / "silver-core-testbed",
 }
 
+# 带 CONTEXT 版本块的包（testbed 是 private 消费者、锁步豁免、版本恒 0.0.0，无版本叙事可言，
+# 故不发块——发了就是一行永不变化的噪音）。
+CONTEXT_PACKAGES = ("silver-core-agent-sdk", "silver-core-maestro-sdk")
+
+# CHANGELOG 发布标题：`## 0.76.0 — 2026-07-22`（破折号为全角 em dash）。日期可缺，缺则标注。
+CHANGELOG_HEADING_RE = re.compile(r"^##\s+(\d+\.\d+\.\d+)\s*(?:—|--|-)?\s*(\d{4}-\d{2}-\d{2})?", re.M)
+
 
 def _pkg(path: Path) -> dict:
     return json.loads((path / "package.json").read_text(encoding="utf-8"))
+
+
+def _latest_release(path: Path) -> tuple[str | None, str | None]:
+    """该包 CHANGELOG 顶部第一条发布标题的 (版本, 日期)。散文里的版本提及不是 `## ` 标题，
+    故不会被误当成最新发布——与 check-version-bump.mjs 同款判据。"""
+    m = CHANGELOG_HEADING_RE.search((path / "CHANGELOG.md").read_text(encoding="utf-8"))
+    return (m.group(1), m.group(2)) if m else (None, None)
 
 
 def _count(pattern: str, root: Path) -> int:
@@ -84,34 +110,106 @@ def render() -> str:
     return "\n".join(lines)
 
 
-def apply(check_only: bool = False) -> int:
-    doc = STATUS_DOC.read_text(encoding="utf-8")
-    block = render()
-    if BEGIN in doc and END in doc:
-        start, tail = doc.split(BEGIN, 1)
-        _, rest = tail.split(END, 1)
-        updated = start + block + rest
-    else:
-        # 首次落块：插在「## 子项目状态」之前——读者看表之前先看到硬数字
-        anchor = "## 子项目状态"
-        if anchor not in doc:
-            print("未找到锚点「## 子项目状态」，无法插入", file=sys.stderr)
-            return 2
-        updated = doc.replace(anchor, block + "\n\n" + anchor, 1)
+def render_context(pkg_name: str) -> str:
+    """某包 CONTEXT.md 的版本标签块。
 
-    if updated == doc:
-        print("状态事实块已是最新")
+    刻意只含**标签**、不含叙事：叙事（「0.75.0 做了什么、堵的是什么」）是判断，生成不出来，
+    仍由人写在块下方，并由 `tests/test_status_doc_facts.py` 守「叙述不得停在多版之前」。
+    两者分工写死在块内提示行里，免得下一个会话把叙述也当成可生成物删掉。
+    """
+    path = PACKAGES[pkg_name]
+    version = _pkg(path)["version"]
+    latest, released = _latest_release(path)
+    sibling = "silver-core-maestro-sdk" if pkg_name == "silver-core-agent-sdk" else "silver-core-agent-sdk"
+    sibling_version = _pkg(PACKAGES[sibling])["version"]
+
+    # CHANGELOG 顶部与 package.json 不符时**照实呈现**，不静默取其一：这正是
+    # check-version-bump.mjs 三方对账要红的情形，生成器不该替它遮丑。
+    if latest is None:
+        release_line = "（`CHANGELOG.md` 无发布标题——异常，查台账）"
+    elif latest != version:
+        release_line = f"（⚠ `CHANGELOG.md` 顶部为 `{latest}`，与 package.json 不符——跑版本守卫）"
+    elif released is None:
+        release_line = "（发布日缺失于 CHANGELOG 标题）"
+    else:
+        release_line = f"发布日 {released}"
+
+    return "\n".join(
+        [
+            CONTEXT_BEGIN,
+            "",
+            f"**当前版本 `{version}`** · {release_line} · 家族锁步对端 `{sibling}` = `{sibling_version}`",
+            "",
+            "> 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，"
+            "**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。"
+            "下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由"
+            "`tests/test_status_doc_facts.py` 守。",
+            "",
+            CONTEXT_END,
+        ]
+    )
+
+
+def _splice(doc: str, block: str, begin: str, end: str, anchor: str, after_anchor: bool) -> str | None:
+    """把 block 换进 doc 的既有标记之间；无标记则按 anchor 首次落块。锚点缺失返回 None。"""
+    if begin in doc and end in doc:
+        head, tail = doc.split(begin, 1)
+        _, rest = tail.split(end, 1)
+        return head + block + rest
+    if anchor not in doc:
+        return None
+    if after_anchor:
+        return doc.replace(anchor, anchor + "\n\n" + block, 1)
+    return doc.replace(anchor, block + "\n\n" + anchor, 1)
+
+
+def _targets() -> list[tuple[Path, str]]:
+    """(档案路径, 期望内容) 全清单——状态档 + 各包 CONTEXT。"""
+    out: list[tuple[Path, str]] = []
+    doc = STATUS_DOC.read_text(encoding="utf-8")
+    spliced = _splice(doc, render(), BEGIN, END, "## 子项目状态", after_anchor=False)
+    if spliced is None:
+        raise SystemExit("未找到锚点「## 子项目状态」，无法插入 STATUS-FACTS 块")
+    out.append((STATUS_DOC, spliced))
+    for name in CONTEXT_PACKAGES:
+        ctx = PACKAGES[name] / "CONTEXT.md"
+        text = ctx.read_text(encoding="utf-8")
+        spliced = _splice(
+            text, render_context(name), CONTEXT_BEGIN, CONTEXT_END, CONTEXT_ANCHOR, after_anchor=True
+        )
+        if spliced is None:
+            raise SystemExit(f"{ctx.relative_to(REPO)} 未找到锚点「{CONTEXT_ANCHOR}」，无法插入")
+        out.append((ctx, spliced))
+    return out
+
+
+def apply(check_only: bool = False) -> int:
+    stale: list[Path] = []
+    for path, expected in _targets():
+        if path.read_text(encoding="utf-8") == expected:
+            continue
+        stale.append(path)
+        if not check_only:
+            path.write_text(expected, encoding="utf-8")
+
+    if not stale:
+        print("状态事实块已是最新（状态档 + 各包 CONTEXT）")
         return 0
+    names = " / ".join(str(p.relative_to(REPO)) for p in stale)
     if check_only:
-        print("状态事实块与权威源不同步：跑 `python3 scripts/build_status_facts.py` 重算", file=sys.stderr)
+        print(
+            f"事实块与权威源不同步（{names}）：跑 `python3 scripts/build_status_facts.py` 重算",
+            file=sys.stderr,
+        )
         return 1
-    STATUS_DOC.write_text(updated, encoding="utf-8")
-    print(f"已更新 {STATUS_DOC.relative_to(REPO)} 的机器生成事实块")
+    print(f"已更新机器生成事实块：{names}")
     return 0
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="生成 project-status.md 的机器事实块")
+    parser = argparse.ArgumentParser(
+        description="生成 project-status.md 与各包 CONTEXT.md 的机器事实块"
+    )
     parser.add_argument("--check", action="store_true", help="只比对不写，不同步则非零退出")
     args = parser.parse_args(argv)
     return apply(check_only=args.check)

--- a/tests/test_status_doc_facts.py
+++ b/tests/test_status_doc_facts.py
@@ -59,8 +59,26 @@ ALLOWLIST: dict[str, str] = {
 }
 
 
+# 机器生成块的通用形态（`<!-- X:BEGIN … -->` … `<!-- X:END -->`）。**搜叙述前必须剥掉**——
+# 见下方 _narrative 的自架空说明。
+GENERATED_BLOCK_RE = re.compile(
+    r"<!--\s*[A-Z-]+:BEGIN\b.*?<!--\s*[A-Z-]+:END\s*-->", re.S
+)
+
+
 def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def _narrative(text: str) -> str:
+    """剥掉所有机器生成块，只留人写的叙述。
+
+    **本函数是本哨兵不被架空的唯一依据**。2026-07-26「招一推进」把版本标签生成进了
+    `CONTEXT.md`（CONTEXT-FACTS 块）与 `project-status.md`（STATUS-FACTS 块）；若照旧在整节
+    里搜版本号，生成块自己就带着那个号——断言永远为真，哨兵活着但什么也不守，而且**红不了**，
+    没人会发现它已经死了。生成层每扩一次射程，都要回头检查是否吃掉了某个哨兵的判据。
+    """
+    return GENERATED_BLOCK_RE.sub("", text)
 
 
 def _latest_changelog_version(changelog_text: str) -> str | None:
@@ -111,8 +129,13 @@ class StatusDocFactsTest(unittest.TestCase):
                     "发布台账与包版本必须同步（消费方按版本 pin tarball）",
                 )
 
-    def test_latest_version_reaches_context_md(self):
-        """最新版本号必须出现在该包 CONTEXT.md 的「当前状态」节内。"""
+    def test_latest_version_reaches_context_narrative(self):
+        """最新版本号必须出现在该包 CONTEXT.md「当前状态」节的**人写叙述**里。
+
+        版本标签本身自 2026-07-26「招一推进」起由 CONTEXT-FACTS 块生成，那一维已无从漂移；
+        本条守的是**叙述有没有跟上**——生成块可以正确写着 0.76.0，而下方叙事仍停在 0.69.0
+        （实证：同日 project-status 的 maestro 节正是这个样子）。故搜索前先 `_narrative` 剥块。
+        """
         for pkg, ctx_heading, _ in WATCHED_PACKAGES:
             with self.subTest(package=pkg):
                 if pkg in ALLOWLIST:
@@ -125,16 +148,19 @@ class StatusDocFactsTest(unittest.TestCase):
                 )
                 self.assertIn(
                     latest,
-                    section,
-                    f"{pkg}/CONTEXT.md「{ctx_heading}」节未提及最新版本 {latest}——"
-                    "状态档落后于发布台账（2026-07-26 落后 12 版的同款漂移）。"
-                    "回写一条摘要即可，逐版全文仍以 CHANGELOG 为唯一权威",
+                    _narrative(section),
+                    f"{pkg}/CONTEXT.md「{ctx_heading}」节的叙述未提及最新版本 {latest}"
+                    "（机器生成块不算数，已剥除）——叙述落后于发布台账"
+                    "（2026-07-26 落后 12 版的同款漂移）。回写一条摘要即可，"
+                    "逐版全文仍以 CHANGELOG 为唯一权威",
                 )
 
-    def test_latest_version_reaches_project_status(self):
-        """最新版本号必须出现在 memory/project-status.md 对应子项目节内。
+    def test_latest_version_reaches_project_status_narrative(self):
+        """最新版本号必须出现在 memory/project-status.md 对应子项目节的**人写叙述**里。
 
         CLAUDE.md §5.3 定该档为「状态唯一权威，进度数字只在此维护」——权威档落后即失权威。
+        同样剥掉生成块再搜：STATUS-FACTS 块目前在别的节，但它若哪天被挪进子项目节，
+        不剥块的断言就地变成永真。**不能靠「块碰巧不在这一节」活着。**
         """
         status_text = _read(PROJECT_STATUS)
         for pkg, _, status_heading in WATCHED_PACKAGES:
@@ -152,10 +178,40 @@ class StatusDocFactsTest(unittest.TestCase):
                 )
                 self.assertIn(
                     latest,
-                    section,
-                    f"memory/project-status.md「{status_heading}」节未提及最新版本 {latest}"
-                    "——状态唯一权威档落后于发布台账（CLAUDE.md §5.3）",
+                    _narrative(section),
+                    f"memory/project-status.md「{status_heading}」节的叙述未提及最新版本 "
+                    f"{latest}（机器生成块不算数，已剥除）——状态唯一权威档落后于发布台账"
+                    "（CLAUDE.md §5.3）",
                 )
+
+    def test_narrative_stripping_is_not_vacuous(self):
+        """非空控：版本号**只**出现在生成块里时，叙述检查必须仍然判负。
+
+        这是本哨兵与生成层共存的命门。没有这一条，「招一又扩了一次射程」就能在无人察觉的
+        情况下把上面两条断言变成永真——测试照常绿，守的东西却没了。
+        """
+        only_in_block = (
+            "## 当前状态\n\n"
+            "<!-- CONTEXT-FACTS:BEGIN 机器生成 -->\n"
+            "**当前版本 `9.9.9`**\n"
+            "<!-- CONTEXT-FACTS:END -->\n\n"
+            "**v1.0.0（旧）**：陈年叙述。\n"
+        )
+        section = _section(only_in_block, "## 当前状态")
+        self.assertIn("9.9.9", section, "前提：整节里确实有该版本号（在生成块内）")
+        self.assertNotIn(
+            "9.9.9",
+            _narrative(section),
+            "剥块失败——生成块里的版本号漏进了叙述搜索面，两条叙述断言就地失效",
+        )
+        # 叙述里真有版本号时不得误杀
+        with_narrative = only_in_block + "\n**v9.9.9（新）**：这一版做了什么。\n"
+        self.assertIn(
+            "9.9.9",
+            _narrative(_section(with_narrative, "## 当前状态")),
+            "误杀——叙述里写了版本号却被剥掉了",
+        )
+
 
     def test_watched_packages_all_exist(self):
         """受管包目录与其三件套档案都在——防「包改名/删档后哨兵静默空转」。"""

--- a/tests/test_status_facts.py
+++ b/tests/test_status_facts.py
@@ -30,6 +30,31 @@ def test_block_is_present() -> None:
     )
 
 
+def test_context_blocks_are_present() -> None:
+    """两包 CONTEXT.md 必须带版本标签块（2026-07-26「3 推进」把招一射程延伸到 CONTEXT）。
+
+    单独钉存在性的理由：块被删掉时，`tests/test_status_doc_facts.py` 的叙述断言仍会绿
+    （叙述里通常也写着版本号），于是版本标签**悄悄退回手抄状态**而无人知晓。
+    同步性由下面的 apply(check_only) 一并覆盖，此处只管「块还在不在」。
+    """
+    for name in bsf.CONTEXT_PACKAGES:
+        ctx = bsf.PACKAGES[name] / "CONTEXT.md"
+        text = ctx.read_text(encoding="utf-8")
+        assert bsf.CONTEXT_BEGIN in text and bsf.CONTEXT_END in text, (
+            f"{name}/CONTEXT.md 缺机器生成版本块：跑 `python3 scripts/build_status_facts.py`"
+        )
+
+
+def test_context_blocks_carry_the_real_version() -> None:
+    """独立复核（不经生成器）：块里的号必须是 package.json 的真号。"""
+    for name in bsf.CONTEXT_PACKAGES:
+        path = bsf.PACKAGES[name]
+        version = json.loads((path / "package.json").read_text(encoding="utf-8"))["version"]
+        text = (path / "CONTEXT.md").read_text(encoding="utf-8")
+        block = text.split(bsf.CONTEXT_BEGIN, 1)[1].split(bsf.CONTEXT_END, 1)[0]
+        assert f"`{version}`" in block, f"{name}/CONTEXT.md 版本块内缺真实版本 {version}"
+
+
 def test_block_is_in_sync_with_the_authoritative_sources() -> None:
     """块必须是仓库当前状态的纯函数——不同步说明有人手改了数字，或权威源变了没重算。"""
     assert bsf.apply(check_only=True) == 0, (


### PR DESCRIPTION
## 概述

守密人 2026-07-26「3 推进」裁定落地：按**「能生成的先生成，生成不了的才架哨兵」**的次序，把 CONTEXT.md 的版本标签从「哨兵要求人手抄」升级为「生成器产出」，并把哨兵收窄到它真正该守的**叙述层**。

**本 PR 最有价值的一条不是新功能，是发现了生成层与检查层共存的一个静默失效模式**——详见下方 §2。

---

## 变更类型

- [x] 其他（请说明）：**治理设施**——生成器扩射程 + 哨兵语义收窄 + 非空控
- [x] 文档完善（CLAUDE.md §7.1 命令表 · memory/methodology.md）

---

## 来源声明

- [x] 本 PR 无外部数据引入。生成块内容全部取自仓内权威源：`package.json`（版本）+ `CHANGELOG.md`（发布日）。

---

## 安全声明（强制）

- [x] **不含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** §1.1-HC 防火墙无涉。
- [x] **不含游戏图片 / 解包资产 / 未公开文本。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`
- [x] 全量验证对话内实跑（读退出码）：**pytest 2979 通过 + 51 skipped**；生成器重跑幂等（`已是最新`）；两个工作流 YAML 解析通过
- [x] **负控实证**：删掉 CONTEXT 块 → 红；改坏块内版本 → 红；还原 → 绿

---

## §1 生成器扩射程

`scripts/build_status_facts.py` 新增 per-package **CONTEXT-FACTS 块**（agent + maestro；testbed 版本恒 `0.0.0`、锁步豁免，发块只是一行永不变化的噪音，故不发）：

```
**当前版本 `0.76.0`** · 发布日 2026-07-22 · 家族锁步对端 `silver-core-maestro-sdk` = `0.76.0`
```

三条设计取舍：
- **只放标签，不放规模数字**——规模指 `project-status.md` 的 STATUS-FACTS 块，不开第二张手抄表；
- **package.json 与 CHANGELOG 不符时块内照实标 ⚠**，不静默取其一：那正是版本守卫该红的情形，生成器不替它遮丑；
- `apply()` 重构为多目标（状态档 + 两包 CONTEXT），`--check` 一并覆盖，报哪个档不同步。

原哨兵那条「最新版本号必须出现在 CONTEXT.md 当前状态节」实质是**要求人手抄一个每次发布都变的数字**，与招一立身之本相抵——现已由生成消灭该维度。

## §2 关键发现：生成层会静默吃掉哨兵的判据

把版本号生成进 CONTEXT.md 的**那一刻**，哨兵的断言「版本号出现在当前状态节」就地变成**永真**——生成块自己就带着那个号。

> **测试照常绿，守的东西却没了，而且它红不了，所以没人会发现它已经死了。**

这不是本次特有的坑，是生成层与检查层共存的通用失效模式。三条应对：

1. **搜叙述前先剥生成块**——`_narrative()` 按 `<!-- X:BEGIN … X:END -->` **通配**剥除，不硬编码块名（下一个块不会再触发同样的事故）；两条叙述断言（CONTEXT + project-status）同时改用。project-status 那条目前的生成块在别的节，但**不能靠「块碰巧不在这一节」活着**。
2. **为「不被架空」本身写非空控**——`test_narrative_stripping_is_not_vacuous`：构造一份版本号只存在于生成块里的档案，断言叙述检查仍判负；并反向验不误杀。哨兵的负控证明它会咬，这一条证明**它咬的还是原来那块肉**。
3. **块存在性归位**——移到 `tests/test_status_facts.py`（生成器契约所在地），不在两处各写一遍。理由写在档内：块被删时叙述断言仍会绿，于是版本标签**悄悄退回手抄状态**而无人知晓。

`memory/methodology.md` 新增小节记录这条通用纪律：**生成层每扩一次射程，回头点一遍现有哨兵的判据有没有被自己吃掉。**

---

## 关联 Issue

- Refs #818（本 PR 是其余项 ③ 的执行）· Refs #815
- Refs: 2026-07-26 银芯 SDK 审视会话，守密人「3 推进」裁定

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjSu97MiPywX3fTkJ1FsQQ)_