### PR TITLE
docs(sdk): 把「不做 Windows 沙箱」写成决定而非待办（T66 销案的产品面收尾）

### DIFF
--- a/projects/silver-core-sdk/README.md
+++ b/projects/silver-core-sdk/README.md
@@ -209,6 +209,22 @@ that ship on Windows (BPT Desktop / Electron is the reference consumer) should
 size their `Bash` rules for that reality rather than assume the sandbox row in
 the compatibility matrix applies to them.
 
+**No Windows backend is planned** — a decision, not a backlog item (keeper
+ruling 2026-07-26). It rests on three findings: official Claude Code ships no
+Windows sandbox either, so this is the state of the art rather than a gap
+peculiar to this SDK; Windows offers no bubblewrap equivalent to port (a Job
+Object does not govern filesystem writes, AppContainer sits awkwardly around an
+arbitrary shell, and Windows Sandbox is VM-level and Pro-only), so building one
+would mean inventing a new isolation semantics rather than porting an existing
+one; and the "the consumer would not know" cost does not apply, because this
+section exists. Recording that decision did NOT remove the exposure. Plan for
+the permission layer being load-bearing on Windows **permanently, not
+provisionally.**
+
+macOS is a different case and is deliberately NOT covered by that ruling:
+official Claude Code does have a Seatbelt sandbox there, so the missing macOS
+backend remains an unimplemented gap rather than a settled decision.
+
 Two related caveats that hold even where the sandbox DOES resolve: it does not
 scrub the environment by default (opt in with `SandboxOptions.envScrub`), and
 bubblewrap gives a sandboxed command no SIGTERM grace window. Full detail, and


### PR DESCRIPTION
## 概述

守密人 2026-07-26 裁定「T66 确定不做」。台账侧已由前序会话按裁定销案并归入已清节（守卫通过），**缺的是产品面**：`README.md` 把暴露面写清了，但读起来像「尚未实现」——而一个正在设计安全姿态的宿主，需要知道 Windows 上权限层是**永久**承重，不是暂时的。

同时划清这条裁定**不覆盖**的边界：官方 Claude Code 在 macOS 上**有** Seatbelt 沙箱，故缺失的 macOS 后端仍是未实现缺口，不是已定案的不做。**不把裁定悄悄扩大**。

---

## 变更类型

- [x] 文档完善（`projects/silver-core-sdk/README.md`）

---

## 来源声明

- [x] 本 PR 无外部数据引入。内容为守密人裁定的转述 + 本仓既有实测（沙箱后端仅 bubblewrap，2026-07-26 探路腿 vitest 输出实证）。

---

## 安全声明（强制）

- [x] **不含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** §1.1-HC 防火墙无涉。
- [x] **不含游戏图片 / 解包资产 / 未公开文本。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 不引入 emoji
- [x] 未动 `memory/decisions.md` / `memory/lessons-learned.md`（本 PR 仅动 README）
- [x] 对话内实跑：`readme-export-contract` + `sandbox` 套件 **34 通过 + 2 skipped** · pytest **2985 通过 + 51 skipped** · version-bump 守卫 OK（docs-only，无需 bump）

---

## 关键措辞

三条判据照抄裁定（官方同样无 Windows 沙箱 / Windows 无 bubblewrap 对等物可移植 / 「消费方不知情」这条代价不成立因为本节存在），并明写一句**诚实边界**：

> Recording that decision did NOT remove the exposure.

**销案 ≠ 风险解除**——这是本 PR 唯一真正想钉住的东西。

---

## 附：平台探路终态（本会话，供参考）

合并后的 0.77.0 在 main 上的探路结果：**Windows conclusion: success（全绿）**（[run 14](https://github.com/lightproud/BIAV-SC-CODE/actions/runs/30202411464)）· macOS 全绿。首轮 Windows 曾 15 个测试档失败。

---

## 关联 Issue

- Refs #825 · Refs `memory/todo.md` T66（已清）
- Refs: 守密人 2026-07-26「T66 确定不做」

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjSu97MiPywX3fTkJ1FsQQ)_