### PR TITLE
fix(ci): make the pointer guard read the index, and pay the missing 0.79.1 bump

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,8 +82,8 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.79.0` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.79.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.79.1` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.79.1` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
 | agent SDK 源文件 / 测试档 | 124 / 198 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
@@ -249,6 +249,8 @@
 > schedule 错过补偿核对（已实现有测试，免补）+ 质量切换：棘轮五族全靶（新增 delivery-channel 100 /
 > workflow-load 100，CI 矩阵六靶）、四份 e2e 全部假钟化（三连稳、秒级降毫秒级）；测试 171→180。
 >
+> **v0.79.1（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.79.1（transport / MCP 内部去重）前进。
+>
 > **v0.79.0（2026-07-26）**：**重开语义（T67 甲案）+ 三项余项推进**（守密人「按你建议推进」）——`TaskLedger.reopenSession`/`reopenChain`（新会话 + `reopenOf`/`attemptRound` 链，**封闭状态机未动**：终态不可变是 CAS 围栏/幂等派发/重启不复活的共同立足点，缺的从来不是边而是链接；前驱须终态、`cancelled` 默认拒绝、后继 id 从链根派生、payload 可覆盖）· **T68** `docs/CONCURRENCY.md`（本包第二份文档）· **T69** 棘轮 `cadence` 分档（三个零消费靶降月检，加字段不删腿，cadence 自身三条治理断言）· **T70** 空转措辞钉死 + `scripts/sdk_substantive_versions.py`（守卫首跑抓到两条真漂移）。测试 404 → **421**。
 > **v0.78.1（2026-07-26）**：**产品审视四项裁定**（审视档 `Public-Info-Pool/Resource/repo-engineering/maestro-sdk-product-review-20260726.md`，同日第二轮，问「作为产品是否成立/有效」）——**P1** 删除无代码支撑的 peerDependency（src 对代理零 import，npm 7+ 自动装 peer 与硬性质①冲突）· **P2** 六族两级成熟度标注（`ledger`/`driver`/`scheduler` **已验证**：两个互不相干真实消费方；`workflow`/`goal`/`delivery` **实验面零调用点**）+ 需求档 §6 补「已验证」标尺（须有非为演示它而写的消费方）· **P3** 首份 `docs/ONBOARDING.md`（store 可复制样板，实测两消费方各自手写 43/38 行、相似度 86%；**测试从 markdown 提取样板真跑契约套件**）· **P5** 判别式补第三维「触发权」（delivery 归属正当、是判据漏维）。**运行时行为零变化**，测试 400 → **404**。
 > **v0.78.0（2026-07-26）**：**设计审视四缝全修**（审视档 `Public-Info-Pool/Resource/repo-engineering/maestro-sdk-design-review-20260726.md`，守密人同日四裁均取推荐案）——F1 `cancelled` 终态穿透场景层（三处硬编码 `done || failed`，默认配置下用户取消致工作流/目标追逐**永久挂死**；`graphStatus` 判 fail-fast、`GoalChaser` 新 action `'cancelled'`，新增 `isTerminal`/`isUnsuccessfulTerminal` + **禁字面量终态对的治理守卫**）· F2 驱动器 `maxConcurrent`（实测 200 到期→峰值 200）+ `claimDue(now,{limit})` · F3 可选存储缝 `deleteSession?` + 网关 `purgeSession`（契约套件 +4 检查）· F4 两长跑组件收 `AbortSignal`。测试 362 → **400**，三机制逐条回退负控实证。**未纳入**：Scheduler 全表扫、F5「重开」语义（挂待裁）。
@@ -314,6 +316,7 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.79.1（2026-07-27）**：内部去重，零表面/行为变化——重试退避与 JSON-RPC 两族重复实现分别收敛为 `transport/http-retry.ts` / `mcp/protocol.ts`，六档净 −288 行。随 #835 合并时漏 bump 致版本门禁在 main 红约一小时，本版为补票（详见 CHANGELOG）。
 - **v0.79.0（2026-07-26，锁步对齐）**：本包**零代码改动**；随 maestro 0.79.0 前进，同批订正本包 0.72.0/0.70.0 两条空转条目措辞（内容未变）。
 - **v0.78.1（2026-07-26，锁步对齐）**：本包**零代码改动**；家族版本钟随 maestro 0.78.1（产品审视四裁，含删除其对本包的无支撑 peerDependency）整体前进。
 - **v0.78.0（2026-07-26，锁步对齐）**：本包**零代码改动**；家族版本钟随 maestro 0.78.0（设计审视四缝全修）整体前进，详见 maestro CHANGELOG。

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,6 +12,11 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
+## 0.79.1 — 2026-07-27
+
+Lockstep alignment only — no changes to this package. The family clock advanced
+for silver-core-agent-sdk 0.79.1 (transport / MCP internal dedup).
+
 ## 0.79.0 — 2026-07-26
 
 Reopen semantics (T67 / design review F5 — keeper ruling 2026-07-26, option 甲:

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,11 +36,14 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.79.0`** · 发布日 2026-07-26 · 家族锁步对端 `silver-core-agent-sdk` = `0.79.0`
+**当前版本 `0.79.1`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.79.1`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.79.1（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.79.1
+（transport / MCP 内部去重）前进。
 
 **v0.79.0（2026-07-26）：重开语义 + 三项余项推进**（守密人「1.写 2.3.4.5.6.按你建议推进」）。
 **T67 重开（甲案）**：`reopenSession` / `reopenChain`——新会话 + `reopenOf`/`attemptRound` 链，

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.79.0';
+export const MAESTRO_SDK_VERSION = '0.79.1';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,25 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.79.1 — 2026-07-27
+
+Internal dedup, no surface or behaviour change. The retry / backoff / error-body
+/ stream-error / idle-watchdog logic that had been copied across
+`transport/anthropic.ts` and `transport/openai.ts` moved into one shared
+`transport/http-retry.ts`; the JSON-RPC message shape / result parsing /
+pagination / version negotiation duplicated between `mcp/http.ts` and
+`mcp/stdio.ts` moved into `mcp/protocol.ts`. Net -288 lines across six src
+files. The unit suite (3,214 tests) and the api-surface guards passed unchanged
+through the move, which is the evidence that the surface did not shift.
+
+**Ledger note**: the change itself shipped in the merge of #835 (2026-07-27),
+which landed WITHOUT a bump — the version-bump guard reded on main and stayed
+red until this entry. Version 0.79.1 therefore labels content that was already
+on main under the 0.79.0 label for roughly one hour. Consumers pinning
+0.79.0 tarballs built in that window get the pre-refactor content; anything
+built after gets 0.79.1. Recorded rather than papered over: the guard did its
+job, the merge went around it.
+
 ## 0.79.0 — 2026-07-26
 
 Lockstep alignment only — no agent-side changes. The family clock advanced for

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -69,11 +69,18 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.79.0`** · 发布日 2026-07-26 · 家族锁步对端 `silver-core-maestro-sdk` = `0.79.0`
+**当前版本 `0.79.1`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.79.1`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.79.1（2026-07-27）：内部去重，零表面变化**——重试/退避/错误体/流错误/空闲看门狗从
+`transport/anthropic.ts` 与 `transport/openai.ts` 各抄一份收敛为 `transport/http-retry.ts`；
+JSON-RPC 报文形状/结果解析/分页/版本协商从 `mcp/http.ts` 与 `mcp/stdio.ts` 收敛为
+`mcp/protocol.ts`。六个 src 档净 −288 行，3,214 测试与 api-surface 守卫原样通过即表面未动的证据。
+**照实记**：该改动随 #835 合并时**未 bump**，版本门禁在 main 上红了约一小时——本条是补票，
+故 0.79.0 标签在那段窗口里同时对应了改动前后两份内容，见 CHANGELOG 同条。
 
 **v0.79.0（2026-07-26）：锁步对齐**——本包**零代码改动**。家族版本钟随 maestro 0.79.0（重开语义 + CONCURRENCY 文档 + 棘轮 cadence 分档）前进；同批订正本档 0.72.0 / 0.70.0 两条空转条目的措辞（内容未变，改为机器可识别的规范开头）。
 

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.79.0';
+export const SDK_VERSION = '0.79.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/tests/test_curated_doc_pointers.py
+++ b/tests/test_curated_doc_pointers.py
@@ -18,11 +18,48 @@ CLAUDE.md §5.2 正面冲突；照着它走的会话会空手而归，还以为�
 from __future__ import annotations
 
 import re
+import subprocess
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
 
 REPO = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# 真相源 = git 索引，不是文件系统。
+#
+# 首版问 `Path.exists()`，本地全绿、CI 当场红两条（`Public-Info-Pool/Record/` 与
+# `…/store-patrol/`）：`test.yml` 走 sparse checkout 排除了 `/Public-Info-Pool/Record/`，
+# 那些档案**在仓里、只是没被检出**。判词随 checkout 形态变化的守卫比没有守卫更坏——
+# 它会指着好路径喊落空，训练人无视它。
+#
+# sparse checkout 只给文件打 skip-worktree，**索引仍是完整的**，故 `git ls-files`
+# 在稀疏与全量检出下给出同一个答案。这也顺带修正了另一半：未被 git 跟踪的生成物
+# 从此不算「存在」——档案本就不该拿一份别人 clone 之后不存在的东西当指针。
+# ---------------------------------------------------------------------------
+@lru_cache(maxsize=1)
+def _tracked() -> frozenset[str]:
+    out = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return frozenset(line for line in out.splitlines() if line)
+
+
+@lru_cache(maxsize=1)
+def _tracked_dirs() -> frozenset[str]:
+    dirs: set[str] = set()
+    for f in _tracked():
+        parts = f.split("/")
+        for i in range(1, len(parts)):
+            dirs.add("/".join(parts[:i]))
+    return frozenset(dirs)
+
+
+def _in_repo(path: str) -> bool:
+    return path in _tracked() or path in _tracked_dirs()
 
 # 被会话当指令执行的档案。dated 范例（example-*.md）是定格快照、不是指令，排除。
 def _curated_docs() -> list[Path]:
@@ -45,7 +82,11 @@ _PACKAGE_ROOTS = [
     "site",
     "game",
 ]
-BASES = [REPO] + [REPO / "projects" / p for p in _PACKAGE_ROOTS]
+BASES = [""] + [f"projects/{p}/" for p in _PACKAGE_ROOTS]
+
+
+def _candidates(path: str) -> list[str]:
+    return [base + path for base in BASES]
 
 # 只认这些顶层段开头的串是「仓内路径」，其余反引号内容（命令、字段名、URL）不管。
 ROOT_SEGMENTS = {
@@ -112,7 +153,7 @@ def _dangling(doc: Path) -> list[tuple[int, str]]:
                 continue
             if (rel_doc, raw) in EXCUSED:
                 continue
-            if any((base / path).exists() for base in BASES):
+            if any(_in_repo(c) for c in _candidates(path)):
                 continue
             out.append((lineno, raw))
     return out
@@ -145,6 +186,23 @@ def test_every_excuse_has_a_reason() -> None:
     """空理由的豁免等于没豁免——它只是把问题藏进了字典。"""
     empty = [k for k, v in EXCUSED.items() if not v.strip()]
     assert not empty, f"以下豁免没写理由: {empty}"
+
+
+def test_existence_is_decided_by_the_index_not_the_worktree() -> None:
+    """**本组自身的防复发条**：判据必须是 git 索引，不是文件系统。
+
+    首版问 `Path.exists()`，本地 25 绿而 CI 当场红——`test.yml` 走 sparse checkout
+    排除 `/Public-Info-Pool/Record/`，档案在仓里却没被检出，守卫指着好路径喊落空。
+    这里拿两条**当时正是这样红掉**的路径当哨兵：它们必须被判为「在仓内」。稀疏检出下
+    它们不在磁盘上，所以任何回退到文件系统的实现都会在这条上当场失败。
+    """
+    for sentinel in ("Public-Info-Pool/Record", "Public-Info-Pool/Record/store-patrol"):
+        assert _in_repo(sentinel), (
+            f"{sentinel} 被判为不在仓内——判据疑似退回文件系统。"
+            f"sparse checkout 下它不在磁盘上，但它在索引里。"
+        )
+    # 反向：索引里没有的东西不能因为磁盘上碰巧有（生成物 / 本地残留）就算数。
+    assert not _in_repo("okf/kb_index.json") or "okf/kb_index.json" in _tracked()
 
 
 def test_the_guard_actually_covers_the_operational_surface() -> None:


### PR DESCRIPTION
main 上两处红，成因不同，一并修。

## 红 1：指针守卫的判词随 checkout 形态变化（#836 的回归，艾瑞卡自己造的）

`test.yml` 走 sparse checkout 排除 `/Public-Info-Pool/Record/`。#836 新增的守卫用 `Path.exists()` 判存在性，于是两条**完全正常**的路径（`Public-Info-Pool/Record/` 与 `…/store-patrol/`）在 CI 上被判落空——本地 25 绿、CI 红 2。

**判词随检出形态变化的守卫比没有守卫更坏**：它指着好路径喊落空，训练人无视它。

改判据为 **git 索引**（`git ls-files`）。sparse checkout 只给文件打 skip-worktree，**索引仍完整**，稀疏与全量检出给出同一答案。顺带收紧另一半：未被跟踪的生成物从此不算「存在」——档案本就不该拿别人 clone 后不存在的东西当指针。

**按 CI 条件实证，非仅本地**：起一个同样 sparse 模式的 detached worktree（`Public-Info-Pool/Record/` **不在磁盘上**），修复后 26 例全绿，修复前同条件红 2。新增一条元测试拿那两条路径当哨兵钉死真相源——任何退回文件系统的实现会在这条上当场失败。

## 红 2：#835 漏 bump（另一会话合并时 SDK 检查红着）

`0732cfd`（PR #835）改了 6 个 `silver-core-sdk/src/` 档（重试退避收敛为 `transport/http-retry.ts`、JSON-RPC 收敛为 `mcp/protocol.ts`，净 −288 行），**未动 package.json**，在其 SDK 检查红着的状态下被并进 main。版本门禁自此持续红。

补票：0.79.0 → **0.79.1**，两包同步（agent 实质变更、maestro 锁步空转——家族版本钟纪律两份 CHANGELOG 均已明写），含 `package.json` + 版本常量 + CHANGELOG + 叙述新鲜度守卫要求的四处人写叙述。

CHANGELOG 里**照实记**「0.79.0 这个标签在约一小时窗口内同时对应改动前后两份内容」，不静默改写：**门禁尽了职，是合并绕过了它**。

## 验证

`pytest tests/` **3,025 通过 / 51 跳过** · agent vitest **3,237 通过** · maestro **428 通过**。

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3PTjiaJAMbzSoEV45XZkk)_