### PR TITLE
fix(sdk): 对齐 2.1.216 快照基准（v0.80.2，补 #845 空合并）

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,8 +82,8 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.80.1` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.80.1` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.80.2` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.80.2` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
 | agent SDK 源文件 / 测试档 | 134 / 198 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
@@ -249,6 +249,8 @@
 > schedule 错过补偿核对（已实现有测试，免补）+ 质量切换：棘轮五族全靶（新增 delivery-channel 100 /
 > workflow-load 100，CI 矩阵六靶）、四份 e2e 全部假钟化（三连稳、秒级降毫秒级）；测试 171→180。
 >
+> **v0.80.2（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.80.2（对齐 2.1.216 快照基准）前进。
+>
 > **v0.80.1（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.80.1（两条提示词溯源 slug 改锚 + 刷新 cron 补自检）前进。
 >
 > **v0.80.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.80.0（工具输出上限对齐 Claude Code 2.1.141：WebFetch 100_000 → Read 的 50_000、Grep `head_limit` 三模式统一默认 250、Bash 输出截断改保尾去头）前进。
@@ -320,6 +322,7 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.80.2（2026-07-27）**：**对齐 2.1.216 快照基准**（守密人裁「3 也直接对齐基准」）——① 手工挖出**第三条指空 slug**（`SendMessage` 引用被快照改名），真因是**缺档检查搭在锚点检查里、而锚点检查跳过 adapted 条目**，现拆为独立测试 faithful/adapted 一视同仁；② 新增 `projects/silver-core-sdk/scripts/description-coverage.mjs`——把「散文基准漂没漂」变成一条命令，**报告体恒 exit 0**（吻合度本就不该满分：红线纪律禁止描述未发货能力）。实测 30 档 18 档 100%，低分端全是已登记改编。**射程边界**：0.80.0 那批**数值上限对不了**（重建档把数字模板化、grep 档无参数级文档），仍只靠一次 2.1.141 二进制提取支撑，重新核验须在装有 Claude Code 的机器上再提取。
 - **v0.80.1（2026-07-27）**：**两条提示词溯源 slug 改锚 + 给刷新 cron 补自检**（守密人 2026-07-27 交互裁「一并修 + 给 cron 补自检」）——上游快照 2.1.173 → 2.1.216（今日 cron 76fe5e6 带 `[skip ci]` 直推 main）改名 24 档 / 删 5 档，SDK 侧两条 slug 指空、两条 corpus-sync 守卫在 main 上报红。① `COORDINATOR_WORKER_PROVENANCE.slug` → `agent-prompt-coordinator-worker-instructions`（纯改名，守卫抽出的 15 个锚点句逐字仍在）· ② `MAIN_LOOP_INTRO.slug` → `system-prompt-harness-instructions`（上游把三个 intro 小档合并进它，原句未变、现居开篇模板的「无 output style」分支；`faithful` 仍成立，注释写明 faithful 于**分支**非整档）。**零 shipped 提示词文本改动**。同批给 `refresh-claude-code-prompts.yml` 补自检：刷新后、提交前跑这两条守卫，**红则不提交不直推**，第二道网是 dead-man-switch 按「最近一次成功超时」抓持续失败。
 - **v0.80.0（2026-07-27）**：**工具输出上限对齐 Claude Code 2.1.141**（守密人交付单三处独立改动，常量取自 `claude.exe` 内含明文 JS）——① WebFetch 上限 **100_000 → 复用 Read 的 50_000**（官方那个数管的是「喂摘要小模型的输入」、主上下文只收摘要；本 SDK 直连无摘要层，同一个数字变成「原文直灌主上下文」，反让 WebFetch 独享两倍 Read 额度，而它拉的是最不可控的外部网页；改为引用`MAX_READ_OUTPUT_CHARS` 常量防两闸门再漂移）· ② Grep `head_limit` **三种 output_mode 统一默认 250**（原 count / files_with_matches 默认无限；OPT-1 担忧的「截断的 count 是错的 count」已由同批的「每种模式都追加截断提示」解决，要可证完整仍显式传 `head_limit=0`）· ③ Bash 输出截断**改保尾去头**、标记移到开头（长命令的结论在末尾：构建成败 / 测试汇总 / 最终报错；新增 `sliceTailSurrogateSafe`镜像 helper，尾切丢的是开头低位代理）。**刻意不改** Read 的字符计量（对齐 token 需引入 tokenizer运行时依赖，且字符计量在中文场景反更宽）。测试新增 5 条（上限对齐三处各自钉死 + 尾切代理边界），本容器实测 **3,247 条**（3,239 通过 / 6 跳过 / **2 失败**——两条均为 2026-07-27 上游提示词快照刷新 76fe5e6 导致的档案锚点漂移治理测试，**HEAD 上同样红**，与本次改动无关）。
 - **v0.79.1（2026-07-27）**：内部去重，零表面/行为变化——重试退避与 JSON-RPC 两族重复实现分别收敛为 `transport/http-retry.ts` / `mcp/protocol.ts`，六档净 −288 行。随 #835 合并时漏 bump 致版本门禁在 main 红约一小时，本版为补票（详见 CHANGELOG）。

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,6 +12,13 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
+## 0.80.2 — 2026-07-27
+
+Lockstep alignment only — no changes to this package. The family clock advanced
+for silver-core-agent-sdk 0.80.2 (prompt-basis realignment against the 2.1.216
+snapshot: a third dangling provenance slug fixed, the existence guard widened to
+adapted entries, and a coverage ruler added).
+
 ## 0.80.1 — 2026-07-27
 
 Lockstep alignment only — no changes to this package. The family clock advanced

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,11 +36,13 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.80.1`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.80.1`
+**当前版本 `0.80.2`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.80.2`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.80.2（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.80.2（对齐 2.1.216 快照基准：第三条指空 slug 修复 + 缺档守卫扩及 adapted 条目 + 新增吻合度尺子）前进。
 
 **v0.80.1（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.80.1
 （两条提示词溯源 slug 随上游快照改名 / 合并而改锚，另给刷新 cron 补自检）前进。

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.80.1';
+export const MAESTRO_SDK_VERSION = '0.80.2';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,48 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.80.2 — 2026-07-27
+
+Baseline realignment against the refreshed 2.1.216-era archive snapshot (keeper
+ruling 2026-07-27, "3 也直接对齐基准"). The comparison basis had gone stale two
+ways at once, and only one of them is fixable in this repository — both are now
+recorded in docs/COMPAT.md under "Baseline realignment".
+
+- **A third dangling provenance slug, found by hand.** `SendMessage` cited
+  `tool-description-sendmessagetool`; the snapshot renamed it to
+  `tool-description-sendmessage`. It stayed green because the existence check
+  rode inside the anchor check, which skips ADAPTED entries — so an adapted
+  description could point at a deleted file indefinitely. Existence is now its
+  own test covering faithful and adapted alike. Same snapshot, three dangling
+  slugs: two reddened main for six hours (0.80.1), this one had no guard looking.
+- **`scripts/description-coverage.mjs`** turns "has the prose basis drifted?"
+  from a hand audit into a command: per cited fragment, how much is still
+  reproduced verbatim, with the fragment's ccVersion. Report-only, always exit 0
+  — coverage is SUPPOSED to be below 100% wherever the red-line discipline
+  forbids describing an unshipped capability, so gating on it would push the
+  descriptions into claiming things this SDK cannot do. Measured now: 18 of 30
+  fragments at 100% (Grep against 2.1.217, Glob against 2.1.215), the low end
+  being the documented adaptations (SendMessage 11%, EnterWorktree 25%).
+
+Honest boundary, stated because it is easy to misread this entry as more than it
+is: the NUMERIC limits from 0.80.0 are NOT realigned and cannot be from here. The
+reconstruction template-izes exactly the numbers (`${MAX_LINES_CONSTANT}`), and
+the grep fragments carry no parameter-level docs — so head_limit=250, Read's
+25,000 tokens, Bash's 30,000 and WebFetch's 100,000 still rest solely on the
+one-off 2.1.141 binary extraction, uncorroborated by anything in this repo.
+Re-verification needs another extraction on a machine with Claude Code installed.
+
+Shipped runtime delta: one slug string and its comment. No description text
+changed, so prompt bytes and cache keys are untouched.
+
+**Ledger note**: PR #845 carries this entry's title but merged an EMPTY diff.
+The work was committed onto a local `main` while the push targeted the
+same-named feature branch — which `git push -u origin <name>` resolves to the
+local BRANCH of that name, not to HEAD — so a stale branch was published and
+merged. Recorded rather than papered over: b3558ce changes zero files, and
+the content below actually landed in the follow-up merge. Anyone bisecting
+0.80.2 should ignore b3558ce entirely.
+
 ## 0.80.1 — 2026-07-27
 
 Two prompt-provenance slugs re-pointed after the upstream snapshot moved under

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -57,6 +57,7 @@ src/
 | 构建 | `npm run build`（ESM + d.ts → dist/） |
 | 单测 | `npm test`（vitest，mock 传输层，零网络；含仿真器端到端集成测试） |
 | 真机 smoke | `ANTHROPIC_API_KEY=... node tests/integration/live-real-api.mjs`（需先 `npm run build`；打真 api.anthropic.com） |
+| 描述基准吻合度 | `node scripts/description-coverage.mjs [--json] [--min=N]`（**尺子不是门禁**：逐条报本包描述对所引快照档还剩多少逐字吻合 + 该档 ccVersion。吻合度本就不该满分——红线纪律禁止描述未发货能力，硬拉满等于逼描述吹本包做不到的事，故**恒 exit 0**、低分要人来分「已登记改编」还是「上游加了新话没跟」。需先 `npm run build`。射程边界：重建档把数字上限模板化，**数值常量在仓内无法核验**）|
 | 双层评估 runEvals（SCS-REQ-002 环二） | `node scripts/run-evals.mjs`（底线层 = 全量 vitest pass/fail；行为层 = `evals/` 20 题 + `claude-sonnet-5` 判卷——12 题 prompt-session + 8 题 Phase 2 harness（`scripts/eval-harnesses.mjs` 故障注入/resume/压缩压力），无 key 走 STUB 验管线；`--judge-batches` 走 Batches API 五折判卷。评估集为守密人定稿权保护路径，任何改动须 `node scripts/update-evals-manifest.mjs` 重签清单，否则治理测试红。回归门禁 `node scripts/check-eval-regression.mjs`（REQ-2.2，报警不阻断）） |
 
 ## 测试三层
@@ -69,11 +70,13 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.80.1`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.80.1`
+**当前版本 `0.80.2`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.80.2`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.80.2（2026-07-27）：对齐 2.1.216 快照基准**（守密人裁「3 也直接对齐基准」）——基准同时从两个方向陈旧了，且只有一个方向能在仓内修，两者都记进 `docs/COMPAT.md`「Baseline realignment」。① **手工挖出第三条指空 slug**：`SendMessage` 引用的 `tool-description-sendmessagetool` 被快照改名，却因**缺档检查搭在锚点检查里、而锚点检查跳过 adapted 条目**而长期报绿——现把「引用的档案必须存在」拆成独立测试，faithful / adapted 一视同仁。同一次快照造了三条指空 slug：两条让 main 红了六小时（0.80.1），这条根本没守卫在看。② 新增 `scripts/description-coverage.mjs`，把「散文基准漂没漂」从人工比对变成一条命令（逐档报还剩多少逐字吻合 + 该档 ccVersion）。**报告体恒 exit 0**：吻合度本就不该是 100%——红线纪律禁止描述未发货能力，硬拉满等于逼描述去吹本包做不到的事。实测 30 档里 18 档 100%（Grep 对 2.1.217、Glob 对 2.1.215），低分端全是已登记改编（SendMessage 11% / EnterWorktree 25%）。**射程边界照实写**：0.80.0 那批**数值上限对不了**——重建档把数字模板化（`${MAX_LINES_CONSTANT}`）、grep 档没有参数级文档，故 250 / 25,000 / 30,000 / 100,000 仍只靠那一次 2.1.141 二进制提取支撑，仓内无任何东西能独立佐证，重新核验需在装有 Claude Code 的机器上再提取一次。发货运行时改动仅一个 slug 字符串及其注释，**描述文本未动**，提示词字节与缓存键不变。
 
 **v0.80.1（2026-07-27）：两条提示词溯源 slug 改锚 + 给刷新 cron 补自检**——上游快照
 2.1.173 → 2.1.216（今日 cron 76fe5e6 直推 main）改名 24 档、删 5 档，两条 slug 指空，

--- a/projects/silver-core-sdk/docs/COMPAT.md
+++ b/projects/silver-core-sdk/docs/COMPAT.md
@@ -406,6 +406,55 @@ SDK implements the agent loop directly against the public Messages API:
 | MultiEdit | REMOVED | SDK-original v0.61.0–0.64.4 (same-file atomic batch edit — edits applied sequentially on one snapshot, all-or-nothing write, single pre-image for rewind, same read-before-write gate as Edit; never had an official parity target — upstream retired MultiEdit in favour of repeated Edit calls, so support was vs our own documented semantics with an authored, not reproduced, description). **v0.65.0: REMOVED (audit r4 Y5-3, keeper alignment) — the tool no longer ships. It is absent from `createBuiltinTools` (tests/tool-parity.test.ts pins the shipped set) and is once again a red-line token that no SHIPPED description may reference (tests/red-line-tool-names.test.ts; `descriptions.ts` header lists it under "retired 0.65.0"). Lifecycle: shipped 2026-07-15, DEPRECATED-but-shipping in v0.64.4, hard-removed in v0.65.0. Consumers use repeated Edit calls (each against live file state, avoiding the snapshot-ambiguity MultiEdit's own not-found triage existed to explain); recoverable from git history if a real consumer need resurfaces.** |
 | NotebookEdit | UNSUPPORTED | deliberately untracked (BPT has no notebook surface) |
 
+## Baseline realignment against the 2.1.216 snapshot (2026-07-27)
+
+The comparison basis had gone stale in two different ways at once, and they are
+worth keeping apart because only one of them is fixable inside this repo.
+
+**Prose basis — realigned, and now measurable on demand.** The archive layer the
+descriptions are reproduced from was refreshed to the 2.1.216-era snapshot; the
+per-fragment `ccVersion` values it carries now span 2.1.14 – 2.1.217 (each
+fragment is stamped with the release it was last observed in, so a spread is
+normal — an unchanged clause keeps its old stamp). `node
+scripts/description-coverage.mjs` reports, per cited fragment, how much of it is
+still reproduced verbatim here. Measured 2026-07-27, 30 cited fragments:
+
+| Coverage | Fragments | Reading |
+|---|---|---|
+| 100% | 18 | Bash (9 of its 10), Edit, Write ×2, Grep (2.1.217), Glob (2.1.215), the Task quadruplet, ExitPlanMode |
+| 80–97% | 4 | Bash git-commit (35/36), Workflow (119/144), AskUserQuestion, WebFetch |
+| 25–71% | 6 | WebSearch, Read, Monitor, TodoWrite, EnterPlanMode, EnterWorktree |
+| 11% | 1 | SendMessage — agentId-only addressing, the largest documented adaptation |
+| n/a | 1 | `bash-timeout`: entirely template, no stable sentence to measure |
+
+Low coverage is NOT a defect signal here and the guard deliberately does not gate
+on it: this SDK refuses to describe capabilities it does not ship (red-line
+discipline), so the WebFetch summarizer clause, Monitor's push channel,
+EnterWorktree's unshipped half and SendMessage's teammate-name addressing are all
+*supposed* to be missing. The guard asks only "does this description still
+recognise its source" (≥1 stable anchor). The coverage number is a signal for a
+human to read, which is why the command exists and why it always exits 0.
+
+**One real defect the realignment found**: `SendMessage` cited
+`tool-description-sendmessagetool`, which the snapshot renamed to
+`tool-description-sendmessage`. It went unnoticed because the existence check
+rode inside the anchor check, which skips adapted entries — so an adapted
+description could point into thin air and stay green. Existence is now its own
+test, applied to faithful and adapted alike. That makes three dangling slugs from
+this one snapshot: two reddened main for six hours (v0.80.1), this third was
+found only by hand.
+
+**Numeric basis — NOT realignable in-repo, and that boundary matters.** The
+v0.80.0 limits work was measured against constants extracted from a 2.1.141
+`claude.exe`. The archive layer cannot refresh those: the reconstruction
+template-izes exactly the numbers (`${MAX_LINES_CONSTANT}` and friends), and the
+grep fragments carry no parameter-level docs at all — so the `head_limit` default
+of 250, Read's 25,000-token cap, Bash's 30,000 and WebFetch's 100,000 rest solely
+on that one extraction and are NOT independently corroborated by anything now in
+this repository. Re-verifying them needs another binary extraction on a machine
+that has Claude Code installed. Until then, treat the numeric column of the
+v0.80.0 changelog entry as sourced-once, not continuously guarded.
+
 ## Tool-description ↔ implementation fidelity (audit r4, 2026-07-18)
 
 The model-side tool descriptions in `src/tools/descriptions.ts` are FAITHFUL

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/scripts/description-coverage.mjs
+++ b/projects/silver-core-sdk/scripts/description-coverage.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * 描述基准吻合度：本 SDK 的每条工具描述，对它所引用的快照档案还剩多少逐字吻合。
+ *
+ * 为什么要有这个命令（守密人 2026-07-27 裁定「3 也直接对齐基准」）：本 SDK 的对照基准
+ * 一直是**一次性的人工快照**——0.80.0 那批常量取自 2.1.141 的 claude.exe，描述层则对着
+ * 更早的重建档写成。上游同期已经跑到 2.1.216+。「基准漂没漂」此前只能靠人手抄着比，
+ * 于是它从来没被真正比过；本命令把它变成一条随时能跑的命令。
+ *
+ * 与 `tests/tool-descriptions-provenance.test.ts` 的分工——**它是门禁，本命令是尺子**：
+ * 守卫只问「这条描述还认不认得它的出处」（每档至少一个稳定锚点仍在，低于此即红），
+ * 因为吻合度**本来就不该是 100%**：本 SDK 刻意不复刻未发货能力（红线纪律），
+ * WebFetch 没有摘要层、Monitor 只有轮询面、EnterWorktree 砍掉一半机制。
+ * 把守卫拉到 100% 等于强迫描述去吹本包做不到的事。所以吻合度是**给人看的信号**，
+ * 不是门禁：低分要么是「已登记的改编」，要么是「上游加了新话我们还没跟」，
+ * 二者只能人来分。**本命令恒 exit 0。**
+ *
+ * 口径：把档案正文切成句，丢掉带 `${...}` 模板变量的句子（那些本就要被解析成本包的具体
+ * 值），剩下的「稳定句」逐条看是否仍在本包描述里逐字出现。取前 45 字符比对，与守卫同口径。
+ *
+ * **测不到什么，明写**：重建档把数字上限模板化了（`${MAX_LINES_CONSTANT}` 一类），
+ * 所以 Read 25,000 token / Bash 30,000 / WebFetch 100,000 这类**数值常量在仓内无法核验**——
+ * 它们只存在于 claude.exe 里。本命令量的是**散文吻合度**，数值基准的重新提取需要守密人
+ * 在本机再跑一次二进制提取。这条边界不写出来，报告就会被误读成「常量也对齐了」。
+ *
+ * 用法：node scripts/description-coverage.mjs [--json] [--min=<百分比>]
+ *      （--min 只影响打印时的高亮，不影响退出码）
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const PKG = join(here, '..');
+const ARCHIVE = join(PKG, '..', '..', 'Public-Info-Pool', 'Reference',
+  'Claude-Code-System-Prompts', 'system-prompts');
+
+const norm = (s) => s.replace(/\s+/g, ' ').trim();
+const stripHeader = (md) => md.replace(/^<!--[\s\S]*?-->\n?/, '');
+
+/** 档案头注释里的 ccVersion —— 必须在 stripHeader 之前取，它就写在那段注释里。 */
+function ccVersion(raw) {
+  const m = raw.match(/ccVersion:\s*["']?([0-9][0-9.]*)/);
+  return m ? m[1] : 'unknown';
+}
+
+function stableSentences(body) {
+  return body
+    .split(/(?<=[.:])\s+/)
+    .map(norm)
+    .filter((s) => s.length >= 40 && !s.includes('${'));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const asJson = args.includes('--json');
+  const min = Number((args.find((a) => a.startsWith('--min=')) || '--min=100').slice(6));
+
+  const distIndex = join(PKG, 'dist', 'tools', 'descriptions.js');
+  if (!existsSync(distIndex)) {
+    console.error('先 `npm run build`：本命令读 dist/ 里编译好的描述常量。');
+    return 0; // 报告体：连尺子都没拿到也不该把别人的流水线判红
+  }
+  const { TOOL_DESCRIPTION_PROVENANCE, TOOL_DESCRIPTION_TEXT } = await import(distIndex);
+
+  if (!existsSync(ARCHIVE)) {
+    console.error(`快照层不在（${ARCHIVE}）——独立包解压态没有它，跳过。`);
+    return 0;
+  }
+
+  const rows = [];
+  for (const p of TOOL_DESCRIPTION_PROVENANCE) {
+    const desc = norm(TOOL_DESCRIPTION_TEXT[p.tool] ?? '');
+    for (const slug of p.slugs) {
+      const file = join(ARCHIVE, `${slug}.md`);
+      if (!existsSync(file)) {
+        rows.push({ tool: p.tool, slug, ccVersion: null, faithful: p.faithful,
+                    hit: 0, total: 0, coverage: null, missing: ['<档案缺失：引用指空>'] });
+        continue;
+      }
+      const raw = readFileSync(file, 'utf8');
+      const sents = stableSentences(norm(stripHeader(raw)));
+      const missing = sents.filter((s) => !desc.includes(s.slice(0, 45)));
+      rows.push({
+        tool: p.tool, slug, ccVersion: ccVersion(raw), faithful: p.faithful,
+        hit: sents.length - missing.length, total: sents.length,
+        // 全模板档没有稳定句可比 —— 记 null（无法测量），不记 100%（测过且满分）。
+        coverage: sents.length ? Math.round((100 * (sents.length - missing.length)) / sents.length) : null,
+        missing: missing.map((s) => s.slice(0, 160)),
+      });
+    }
+  }
+
+  rows.sort((a, b) => (a.coverage ?? 999) - (b.coverage ?? 999));
+
+  if (asJson) {
+    console.log(JSON.stringify({ archive: ARCHIVE, rows }, null, 2));
+    return 0;
+  }
+
+  const versions = [...new Set(rows.map((r) => r.ccVersion).filter(Boolean))].sort();
+  console.log(`快照层 ccVersion 分布：${versions.join(' / ')}`);
+  console.log('（数值上限在重建档里是模板变量，仓内无法核验——本表只量散文吻合度）\n');
+  for (const r of rows) {
+    const cov = r.coverage === null ? (r.total === 0 && r.ccVersion ? ' 全模板' : ' 引用指空') : `${String(r.coverage).padStart(4)}%`;
+    const flag = r.coverage !== null && r.coverage < min ? ' ←' : '';
+    console.log(`${cov}  ${r.tool.padEnd(16)} ${r.slug.slice(0, 54).padEnd(54)} ` +
+                `${(r.ccVersion ?? '-').padEnd(8)} ${r.hit}/${r.total} ` +
+                `${r.faithful ? 'faithful' : 'adapted '}${flag}`);
+  }
+  const dangling = rows.filter((r) => r.ccVersion === null);
+  if (dangling.length) {
+    console.log(`\n引用指空 ${dangling.length} 条——这是真缺陷，守卫会红：` +
+                dangling.map((r) => `${r.tool}/${r.slug}`).join(', '));
+  }
+  return 0;
+}
+
+main().then((code) => process.exit(code));

--- a/projects/silver-core-sdk/src/tools/descriptions.ts
+++ b/projects/silver-core-sdk/src/tools/descriptions.ts
@@ -815,8 +815,9 @@ The tool result includes a runId. To resume after a failure or script edit, rela
 
 /**
  * SendMessage (O-B2) — ADAPTED reproduction of the agent-teams SendMessage
- * description (archive slug tool-description-sendmessagetool, ccVersion
- * 2.1.199). Adaptations, per the red-line discipline (never describe an
+ * description (archive slug tool-description-sendmessage — renamed from
+ * tool-description-sendmessagetool in the 2.1.216 snapshot; ccVersion 2.1.199
+ * at the time of reproduction). Adaptations, per the red-line discipline (never describe an
  * unshipped capability): teammate-NAME addressing, the `"main"` address and
  * the automatic teammate-delivery sentence are omitted (this SDK ships no
  * agent-teams naming machinery — agentId addressing only); the official
@@ -903,7 +904,7 @@ export const TOOL_DESCRIPTION_PROVENANCE: ToolDescriptionProvenance[] = [
   {
     tool: 'SendMessage',
     faithful: false,
-    slugs: ['tool-description-sendmessagetool'],
+    slugs: ['tool-description-sendmessage'],
   },
 ];
 

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.80.1';
+export const SDK_VERSION = '0.80.2';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/tool-descriptions-provenance.test.ts
+++ b/projects/silver-core-sdk/tests/tool-descriptions-provenance.test.ts
@@ -57,6 +57,32 @@ describe('tool-description provenance (corpus-sync guard)', () => {
     }
   });
 
+  /**
+   * A cited slug that names no file is broken provenance regardless of whether
+   * the description is faithful or adapted — an adapted description still has
+   * to say WHERE it was adapted FROM, and a pointer into thin air says nothing.
+   *
+   * Split out of the anchor check on 2026-07-27: the anchor check skips adapted
+   * entries (their text legitimately diverges), and the existence check used to
+   * ride along inside it. So when the 2.1.216 snapshot renamed
+   * tool-description-sendmessagetool -> tool-description-sendmessage, the
+   * SendMessage entry — adapted — pointed at a deleted file and the suite
+   * stayed green. Two of the three dangling slugs that snapshot created were
+   * caught the hard way (main went red for six hours); this third one was
+   * caught only by a hand audit, because the guard was not looking.
+   */
+  it.runIf(haveArchive)('every cited archive fragment exists, faithful or adapted', () => {
+    const dangling: string[] = [];
+    for (const p of TOOL_DESCRIPTION_PROVENANCE) {
+      for (const slug of p.slugs) {
+        if (!existsSync(join(ARCHIVE, `${slug}.md`))) {
+          dangling.push(`${p.tool}: cited archive fragment missing (${slug}.md)`);
+        }
+      }
+    }
+    expect(dangling, dangling.join('\n')).toEqual([]);
+  });
+
   it.runIf(haveArchive)('each faithful description still represents every archive fragment it cites', () => {
     const drifted: string[] = [];
     for (const p of TOOL_DESCRIPTION_PROVENANCE) {


### PR DESCRIPTION
## 概述

守密人 2026-07-27 裁定「3 也直接对齐基准」的**真正内容**。

**先说清为什么有这个 PR**：[#845](https://github.com/lightproud/BIAV-SC-CODE/pull/845) 顶着同一个标题合并，但**改动零文件**（[`b3558ce`](https://github.com/lightproud/BIAV-SC-CODE/commit/b3558ce) stat 为空）。真因是艾瑞卡在**本地 main** 上开发并提交，推送却用了 `git push -u origin <分支名>`——该写法推的是**同名本地分支**而非 HEAD，于是把停在【1】的旧分支推了上去，PR 合的是已在 main 的内容。提交对象经 reflog 找回，本 PR 即其内容，并在 CHANGELOG 里如实留了一条 ledger note（bisect 0.80.2 的人应当整个忽略 b3558ce）。

---

## 变更类型

- [x] Bug 修复（第三条指空 slug + 守卫盲区）
- [x] 文档完善（COMPAT.md 基准现状 + SDK CONTEXT 命令表 + CHANGELOG 空合并留痕）
- [x] 其他（请说明）：新增吻合度量尺 + 家族锁步版本推进

对下来发现：**基准同时从两个方向陈旧了，而只有一个方向能在仓内修**。两者都写进 `docs/COMPAT.md`「Baseline realignment」，免得又变成口口相传。

### ① 散文基准：已对齐，且从此可随时量

**手工挖出第三条指空 slug**：`SendMessage` 引用 `tool-description-sendmessagetool`，被 2.1.216 快照改名为 `tool-description-sendmessage`。

它为什么一直报绿——**缺档检查搭在锚点检查里，而锚点检查按设计跳过 adapted 条目**（adapted 描述的文本本就该有出入）。于是一条 adapted 描述可以无限期指着一个已删除的档案而无人过问。现把「引用的档案必须存在」拆成**独立测试**，faithful / adapted 一视同仁——**adapted 也得说清自己从哪儿改编来的，指向空气等于什么都没说。**

> 同一次快照造了三条指空 slug：两条让 main 红了六小时（0.80.1 修），第三条没有任何守卫在看，只能靠手挖。

**新增 `scripts/description-coverage.mjs`**：把「散文基准漂没漂」从人工比对变成一条命令——逐条报本包描述对所引快照档还剩多少逐字吻合、外加该档 ccVersion。

**报告体，恒 exit 0。** 这是刻意的：吻合度**本就不该是 100%**——红线纪律禁止描述未发货能力，WebFetch 的摘要层、Monitor 的推送通道、EnterWorktree 被砍掉的一半、SendMessage 的 teammate 名址，**本来就该缺**。把守卫拉到满分等于逼描述去吹本包做不到的事。守卫只问「这条描述还认不认得它的出处」，吻合度是给人看的信号。

实测 30 条引用（2026-07-27）：

| 吻合度 | 条数 | 内容 |
|---|---|---|
| 100% | 18 | Bash（10 条中 9 条）· Edit · Write ×2 · **Grep（对 2.1.217）** · **Glob（对 2.1.215）** · Task 四件 · ExitPlanMode |
| 80–97% | 4 | Bash git-commit 35/36 · Workflow 119/144 · AskUserQuestion · WebFetch |
| 25–71% | 6 | WebSearch · Read · Monitor · TodoWrite · EnterPlanMode · EnterWorktree |
| 11% | 1 | SendMessage——agentId-only 名址，最大的一处已登记改编 |
| 无法测量 | 1 | `bash-timeout`：全模板档，没有稳定句可比（记 n/a，**不记 100%**）|

### ② 数值基准：**对不了**，且这条边界必须写明

0.80.0 那批上限取自 **2.1.141 的 `claude.exe`**。快照层**刷新不了这些数字**——重建档恰恰把数字模板化（`${MAX_LINES_CONSTANT}` 一类），且 grep 的两个片段**根本不含参数级文档**。

所以 `head_limit=250`、Read 的 25,000 token、Bash 的 30,000、WebFetch 的 100,000，**至今仍只靠那一次二进制提取支撑，仓内没有任何东西能独立佐证**。重新核验需在装有 Claude Code 的机器上再提取一次。

**发货运行时改动仅一个 slug 字符串及其注释——描述文本一字未动**，提示词字节与缓存键不变。

---

## 来源声明

- [x] 不涉及游戏数据。对照基准为仓内公开参照层 `Public-Info-Pool/Reference/Claude-Code-System-Prompts/`。

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不上传内部美术资产 / 客户端解包原始文件 / 未公开剧情草稿。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py --sparse` 在**找回后的分支上重跑，全部通过**（exit 0），稀疏检出形态同样通过
- [x] agent SDK **3,243 通过 / 5 跳过（共 3,248）** · Python **3,049 通过 / 51 跳过** · maestro **428** · testbed **37**
- [x] 量尺本地真跑，表格数字为实测非估算
- [x] 不引入 emoji
- [x] 未改 `memory/decisions.md` / `memory/lessons-learned.md`

## 家族锁步

改 slug 属 shipped 运行时改动：两包同步 **0.80.1 → 0.80.2**（patch），maestro 侧 `Lockstep alignment only` 空转条；机器事实块经 `build_status_facts.py` 重算。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr

---
_Generated by [Claude Code](https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr)_