### PR TITLE
feat: 产出↔消费对账（L3「意义性」第一件仪器）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,6 +425,7 @@ wiki 旧结构化层的 6 个占位 JSON（2026-06-15 裁定清空者）。**守
 | 数据校验（wiki JSON）| slash `/validate-data` 或 `python scripts/...`（见 schema 目录）|
 | 跨档案检索 | `rg "<关键词>" memory/ assets/`（ripgrep） |
 | 死手开关（沉默检测）| `python3 scripts/dead_man_switch.py [--dry-run]`（**只数空座位**：查全部带 cron 工作流的最近一次成功，超阈值报 `STALE`、从无成功报 `NEVER`；阈值由各自 cron 推导 ×2 + 宽限，状态落 `Public-Info-Pool/Record/heartbeat/status.json`，CI `dead-man-switch.yml` 每日北京 15:50；设计档见 `Public-Info-Pool/Resource/proposal/dead-man-switch-design-20260726.md`，单测 `tests/test_dead_man_switch.py`）|
+| 产出↔消费对账 | `python3 scripts/consumption_audit.py [--dry-run]`（**找没人读的产物**：静态引用图判「谁在读」，零消费 / 仅档案提及 / 经解析器读三档，报告落 `Public-Info-Pool/Record/heartbeat/consumption.json`；**候选清单供人裁、不是退役触发器**——静态图看不见守密人翻阅 / 会话内读档 / 黑池侧消费；单测 `tests/test_consumption_audit.py`）|
 | 状态档事实块重算 | `python3 scripts/build_status_facts.py [--check]`（`memory/project-status.md` 的版本 / 规模 / 台账数字 **+ 两包 `CONTEXT.md` 的版本标签块**由权威源生成，**勿手抄**；同步守卫 `tests/test_status_facts.py`，叙述新鲜度另由 `tests/test_status_doc_facts.py` 守）|
 | 记忆保鲜巡检 | `python3 scripts/memory_freshness.py`（lessons 指针/编号不变量门禁见 `tests/test_memory_freshness.py`；月检例程与 `/sync-memory` 手册共用一套流程）|
 | 知识库有效性记分卡 | `python3 scripts/kb_eval.py`（黄金问题集 hit@k + MRR；需求侧有效性回归见 `tests/test_kb_golden.py`）|

--- a/Public-Info-Pool/Record/heartbeat/consumption.json
+++ b/Public-Info-Pool/Record/heartbeat/consumption.json
@@ -1,0 +1,725 @@
+{
+  "method": "static-reference-graph",
+  "blind_spots": [
+    "守密人本人翻阅（不可见）",
+    "会话内按需读档（不可见）",
+    "黑池侧消费（防火墙外，结构上不可见）"
+  ],
+  "artifacts": 27,
+  "orphans": 3,
+  "doc_only": 1,
+  "parent_consumed": 9,
+  "entries": [
+    {
+      "artifact": "Public-Info-Pool/Record/heartbeat",
+      "producers": [
+        "dead-man-switch.yml"
+      ],
+      "verdict": "parent-consumed",
+      "consumers": {
+        "doc": [
+          "CLAUDE.md:427:| 死手开关（沉默检测）| `python3 scripts/dead_man_switch.py [--dry-run]`（**只数空座位**：查全部带 cron 工作流的最近一次成功，超阈值报 `STALE`、从无成功报 `NEVER`；阈值由各自 cron 推导 ×2 + 宽限，状态落 `Public-Info-Pool/Record/heartbeat/status.json`，CI `dead-man-switch.yml` 每日北京 15:50；设计档见 `Public-Info-Pool/Resource/proposal/dead-man-switch-design-20260726.md`，单测 `tests/test_dead_man_switch.py`）|",
+          "Public-Info-Pool/Resource/proposal/dead-man-switch-design-20260726.md:77:2. **状态落成仓内单文件**（如 `Public-Info-Pool/Record/heartbeat/status.json`，含",
+          "memory/methodology.md:308:看 `Public-Info-Pool/Record/heartbeat/status.json` 的 **`generated_at`**。它若停在上个月，"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 3
+      },
+      "consumed_via_parent": "Public-Info-Pool/Record"
+    },
+    {
+      "artifact": "Public-Info-Pool/Record/store-patrol",
+      "producers": [
+        "store-patrol.yml"
+      ],
+      "verdict": "parent-consumed",
+      "consumers": {
+        "doc": [
+          "Public-Info-Pool/Resource/repo-engineering/biav-sc-p27-history-rewrite-runbook-20260720.md:95:git ls-tree -r --name-only HEAD | grep -c '^Public-Info-Pool/Record/store-patrol/' # 期望 >0（保留项未误伤）",
+          "memory/decisions.md:135:| **编排 SDK 第二战:商店巡检真实场景接入落地 — 守密人 2026-07-18「第二战点火」口谕(施工封面 §2 留白授权,授权代写)**:需求档 §8「新场景首发」验收兑现——首个**生产**循环任务直接长在 Maestro SDK 台账 + 驱动器上。**设计填空清单**:(a) **巡检面 = Morimens Steam 双官方公开 JSON 端点**(appdetails 价格/发行面,appid 3052450;appreviews 评价总量面——后者 news 层 `aggregator_collectors.py` 已有消费先例,**零新增 ToS 面**;TapTap 等留注册表扩展位 `examples/store-patrol.targets.json`,加新商店 = 加一段配置零新代码,承 archive_engine 注册表哲学);(b) **签名指纹法**:响应归约为稳定字段集(排除 num_reviews 等请求域易变字段),逐日比对,变即追加 `changes.jsonl`;(c) **归档落点** `Public-Info-Pool/Record/store-patrol/{target}/`(latest.json + {date}.json + changes.jsonl)+ 台账持久化 `state/ledger.json`(宿主文件店,跨重启恢复真实生效);(d) **幂等派发键** `patrol:{target}:{date}`(同日重跑跳过;failed 终态自动开 `:rN` 重试会话);(e) **失败面**:驱动器超时经 AbortSignal 真中断 fetch,3 次退避耗尽进 failed 并翻进程退出码(CI 可见化);(f) **节拍**:每日北京 15:15(07:15 UTC,并入 2026-07-11 十五点档、分钟错峰),CI `store-patrol.yml` sparse 排除大档案层但**纳回** store-patrol 子目录(`git sparse-checkout check-rules` 实证);(g) 巡检不用代理 SDK(executor 纯 HTTP,零 API 花销——台账/驱动器本就 agent 无关,§1 硬性质 1「零件可单独拿取」的实证)。**验收实绩**:e2e 四场景绿(基线归档/跨日变更检测+同日幂等/500→200 重试进 done/挂死超时×3 进 failed+同日 r2 重开),2026-07-18 首次生产真跑绿(两目标 done,基线:免费/发行 2024-08-01/Very Positive 3989 正:797 负:4786 总);examples/tests 非发货面,maestro 版本 0.3.0 不动(发版纪律:仅 shipped 运行时变更 bump) | Maestro SDK / 商店巡检 | 承需求档 §8 与 2026-07-18 第一战条;周报 loop 迁入(§8 改轨)另役待点 |",
+          "memory/project-status.md:234:> Morimens Steam 双端点每日指纹比对，快照 + 变更日志落 `Public-Info-Pool/Record/store-patrol/`，",
+          "projects/silver-core-maestro-sdk/CONTEXT.md:53:  `Public-Info-Pool/Record/store-patrol/`;台账经宿主文件店持久化,跨重启恢复真实生效;"
+        ],
+        "other": [
+          "projects/silver-core-maestro-sdk/examples/store-patrol.targets.json:4:    \"archive\": \"Public-Info-Pool/Record/store-patrol/{target-id}/ — latest.json (current signature) + {date}.json (daily snapshot) + changes.jsonl (append-only change log)\""
+        ]
+      },
+      "consumer_counts": {
+        "doc": 4,
+        "other": 1
+      },
+      "consumed_via_parent": "Public-Info-Pool/Record"
+    },
+    {
+      "artifact": "Public-Info-Pool/Reference/Claude-Code-System-Prompts",
+      "producers": [
+        "refresh-claude-code-prompts.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          "CLAUDE.md:436:| 刷新 Claude Code 提示词参照 | `python3 scripts/refresh_claude_code_prompts.py`（浅克隆上游公开仓库、同步进 `Public-Info-Pool/Reference/Claude-Code-System-Prompts/`；每周定时 CI `refresh-claude-code-prompts.yml` 自动跑，手动亦可）|",
+          "Public-Info-Pool/Resource/proposal/bpt-prompt-assembly-layer-design-20260705.md:143: │  Public-Info-Pool/Reference/Claude-Code-System-Prompts/system-prompts/│",
+          "Public-Info-Pool/Resource/proposal/bpt-prompt-assembly-layer-design-20260705.md:422:- **INPUT**：`Public-Info-Pool/Reference/Claude-Code-System-Prompts/system-prompts/*.md`（CI 刷新的 Piebald 归档）+ `scripts/prompt-adaptation.json`（唯一改写/略过账本）+ **`ls src/tools/*.ts src/subagents/*.ts` 生成的面清单**（用于 §6.4 勘定对账与红线覆盖，取代手抄清单）。",
+          "Public-Info-Pool/Resource/proposal/bpt-sdk-v06-remaining-execution-roadmap-20260705.md:34:**G-VERIFY + G-SUMMARY.** Both are additive utility-call surfaces over the shipped runtime, each ships its prompt *with* a runnable exported caller (no unshipped-capability risk), and each carries a corpus-sync guard against its cited archive slug (all target slugs verified present in `Public-Info-Pool/Reference/Claude-Code-System-Prompts/system-prompts/`). G-VERIFY has zero regression surface (greenfield); G-SUMMARY is a guarded superset of current fold behavior. If maximally conservative, ship **G-VERIFY alone** — it is the only item with literally no touch to existing runtime behavior.",
+          "Public-Info-Pool/Resource/repo-engineering/bpt-desktop-builtin-commands-batch1-20260711.md:231:  （`Public-Info-Pool/Reference/Claude-Code-System-Prompts/`，553 份）ripgrep 反查。"
+        ],
+        "other": [
+          "okf/kb_index.json:3978:      \"description\": \"可见的行为面。与静态提示词快照（`Public-Info-Pool/Reference/Claude-Code-System-Prompts/`）（格式：md）\","
+        ],
+        "script": [
+          "projects/silver-core-sdk/src/engine/compaction.ts:86: * Public-Info-Pool/Reference/Claude-Code-System-Prompts/): the structured",
+          "projects/silver-core-sdk/src/engine/prompt-fragments.ts:10: * (Public-Info-Pool/Reference/Claude-Code-System-Prompts/).",
+          "projects/silver-core-sdk/src/engine/prompts.ts:10: * distributed CLI; archived under Public-Info-Pool/Reference/Claude-Code-System-Prompts/),",
+          "projects/silver-core-sdk/src/engine/prompts.ts:156: * Public-Info-Pool/Reference/Claude-Code-System-Prompts/). Open reproduction",
+          "projects/silver-core-sdk/src/generators/prompts.ts:11: * Public-Info-Pool/Reference/Claude-Code-System-Prompts/system-prompts/ and"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 13,
+        "other": 1,
+        "script": 11
+      }
+    },
+    {
+      "artifact": "Record/Community",
+      "producers": [
+        "backfill-gap.yml",
+        "backfill-news.yml",
+        "community-cold-compress.yml",
+        "update-news.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          ".claude/commands/biav-report.md:5:1. 确认数据层（§4 硬约束）：报告类一律走全量档案层 `Public-Info-Pool/Record/Community/`（2026-06-21 迁入，text 全量永驻 git），禁用输出层充全量（lesson #30）。日报/快查才用 `projects/news/output/*-latest.json`。",
+          ".claude/commands/biav-report.md:8:   - Discord：`Public-Info-Pool/Record/Community/discord/channel_index.json` 映射 `{name→dir}`；消息在 `Public-Info-Pool/Record/Community/discord/channels/{id_suffix}/{date}.jsonl` 逐行 JSON，字段 `content`/`author_id`/`author_bot`(过滤bot)/`timestamp`/`reactions`。**紧凑 schema（缺字段=默认值，见 CLAUDE.md §5.2）：读取必用 `.get(默认)`**，需稳定全字段调 `projects/news/scripts/discord_compact.py` 的 `expand_record()`。",
+          ".claude/commands/biav-report.md:9:   - 平台：`Public-Info-Pool/Record/Community/{plat}/{date}.json`（含区服子层时为 `{plat}/{region}/{type}/{date}.json`；平台清单以 `ls Public-Info-Pool/Record/Community/` 为准），字段 `title`/`summary`/`lang`/`url`/`content_type`/`engagement`。",
+          ".claude/skills/domain-modeling/SKILL.md:31:the words to avoid. \"守密人说『数据层』—— 指全量档案层（`Public-Info-Pool/Record/Community/`）还是",
+          ".claude/skills/intel-weekly/SKILL.md:14:1. **数据层**：只用全量档案层 `Public-Info-Pool/Record/Community/`，禁用"
+        ],
+        "other": [
+          ".gitignore:90:# Public-Info-Pool/Record/Community: 社区全量档案数据湖 2026-07-20 迁 BIAV-SC-DATA（T62 P2-5 §7甲）。",
+          ".gitignore:93:Public-Info-Pool/Record/Community/",
+          "okf/kb_index.json:1277:      \"resource\": \"/Public-Info-Pool/Record/Community/appstore/global/\",",
+          "okf/kb_index.json:1291:      \"resource\": \"/Public-Info-Pool/Record/Community/arca_live/\",",
+          "okf/kb_index.json:1305:      \"resource\": \"/Public-Info-Pool/Record/Community/bahamut/\","
+        ],
+        "script": [
+          "projects/news/scripts/archive_layout.py:4:背景（2026-07-02 体质改进 P0-1）：Record/Community 的目录布局知识此前散落在",
+          "projects/news/scripts/archive_layout.py:53:    \"\"\"社区全量档案根：<pool>/Record/Community（discord + 16+ 平台摊平）。\"\"\"",
+          "projects/news/scripts/archive_platforms.py:52:# 平台摊平到 BPT 4R Record/Community 下，与 discord 同级（2026-06-21 迁移）",
+          "projects/news/scripts/collect_arca_daily.py:47:    # 按内容日期分桶落 Record/Community/arca_live/{date}.json（平铺源，无区服/类型层）",
+          "projects/news/scripts/collect_arca_daily.py:73:    run('git', 'add', 'Public-Info-Pool/Record/Community/arca_live/')"
+        ],
+        "test": [
+          "tests/kb_semantic_golden.jsonl:10:{\"id\": \"sem-en-04\", \"query\": \"just picked up the game, why is she rated so weak\", \"target_text\": \"New player here. HOW is this character considered ass/low-tier\", \"target_ref\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"target_source\": \"reddit\", \"capability\": \"paraphrase_recall\", \"rationale\": \"真消息零共享-token 语义改写（grep 臂校验通过）\", \"distractors\": [\"Code: TEAHFONZM5 Enter it in the new Mythag Invite / Bind Invitation tab on the left.\", \"——高清切图可在评论区查看！ High-resolution cutouts can be viewed in the comments section!\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}",
+          "tests/kb_semantic_golden.jsonl:11:{\"id\": \"sem-en-05\", \"query\": \"looking for tips to make my squad stronger\", \"target_text\": \"Need advice to improve mi team.\", \"target_ref\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"target_source\": \"reddit\", \"capability\": \"paraphrase_recall\", \"rationale\": \"真消息零共享-token 语义改写（grep 臂校验通过）\", \"distractors\": [\"——高清切图可在评论区查看！ High-resolution cutouts can be viewed in the comments section!\", \"New Player With Question On Translation progression\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}",
+          "tests/kb_semantic_golden.jsonl:12:{\"id\": \"sem-en-06\", \"query\": \"beginner unsure where to spend the complimentary summons\", \"target_text\": \"I just started today and have no idea on which banner I should use the free 100 pulls. Any tips\", \"target_ref\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"target_source\": \"reddit\", \"capability\": \"paraphrase_recall\", \"rationale\": \"真消息零共享-token 语义改写（grep 臂校验通过）\", \"distractors\": [\"New Player With Question On Translation progression\", \"[Steam论坛] New invite code! 300 silver.\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}",
+          "tests/kb_semantic_golden.jsonl:13:{\"id\": \"sem-en-07\", \"query\": \"cleared the toughest mode running a no-resource build\", \"target_text\": \"Finally beaten Madness Rail difficulty with zero energy gnosis\", \"target_ref\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"target_source\": \"reddit\", \"capability\": \"paraphrase_recall\", \"rationale\": \"真消息零共享-token 语义改写（grep 臂校验通过）\", \"distractors\": [\"[Steam论坛] New invite code! 300 silver.\", \"YouSavedMorimens- again\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}",
+          "tests/kb_semantic_golden.jsonl:14:{\"id\": \"sem-en-08\", \"query\": \"which unit deserves this rare limited weapon\", \"target_text\": \"who should I use my prototype horizon on?\", \"target_ref\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"target_source\": \"reddit\", \"capability\": \"paraphrase_recall\", \"rationale\": \"真消息零共享-token 语义改写（grep 臂校验通过）\", \"distractors\": [\"YouSavedMorimens- again\", \"And if it's not tomorrow, then it's the day after\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/reddit/2026-04-07.json\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}"
+        ],
+        "workflow": [
+          ".github/workflows/backfill-media.yml:6:# T62 P2-3c 已切换（2026-07-19）：源读根 SRC（Record/Community）经 community_root() 分仓桥接",
+          ".github/workflows/build-okf-bundle.yml:10:    # 刻意不含每小时归档层（Public-Info-Pool/Record/Community、projects/news/output 流快照）：",
+          ".github/workflows/collect-comments.yml:4:# Record/Community/youtube_comments/{date}.json，供会话内报告引用。",
+          ".github/workflows/collect-comments.yml:74:          git add Record/Community/youtube_comments/",
+          ".github/workflows/community-platform-backup.yml:10:# 原从 code 仓 sparse 取 `Public-Info-Pool/Record/Community` —— 而 T62 §7甲（07-20）"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 188,
+        "other": 47,
+        "script": 23,
+        "test": 29,
+        "workflow": 17
+      }
+    },
+    {
+      "artifact": "Record/Community/discord",
+      "producers": [
+        "discord-archive.yml",
+        "discord-cold-compress.yml",
+        "discord-history-backfill.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          ".claude/commands/biav-report.md:8:   - Discord：`Public-Info-Pool/Record/Community/discord/channel_index.json` 映射 `{name→dir}`；消息在 `Public-Info-Pool/Record/Community/discord/channels/{id_suffix}/{date}.jsonl` 逐行 JSON，字段 `content`/`author_id`/`author_bot`(过滤bot)/`timestamp`/`reactions`。**紧凑 schema（缺字段=默认值，见 CLAUDE.md §5.2）：读取必用 `.get(默认)`**，需稳定全字段调 `projects/news/scripts/discord_compact.py` 的 `expand_record()`。",
+          ".claude/skills/intel-weekly/reference.md:43:署名：拿文件名里的 attachment_id 在 `Record/Community/discord/` 全档 `grep -rm1`，",
+          ".claude/skills/intel-weekly/reference.md:5:- Discord 三服：`Record/Community/discord/{global|jp|volunteer}/`",
+          "CLAUDE.md:253:- 全量档案（2026-06-21 迁入 BPT 4R，text 全量永驻数据仓）：`Record/Community/discord/{区服}/channels/{id_suffix}/{date}.jsonl`（区服 ∈ global / jp / volunteer，2026-07-10 方案甲三服统一；guild↔区服映射唯一源 = `projects/news/scripts/archive_layout.py` `DISCORD_GUILD_REGIONS`，新 guild 未登记归档即响亮失败）+ `Public-Info-Pool/Record/Community/{platform}/`（16+ 平台与 discord 平级摊平，以 `ls` 为准）。**discord JSONL 为紧凑 schema（2026-06-22 精简，工作树 3.4G→2.0G 省 41%）：缺字段 = 默认值**（`type`→0 / `author_bot`→false / `pinned`→false / `flags`→0 / `has_thread`→false / `thread_id`·`edited_timestamp`·`reply_to`→null / `mentions`·`reactions`·`attachments`·`embeds`→[]）；恒留 `id`/`channel_id`/`author_id`/`author_name`/`content`/`timestamp`。读取**必用 `.get(默认)`**，需稳定全字段用 `projects/news/scripts/discord_compact.py` 的 `expand_record()`。",
+          "CLAUDE.md:262:- Discord 每日纯统计：`Public-Info-Pool/Record/Community/discord/{区服}/activity_daily/{date}.json`（主服在 global 区服目录）"
+        ],
+        "other": [
+          "okf/kb_index.json:1333:      \"resource\": \"/Public-Info-Pool/Record/Community/discord/\",",
+          "okf/kb_index.json:1360:      \"description\": \"全量社区档案静态分析台账：百万级 条（精确值见指针本体）/ 17 平台，词典法零 ML。discord 全量历史 2026-06-21 de-tier 后永驻 git（Record/Community/discord/），直接读取，无需从 Rele\",",
+          "okf/kb_index.json:4567:      \"resource\": \"/Public-Info-Pool/Record/Community/discord/\",",
+          "projects/news/index/community_index.json:11:  \"data_note\": \"discord 全量历史 2026-06-21 de-tier 后永驻 git（Record/Community/discord/），直接读取，无需从 Release 还原；community-data release 已退役删除。\"",
+          "projects/news/scripts/archive_sources.json:3:    \"base_dir\": \"Public-Info-Pool/Record/Community/discord\","
+        ],
+        "script": [
+          "scripts/build_community_index.py:301:                         \"（Record/Community/discord/），直接读取，无需从 Release 还原；\"",
+          "scripts/compact_discord_archive.py:10:  - 提交前整体可 `git checkout -- Public-Info-Pool/Record/Community/discord` 回退；",
+          "scripts/restore_release_data.py:21:        --dest Public-Info-Pool/Record/Community/discord"
+        ],
+        "test": [
+          "tests/kb_semantic_golden.jsonl:15:{\"id\": \"sem-en-09\", \"query\": \"honestly nothing much remains worth talking about here\", \"target_text\": \"ig bcuz we barely have anything else to discuss in this game\", \"target_ref\": \"Public-Info-Pool/Record/Community/discord/channels/00578363/2026-03-31.jsonl\", \"target_source\": \"discord\", \"capability\": \"paraphrase_recall\", \"rationale\": \"真消息零共享-token 语义改写（grep 臂校验通过）\", \"distractors\": [\"And if it's not tomorrow, then it's the day after\", \"Code: TEAHFONZM5 Enter it in the new Mythag Invite / Bind Invitation tab on the left.\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/discord/channels/00578363/2026-03-31.jsonl\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}",
+          "tests/kb_semantic_golden.jsonl:16:{\"id\": \"sem-en-10\", \"query\": \"love the redrawn illustration of that spider lady\", \"target_text\": \"The new Arachne art revision is fantastic!\", \"target_ref\": \"Public-Info-Pool/Record/Community/discord/channels/00578363/2026-03-31.jsonl\", \"target_source\": \"discord\", \"capability\": \"paraphrase_recall\", \"rationale\": \"真消息零共享-token 语义改写（grep 臂校验通过）\", \"distractors\": [\"Code: TEAHFONZM5 Enter it in the new Mythag Invite / Bind Invitation tab on the left.\", \"——高清切图可在评论区查看！ High-resolution cutouts can be viewed in the comments section!\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/discord/channels/00578363/2026-03-31.jsonl\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}",
+          "tests/kb_semantic_golden.jsonl:3:{\"id\": \"sem-en-01\", \"query\": \"you shouldn't measure a failing mobile title against beloved older adult visual novels from otaku fandom\", \"target_text\": \"I mean its unfair to compare a dead gachage with cult classic \\\"eroge\\\" amongst pre-covid weebs kkk\", \"target_ref\": \"Public-Info-Pool/Record/Community/discord/channels/00578363/2026-03-31.jsonl\", \"target_source\": \"discord\", \"capability\": \"paraphrase_recall\", \"rationale\": \"同义改写：failing mobile↔dead gacha, adult visual novels↔eroge，零共享 token\", \"distractors\": [\"Code: TEAHFONZM5 Enter it in the new Mythag Invite / Bind Invitation tab on the left.\", \"——高清切图可在评论区查看！ High-resolution cutouts can be viewed in the comments section!\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/discord/channels/00578363/2026-03-31.jsonl\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}",
+          "tests/kb_semantic_golden.jsonl:5:{\"id\": \"sem-en-03\", \"query\": \"worried the collaboration event may arrive right before the servers shut down\", \"target_text\": \"By the time the crossover rolls around, there might he another near-eos situation\", \"target_ref\": \"Public-Info-Pool/Record/Community/discord/channels/00578363/2026-04-03.jsonl\", \"target_source\": \"discord\", \"capability\": \"paraphrase_recall\", \"rationale\": \"collaboration↔crossover, servers shut down↔eos，零共享 token\", \"distractors\": [\"New Player With Question On Translation progression\", \"[Steam论坛] New invite code! 300 silver.\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/discord/channels/00578363/2026-04-03.jsonl\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}",
+          "tests/kb_semantic_golden.jsonl:9:{\"id\": \"sem-zh-03\", \"query\": \"怀疑是异常：暴走护盾错误分给了后排治疗位\", \"target_text\": \"如圖我船長狂氣爆發選擇船長給三屏障， 結果連二號位的醫生都有拿到三屏障\", \"target_ref\": \"Public-Info-Pool/Record/Community/discord/channels/00110557/2026-03-10.jsonl\", \"target_source\": \"discord\", \"capability\": \"paraphrase_recall\", \"rationale\": \"繁简+同义：暴走↔狂氣爆發, 护盾↔屏障, 后排治疗↔二號位醫生，零共享 token\", \"distractors\": [\"——高清切图可在评论区查看！ High-resolution cutouts can be viewed in the comments section!\", \"New Player With Question On Translation progression\"], \"provenance\": {\"message_id\": null, \"harvested_from\": \"Public-Info-Pool/Record/Community/discord/channels/00110557/2026-03-10.jsonl\", \"curated_by\": \"erica-session-2026-07-05\", \"confirmed\": true}, \"data_layer\": \"full_archive\"}"
+        ],
+        "workflow": [
+          ".github/workflows/discord-archive-jp.yml:87:          git add Record/Community/discord/jp/",
+          ".github/workflows/discord-archive-volunteer.yml:68:          git add Record/Community/discord/volunteer/",
+          ".github/workflows/discord-discover-guilds.yml:64:          git add Record/Community/discord/guilds_seen.json"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 33,
+        "other": 5,
+        "script": 3,
+        "test": 6,
+        "workflow": 3
+      }
+    },
+    {
+      "artifact": "Record/Community/discord/guilds_seen.json",
+      "producers": [
+        "discord-discover-guilds.yml"
+      ],
+      "verdict": "parent-consumed",
+      "consumers": {
+        "doc": [
+          "projects/news/CONTEXT.md:91:   `Public-Info-Pool/Record/Community/discord/guilds_seen.json` 并提交回仓库。日服 ID 即在该快照中。"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 1
+      },
+      "consumed_via_parent": "Record/Community/discord"
+    },
+    {
+      "artifact": "Record/Community/discord/jp",
+      "producers": [
+        "discord-archive-jp.yml"
+      ],
+      "verdict": "parent-consumed",
+      "consumers": {
+        "doc": [
+          "projects/news/CONTEXT.md:78:- discord-archive-jp.yml 日服服务器归档（数据落 `Public-Info-Pool/Record/Community/discord/jp/`）：**已启用**（JP_GUILD_ID 已填、:45 错峰 cron 在跑，07-10 实测正常落档）",
+          "projects/news/CONTEXT.md:97:`Public-Info-Pool/Record/Community/discord/jp/`（2026-07-10 方案甲区服布局；新 guild 须先登记"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 2
+      },
+      "consumed_via_parent": "Record/Community/discord"
+    },
+    {
+      "artifact": "Record/Community/discord/volunteer",
+      "producers": [
+        "discord-archive-volunteer.yml"
+      ],
+      "verdict": "parent-consumed",
+      "consumers": {
+        "doc": [
+          "projects/news/CONTEXT.md:77:- discord-archive-volunteer.yml 每 3 小时 :15（志愿者服务器 guild，数据落 `Public-Info-Pool/Record/Community/discord/volunteer/`）"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 1
+      },
+      "consumed_via_parent": "Record/Community/discord"
+    },
+    {
+      "artifact": "Record/Community/youtube_comments",
+      "producers": [
+        "collect-comments.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          "memory/project-status.md:140:    `data/platforms/`，权威档案断更 10 天；已改写 `Record/Community/youtube_comments/`",
+          "okf/community/community-youtube-comments.md:12:> 放指针不放本体：本体权威在 `Public-Info-Pool/Record/Community/youtube_comments/`，本 concept 仅描述与定位、不复刻正文。",
+          "okf/community/community-youtube-comments.md:14:- 本体路径：`Public-Info-Pool/Record/Community/youtube_comments/`",
+          "okf/community/community-youtube-comments.md:5:resource: \"/Public-Info-Pool/Record/Community/youtube_comments/\"",
+          "okf/sources/youtube_comments.md:17:| 全量档案层（本体） | `Public-Info-Pool/Record/Community/youtube_comments/` |"
+        ],
+        "other": [
+          "okf/kb_index.json:1515:      \"resource\": \"/Public-Info-Pool/Record/Community/youtube_comments/\",",
+          "okf/kb_index.json:4777:      \"resource\": \"/Public-Info-Pool/Record/Community/youtube_comments/\","
+        ],
+        "script": [
+          "projects/news/scripts/collect_video_comments.py:7:存储（Public-Info-Pool/Record/Community/youtube_comments/，2026-07-02 对齐 BPT 4R",
+          "projects/news/scripts/sources.py:102:    'youtube_comments',  # collect_video_comments.py 直写 Record/Community/youtube_comments/"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 6,
+        "other": 2,
+        "script": 2
+      }
+    },
+    {
+      "artifact": "memory/capability-index.md",
+      "producers": [
+        "build-capability-registry.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          "CLAUDE.md:285:| `memory/capability-index.md` | 银芯全功能目录 + 动态编排可达性（CI 自动生成；含孤儿检测。人工用途补注在 `memory/capability-annotations.json`，机器权威数据在 `memory/capability-registry.json`）|",
+          "okf/memory/capability-index.md:12:> 放指针不放本体：正文权威在 `memory/capability-index.md`，本 concept 不复刻其内容。",
+          "okf/memory/capability-index.md:14:- 本体路径：`memory/capability-index.md`",
+          "okf/memory/capability-index.md:5:resource: \"/memory/capability-index.md\"",
+          "okf/memory/index.md:15:* [capability-index.md](/memory/capability-index.md) - 银芯全功能目录 + 动态编排可达性"
+        ],
+        "other": [
+          "okf/graph.json:1213:      \"id\": \"/memory/capability-index.md\",",
+          "okf/graph.json:4679:      \"source\": \"/memory/capability-index.md\",",
+          "okf/kb_index.json:10218:      \"/memory/capability-index.md\",",
+          "okf/kb_index.json:10967:      \"/memory/capability-index.md\",",
+          "okf/kb_index.json:11302:      \"/memory/capability-index.md\","
+        ],
+        "script": [
+          "scripts/build_capability_registry.py:27:  memory/capability-index.md       人类可读 Markdown（含编排与可达性专章）"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 5,
+        "other": 52,
+        "script": 1
+      }
+    },
+    {
+      "artifact": "memory/capability-registry.json",
+      "producers": [
+        "build-capability-registry.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          "CLAUDE.md:285:| `memory/capability-index.md` | 银芯全功能目录 + 动态编排可达性（CI 自动生成；含孤儿检测。人工用途补注在 `memory/capability-annotations.json`，机器权威数据在 `memory/capability-registry.json`）|",
+          "Public-Info-Pool/Resource/repo-engineering/repo-slim-audit-20260711.md:42:  `memory/capability-registry.json` 由 CI 自动重生成，无需手改。",
+          "memory/archive/bpt-strategic-shift-2026-04-19/blackpool-architecture.md:178:| 建设模块 | `memory/capability-registry.json`；`scripts/capability_manager.py` |",
+          "memory/archive/bpt-strategic-shift-2026-04-19/blackpool-architecture.md:223:| **P8** 能力注册表初版 | `memory/capability-registry.json` | P1 |",
+          "memory/archive/bpt-strategic-shift-2026-04-19/blackpool-architecture.md:277:- `memory/capability-registry.json` —— Phase B P8 产出目标"
+        ],
+        "other": [
+          "okf/kb_index.json:1954:      \"resource\": \"/memory/capability-registry.json\","
+        ],
+        "script": [
+          "scripts/build_capability_registry.py:26:  memory/capability-registry.json  机器权威 JSON（含可达性字段）",
+          "scripts/build_capability_registry.py:390:        \"> 中文用途补注请改 `memory/capability-annotations.json`；机器权威数据见 `memory/capability-registry.json`。\","
+        ]
+      },
+      "consumer_counts": {
+        "doc": 9,
+        "other": 1,
+        "script": 2
+      }
+    },
+    {
+      "artifact": "okf",
+      "producers": [
+        "build-okf-bundle.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          "CLAUDE.md:124:   （concept 元数据 + 正文 + `graph.json`）造的静态导航索引 `okf/kb_index.json`（倒排表 + 邻接表，",
+          "CLAUDE.md:127:   指针，本体仍原地不动。重建随 `scripts/build_okf_bundle.py` 末尾自动跑，或 `python3 scripts/build_kb_index.py` 单独重建。",
+          "CLAUDE.md:312:├── okf/                           # Open Knowledge Format v0.1 bundle（生成物，见 §6.1）",
+          "CLAUDE.md:334:### §6.1 OKF Bundle（`okf/`）",
+          "CLAUDE.md:336:`okf/` 是银芯知识层的 **Open Knowledge Format v0.1** 捆绑包（Google Cloud 2026-06-12"
+        ],
+        "other": [
+          ".gitignore:58:okf/kb_vectors.json.gz",
+          ".gitleaks.toml:15:  '''okf/.*''',",
+          "Binary file assets/images/portraits/uvhash.png matches",
+          "Public-Info-Pool/Record/heartbeat/status.json:42:      \"workflow\": \"build-okf-bundle.yml\",",
+          "memory/capability-registry.json:487:      \"id\": \"build_okf_bundle.py\","
+        ],
+        "script": [
+          "scripts/build_kb_index.py:105:    \"\"\"Scan ``okf/`` into a runtime navigation index and write ``okf/kb_index.json``.",
+          "scripts/build_kb_index.py:111:            f\"OKF bundle missing at {BUNDLE} — run scripts/build_okf_bundle.py first\"",
+          "scripts/build_kb_index.py:184:            \"source\": \"okf/ bundle (concept frontmatter + body + graph edges)\",",
+          "scripts/build_kb_index.py:20:生成物，重跑覆盖。``python3 scripts/build_okf_bundle.py`` 末尾自动调用本模块，",
+          "scripts/build_kb_index.py:22:就已存在的 ``okf/`` 重建。"
+        ],
+        "test": [
+          "tests/test_build_okf_bundle_unit.py:124:    b = tmp_path / \"okf\"",
+          "tests/test_build_okf_bundle_unit.py:18:import build_okf_bundle as bok",
+          "tests/test_build_okf_bundle_unit.py:19:import okf_pointer_layers as opl",
+          "tests/test_build_okf_bundle_unit.py:1:\"\"\"build_okf_bundle 纯函数与构建逻辑单测（_unit 后缀，避免与 test_okf_bundle.py 冲突）。",
+          "tests/test_build_okf_bundle_unit.py:271:    assert any(n.startswith(\"okf\") for n in names)"
+        ],
+        "workflow": [
+          ".github/workflows/build-community-vectors.yml:13:#   --pattern 'kb_vectors.json.gz' --dest okf。actions artifact 保留供 run 内检视。",
+          ".github/workflows/build-community-vectors.yml:59:          # 桩索引污染 okf/），CI 建生产索引须落回 okf/ 供上传。",
+          ".github/workflows/build-community-vectors.yml:63:            --out okf/kb_vectors.json.gz",
+          ".github/workflows/build-community-vectors.yml:68:          gh release upload community-assets okf/kb_vectors.json.gz --clobber \\",
+          ".github/workflows/build-community-vectors.yml:75:          path: okf/kb_vectors.json.gz"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 95,
+        "other": 17,
+        "script": 49,
+        "test": 65,
+        "workflow": 7
+      }
+    },
+    {
+      "artifact": "projects/news/data",
+      "producers": [
+        "backfill-gap.yml",
+        "backfill-news.yml",
+        "update-news.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          ".claude/skills/intel-weekly/reference.md:45:嵌入前缩图（长边 ≤700px，JPEG q84）落 `projects/news/data/fanart/`（gitignored，仅渲染用）。",
+          "Public-Info-Pool/Resource/community-analysis/community-deep-analysis-20260518-26.md:1146:- **平台层**：遍历 `projects/news/data/platforms/{平台}/2026-05-{18..26}.json`，读取",
+          "Public-Info-Pool/Resource/community-analysis/community-deep-analysis-20260518-26.md:1148:- **Discord 内容**：遍历 `projects/news/data/discord/channels/{dir}/2026-05-{18..25}.jsonl`，",
+          "Public-Info-Pool/Resource/community-analysis/community-deep-analysis-20260518-26.md:16:> `projects/news/data/` 下的原始归档文件，复算脚本逻辑见附录 §9。",
+          "Public-Info-Pool/Resource/community-analysis/community-deep-analysis-20260518-26.md:5:data_layer: 全量档案层 projects/news/data/（严格遵 CLAUDE.md §4，未混入 output 选样层）"
+        ],
+        "other": [
+          ".gitignore:24:projects/news/data/collected_raw.json",
+          ".gitignore:36:projects/news/data/media/*.jpg",
+          ".gitignore:37:projects/news/data/media/*.jpeg",
+          ".gitignore:38:projects/news/data/media/*.png",
+          ".gitignore:39:projects/news/data/media/*.gif"
+        ],
+        "script": [
+          "projects/news/scripts/aggregator_collectors.py:29:    旧根 projects/news/data/discord 已死——本桥曾读旧根静默零条 19 天，",
+          "projects/news/scripts/archive_engine.py:19:统一索引: projects/news/data/releases-index.json（自动生成，治「Release 好难认」）",
+          "projects/news/scripts/archive_engine.py:57:    `projects/news/data/fanart`）仍相对 REPO_ROOT。env 未设时与旧 `REPO_ROOT / base_dir`",
+          "projects/news/scripts/archive_platforms.py:6:  projects/news/data/platforms/",
+          "projects/news/scripts/backfill_gap.py:31:# 4R 迁移后全量档案层现址（旧 projects/news/data/platforms 已废，2026-07-12 修复）"
+        ],
+        "test": [
+          "tests/test_aggregator_unit.py:30:    # projects/news/data/collection_state.json.",
+          "tests/test_archive_engine.py:41:        self.assertEqual(cfg[\"base_dir\"], \"projects/news/data/fanart\")",
+          "tests/test_archive_platforms_unit.py:4:绝不触碰真实 projects/news/data/platforms。",
+          "tests/test_backfill_gap_more.py:63:    # never leak a real file into projects/news/data/platforms/ (test isolation).",
+          "tests/test_data_discipline.py:191:        # DATA_OLD (legacy projects/news/data). Point COMMUNITY_NEW at a missing"
+        ],
+        "workflow": [
+          ".github/workflows/backfill-media.yml:96:          git add projects/news/data/media/backfill_manifest.json",
+          ".github/workflows/collect-fanart.yml:4:# projects/news/data/fanart/{date}/ 后直传 community-assets release 当月资产",
+          ".github/workflows/collect-fanart.yml:63:          python projects/news/scripts/collect_fanart.py --date \"$D\" --out \"projects/news/data/fanart/$D\"",
+          ".github/workflows/collect-fanart.yml:70:          BASE=projects/news/data/fanart",
+          ".github/workflows/recover-fanart.yml:54:              --out \"projects/news/data/fanart/$D\""
+        ]
+      },
+      "consumer_counts": {
+        "doc": 47,
+        "other": 21,
+        "script": 19,
+        "test": 6,
+        "workflow": 6
+      }
+    },
+    {
+      "artifact": "projects/news/data/media/backfill_manifest.json",
+      "producers": [
+        "backfill-media.yml"
+      ],
+      "verdict": "orphan",
+      "consumers": {},
+      "consumer_counts": {}
+    },
+    {
+      "artifact": "projects/news/index",
+      "producers": [
+        "build-analysis-index.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          "CLAUDE.md:264:- **全量分析索引**：`projects/news/index/community_index.json`（构建期静态台账，零 ML / 零常驻；732 万条按平台×月聚合：消息量 / 语言 / 词典法情感极性 / 高频词 / 采集覆盖；timeline 带 `vol_index`=本月量÷前6月中位数，抓量异常如 2026-02/03 断崖；服务「社区这一年有什么变化」类全量时序分析）。`_meta.data_layer=full_archive`，全文钻取回落 dated 原文件 ripgrep。**全量 discord 历史现驻数据仓 BIAV-SC-DATA `Record/Community/discord`**（2026-06-21 de-tier 退役月度 git_rm；2026-07-20 T62 P2-5 §7甲 迁出 code 仓），经 `BIAV_SC_DATA_ROOT` 读、无需 Release 还原。重建：`BIAV_SC_DATA_ROOT=<data仓> python3 scripts/build_community_index.py`（消费方双布局：新路径优先、回落旧）。分词用领域词典 FMM，top_terms 为粗粒度主题信号",
+          "Public-Info-Pool/Resource/community-analysis/light-selfreport-crosscheck-20260705.md:6:  + 全量分析索引 `projects/news/index/community_index.json`（`data_layer=full_archive`）。",
+          "Public-Info-Pool/Resource/community-analysis/producer-light-evaluation-20260704.md:128:| 全量分析索引 | `projects/news/index/community_index.json` |",
+          "Public-Info-Pool/Resource/community-analysis/producer-light-evaluation-20260704.md:7:  （7,565,639 条 / 17 平台，索引 `projects/news/index/community_index.json`，",
+          "Public-Info-Pool/Resource/data-diagnostics/weixin-noise-cleanup-20260712.md:139:- `projects/news/index/community_index.json` 中 weixin 各月计数将随下次 CI 索引重建自动收敛（build-analysis-index）。"
+        ],
+        "other": [
+          "okf/kb_index.json:1361:      \"resource\": \"/projects/news/index/community_index.json\",",
+          "okf/kb_index.json:1473:      \"resource\": \"/projects/news/index/community_index.json\",",
+          "okf/kb_index.json:2998:      \"description\": \"（7,565,639 条 / 17 平台，索引 `projects/news/index/community_index.json`，（格式：md）\",",
+          "projects/site/design/morimens-design-system-guide.html:130:projects/news/index.html"
+        ],
+        "script": [
+          "scripts/build_community_index.py:45:OUT = REPO / \"projects/news/index/community_index.json\""
+        ],
+        "test": [
+          "tests/test_analysis_index.py:19:COMMUNITY = REPO / \"projects/news/index/community_index.json\"",
+          "tests/test_kb_coverage_sentinel.py:29:    \"projects/news/index/community_index.json\","
+        ],
+        "workflow": [
+          ".github/workflows/deploy-site.yml:15:      - 'projects/news/index.html'",
+          ".github/workflows/deploy-site.yml:86:          cp projects/news/index.html dist/news/index.html"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 17,
+        "other": 4,
+        "script": 1,
+        "test": 2,
+        "workflow": 2
+      }
+    },
+    {
+      "artifact": "projects/news/output",
+      "producers": [
+        "update-news.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          ".claude/commands/biav-report.md:5:1. 确认数据层（§4 硬约束）：报告类一律走全量档案层 `Public-Info-Pool/Record/Community/`（2026-06-21 迁入，text 全量永驻 git），禁用输出层充全量（lesson #30）。日报/快查才用 `projects/news/output/*-latest.json`。",
+          ".claude/commands/daily-news.md:4:2. Check `projects/news/output/news.json` is non-empty (item count > 0)",
+          ".claude/skills/domain-modeling/SKILL.md:32:输出展示层（`projects/news/output/`）？二者语义不可互换（§4.1）。\"",
+          ".claude/skills/intel-weekly/SKILL.md:15:   `projects/news/output/` 选样层充全量。",
+          "CLAUDE.md:210:（`projects/news/output/`，过滤选样），两者语义不可互换。"
+        ],
+        "other": [
+          ".gitignore:53:projects/news/output/alerts.json",
+          ".gitleaks.toml:14:  '''projects/news/output/.*''',",
+          "Public-Info-Pool/Resource/community-analysis/community-deep-analysis-20260518-26.html:110:逐条数据）与<strong>输出展示层</strong>（<code>projects/news/output/</code>，过滤选样）之分，二者语义不可互换。",
+          "memory/capability-registry.json:1117:      \"summary\": \"split_output.py — 按数据源分割 projects/news/output/news.json\",",
+          "okf/kb_index.json:2245:      \"resource\": \"/projects/news/output/all-latest.json\","
+        ],
+        "script": [
+          "projects/news/scripts/aggregator.py:18:  4. 输出: projects/news/output/news.json",
+          "projects/news/scripts/aggregator.py:42:# 路径在 output/ 之外，避免被 `git add projects/news/output/` 提交进仓库。",
+          "projects/news/scripts/aggregator.py:4:从各社区平台抓取24小时内的热门话题并生成 projects/news/output/news.json",
+          "projects/news/scripts/split_output.py:10:  projects/news/output/twitter-latest.json",
+          "projects/news/scripts/split_output.py:11:  projects/news/output/youtube-latest.json"
+        ],
+        "test": [
+          "tests/test_collect_global.py:167:        # no-op, otherwise the test would clobber the real projects/news/output/*.json.",
+          "tests/test_data_discipline.py:152:        assert \"/projects/news/output/\" not in resource, (",
+          "tests/test_data_discipline.py:7:    OUTPUT/DISPLAY layer  projects/news/output/  过滤选样（抽样）",
+          "tests/test_data_discipline.py:94:        health = fake_repo / \"projects/news/output/source-health.json\"",
+          "tests/test_kb_coverage_sentinel.py:30:    \"projects/news/output/*-latest.json\","
+        ],
+        "workflow": [
+          ".github/workflows/build-okf-bundle.yml:10:    # 刻意不含每小时归档层（Public-Info-Pool/Record/Community、projects/news/output 流快照）：",
+          ".github/workflows/build-okf-bundle.yml:22:      - 'projects/news/output/source-health.json'",
+          ".github/workflows/deploy-site.yml:88:          [ -f projects/news/output/news.json ] && cp projects/news/output/news.json dist/news/data/news.json"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 129,
+        "other": 28,
+        "script": 17,
+        "test": 5,
+        "workflow": 3
+      }
+    },
+    {
+      "artifact": "projects/silver-core-sdk/tests/conformance/pins.json",
+      "producers": [
+        "conformance-drift.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "script": [
+          "projects/silver-core-sdk/tests/conformance/drift-check.mjs:210:    'This **draft** bumps `projects/silver-core-sdk/tests/conformance/pins.json` to',"
+        ]
+      },
+      "consumer_counts": {
+        "script": 1
+      }
+    },
+    {
+      "artifact": "projects/silver-core-testbed/memory",
+      "producers": [
+        "testbed-patrol.yml"
+      ],
+      "verdict": "parent-consumed",
+      "consumers": {},
+      "consumer_counts": {},
+      "consumed_via_parent": "projects/silver-core-testbed"
+    },
+    {
+      "artifact": "projects/silver-core-testbed/state",
+      "producers": [
+        "testbed-patrol.yml"
+      ],
+      "verdict": "parent-consumed",
+      "consumers": {
+        "doc": [
+          "memory/todo.md:19:| T57 | testbed 验收 2「四巡检器连续 7 天无人值守」核验：CI `testbed-patrol.yml` 每日北京 15:20 首轮起算，D+7 核 Actions 日志与台账（`projects/silver-core-testbed/state/ledger.json` 逐轮 sched 会话 + 记忆区日报告/卡）全绿即销；首轮亦需核 deploy key 推送四步走通。（原编 T56，合并时与审计账撞号让号）**首轮 7 天验收诚实判定为失败（2026-07-26 仓库审视会话核 Actions 日志）**：07-18 首轮 success 后，07-19 → 07-25 **连续 7 轮全 failure**（最新 [run 30152439641](https://github.com/lightproud/BIAV-SC-CODE/actions/runs/30152439641)）。四巡检器本身每轮 ok/done，唯 `dream` 归并任务必败——`INDEX_PATH=/memories/MEMORY.md` 每轮用 create-only 语义重写，07-18 落库后天天撞 already exists；台账重试时又撞尝试 1 已写的当日值班卡，**后者掩盖前者**（日志末行报 cards 冲突，真凶在索引行）。守密人 2026-07-26 裁定「修 dream 幂等 + 重算 T57」：修复落 `src/dream.mjs` / `src/memory.mjs`（`replaceFile` 显式先删后建，不改 SDK 侧 create 参照语义）+ 3 例回归（负控实证旧源转红），**D+7 计时自修复后首个绿轮重新起算，不顺延**。**新起算锚点已定**：2026-07-26 dispatch [run 30185091549](https://github.com/lightproud/BIAV-SC-CODE/actions/runs/30185091549) 全步 success，四巡检器报告 + 值班卡 + 索引改写 + 台账均真落 main（提交 `af3188d`，含此前不可能成功的 `MEMORY.md` 改写），**D+7 = 2026-08-02** 核 07-26 → 08-01 七轮定时是否连绿。 | 观察 | 施工封面 §4.2 + `projects/silver-core-testbed/CONTEXT.md` 当前状态节 | 开 |"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 1
+      },
+      "consumed_via_parent": "projects/silver-core-testbed"
+    },
+    {
+      "artifact": "projects/wiki/data/processed/story/story_search_index.json",
+      "producers": [
+        "build-analysis-index.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          "Public-Info-Pool/Resource/methodology/knowledge-engineering-primer-20260704.md:95:| `projects/wiki/data/processed/story/story_search_index.json` | 1026 条剧情 lore 倒排表 + 单元画像 | `scripts/build_story_index.py` |",
+          "okf/story/story_search_index.md:12:> 放指针不放本体：本体在 `projects/wiki/data/processed/story/story_search_index.json`，本 concept 仅定位。",
+          "okf/story/story_search_index.md:14:- 本体路径：`projects/wiki/data/processed/story/story_search_index.json`",
+          "okf/story/story_search_index.md:5:resource: \"/projects/wiki/data/processed/story/story_search_index.json\""
+        ],
+        "other": [
+          "okf/kb_index.json:4917:      \"resource\": \"/projects/wiki/data/processed/story/story_search_index.json\","
+        ],
+        "test": [
+          "tests/test_analysis_index.py:20:STORY = REPO / \"projects/wiki/data/processed/story/story_search_index.json\""
+        ]
+      },
+      "consumer_counts": {
+        "doc": 4,
+        "other": 1,
+        "test": 1
+      }
+    },
+    {
+      "artifact": "projects/wiki/data/processed/versions.json",
+      "producers": [
+        "check-version.yml"
+      ],
+      "verdict": "parent-consumed",
+      "consumers": {
+        "doc": [
+          "okf/wiki-data/wiki-data-versions.md:12:> 放指针不放本体：本体权威在 `projects/wiki/data/processed/versions.json`，本 concept 仅描述与定位、不复刻正文。",
+          "okf/wiki-data/wiki-data-versions.md:14:- 本体路径：`projects/wiki/data/processed/versions.json`",
+          "okf/wiki-data/wiki-data-versions.md:5:resource: \"/projects/wiki/data/processed/versions.json\""
+        ],
+        "other": [
+          "okf/kb_index.json:5156:      \"resource\": \"/projects/wiki/data/processed/versions.json\","
+        ]
+      },
+      "consumer_counts": {
+        "doc": 3,
+        "other": 1
+      },
+      "consumed_via_parent": "projects/wiki/data/processed"
+    },
+    {
+      "artifact": "projects/wiki/docs/public/atom.xml",
+      "producers": [
+        "check-version.yml"
+      ],
+      "verdict": "orphan",
+      "consumers": {},
+      "consumer_counts": {}
+    },
+    {
+      "artifact": "projects/wiki/docs/public/feed.xml",
+      "producers": [
+        "check-version.yml"
+      ],
+      "verdict": "orphan",
+      "consumers": {},
+      "consumer_counts": {}
+    },
+    {
+      "artifact": "projects/wiki/output/client_extract",
+      "producers": [
+        "extract-game-data.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "script": [
+          "projects/wiki/scripts/extract_client_data.py:537:        help=\"Output directory (default: projects/wiki/output/client_extract/)\","
+        ]
+      },
+      "consumer_counts": {
+        "script": 1
+      }
+    },
+    {
+      "artifact": "projects/wiki/output/version_check_result.json",
+      "producers": [
+        "check-version.yml"
+      ],
+      "verdict": "parent-consumed",
+      "consumers": {},
+      "consumer_counts": {},
+      "consumed_via_parent": "projects/wiki/output"
+    },
+    {
+      "artifact": "community-assets",
+      "producers": [
+        "build-community-vectors.yml"
+      ],
+      "verdict": "consumed",
+      "consumers": {
+        "doc": [
+          ".claude/skills/intel-weekly/reference.md:41:fanart 月度包在 Releases `community-assets` / `fanart-archive-{YYYY-MM}.tar.gz`",
+          "CLAUDE.md:402:| **`community-data` / `community-assets` Release** | discord 33 月历史副本（2023-07 → 2026-05）· fanart 与回填媒体 | `scripts/restore_release_data.py` |",
+          "Public-Info-Pool/Resource/proposal/silver-core-vector-leg-design-20260705.md:22:| 索引落存 | Release `community-assets` + git 只留小 manifest（`.gitignore:48-52` 已排除 `vectors.json` 类） | **云容器不能写 Release**，构建+上传只能在 CI（`gh release upload --clobber`）；还原照 `scripts/restore_release_data.py`（urllib+tarfile，api 封禁回退 `--months`） |",
+          "Public-Info-Pool/Resource/repo-engineering/bpt-demo-residue-scan-20260712.md:22:现役 Release 桶仅 `unpacked-assets`（解包）与 `community-assets`（社区二创），登记内容全部为",
+          "Public-Info-Pool/Resource/repo-engineering/kb-vector-remaining-handoff-20260705.md:17:1. **索引落存 = Release `community-assets` + restore**（不入 git，合本仓「二进制→Release、git 留指针」范式，避撞瘦身）。"
+        ],
+        "other": [
+          ".gitignore:56:# 可 MB→GB，放指针不放本体：不进 git，CI 构建后上传 Release community-assets，",
+          ".gitignore:74:# 走 community-assets「社区二创」release；采集落以下 staging 但不入 git。",
+          "projects/news/scripts/archive_sources.json:19:    \"release_tag\": \"community-assets\","
+        ],
+        "script": [
+          "projects/news/scripts/backfill_media.py:148:    # 2026-06-21 收敛：media 二进制并入「社区二创」community-assets（与 fanart 同桶），",
+          "projects/news/scripts/backfill_media.py:14:  5. --upload：打包 media/files/ 传 GitHub Releases（tag=community-assets「社区二创」，需 GH_TOKEN）。",
+          "projects/news/scripts/backfill_media.py:39:RELEASE_TAG = \"community-assets\"  # 2026-06-21 收敛：media 并入「社区二创」桶",
+          "scripts/kb_vector.py:19:不进 git（见 .gitignore），由 CI 构建并上传 Release ``community-assets``，运行时经",
+          "scripts/restore_release_data.py:25:        --tag community-assets --pattern 'kb_vectors.json.gz' --dest okf"
+        ],
+        "test": [
+          "tests/test_archive_engine.py:47:        self.assertEqual(cfg[\"release_tag\"], \"community-assets\")",
+          "tests/test_restore_release_data_unit.py:162:    n = rrd.restore(\"community-assets\", \"kb_vectors.json.gz\", Path(\"okf\"), force=False)"
+        ],
+        "workflow": [
+          ".github/workflows/collect-fanart.yml:4:# projects/news/data/fanart/{date}/ 后直传 community-assets release 当月资产",
+          ".github/workflows/collect-fanart.yml:66:      - name: Upload to community-assets release (merge month asset)",
+          ".github/workflows/collect-fanart.yml:79:          gh release view community-assets --json assets -q '.assets[].name' \\",
+          ".github/workflows/collect-fanart.yml:82:            gh release download community-assets --pattern \"$ASSET\" \\",
+          ".github/workflows/consolidate-releases.yml:17:        description: '目标 release tag（如 unpacked-data / community-data / community-assets）'"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 27,
+        "other": 3,
+        "script": 5,
+        "test": 2,
+        "workflow": 9
+      },
+      "kind": "release"
+    },
+    {
+      "artifact": "community-platforms",
+      "producers": [
+        "community-platform-backup.yml"
+      ],
+      "verdict": "doc-only",
+      "consumers": {
+        "doc": [
+          "Public-Info-Pool/Resource/repo-engineering/silver-core-repo-split-migration-plan-20260719.md:68:  月度 + `workflow_dispatch` 打包 16 非 discord 平台 → `community-platforms` release（滚动全量、`--clobber`）。",
+          "memory/todo.md:40:| T65 | **三网站岗（接棒 T29，守密人 2026-07-26 裁定「销案，改立新站岗」）**：本仓 git 历史只到 2026-07-20（§7乙 压扁 + 备份分支已删），此后**唯一抢救网 = 三处**——① **BIAV-SC-DATA 数据仓**（社区全量档案本体）② **`community-data` / `community-assets` Release**（discord 33 月副本 2023-07→2026-05 + fanart / 回填媒体）③ **`unpacked-assets` Release**（游戏二进制，解包 text 层的唯一还原源，管线 `extract-game-data.yml` + `extract_client_data.py` + `scripts/parse_*.py` 均在）。**站岗内容**：删除 / 覆盖 / 迁移三者中任一处前必须先确认另有副本——它们背后**不再有 git 历史兜底**，删即永久。**16 平台第二网已建成（2026-07-26 守密人裁定「修好并立即跑一轮」）**：`community-platform-backup.yml` 原从 code 仓取已被 §7甲 搬走的目录、且自建成（07-19）起从未触发过（首个 cron 为 08-03），即「建好就坏、坏了还没人知道」；已改 clone BIAV-SC-DATA + 经 `archive_layout.community_root()` 解析路径（不再手拼），同日 dispatch [run 30192652167](https://github.com/lightproud/BIAV-SC-CODE/actions/runs/30192652167) success，[`community-platforms` Release](https://github.com/lightproud/BIAV-SC-CODE/releases/tag/community-platforms) 落 **16 个平台副本 / 6.39MB**（appstore · arca_live · bahamut · bilibili · google_play · note_com · pixiv · reddit · ruliweb · steam · stopgame · taptap · weibo · weixin · youtube · youtube_comments）。**三网自此全部到位**，本条转为常态站岗：删 / 覆盖 / 迁移任一网之前先确认另有副本。 | **已清（2026-07-26 守密人裁定「只销台账，机制与桶保留」）**：本条不再作为开着的站岗项，**四个 Release 桶与月度备份工作流原样保留、不删不停**——所裁的是「台账里不必再挂一条提醒」，**不是**「不要副本」。核实时点四桶实况：`community-platforms` 16 资产 / 6.4MB（当日新建）· `community-data` 33 / 272MB（discord 2023-07→2026-05）· `community-assets` 3 / 743MB（fanart + 回填媒体）· `unpacked-assets` 20 / **10.2GB**（游戏二进制，**解包 text 层的唯一还原源**——该层 2026-07-12 已整层删除，此桶删则永久不可推导）。**纪律仍然生效，只是不再靠台账提醒**：三网背后已无 git 历史兜底（07-20 压扁 + 备份分支删除，见 CLAUDE.md §6.3），删 / 覆盖 / 迁移任一网前须先确认另有副本；该纪律的常驻载体 = CLAUDE.md §6.3 表格本身。｜原类别：观察｜源出处：T29 销案条 + CLAUDE.md §6.3 + 守密人 2026-07-26 裁定 |",
+          "memory/todo.md:42:| T62 | **数据层剥离评估战线（守密人 2026-07-19 裁定「丙 · 立项重估形态」，回应 KIMI3 静态审查头号 P0）**：产「代码+指针+小样本」目标形态迁移评估，分四阶段决策门（P0 盘点核验 / P1 选型 / P2 增量掐口乙案 / P3 历史处置）。**立项 charter 已落** `Public-Info-Pool/Resource/proposal/data-layer-detachment-evaluation-20260719.md`。**关键发现**：`community-data` Release 实含 33 月 discord 副本（2023-07→2026-05，仅缺 2023-08/09），大幅松动 T29 悲观假设。**逐门待裁**：~~门①~~ **已放行完成**（2026-07-19，见下）→ 门② 选型 + 乙案 → 门③ 历史重写（最高风险，触发线未破倾向暂缓）。不触任何不可逆动作前置守密人裁定。**门① · P0 盘点核验结论**（报告 `Public-Info-Pool/Resource/data-diagnostics/discord-rescue-net-completeness-20260719.md`）：discord 抢救网 = 高保真（重叠月 2026-04 逐条相等 620,970 行 / 33 月连续 2023-07→2026-05），T29 悲观假设推翻；**新发现风险 → 门③ 硬前置**：16 个非 discord 平台无任何 Release 副本，历史重写前须先为其建副本。**门② 已定案（2026-07-19 守密人裁分仓）**：新仓 `BIAV-SC-DATA`（数据湖）+ 现仓改名 `BIAV-SC-CODE`（代码/大脑）；目标形态由存储后端选型升级为分仓拓扑，**分仓不要求历史重写、绕开 T29**。可执行迁移计划落 `Public-Info-Pool/Resource/repo-engineering/silver-core-repo-split-migration-plan-20260719.md`。**B 段可逆准备已交付（2026-07-19，守密人「B 我做 A」授权）**：① 桥接定案**方案 B**（兄弟 checkout + 环境根）+ 首批收口——`archive_layout` 加 `pool_root/community_root/discord_root` 环境根 resolver（env `BIAV_SC_DATA_ROOT`，向后兼容）、8 采集/数据脚本切用、契约测试 4 例；② 16 非 discord 平台备份 workflow `community-platform-backup.yml`（月度 + dispatch，`community-platforms` release 滚动全量）。**A 段进展**：`BIAV-SC-DATA` **已建**（2026-07-19 守密人建，空仓）；会话代理对其只读（写 403），故阶段一填充走**乙方案**——`data-repo-sync.yml`（workflow_dispatch + `MIGRATE` 门，sparse 读 Record/Community、经 deploy key 推 data 仓、rsync 镜像）已落。**A 段改名已完成**（2026-07-19，`BIAV-SC-CODE` 生效、GitHub 重定向）。**阶段一迁移已完成并验证**（2026-07-19，run #29683057765）：守密人配细粒度 PAT + secret `BIAV_SC_DATA_TOKEN`，艾瑞卡直接触发 `data-repo-sync.yml`，`Record/Community` 快照落 BIAV-SC-DATA（HEAD d078b93c→537b231c，**21,815 文件逐一相等**、657M、discord 三区服 + 16 平台齐）。**仍待守密人**：① 历史体量甲/乙（独立可延后）。**阶段二执行计划已出**（守密人 2026-07-19「推进」，`Public-Info-Pool/Resource/repo-engineering/biav-sc-split-stage2-execution-plan-20260719.md`）：拆两目标——**A 止增长**（11 采集 CI 改写 data 仓，独立见效、不涉 T29）+ **B 缩体积**（移除 Community，**§7 甲下只省工作树、clone 不减，须乙历史重写才真缩**）。破坏点清单：~25 读脚本（8 已桥接）/ 11 写侧 CI / 8 测试。**守密人 2026-07-19 裁 1 甲（P2-1+P2-2）+ 2 甲（§7 暂缓）**。**P2-1 已完成**（两批共 13 脚本桥接 archive_layout 数据根 resolver，全量 2961 绿；剩 extract_aliases/memory_freshness/指针字符串类/restore 暂缓，B 暂缓不急）。**P2-2 目标 A 试点已落**：隔离 workflow `discord-archive-datarepo-pilot.yml`（不碰 live），discord_archiver 经 env 根写 BIAV-SC-DATA + PAT 推送。**P2-2 试点已验证通过**（2026-07-19 run #29689243312：discord_archiver 经 env 根写 BIAV-SC-DATA、推送成功 `537b231c`→`0103b77c`、code 仓未动、全步 success）——目标 A 止增长机制打通。**P2-3 全切换方案已细化**（`Public-Info-Pool/Resource/repo-engineering/biav-sc-split-p23-cutover-plan-20260719.md`）：a 停 mirror sync（删除硬前置）→ b 读桥接收尾（含 archive_engine）→ c 11 采集 CI 分批切写 data 仓 → d/e 测试与全系统验证；**删除（P2-5）待全绿 + §7 甲/乙**。**P2-3a+b 已落**（2026-07-19，守密人「按建议推进」）：a `data-repo-sync.yml` **退役**（旧 MIGRATE 令牌失效、须强警示词 FORCE-DESTRUCTIVE-RESYNC，防 --delete footgun）；b 读桥接收尾——干净 FS 读常量消费者全桥接（+extract_aliases/memory_freshness，全量 2961 绿）。**archive_engine + 相对字符串/写入型（collect/backfill）归 P2-3c**（与写侧 git 操作耦合，非简单读桥）；okf 指针字符串保持逻辑相对（不随物理仓变）。**P2-3c 开工（守密人 2026-07-19「开工」）**：archive_engine base_dir env 感知已落（0.71 桥接，全平台归档使能，全量 2963 绿）；discord 三写脚本（archiver/forum-starters/engine）全 honor `BIAV_SC_DATA_ROOT`。**discord 族六个全部切写 data 仓**（`discord-archive` global 已 dispatch 验证 run#294 → data 仓 commit 54d9b1e4；jp/volunteer/history-backfill/discover-guilds/cold-compress 同模板已改，待 dispatch 验证）+ 冗余 pilot 已删（活由正式 discord-archive 接管）。`data-repo-sync.yml` 确认 P2-3a 退役。**news 族分三类**：纯 data 仓（collect-comments · community-cold-compress，已切）· 双目标 Record→data+output/state→code（update-news · backfill-news · backfill-gap，**已切**，待 dispatch 验证）· 读 data 写 code（backfill-media，**已切**）。双目标模式=code 仓 checkout 保 ssh-key 推 output/state + clone data 仓 PAT 推 Record/Community + defaults working-directory code-repo 兄弟目录。collect-comments/community-cold-compress dispatch 验证 success。P2-3b 读侧桥接补齐：collect_video_comments（DEST+glob）+ backfill_media（SRC）经 community_root()（repair_gaps/archive_platforms/backfill_platforms/backfill_gap/community_cold_compress 早已桥接；aggregator/split_output/download_media 只写 output/media 留 code 仓）。切完 → P2-5（删 code 存量）→ §7 甲/乙。 **P2-3e 全系统验证已跑（只读）**：数据移出树 + env 根，全量 pytest **2963 绿**、build_community_index honor env 根、kb_eval 不读 Record——运行时读侧位置无关。**抓到消费侧 build 缺口并已修**：`okf_pointer_layers._archive_resource`（community 层门）+ `build_okf_bundle.build_sources`（sources 层门）+ `_mention_texts`（mention 边读 archive 本体）三处存在检查/本体读**硬编码在树** → 改经 `community_root()`（env 感知、指针字符串保逻辑）；`test_data_discipline` fixture 改喂 env 根（P2-3d 适配）。验证：env-根构建与 committed **逐字节一致**（nodes 370/edges 稳）、env-未设与 committed 零差异（行为保持）。**P2-5 §7甲 已执行（守密人 2026-07-20「启动」）**：`git rm -r --cached Public-Info-Pool/Record/Community`（21829 文件 / 658M 取消跟踪 + .gitignore，git 历史保留可恢复）；store-patrol 等非数据湖子目录保留。前置接线先落：build-okf-bundle + build-analysis-index clone data 仓 + env 根（dispatch 验证读 data 仓绿）；test.yml 自 P0-2 sparse 排除 Record，required 门无涉。CLAUDE.md §1.4/§5.2 三处「永驻 git」改「迁 BIAV-SC-DATA、经 BIAV_SC_DATA_ROOT 读」+ test_claude_md 数据湖路径豁免适配。**T62 目标 A 止增长 + §7甲 数据湖出仓全部完成**。**§7乙（历史压扁真缩 clone）已执行（守密人 2026-07-20「全仓压扁」裁 + 会话内协助执行完成）**：守密人改选**全历史压扁**（非 filter-repo 单路径 purge——手册 `biav-sc-p27-history-rewrite-runbook-20260720.md` 记备选路径，仍存档）。执行经过：① GitHub 建备份分支 `pre-flatten-backup-20260720`（全历史，回滚保险）② orphan 单提交从当前树重建（`git checkout --orphan`，gitignore 排除 Record/Community）③ 压扁树与原 main **逐字节相同**（tree e5d2489f）④ fresh clone 验证：1 提交 / 2223 文件 / 0 数据 / `.git` 22M（原 445M）/ 整 clone 39M ⑤ 守密人临时解 main 保护 → force-push `dc918b4b:main` 上位 → 守密人复原保护。**诚实记录**：压扁基于备份点 73dcb493，漏 force-push 前一轮 update-news 自动 news 输出提交 58d64a1a（`projects/news/output/*`+state 快照，[skip ci]）——自愈型陈旧（output 每 3h 重生、state 下轮自纠），永久内容零丢失（已触发 update-news 刷新）。**收尾待守密人确认后**：删 `flat-main-20260720` + `pre-flatten-backup-20260720`（回滚保险，确认前绝不删）+ 残留旧分支 → GitHub 回收旧 blob，clone ~1G→39M 落地。**T62 分仓工程全线完成（目标 A + §7甲 + §7乙）。** | **已清（2026-07-26 守密人裁定「销案」）**：分仓工程全线完成——门① P0 盘点放行、门② 定案分仓拓扑（新仓 BIAV-SC-DATA + 现仓改名 BIAV-SC-CODE）、**门③ 历史处置已于 07-20 §7乙 全仓压扁实际执行**（clone ~1G→39M）；目标 A 止增长 + §7甲 数据湖出仓 + §7乙 压扁三段俱已落地，残余「历史体量甲/乙」随压扁自然作废。**状态列此前滞后于正文事实**，本次一并订正。｜原类别：裁定｜源出处：守密人 2026-07-19 丙裁 + 门①放行；`Public-Info-Pool/Resource/proposal/data-layer-detachment-evaluation-20260719.md` + `.../data-diagnostics/discord-rescue-net-completeness-20260719.md` |"
+        ]
+      },
+      "consumer_counts": {
+        "doc": 3
+      },
+      "kind": "release"
+    }
+  ]
+}

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -88,7 +88,7 @@
 | agent SDK 源文件 / 测试档 | 122 / 198 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 16 / 29 | 磁盘实况 |
 | testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
-| Python 测试档 | 129 | 磁盘实况 |
+| Python 测试档 | 130 | 磁盘实况 |
 | CI 工作流 / 其中定时 | 45 / 26 | `.github/workflows/` |
 | 挂账台账 开 / 已清 | 16 / 56 | `memory/todo.md` |
 

--- a/scripts/consumption_audit.py
+++ b/scripts/consumption_audit.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""产出↔消费对账 —— 「没人读的产物，该退役而不是被更好地监控」。
+
+2026-07-26 第一轮审视的结论（守密人裁定「装产出↔消费对账」）：银芯有 20+ 个定时机制
+在产数据，却**没有任何东西回答「谁在读」**。代价当天可见——`backfill-media` 停摆 **35 天**
+无人察觉：若它的产物真被消费，早该有人喊。
+
+**设计取舍：静态引用图，不做运行时埋点。**
+银芯的消费绝大多数是**结构性**的（脚本读某路径 / 工作流喂某脚本 / 档案指某产物），
+静态可判、当天出数。运行时埋点要有人记得开、要等数据——`kb_telemetry.py` 已实证该路
+会变成空登记本（工具在、`Record/kb-usage/` 零条）。本脚本因此只读仓库文本，零配置、
+零常驻、不依赖任何人记得。
+
+**诚实边界（务必随报告一起读）**：静态图看不见
+① 守密人本人翻阅报告；② 会话内艾瑞卡按需读档案；③ 黑池侧消费（防火墙外，结构上不可见）。
+故输出是**候选清单供人裁**，绝不是自动退役触发器。零消费者 = 「值得问一句还要不要」，
+不等于「可以删」。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = REPO / ".github" / "workflows"
+REPORT_PATH = REPO / "Public-Info-Pool" / "Record" / "heartbeat" / "consumption.json"
+
+# 产出声明：工作流里 `git add <路径...>` 与 `gh release upload <tag>`。
+GIT_ADD_RE = re.compile(r"^\s*git add\s+(.+)$", re.M)
+RELEASE_RE = re.compile(r"gh release upload\s+\"?([A-Za-z][\w.-]*)\"?", re.M)
+# 消费面：按文件类型分档，判「谁在读」时权重不同（代码 > 工作流 > 档案）。
+CONSUMER_GLOBS = {
+    "script": ["scripts/**/*.py", "projects/**/scripts/**/*.py", "projects/**/src/**/*.mjs"],
+    "workflow": [".github/workflows/*.yml"],
+    "test": ["tests/**/*.py"],
+    "doc": ["*.md", "memory/**/*.md", "projects/*/CONTEXT.md", ".claude/**/*.md"],
+}
+
+
+def produced_paths() -> dict[str, list[str]]:
+    """{产出路径: [声明它的工作流...]}。`git add -A` 无信息量，跳过。"""
+    produced: dict[str, list[str]] = {}
+    for wf in sorted(WORKFLOW_DIR.glob("*.yml")):
+        text = wf.read_text(encoding="utf-8")
+        for line in GIT_ADD_RE.findall(text):
+            for token in line.split():
+                if token.startswith("-"):  # -A / --all 等旗标：范围不明，无从对账
+                    continue
+                path = token.strip().rstrip("/")
+                if not path or path.startswith("$"):
+                    continue
+                produced.setdefault(path, []).append(wf.name)
+    return produced
+
+
+def produced_releases() -> dict[str, list[str]]:
+    """{release tag: [上传它的工作流...]}。"""
+    out: dict[str, list[str]] = {}
+    for wf in sorted(WORKFLOW_DIR.glob("*.yml")):
+        for tag in RELEASE_RE.findall(wf.read_text(encoding="utf-8")):
+            if tag and not tag.startswith("$"):
+                out.setdefault(tag, []).append(wf.name)
+    return out
+
+
+def _grep(needle: str) -> list[str]:
+    """全仓字面量检索，返回 `path:line`。用 git grep：只看被跟踪文件，不扫产物本身。"""
+    try:
+        res = subprocess.run(
+            ["git", "grep", "-n", "-F", needle],
+            cwd=REPO, capture_output=True, text=True, timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    return [l for l in res.stdout.splitlines() if l.strip()]
+
+
+def _classify(hit_path: str) -> str:
+    if hit_path.startswith(".github/workflows/"):
+        return "workflow"
+    if hit_path.startswith("tests/"):
+        return "test"
+    if hit_path.endswith((".py", ".mjs", ".ts")):
+        return "script"
+    if hit_path.endswith(".md"):
+        return "doc"
+    return "other"
+
+
+def audit_one(artifact: str, producers: list[str]) -> dict:
+    """一件产出的消费面。生产者自身的引用不算消费——自己写自己不叫有人读。"""
+    kinds: dict[str, list[str]] = {}
+    for hit in _grep(artifact):
+        hit_path = hit.split(":", 1)[0]
+        if hit_path in {f".github/workflows/{p}" for p in producers}:
+            continue
+        kinds.setdefault(_classify(hit_path), []).append(hit)
+    code_side = sum(len(kinds.get(k, [])) for k in ("script", "workflow", "test"))
+    via: str | None = None
+    if code_side:
+        verdict = "consumed"
+    else:
+        # 解析器盲区（本审计最重要的一条自我修正）：银芯纪律要求读侧经单一真相源
+        # 取路径（`archive_layout.community_root()` 等），于是**越守纪律的路径越不会
+        # 以字面量出现**，字面量法会把它们全判成无人读。故沿父路径回溯：父级若有代码
+        # 消费，说明该产物经解析器被读到，标 parent-consumed 而非 orphan。
+        # **只回溯一级**。首版无限上溯，结果把一切都吸收成 parent-consumed（零消费
+        # 7 件 → 0 件）——任何路径的祖先里总有个被代码提到的项目目录，守卫过度宽容
+        # 等于没有守卫。一级足以覆盖真实的解析器形态（`.../discord/jp` 经
+        # `archive_layout` 拿到的是 `.../discord`），再往上就是猜。
+        parent = str(Path(artifact).parent)
+        phits = (
+            [h for h in _grep(parent) if _classify(h.split(":", 1)[0]) in ("script", "test")]
+            if parent not in (".", "/", "")
+            else []
+        )
+        if phits:
+            verdict, via = "parent-consumed", parent
+        else:
+            verdict = "doc-only" if kinds.get("doc") else "orphan"
+    entry = {
+        "artifact": artifact,
+        "producers": sorted(set(producers)),
+        "verdict": verdict,
+        "consumers": {k: sorted(set(v))[:5] for k, v in sorted(kinds.items())},
+        "consumer_counts": {k: len(set(v)) for k, v in sorted(kinds.items())},
+    }
+    if via:
+        entry["consumed_via_parent"] = via
+    return entry
+
+
+def build_report() -> dict:
+    entries = [audit_one(p, w) for p, w in sorted(produced_paths().items())]
+    entries += [
+        {**audit_one(tag, wfs), "kind": "release"}
+        for tag, wfs in sorted(produced_releases().items())
+    ]
+    orphans = [e for e in entries if e["verdict"] == "orphan"]
+    doc_only = [e for e in entries if e["verdict"] == "doc-only"]
+    via_parent = [e for e in entries if e["verdict"] == "parent-consumed"]
+    return {
+        "method": "static-reference-graph",
+        "blind_spots": [
+            "守密人本人翻阅（不可见）",
+            "会话内按需读档（不可见）",
+            "黑池侧消费（防火墙外，结构上不可见）",
+        ],
+        "artifacts": len(entries),
+        "orphans": len(orphans),
+        "doc_only": len(doc_only),
+        "parent_consumed": len(via_parent),
+        "entries": entries,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="产出↔消费对账：找没人读的产物")
+    parser.add_argument("--out", type=Path, default=REPORT_PATH)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = build_report()
+    marks = {"orphan": "ORPHAN  ", "doc-only": "DOC-ONLY", "parent-consumed": "VIA-PARENT"}
+    for entry in report["entries"]:
+        if entry["verdict"] in ("orphan", "doc-only"):
+            print(f"  [{marks[entry['verdict']]}] {entry['artifact']}  ← {', '.join(entry['producers'])}")
+    print(
+        f"产出↔消费对账：产出 {report['artifacts']} 件 / 零消费 {report['orphans']} 件 / "
+        f"仅档案提及 {report['doc_only']} 件 / 经解析器读 {report['parent_consumed']} 件"
+    )
+    print("（静态图看不见守密人翻阅、会话内读档、黑池侧消费——候选清单供人裁，不是退役触发器）")
+
+    if not args.dry_run:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(f"报告已写入 {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_consumption_audit.py
+++ b/tests/test_consumption_audit.py
@@ -1,0 +1,97 @@
+"""产出↔消费对账单测 —— 守的是「判据别太松也别太紧」。
+
+本审计的价值全在判据的**校准**：太紧则把经解析器读的路径全诬告成无人读，太松则把
+一切吸收成「有人读」、信号归零。首版两头都撞过——无限上溯父路径时，零消费从 7 件
+变 0 件（任何路径的祖先里总有个被代码提到的项目目录）。故本组重点钉四条：
+
+1. 生产者自引不算消费（自己写自己不叫有人读）；
+2. 代码消费 > 档案提及（只有 md 提到 = doc-only 弱信号，不是 consumed）；
+3. 解析器盲区**只回溯一级**（覆盖真实形态，不吞掉信号）；
+4. 报告必须携带盲区声明（静态图看不见的三类消费，不许悄悄省掉）。
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import consumption_audit as ca  # noqa: E402
+
+
+def _fake_grep(mapping: dict[str, list[str]]):
+    return lambda needle: mapping.get(needle, [])
+
+
+class TestVerdicts:
+    def test_producer_self_reference_is_not_consumption(self, monkeypatch):
+        """产出路径只在生产它的工作流里出现 = 无人消费。"""
+        monkeypatch.setattr(ca, "_grep", _fake_grep({
+            "out/thing.json": [".github/workflows/maker.yml:12: git add out/thing.json"],
+        }))
+        assert ca.audit_one("out/thing.json", ["maker.yml"])["verdict"] == "orphan"
+
+    def test_code_reference_counts_as_consumed(self, monkeypatch):
+        monkeypatch.setattr(ca, "_grep", _fake_grep({
+            "out/thing.json": ["scripts/reader.py:3: open('out/thing.json')"],
+        }))
+        assert ca.audit_one("out/thing.json", ["maker.yml"])["verdict"] == "consumed"
+
+    def test_doc_only_mention_is_a_weaker_verdict(self, monkeypatch):
+        """档案提到 ≠ 有人读。这一档单列，供人判「是真引用还是历史残句」。"""
+        monkeypatch.setattr(ca, "_grep", _fake_grep({
+            "out/thing.json": ["memory/notes.md:9: 见 out/thing.json"],
+        }))
+        assert ca.audit_one("out/thing.json", ["maker.yml"])["verdict"] == "doc-only"
+
+    def test_resolver_mediated_path_is_credited_via_parent(self, monkeypatch):
+        """经 archive_layout 取路径的消费者不会写字面量子路径——不能因此诬告成无人读。"""
+        monkeypatch.setattr(ca, "_grep", _fake_grep({
+            "Record/Community/discord/jp": [],
+            "Record/Community/discord": ["projects/news/scripts/archive_layout.py:40: discord"],
+        }))
+        entry = ca.audit_one("Record/Community/discord/jp", ["archiver.yml"])
+        assert entry["verdict"] == "parent-consumed"
+        assert entry["consumed_via_parent"] == "Record/Community/discord"
+
+    def test_parent_walk_stops_at_one_level(self, monkeypatch):
+        """只回溯一级——无限上溯会把一切吸收成「有人读」，信号归零（首版真踩过）。"""
+        monkeypatch.setattr(ca, "_grep", _fake_grep({
+            "projects/wiki/docs/public/feed.xml": [],
+            "projects/wiki/docs/public": [],
+            # 祖父级有代码引用，但不得据此赦免
+            "projects/wiki/docs": ["scripts/build.py:1: projects/wiki/docs"],
+            "projects/wiki": ["scripts/build.py:2: projects/wiki"],
+        }))
+        assert ca.audit_one("projects/wiki/docs/public/feed.xml", ["w.yml"])["verdict"] == "orphan"
+
+
+class TestProducerParsing:
+    def test_bare_flags_are_skipped(self, tmp_path, monkeypatch):
+        """`git add -A` 范围不明，无从对账——跳过而不是当成一件叫「-A」的产物。"""
+        wf = tmp_path / "workflows"
+        wf.mkdir()
+        (wf / "a.yml").write_text("    git add -A\n    git add out/real.json\n", encoding="utf-8")
+        monkeypatch.setattr(ca, "WORKFLOW_DIR", wf)
+        assert list(ca.produced_paths()) == ["out/real.json"]
+
+    def test_release_tag_is_captured_whole(self, tmp_path, monkeypatch):
+        """带连字符的 tag 必须整取——首版正则把 community-assets 截成 `-assets`。"""
+        wf = tmp_path / "workflows"
+        wf.mkdir()
+        (wf / "b.yml").write_text(
+            "  gh release upload community-assets okf/x.gz --clobber\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(ca, "WORKFLOW_DIR", wf)
+        assert list(ca.produced_releases()) == ["community-assets"]
+
+
+def test_report_carries_its_blind_spots(monkeypatch):
+    """盲区声明是报告的一部分——省掉它，读者会把「零消费」当成「确实没人要」。"""
+    monkeypatch.setattr(ca, "produced_paths", lambda: {})
+    monkeypatch.setattr(ca, "produced_releases", lambda: {})
+    report = ca.build_report()
+    assert report["method"] == "static-reference-graph"
+    assert len(report["blind_spots"]) == 3
+    assert any("黑池" in b for b in report["blind_spots"])


### PR DESCRIPTION
## 概述

守密人 2026-07-26 裁定「装产出↔消费对账」。第一轮审视的设计结论：自检有三层——**存在性**（今天装的死手开关）· **正确性**（测试 / 棘轮 / 巡检器）· **意义性**（此前完全空白）。本 PR 是第三层的第一件仪器。

---

## 变更类型

- [x] Bug 修复 / 新能力（治理工具）
- [x] 文档完善（CLAUDE.md 命令表）
- [ ] 数据补全
- [ ] 翻译贡献
- [ ] 视觉/前端改进

---

## 来源声明

不涉及游戏数据。产出面取自工作流声明、消费面取自仓内被跟踪文本：

```
产出：.github/workflows/*.yml 的 `git add <路径>` 与 `gh release upload <tag>`
消费：git grep -F 字面量检索（只看被跟踪文件）
对照物：scripts/kb_telemetry.py 在、Public-Info-Pool/Record/kb-usage/ 零条
```

---

## 安全声明（强制）

- [x] **不含 BIAV 内网 / 黑池 / 未发布渠道数据。** 只读本仓文本。
- [x] **不含内部美术资产 / 解包原始文件 / 未公开草稿。**
- [x] **同意按 MIT License 提交。**

---

## 变更内容

### 一、为什么是静态引用图，不是运行时埋点

银芯的消费绝大多数是**结构性**的（脚本读某路径 / 工作流喂某脚本 / 档案指某产物），静态可判、**当天出数**。运行时埋点要有人记得开、要等数据——`kb_telemetry.py` 已实证那条路的终点：**工具在，`Record/kb-usage/` 零条**。仪器装了，登记本是空的。

### 二、判据校准是这件事的全部难度（两个方向都撞过）

| 版本 | 结果 | 教训 |
|---|---|---|
| 首版严格字面量 | 9 条经 `archive_layout` 解析的路径被**诬告成无人读** | **SSOT 纪律越好，字面量法越瞎**——守纪律的路径根本不写字面量 |
| 加父级无限上溯 | 零消费 **7 → 0**，信号被自己抹平 | 任何路径的祖先里总有个被代码提到的项目目录；**守卫过度宽容 = 没有守卫** |
| 现版：**只回溯一级** | 零消费 3 件，信号清晰 | 一级覆盖真实解析器形态，再往上就是猜 |

两个方向都由测试钉死（8 例）。另修一处 release 正则误截（`community-assets` → `-assets`）。

比喻：查「这本书有没有人借」，先是只认签了全名的借条（漏掉所有走图书证的人），改成认「借过这个书架的都算」（那全馆的书都算有人借），最后定在「认这一层书架」。

### 三、首跑结果

**27 件产出：3 件零消费 · 1 件仅档案提及 · 9 件经解析器读 · 14 件真实消费。**

零消费三件：`projects/news/data/media/backfill_manifest.json`（backfill-media）· `projects/wiki/docs/public/feed.xml` 与 `atom.xml`（check-version 产的 RSS，而 wiki 已冻结）。

### 四、报告自带盲区声明

静态图**看不见**三类消费：守密人本人翻阅 · 会话内按需读档 · **黑池侧消费（防火墙外，结构上不可见）**。这三条随报告一起落盘。**零消费 = 「值得问一句还要不要」，绝不等于「可以删」**——判据写进脚本文档字串与报告 JSON，防止下一个读者把候选清单当成删除清单。

---

## 验证清单

- [x] `pytest tests/` — **2993 通过 / 51 跳过**（2985 + 新增 8）
- [x] 两个失败方向各有测试钉死（诬告 / 过度宽容）
- [x] 首跑产出报告已落盘 `Public-Info-Pool/Record/heartbeat/consumption.json`
- [x] CLAUDE.md 命令表补行（对账三卫要求）
- [x] 不引入 emoji

---

## 关联

- 设计依据：`Public-Info-Pool/Resource/proposal/drift-resistant-architecture-20260726.md`
- 本会话前序：#804 → #824（14 个 PR）

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3PTjiaJAMbzSoEV45XZkk)_