### PR TITLE
fix(sdk): 两条提示词溯源 slug 改锚 + 给刷新 cron 补自检（v0.80.1）

### DIFF
--- a/.github/workflows/refresh-claude-code-prompts.yml
+++ b/.github/workflows/refresh-claude-code-prompts.yml
@@ -34,6 +34,40 @@ jobs:
       - name: Refresh upstream prompts snapshot
         run: python3 scripts/refresh_claude_code_prompts.py
 
+      # 自检（2026-07-27 守密人裁定）：本任务带 [skip ci] 直推 main，破绽要等下一个
+      # 不相干的 PR 跑门禁才暴露——2026-07-27 就是一次工具上限对齐替本任务扛了报红。
+      # SDK 侧有两条「提示词溯源锚点」守卫按 slug 指向本快照的具体档案，上游一改名 /
+      # 删档就断。故刷新后、提交前就地跑一遍：**红则不提交、不直推**，本任务自己报红。
+      # 快照本身没丢——上游仓库还在，修好 slug 后下一轮照常采回来。
+      # 第二道网：本任务持续失败会被 dead-man-switch.yml 按「最近一次成功超时」抓出。
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install deps (workspace root)
+        run: npm ci
+
+      - name: Provenance guard — refreshed snapshot must still anchor the SDK's faithful fragments
+        working-directory: projects/silver-core-sdk
+        run: npx vitest run tests/prompt-fragments-provenance.test.ts tests/sendmessage.test.ts
+
+      - name: Explain the drift (guard failed — snapshot NOT committed)
+        if: failure()
+        run: |
+          {
+            echo "## 提示词快照刷新被自检拦下"
+            echo
+            echo "上游快照已刷新，但 SDK 侧溯源锚点守卫报红，**本轮未提交、未直推 main**。"
+            echo
+            echo "多半是上游改名或删档，导致某条 \`slug\` 指空。修法："
+            echo
+            echo "1. 看上面守卫日志里点名的 slug；"
+            echo "2. 在 \`Public-Info-Pool/Reference/Claude-Code-System-Prompts/system-prompts/\` 里找它的新名字（或合并去处）；"
+            echo "3. 改 \`projects/silver-core-sdk/src/engine/prompt-fragments.ts\` / \`src/subagents/agents.ts\` 里的 slug；"
+            echo "4. 改 slug 属 shipped 运行时改动，须 bump 版本（两包锁步）+ CHANGELOG 一行；"
+            echo "5. 合并后手动 \`workflow_dispatch\` 重跑本任务，把快照采回来。"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Commit refreshed snapshot
         run: |
           git config user.name "github-actions[bot]"

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,8 +82,8 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.80.0` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.80.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.80.1` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.80.1` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
 | agent SDK 源文件 / 测试档 | 134 / 198 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
@@ -249,6 +249,8 @@
 > schedule 错过补偿核对（已实现有测试，免补）+ 质量切换：棘轮五族全靶（新增 delivery-channel 100 /
 > workflow-load 100，CI 矩阵六靶）、四份 e2e 全部假钟化（三连稳、秒级降毫秒级）；测试 171→180。
 >
+> **v0.80.1（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.80.1（两条提示词溯源 slug 改锚 + 刷新 cron 补自检）前进。
+>
 > **v0.80.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.80.0（工具输出上限对齐 Claude Code 2.1.141：WebFetch 100_000 → Read 的 50_000、Grep `head_limit` 三模式统一默认 250、Bash 输出截断改保尾去头）前进。
 >
 > **v0.79.1（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.79.1（transport / MCP 内部去重）前进。
@@ -318,6 +320,7 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.80.1（2026-07-27）**：**两条提示词溯源 slug 改锚 + 给刷新 cron 补自检**（守密人 2026-07-27 交互裁「一并修 + 给 cron 补自检」）——上游快照 2.1.173 → 2.1.216（今日 cron 76fe5e6 带 `[skip ci]` 直推 main）改名 24 档 / 删 5 档，SDK 侧两条 slug 指空、两条 corpus-sync 守卫在 main 上报红。① `COORDINATOR_WORKER_PROVENANCE.slug` → `agent-prompt-coordinator-worker-instructions`（纯改名，守卫抽出的 15 个锚点句逐字仍在）· ② `MAIN_LOOP_INTRO.slug` → `system-prompt-harness-instructions`（上游把三个 intro 小档合并进它，原句未变、现居开篇模板的「无 output style」分支；`faithful` 仍成立，注释写明 faithful 于**分支**非整档）。**零 shipped 提示词文本改动**。同批给 `refresh-claude-code-prompts.yml` 补自检：刷新后、提交前跑这两条守卫，**红则不提交不直推**，第二道网是 dead-man-switch 按「最近一次成功超时」抓持续失败。
 - **v0.80.0（2026-07-27）**：**工具输出上限对齐 Claude Code 2.1.141**（守密人交付单三处独立改动，常量取自 `claude.exe` 内含明文 JS）——① WebFetch 上限 **100_000 → 复用 Read 的 50_000**（官方那个数管的是「喂摘要小模型的输入」、主上下文只收摘要；本 SDK 直连无摘要层，同一个数字变成「原文直灌主上下文」，反让 WebFetch 独享两倍 Read 额度，而它拉的是最不可控的外部网页；改为引用`MAX_READ_OUTPUT_CHARS` 常量防两闸门再漂移）· ② Grep `head_limit` **三种 output_mode 统一默认 250**（原 count / files_with_matches 默认无限；OPT-1 担忧的「截断的 count 是错的 count」已由同批的「每种模式都追加截断提示」解决，要可证完整仍显式传 `head_limit=0`）· ③ Bash 输出截断**改保尾去头**、标记移到开头（长命令的结论在末尾：构建成败 / 测试汇总 / 最终报错；新增 `sliceTailSurrogateSafe`镜像 helper，尾切丢的是开头低位代理）。**刻意不改** Read 的字符计量（对齐 token 需引入 tokenizer运行时依赖，且字符计量在中文场景反更宽）。测试新增 5 条（上限对齐三处各自钉死 + 尾切代理边界），本容器实测 **3,247 条**（3,239 通过 / 6 跳过 / **2 失败**——两条均为 2026-07-27 上游提示词快照刷新 76fe5e6 导致的档案锚点漂移治理测试，**HEAD 上同样红**，与本次改动无关）。
 - **v0.79.1（2026-07-27）**：内部去重，零表面/行为变化——重试退避与 JSON-RPC 两族重复实现分别收敛为 `transport/http-retry.ts` / `mcp/protocol.ts`，六档净 −288 行。随 #835 合并时漏 bump 致版本门禁在 main 红约一小时，本版为补票（详见 CHANGELOG）。
 - **v0.79.0（2026-07-26，锁步对齐）**：本包**零代码改动**；随 maestro 0.79.0 前进，同批订正本包 0.72.0/0.70.0 两条空转条目措辞（内容未变）。

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,6 +12,12 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
+## 0.80.1 — 2026-07-27
+
+Lockstep alignment only — no changes to this package. The family clock advanced
+for silver-core-agent-sdk 0.80.1 (two prompt-provenance slugs re-pointed after
+the upstream snapshot renamed one source file and folded another away).
+
 ## 0.80.0 — 2026-07-27
 
 Lockstep alignment only — no changes to this package. The family clock advanced

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,11 +36,14 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.80.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.80.0`
+**当前版本 `0.80.1`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.80.1`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.80.1（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.80.1
+（两条提示词溯源 slug 随上游快照改名 / 合并而改锚，另给刷新 cron 补自检）前进。
 
 **v0.80.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.80.0
 （工具输出上限对齐 Claude Code 2.1.141：WebFetch 100_000 → Read 的 50_000、Grep `head_limit`

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.80.0';
+export const MAESTRO_SDK_VERSION = '0.80.1';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,36 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.80.1 — 2026-07-27
+
+Two prompt-provenance slugs re-pointed after the upstream snapshot moved under
+them (2.1.173 -> 2.1.216, refreshed onto main by cron in 76fe5e6). Both had
+been left naming files that no longer exist, so the two corpus-sync guards —
+the tests whose whole job is to turn upstream drift into a failure instead of a
+silent divergence — were red on main. They did their job; this is the follow-up
+they were asking for.
+
+- `COORDINATOR_WORKER_PROVENANCE.slug`:
+  `system-prompt-coordinator-worker-instructions` ->
+  `agent-prompt-coordinator-worker-instructions`. A rename in upstream's
+  naming pass; all 15 anchor sentences the guard extracts are still present in
+  the shipped instructions verbatim, so nothing but the slug moved.
+- `MAIN_LOOP_INTRO.slug`: `system-prompt-interactive-agent-intro-short` ->
+  `system-prompt-harness-instructions`. Upstream folded the three standalone
+  intro files into one harness-instructions reconstruction; the sentence is
+  unchanged, now living in that file's opening template as the no-output-style
+  branch. Still `faithful: true`, with a comment recording what it is faithful
+  TO: one branch of a templated source, not the file end to end.
+
+No shipped prompt TEXT changed — only the two provenance pointers and their
+comments. Guarded surfaces re-verified green (23 tests across the two files).
+
+Outside the package, the cron that refreshes the snapshot
+(`refresh-claude-code-prompts.yml`) now runs these two guards after refreshing
+and BEFORE committing, and pushes nothing when they red. That cron commits with
+`[skip ci]` straight to main, so until now the breakage it caused surfaced only
+in the next unrelated PR's merge gate — which is exactly how it was found.
+
 ## 0.80.0 — 2026-07-27
 
 Tool-output limits realigned with Claude Code 2.1.141 (keeper delivery note,

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -69,11 +69,23 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.80.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.80.0`
+**当前版本 `0.80.1`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.80.1`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.80.1（2026-07-27）：两条提示词溯源 slug 改锚 + 给刷新 cron 补自检**——上游快照
+2.1.173 → 2.1.216（今日 cron 76fe5e6 直推 main）改名 24 档、删 5 档，两条 slug 指空，
+两条 corpus-sync 守卫在 main 上报红。① `COORDINATOR_WORKER_PROVENANCE.slug` 随上游命名
+规范化改指 `agent-prompt-coordinator-worker-instructions`（守卫抽出的 15 个锚点句在
+shipped 文本里逐字仍在，只动 slug）；② `MAIN_LOOP_INTRO.slug` 改指
+`system-prompt-harness-instructions`——上游把三个 intro 小档合并进它，那句话逐字未变、
+现居该档开篇模板的「无 output style」分支，故 `faithful: true` 仍成立，但注释里写明它
+faithful 于**模板档的一个分支**而非整档。**零 shipped 提示词文本改动**。
+包外同批：`refresh-claude-code-prompts.yml` 刷新后、提交前就地跑这两条守卫，**红则不提交
+不直推**——该 cron 带 `[skip ci]` 直推 main，此前它捅的破绽要等下一个不相干 PR 跑门禁才
+暴露（本次正是这么被发现的）。
 
 **v0.80.0（2026-07-27）：工具输出上限对齐 Claude Code 2.1.141**——守密人交付单三处独立改动
 （常量取自 `claude.exe` 内含明文 JS）。① **WebFetch 上限 100_000 → 复用 Read 的 50_000**：

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/prompt-fragments.ts
+++ b/projects/silver-core-sdk/src/engine/prompt-fragments.ts
@@ -138,10 +138,20 @@ export const CONTINUATION_FRAGMENT: PromptFragment = {
     'control (say exactly what is missing).',
 };
 
-/** The identity intro (always first). */
+/**
+ * The identity intro (always first).
+ *
+ * Re-anchored 2026-07-27 (upstream 2.1.173 -> 2.1.216): the three standalone
+ * `system-prompt-interactive-agent-intro-*` files were folded into the single
+ * `system-prompt-harness-instructions` reconstruction, and the old slug's file
+ * no longer exists. The sentence itself did not change — it now lives in that
+ * file's opening template, as the branch taken when no output style is
+ * configured. `faithful` therefore still holds, but note what it is faithful
+ * TO: one BRANCH of a templated source, not the file end to end.
+ */
 export const MAIN_LOOP_INTRO: PromptFragment = {
   id: 'intro',
-  slug: 'system-prompt-interactive-agent-intro-short',
+  slug: 'system-prompt-harness-instructions',
   faithful: true,
   text: 'You are an interactive agent that helps users with software engineering tasks.',
 };

--- a/projects/silver-core-sdk/src/subagents/agents.ts
+++ b/projects/silver-core-sdk/src/subagents/agents.ts
@@ -428,7 +428,8 @@ export const COORDINATOR_MODE_PROMPT_PROVENANCE = {
 /**
  * Coordinator worker instructions — a faithful OPEN reproduction of the
  * official coordinator-assigned-worker prompt (archive slug
- * system-prompt-coordinator-worker-instructions, ccVersion 2.1.213 — synced
+ * agent-prompt-coordinator-worker-instructions — renamed from system-prompt-…
+ * in the 2.1.216 snapshot; ccVersion 2.1.213 — synced
  * 2026-07-20 when upstream flipped the no-subagents rule to bounded fan-out),
  * with the single \`\${AGENT_TOOL_NAME}\` variable resolved to Agent.
  * Corpus-sync guard: tests/subagents.test.ts.
@@ -471,9 +472,16 @@ Structure your response as:
 Good summary: "Added Redis cache implementation. Tests pass, typecheck clean. Committed abc123."
 Bad summary: "I looked at files X, Y, and Z. Y has the changes you mentioned."`;
 
-/** Provenance for the coordinator-worker instructions surface. */
+/**
+ * Provenance for the coordinator-worker instructions surface.
+ *
+ * Slug updated 2026-07-27 (upstream 2.1.173 -> 2.1.216): the reconstruction was
+ * renamed `system-prompt-…` -> `agent-prompt-…` with the rest of that snapshot's
+ * naming pass. Rename only as far as this surface is concerned — all 15 anchor
+ * sentences the corpus-sync guard extracts are still present verbatim below.
+ */
 export const COORDINATOR_WORKER_PROVENANCE = {
-  slug: 'system-prompt-coordinator-worker-instructions',
+  slug: 'agent-prompt-coordinator-worker-instructions',
   faithful: true,
 } as const;
 

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.80.0';
+export const SDK_VERSION = '0.80.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;


### PR DESCRIPTION
## 概述

修 main 上两条既有红档，并堵住让它们悄悄进 main 的那条路。守密人 2026-07-27 交互裁定「一并修 + 给 cron 补自检」。

每周 cron 把上游提示词快照从 **2.1.173 刷到 2.1.216** 并带 `[skip ci]` 直推 main（[76fe5e6](https://github.com/lightproud/BIAV-SC-CODE/commit/76fe5e6)），这一版做了命名规范化：**改名 24 档、删 5 档**。SDK 侧两条 slug 因此指向不存在的档案，两条 corpus-sync 守卫报红——这两条守卫存在的唯一目的就是「把上游漂移变成一次测试失败，而不是一次静默分歧」，它们尽职响了，本 PR 是它们要的后续动作。

---

## 变更类型

- [x] Bug 修复（两条 slug 指空）
- [x] 其他（请说明）：CI 工作流补自检 + 家族锁步版本推进

### ① `COORDINATOR_WORKER_PROVENANCE.slug`

`system-prompt-coordinator-worker-instructions` → `agent-prompt-coordinator-worker-instructions`。纯改名（上游命名规范化那一批）。**实测**：守卫从新档抽出 **15 个锚点句，SDK 侧缺失 0**——git 判定的 22% 内容差异全部落在锚点句以外，shipped 文本一字未动，只有指针移了。

### ② `MAIN_LOOP_INTRO.slug`

`system-prompt-interactive-agent-intro-short` → `system-prompt-harness-instructions`。上游把三个 `interactive-agent-intro-*` 小档合并进了 harness-instructions 一档；那句话逐字未变，现居该档开篇模板中「无 output style」的分支：

```
${OUTPUT_STYLE_CONFIG!==null?'…according to your "Output Style"…':"You are an interactive agent that helps users with software engineering tasks."}
```

故 `faithful: true` 仍成立，但注释里写明了它 faithful 于**模板档的一个分支**、而非整档逐字对齐——免得下次有人误以为整档都该对上。

**两处合计零 shipped 提示词文本改动**，只动指针与注释。

### ③ 给刷新 cron 补自检

`.github/workflows/refresh-claude-code-prompts.yml`：刷新后、提交前就地跑这两条守卫，**红则不提交、不直推**，任务自己报红。快照不会因此丢失——上游仓库还在，slug 修好后手动 `workflow_dispatch` 一跑就采回来；守卫红时另写一段 step summary 说明修法。第二道网：本任务持续失败会被 `dead-man-switch.yml` 按「最近一次成功超时」抓出（它数的正是空座位）。

根因：该 cron 带 `[skip ci]` 直推 main，此前它捅的破绽要等**下一个不相干 PR** 跑合并前门禁才暴露——本次正是一次工具上限对齐替它扛了报红。

---

## 来源声明

- [x] 不涉及游戏数据。改动落在银芯自有工程产物与 CI 配置内；引用的上游快照为公开参照层既有内容。

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不上传内部美术资产 / 客户端解包原始文件 / 未公开剧情草稿。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py` **全部通过**（exit 0）
- [x] `python3 scripts/premerge_gate.py --sparse` **稀疏检出形态下同样通过**（本改动正属「档案路径判据」这一类，即 2026-07-27 #836 让 main 变红的第二类差集）
- [x] agent SDK **3,242 通过 / 5 跳过（共 3,247）**——两条红档转绿，另一条原因档案缺失而跳过的用例现在真跑了
- [x] Python **3,049 通过 / 51 跳过** · maestro **428** · testbed **37**
- [x] 不引入 emoji
- [x] 未改 `memory/decisions.md` / `memory/lessons-learned.md`

## 家族锁步

改 slug 属 shipped 运行时改动，触发版本纪律：两包同步 **0.80.0 → 0.80.1**（patch），maestro 侧为 `Lockstep alignment only` 空转条；机器事实块经 `python3 scripts/build_status_facts.py` 重算。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr

---
_Generated by [Claude Code](https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr)_