### PR TITLE
fix(wiki): check_version 落点改现行数据层（死手开关第三条，连红 5 周）

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -48,12 +48,18 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add projects/wiki/data/db/versions.json
+          git add projects/wiki/data/processed/versions.json
           git add projects/wiki/docs/public/feed.xml
           git add projects/wiki/docs/public/atom.xml
           git add projects/wiki/output/version_check_result.json
-          git diff --cached --quiet || git commit -m "chore(wiki): auto-update version data and RSS feeds"
-          git push
+          git diff --cached --quiet || git commit -m "chore(wiki): auto-update version data and RSS feeds [skip ci]"
+          for i in 1 2 3 4; do
+            if git pull --rebase origin main && git push origin main; then exit 0; fi
+            echo "Push attempt $i failed, retrying in ${i}s..."
+            sleep $i
+          done
+          echo "All push attempts failed"
+          exit 1
 
       - name: Create issue for new version
         if: steps.check.outputs.new_version == 'true'

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -88,7 +88,7 @@
 | agent SDK 源文件 / 测试档 | 122 / 197 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 16 / 29 | 磁盘实况 |
 | testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
-| Python 测试档 | 128 | 磁盘实况 |
+| Python 测试档 | 129 | 磁盘实况 |
 | CI 工作流 / 其中定时 | 45 / 26 | `.github/workflows/` |
 | 挂账台账 开 / 已清 | 19 / 53 | `memory/todo.md` |
 

--- a/okf/wiki-data/wiki-data-versions.md
+++ b/okf/wiki-data/wiki-data-versions.md
@@ -1,0 +1,16 @@
+---
+type: "dataset"
+title: "versions"
+description: "versions 数据集"
+resource: "/projects/wiki/data/processed/versions.json"
+tags: ["data_layer:curated", "unpacked-bootstrap", "domain:meta"]
+timestamp: "2026-07-26"
+---
+
+# 指针概念
+
+> 放指针不放本体：本体权威在 `projects/wiki/data/processed/versions.json`，本 concept 仅描述与定位、不复刻正文。
+
+- 本体路径：`projects/wiki/data/processed/versions.json`
+- 摘要：versions 数据集
+- 标签：data_layer:curated · unpacked-bootstrap · domain:meta

--- a/projects/wiki/data/processed/versions.json
+++ b/projects/wiki/data/processed/versions.json
@@ -1,0 +1,16 @@
+{
+  "versions": [
+    {
+      "version": "2.5.3",
+      "title": "2.5.3版本（自动检测）",
+      "period": "2026",
+      "highlights": [
+        "版本 2.5.3 由自动检测系统于 2026-07-26 通过 steam_news 发现",
+        "具体更新内容待补充"
+      ],
+      "_auto_detected": true,
+      "_detected_at": "2026-07-26T11:16:41.050044+00:00",
+      "_source": "steam_news"
+    }
+  ]
+}

--- a/projects/wiki/scripts/check_version.py
+++ b/projects/wiki/scripts/check_version.py
@@ -24,8 +24,13 @@ FANDOM_RC_URL = (
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-VERSIONS_PATH = REPO_ROOT / "data" / "db" / "versions.json"
-META_PATH = REPO_ROOT / "data" / "db" / "meta.json"
+# 2026-07-26（守密人裁定「改写到现行数据层」）：原落点 data/db/ 已于 2026-06-15 裁定
+# **整层删除**（占位数据长期误导引用），本脚本却仍往那里写——**读侧优雅降级、写侧硬崩**，
+# 于是每周红一次、连红 5 周无人知，直到死手开关首跑把它数出来。
+# 现行唯一权威数据层是 data/processed/，故落点改此；**不重建已被裁定删除的 data/db/**。
+DATA_DIR = REPO_ROOT / "data" / "processed"
+VERSIONS_PATH = DATA_DIR / "versions.json"
+META_PATH = DATA_DIR / "meta.json"
 OUTPUT_PATH = REPO_ROOT / "output" / "version_check_result.json"
 
 
@@ -176,6 +181,7 @@ def create_stub_version(version: str, source: str) -> dict:
 
 def save_versions(versions_data: dict) -> None:
     """Save updated versions.json."""
+    VERSIONS_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(VERSIONS_PATH, "w", encoding="utf-8") as f:
         json.dump(versions_data, f, ensure_ascii=False, indent=2)
         f.write("\n")

--- a/scripts/okf_pointer_layers.py
+++ b/scripts/okf_pointer_layers.py
@@ -286,6 +286,9 @@ _WIKI_DOMAIN = {
     "character_index": "index",
     "aliases": "index",  # 厚锚别名侧表（chunk3）：角色索引的 sibling 扩展
     "language_config": "localization", "panel_text": "localization",
+    # 版本台账（2026-07-26 check_version 落点改现行数据层后新增）：它记的是产品时间线
+    # 本身，既非剧情也非玩法，故单列 meta 域，不硬塞进 index 混淆语义。
+    "versions": "meta",
 }
 
 

--- a/tests/test_check_version_paths.py
+++ b/tests/test_check_version_paths.py
@@ -1,0 +1,61 @@
+"""check_version 落点守卫 —— 「写盘目标不能指向已被裁定删除的层」。
+
+2026-07-26 死手开关首跑数出来的第三条：本脚本每周红一次、**连红 5 周以上无人知**。
+根因不在检测逻辑（它当场仍识别出新版本 2.5.3），而在落点——它写
+`projects/wiki/data/db/versions.json`，而 `data/db/` 整层已于 **2026-06-15 守密人裁定
+删除**（占位数据长期误导引用）。读侧写了优雅降级、写侧没有，于是**看得见敌情、报不出来**。
+
+守两条不变量：
+1. 落点必须在**现行数据层** `data/processed/`，且**绝不重建**已被裁定删除的 `data/db/`；
+2. 写盘自建父目录——本脚本是 versions.json 的唯一写者，目录不该指望别人替它准备。
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "projects" / "wiki" / "scripts" / "check_version.py"
+
+
+@pytest.fixture(scope="module")
+def cv():
+    spec = importlib.util.spec_from_file_location("check_version", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_version"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_write_target_is_the_live_data_layer(cv) -> None:
+    assert cv.VERSIONS_PATH.parent.name == "processed", (
+        f"落点不在现行数据层: {cv.VERSIONS_PATH}"
+    )
+    assert cv.META_PATH.parent.name == "processed", f"meta 落点不在现行数据层: {cv.META_PATH}"
+
+
+def test_the_deleted_layer_is_never_referenced(cv) -> None:
+    """2026-06-15 裁定删除的 data/db/ 不得在本脚本任何路径常量里复活。"""
+    for name in ("VERSIONS_PATH", "META_PATH", "OUTPUT_PATH"):
+        path = str(getattr(cv, name))
+        assert "/data/db/" not in path, f"{name} 指向已被裁定删除的 data/db/: {path}"
+
+
+def test_save_versions_creates_its_own_parent_directory(cv, tmp_path, monkeypatch) -> None:
+    """目录不存在时自建——原实现在这里 FileNotFoundError，正是连红 5 周的那一行。"""
+    target = tmp_path / "nonexistent" / "versions.json"
+    monkeypatch.setattr(cv, "VERSIONS_PATH", target)
+    cv.save_versions({"versions": [{"version": "9.9.9"}]})
+    assert json.loads(target.read_text(encoding="utf-8"))["versions"][0]["version"] == "9.9.9"
+
+
+def test_reads_degrade_gracefully_when_files_are_absent(cv, tmp_path, monkeypatch) -> None:
+    """读侧本就优雅降级（本次事故中它一直是对的）——锁住，别在修写侧时顺手改坏。"""
+    monkeypatch.setattr(cv, "VERSIONS_PATH", tmp_path / "missing.json")
+    monkeypatch.setattr(cv, "META_PATH", tmp_path / "missing-meta.json")
+    assert cv.load_versions() is not None
+    assert cv.load_meta() is not None


### PR DESCRIPTION
## 概述

死手开关首跑三条发现的最后一条，按守密人裁定**改写到现行数据层**（而非退役）。

---

## 变更类型

- [x] Bug 修复
- [ ] 文档完善
- [ ] 数据补全
- [ ] 翻译贡献
- [ ] 视觉/前端改进

---

## 来源声明

依据为本地复现与仓内裁定记录：

```
本地复现：FileNotFoundError projects/wiki/data/db/versions.json（写盘处）
data/db/ 整层删除 = 2026-06-15 守密人裁定（见 CLAUDE.md §1.4 第 2 条）
复现同时检出：NEW VERSION DETECTED: 2.5.3 (from Steam news)
```

---

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布渠道数据。** 版本信息取自 Steam 公开 news 接口。
- [x] **不含内部美术资产 / 解包原始文件 / 未公开草稿。**
- [x] **同意按 MIT License 提交。**

---

## 变更内容

### 根因

写 `projects/wiki/data/db/versions.json`，而该层已于 **2026-06-15 裁定整层删除**。**读侧优雅降级、写侧没有**，于是每周红一次、连红 5 周以上——因为此前**没有任何东西在盯沉默**。

**它值得修而不是退役的理由**：检测逻辑从未坏过。本地复现中它**成功识别出新版本 2.5.3**（Steam news），随后才崩在写盘——也就是说这 5 周里，每一次版本变更信号都被丢掉了。

比喻：哨兵眼睛好好的、也看见了敌情，但记录本被撤走，于是他每次都在写报告时摔倒，情报一次也没送出去。

### 修法

落点改 `data/processed/`（现行唯一权威层），**不重建已被裁定删除的 `data/db/`**；`save_versions` 自建父目录——本脚本是该文件的唯一写者，不该指望别人替它备好目录；工作流提交路径跟改，并补上与兄弟工作流一致的推送重试。

`tests/test_check_version_paths.py` 锁四条：落点在现行层 / 路径常量里不得出现 `data/db` / 写盘自建父目录 / **读侧优雅降级保持不变**（它是本次事故中唯一一直正确的部分，修写侧时不该顺手改坏）。**负控实证**：落点改回 `data/db` 立即两例转红。

### 两道守卫当场生效

新 `versions.json` 触发 KB 覆盖哨兵（无概念指针）与 wiki 领域绊线（落入兜底 `domain:misc`），二者都报得对。已补指针 + 新增 **`meta`** 域——产品时间线既非剧情也非玩法，硬塞进 `index` 会把 index 的语义搅浑。

---

## 验证清单

- [x] `pytest tests/` — **2985 通过 / 51 跳过**
- [x] 本地实跑 `check_version.py` 走完全程、exit 0，`versions.json` 与结果文件均落盘
- [x] 负控实证：落点改回 `data/db` 转红
- [ ] **合并后 dispatch 一轮实证**（按首跑实证纪律）
- [x] 不引入 emoji

---

## 关联

- 死手开关三条发现收官（另两条见 #819）
- 本会话前序：#804 / #805 / #810 / #811 / #812 / #813 / #814 / #816 / #817 / #819

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3PTjiaJAMbzSoEV45XZkk)_