### PR TITLE
feat(sdk): Read 截断页脚补齐官方三件套（v0.81.0）+ 数值基准获独立佐证

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,8 +82,8 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.80.2` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.80.2` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.81.0` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.81.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
 | agent SDK 源文件 / 测试档 | 134 / 198 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
@@ -249,6 +249,8 @@
 > schedule 错过补偿核对（已实现有测试，免补）+ 质量切换：棘轮五族全靶（新增 delivery-channel 100 /
 > workflow-load 100，CI 矩阵六靶）、四份 e2e 全部假钟化（三连稳、秒级降毫秒级）；测试 171→180。
 >
+> **v0.81.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.81.0（Read 截断页脚补齐官方三件套）前进。
+>
 > **v0.80.2（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.80.2（对齐 2.1.216 快照基准）前进。
 >
 > **v0.80.1（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.80.1（两条提示词溯源 slug 改锚 + 刷新 cron 补自检）前进。
@@ -322,6 +324,7 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.81.0（2026-07-27）**：**Read 截断页脚补齐官方三件套 + 数值基准获独立佐证**——守密人报「一次 Read 后模型连发六轮自动翻页、上下文推到 300K+ 字符」，旧页脚只给一句「Use offset=N to continue reading.」别无他物。**交付单诊断对了一半**：它认为官方从不给具体值，实测**官方 2.1.220 也给值**，且同时给 **Grep 替代路径**与**「不要单凭本页作答」告诫**——差别从不在那个值，在银芯只给了三件套的第一件。守密人裁定取官方口径，两处截断分支均补齐；大档 Grep 提示改为**只看体积**（原还要求有超 2000 字符长行，普通源码没有那种行，故几乎从未触发、且零测试覆盖）。**同批订正 0.80.2 的错误结论**——「数值基准须在装有 Claude Code 的机器上才能提取」是错的：官方二进制是**公开 npm 发行物**（平台 optionalDependency），本仓一致性作业本就装它作对照臂。已提取 2.1.220：Read **25000 token** / Bash **30000 默认 · 150000 上限** / Grep **「Defaults to 250」逐字**，与 2.1.141 三项全部一致（79 版未变）。
 - **v0.80.2（2026-07-27）**：**对齐 2.1.216 快照基准**（守密人裁「3 也直接对齐基准」）——① 手工挖出**第三条指空 slug**（`SendMessage` 引用被快照改名），真因是**缺档检查搭在锚点检查里、而锚点检查跳过 adapted 条目**，现拆为独立测试 faithful/adapted 一视同仁；② 新增 `projects/silver-core-sdk/scripts/description-coverage.mjs`——把「散文基准漂没漂」变成一条命令，**报告体恒 exit 0**（吻合度本就不该满分：红线纪律禁止描述未发货能力）。实测 30 档 18 档 100%，低分端全是已登记改编。**射程边界**：0.80.0 那批**数值上限对不了**（重建档把数字模板化、grep 档无参数级文档），仍只靠一次 2.1.141 二进制提取支撑，重新核验须在装有 Claude Code 的机器上再提取。
 - **v0.80.1（2026-07-27）**：**两条提示词溯源 slug 改锚 + 给刷新 cron 补自检**（守密人 2026-07-27 交互裁「一并修 + 给 cron 补自检」）——上游快照 2.1.173 → 2.1.216（今日 cron 76fe5e6 带 `[skip ci]` 直推 main）改名 24 档 / 删 5 档，SDK 侧两条 slug 指空、两条 corpus-sync 守卫在 main 上报红。① `COORDINATOR_WORKER_PROVENANCE.slug` → `agent-prompt-coordinator-worker-instructions`（纯改名，守卫抽出的 15 个锚点句逐字仍在）· ② `MAIN_LOOP_INTRO.slug` → `system-prompt-harness-instructions`（上游把三个 intro 小档合并进它，原句未变、现居开篇模板的「无 output style」分支；`faithful` 仍成立，注释写明 faithful 于**分支**非整档）。**零 shipped 提示词文本改动**。同批给 `refresh-claude-code-prompts.yml` 补自检：刷新后、提交前跑这两条守卫，**红则不提交不直推**，第二道网是 dead-man-switch 按「最近一次成功超时」抓持续失败。
 - **v0.80.0（2026-07-27）**：**工具输出上限对齐 Claude Code 2.1.141**（守密人交付单三处独立改动，常量取自 `claude.exe` 内含明文 JS）——① WebFetch 上限 **100_000 → 复用 Read 的 50_000**（官方那个数管的是「喂摘要小模型的输入」、主上下文只收摘要；本 SDK 直连无摘要层，同一个数字变成「原文直灌主上下文」，反让 WebFetch 独享两倍 Read 额度，而它拉的是最不可控的外部网页；改为引用`MAX_READ_OUTPUT_CHARS` 常量防两闸门再漂移）· ② Grep `head_limit` **三种 output_mode 统一默认 250**（原 count / files_with_matches 默认无限；OPT-1 担忧的「截断的 count 是错的 count」已由同批的「每种模式都追加截断提示」解决，要可证完整仍显式传 `head_limit=0`）· ③ Bash 输出截断**改保尾去头**、标记移到开头（长命令的结论在末尾：构建成败 / 测试汇总 / 最终报错；新增 `sliceTailSurrogateSafe`镜像 helper，尾切丢的是开头低位代理）。**刻意不改** Read 的字符计量（对齐 token 需引入 tokenizer运行时依赖，且字符计量在中文场景反更宽）。测试新增 5 条（上限对齐三处各自钉死 + 尾切代理边界），本容器实测 **3,247 条**（3,239 通过 / 6 跳过 / **2 失败**——两条均为 2026-07-27 上游提示词快照刷新 76fe5e6 导致的档案锚点漂移治理测试，**HEAD 上同样红**，与本次改动无关）。

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,6 +12,12 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
+## 0.81.0 — 2026-07-27
+
+Lockstep alignment only — no changes to this package. The family clock advanced
+for silver-core-agent-sdk 0.81.0 (Read's truncation footer no longer states a
+computed next offset, and the large-file Grep hint fires on size alone).
+
 ## 0.80.2 — 2026-07-27
 
 Lockstep alignment only — no changes to this package. The family clock advanced

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,11 +36,13 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.80.2`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.80.2`
+**当前版本 `0.81.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.81.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.81.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.81.0（Read 截断页脚补齐官方三件套 + 大档 Grep 提示改为只看体积 + 数值基准经官方 npm 发行物获独立佐证）前进。
 
 **v0.80.2（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.80.2（对齐 2.1.216 快照基准：第三条指空 slug 修复 + 缺档守卫扩及 adapted 条目 + 新增吻合度尺子）前进。
 

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.80.2",
+  "version": "0.81.0",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.80.2';
+export const MAESTRO_SDK_VERSION = '0.81.0';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,57 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.81.0 — 2026-07-27
+
+Read's truncation footer now carries all THREE parts of the official banner
+instead of only the first. Minor rather than patch: the footer is part of the
+model-facing contract and its wording changes what the model does next.
+
+Reported symptom (keeper, from observed behaviour): one Read of a ~1500-line
+source file was followed by SIX consecutive auto-paged Reads that walked the
+file to its end, pushing 300K+ chars into the context, with no sign of the model
+deciding for itself when to stop. Our footer ended `Use offset=1301 to continue
+reading.` and said nothing else.
+
+**The diagnosis was half right, and the half that was wrong is worth recording.**
+The delivery note held that official Claude Code never states a computed offset,
+only "the offset parameter". Checked against the official npm artifact for
+2.1.220 (`@anthropic-ai/claude-code-linux-x64`), it states one: "…Call Read with
+offset=${I+1} limit=${I} for the next page, or Grep to find a specific section.
+Do NOT answer from this page alone if the answer may be further in the file."
+So the value was never the difference. The difference was that our footer
+offered NOTHING ELSE — one page, one move, no cheaper route, no caution. Keeper
+ruled for official parity over the further-reaching variant.
+
+- Both truncation branches (character cap and line limit) now end: next-page
+  offset, `use Grep to find a specific section`, and `Do NOT answer from this
+  page alone if the answer may be further in the file`. The last clause guards a
+  failure mode the old footer had no defence against at all — answering
+  confidently off page one.
+- The large-file Grep hint fires on SIZE ALONE. It previously also required a
+  row past the 2000-char per-line cap, and ordinary source (TS/Lua/Python) has
+  no such rows, so the conjunction was almost never true and the hint
+  effectively never fired. The 256KB threshold is unchanged; it had NO test
+  coverage before this change, which is consistent with it never having fired.
+- Read's description is updated to match all three parts.
+
+`MAX_READ_OUTPUT_CHARS` is deliberately untouched at 50000: the problem was
+never how much one call returns, and lowering the cap would make a genuine
+cover-to-cover read page twice as often.
+
+**Numeric baseline, now independently corroborated.** 0.80.2 recorded that the
+v0.80.0 limits rested solely on a one-off 2.1.141 binary extraction with nothing
+in-repo to check them against, and that re-verification needed a machine with
+Claude Code installed. That was wrong: the official binary is a public npm
+artifact (`@anthropic-ai/claude-code-linux-x64`, a platform optionalDependency
+of `@anthropic-ai/claude-code`), and this repo's own conformance job already
+installs the official arm transiently. Extracted from 2.1.220 here: Read output
+cap **25000 tokens** (`CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS`, default 25000),
+Bash output **30000 default / 150000 max** (`BASH_MAX_OUTPUT_LENGTH`), and Grep
+`head_limit` "Defaults to 250 when unspecified. Pass 0 for unlimited" verbatim.
+All three match the 2.1.141 figures the v0.80.0 work was built on — unchanged
+across 79 releases. docs/COMPAT.md is corrected accordingly.
+
 ## 0.80.2 — 2026-07-27
 
 Baseline realignment against the refreshed 2.1.216-era archive snapshot (keeper

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -70,11 +70,14 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.80.2`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.80.2`
+**当前版本 `0.81.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.81.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.81.0（2026-07-27）：Read 截断页脚补齐官方三件套 + 数值基准获独立佐证**——守密人报的现象：一次 Read 读约 1500 行源码后，模型**连发六轮自动翻页**把整档翻完、上下文推到 300K+ 字符。旧页脚只说一句「Use offset=1301 to continue reading.」，**别的什么都不给**。**交付单的诊断对了一半，错的那一半值得记**：它认为官方从不给具体值，只说「the offset parameter」；对着**官方 npm 发行物 2.1.220** 提取实测，官方**也给值**——「…Call Read with offset=${I+1} limit=${I} for the next page, **or Grep to find a specific section**. **Do NOT answer from this page alone** if the answer may be further in the file.」。可见具体值从不是差别，差别是银芯只给了三件套的**第一件**：一条路、一个动作、没有更便宜的替代、没有告诫。守密人裁定取官方口径。两处截断分支（字符上限 / 行数上限）现均补齐三件套；大档 Grep 提示改为**只看体积**（原还要求存在超 2000 字符的长行，而 TS/Lua/Python 普通源码根本没有那种行，故该提示**几乎从未触发过**——它此前零测试覆盖，正与此吻合），256KB 阈值不动。`MAX_READ_OUTPUT_CHARS` 刻意不动。
+**同批订正 0.80.2 的一处错误结论**：那条说数值基准「须在装有 Claude Code 的机器上才能重新提取」——**错了**。官方二进制是**公开 npm 发行物**（`@anthropic-ai/claude-code` 的平台 optionalDependency），本仓一致性作业本就`--no-save` 装它作对照臂，属净室边界①「官方发行渠道产物」。已就地提取 2.1.220 实测：Read 输出上限 **25000 token**、Bash 输出 **30000 默认 / 150000 上限**、Grep `head_limit` **「Defaults to 250 when unspecified」逐字**——与 0.80.0 所依据的 2.1.141 三项**全部一致**，79 个版本未变。WebFetch 的 100000 本轮未再定位到，照实记。
 
 **v0.80.2（2026-07-27）：对齐 2.1.216 快照基准**（守密人裁「3 也直接对齐基准」）——基准同时从两个方向陈旧了，且只有一个方向能在仓内修，两者都记进 `docs/COMPAT.md`「Baseline realignment」。① **手工挖出第三条指空 slug**：`SendMessage` 引用的 `tool-description-sendmessagetool` 被快照改名，却因**缺档检查搭在锚点检查里、而锚点检查跳过 adapted 条目**而长期报绿——现把「引用的档案必须存在」拆成独立测试，faithful / adapted 一视同仁。同一次快照造了三条指空 slug：两条让 main 红了六小时（0.80.1），这条根本没守卫在看。② 新增 `scripts/description-coverage.mjs`，把「散文基准漂没漂」从人工比对变成一条命令（逐档报还剩多少逐字吻合 + 该档 ccVersion）。**报告体恒 exit 0**：吻合度本就不该是 100%——红线纪律禁止描述未发货能力，硬拉满等于逼描述去吹本包做不到的事。实测 30 档里 18 档 100%（Grep 对 2.1.217、Glob 对 2.1.215），低分端全是已登记改编（SendMessage 11% / EnterWorktree 25%）。**射程边界照实写**：0.80.0 那批**数值上限对不了**——重建档把数字模板化（`${MAX_LINES_CONSTANT}`）、grep 档没有参数级文档，故 250 / 25,000 / 30,000 / 100,000 仍只靠那一次 2.1.141 二进制提取支撑，仓内无任何东西能独立佐证，重新核验需在装有 Claude Code 的机器上再提取一次。发货运行时改动仅一个 slug 字符串及其注释，**描述文本未动**，提示词字节与缓存键不变。
 

--- a/projects/silver-core-sdk/docs/COMPAT.md
+++ b/projects/silver-core-sdk/docs/COMPAT.md
@@ -444,16 +444,35 @@ test, applied to faithful and adapted alike. That makes three dangling slugs fro
 this one snapshot: two reddened main for six hours (v0.80.1), this third was
 found only by hand.
 
-**Numeric basis — NOT realignable in-repo, and that boundary matters.** The
-v0.80.0 limits work was measured against constants extracted from a 2.1.141
-`claude.exe`. The archive layer cannot refresh those: the reconstruction
-template-izes exactly the numbers (`${MAX_LINES_CONSTANT}` and friends), and the
-grep fragments carry no parameter-level docs at all — so the `head_limit` default
-of 250, Read's 25,000-token cap, Bash's 30,000 and WebFetch's 100,000 rest solely
-on that one extraction and are NOT independently corroborated by anything now in
-this repository. Re-verifying them needs another binary extraction on a machine
-that has Claude Code installed. Until then, treat the numeric column of the
-v0.80.0 changelog entry as sourced-once, not continuously guarded.
+**Numeric basis — corroborated 2026-07-27 against 2.1.220 (this paragraph
+replaces an incorrect one).** The ARCHIVE layer genuinely cannot supply these:
+the reconstruction template-izes exactly the numbers (`${MAX_LINES_CONSTANT}`
+and friends) and the grep fragments carry no parameter-level docs. From that,
+v0.80.2 concluded the figures could not be re-verified without a machine that
+has Claude Code installed. **That conclusion was wrong, and the way it was
+reached is the instructive part**: the keeper's extraction happened to run
+against a locally installed `claude.exe`, and that one path was mistaken for the
+only path. The official binary is a public npm artifact — a platform
+`optionalDependency` of `@anthropic-ai/claude-code`
+(`@anthropic-ai/claude-code-linux-x64` and siblings) — and this repository's own
+conformance job already installs the official arm transiently with `--no-save`.
+It is squarely inside the clean-room boundary's clause ①, which admits official
+release-channel artifacts.
+
+Extracted from 2.1.220 and cross-checked against the 2.1.141 figures the
+v0.80.0 work was built on:
+
+| Constant | 2.1.141 (keeper) | 2.1.220 (verified here) | |
+|---|---|---|---|
+| Read output cap | 25,000 tokens | `25000`, env `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS` | unchanged |
+| Bash output | 30,000 default / 150,000 max | `30000` / `150000`, env `BASH_MAX_OUTPUT_LENGTH` | unchanged |
+| Grep `head_limit` | 250, all three modes | "Defaults to 250 when unspecified. Pass 0 for unlimited" verbatim | unchanged |
+
+Unchanged across 79 releases, so the v0.80.0 limits work stands on corroborated
+ground rather than a single reading. Two caveats kept honest: WebFetch's 100,000
+was not re-located in this pass (the 2.1.220 build does not expose the same
+symbol shape), and the extraction is a point-in-time check, not a standing
+guard — nothing re-runs it automatically.
 
 ## Tool-description ↔ implementation fidelity (audit r4, 2026-07-18)
 

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.80.2",
+  "version": "0.81.0",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/tools/descriptions.ts
+++ b/projects/silver-core-sdk/src/tools/descriptions.ts
@@ -218,7 +218,7 @@ Usage:
 - The file_path parameter must be an absolute path, not a relative path
 - By default, it reads up to 2000 lines starting from the beginning of the file
 - Any lines longer than 2000 characters will be truncated
-- Output is also capped at ~50000 characters total; when truncated, a footer shows the exact line range returned and the offset to continue reading from
+- Output is also capped at ~50000 characters total; when truncated, a footer shows the exact line range returned, the offset for the next page, and a reminder to consider Grep instead of paging - do not answer from one page alone if the answer may be further in the file
 - Results are returned using cat -n format, with line numbers starting at 1
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
 - This tool allows you to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as this is a multimodal model.

--- a/projects/silver-core-sdk/src/tools/read.ts
+++ b/projects/silver-core-sdk/src/tools/read.ts
@@ -375,22 +375,51 @@ export function createReadTool(limits?: ReadLimits): BuiltinTool {
       let content = fmt.text;
       if (fmt.charCapped) {
         // Total-character cap took effect (may be tighter than the line limit).
+        //
+        // The footer carries all THREE parts of the official banner, not just
+        // the first (2026-07-27, keeper delivery note + keeper ruling on the
+        // measured evidence). Reported symptom: one Read of a ~1500-line file
+        // was followed by SIX consecutive auto-paged Reads that walked the file
+        // to its end and pushed 300K+ chars into the context, with no sign of
+        // the model deciding for itself when to stop.
+        //
+        // The diagnosis that a stated `offset=1301` is what caused it does NOT
+        // survive checking: official Claude Code 2.1.220 states one too — its
+        // auto-pagination banner reads "…Call Read with offset=${I+1}
+        // limit=${I} for the next page, or Grep to find a specific section. Do
+        // NOT answer from this page alone if the answer may be further in the
+        // file." (extracted from the official npm linux-x64 artifact). What
+        // this SDK was missing was the OTHER TWO parts: a cheaper alternative,
+        // and the caution against answering off one page. A footer whose only
+        // content is "here is the next page" leaves the model exactly one move.
         let footer =
           `\n\n(Showing lines ${startLine}-${realLastShown} of ${total}; ` +
           `output truncated at ${maxOutputChars} chars. ` +
-          `Use offset=${realLastShown + 1} to continue reading.)`;
-        // §D: a big file whose rows are also long — Grep is usually the better
-        // tool than paging through it. read.ts holds the byte size + long-line
-        // signal that an app-layer hook could only guess at.
-        if (fmt.truncatedLines > 0 && buf.length > GREP_HINT_FILE_BYTES) {
+          `Call Read with offset=${realLastShown + 1} for the next page, or use ` +
+          `Grep to find a specific section. Do NOT answer from this page alone ` +
+          `if the answer may be further in the file.)`;
+        // §D: a big file — Grep is usually the better tool than paging through
+        // it. The long-line precondition was dropped in the same pass: ordinary
+        // source (TS/Lua/Python) rarely has rows past the 2000-char per-line
+        // cap, so `truncatedLines > 0` was almost never true and the hint
+        // effectively never fired — leaving paging as the only route the model
+        // was ever shown. Size alone earns the hint; row width is beside the
+        // point.
+        if (buf.length > GREP_HINT_FILE_BYTES) {
           footer +=
-            '\n(This file is large and has very long lines; consider the Grep ' +
-            'tool to search it instead of reading page by page.)';
+            '\n(This file is large; consider the Grep tool to search it ' +
+            'instead of reading page by page.)';
         }
         content += footer;
       } else if (realLastShown < total) {
         // Line-count limit (or offset window) bounded the output, chars did not.
-        content += `\n\n(Showing lines ${startLine}-${realLastShown} of ${total}. Use offset=${realLastShown + 1} to continue reading.)`;
+        // Same wording as the char-cap branch above: the trigger differs, the
+        // incentive it creates does not.
+        content +=
+          `\n\n(Showing lines ${startLine}-${realLastShown} of ${total}. ` +
+          `Call Read with offset=${realLastShown + 1} for the next page, or use ` +
+          `Grep to find a specific section. Do NOT answer from this page alone ` +
+          `if the answer may be further in the file.)`;
       }
       return { content };
     } catch (e) {

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.80.2';
+export const SDK_VERSION = '0.81.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/read-output-cap.test.ts
+++ b/projects/silver-core-sdk/tests/read-output-cap.test.ts
@@ -102,7 +102,13 @@ describe('Read total-output cap (boundary matrix)', () => {
     const file = await writeFileLines(dir, 'many-short.txt', Array.from({ length: 3000 }, (_, i) => `l${i}`));
     const res = await readTool.execute({ file_path: file }, makeCtx(dir));
     const c = contentOf(res);
-    expect(c).toContain('Showing lines 1-2000 of 3000. Use offset=2001 to continue reading.');
+    // 2026-07-27: the footer carries all three parts of the official 2.1.220
+    // banner. The stated offset was NOT the cause of the six-page auto-paging
+    // run (official states one too) — what was missing were the other two
+    // parts, so those are what these assertions pin.
+    expect(c).toContain('Showing lines 1-2000 of 3000. Call Read with offset=2001 for the next page');
+    expect(c).toContain('use Grep to find a specific section');
+    expect(c).toContain('Do NOT answer from this page alone');
     expect(c).not.toContain('truncated at');
   });
 
@@ -119,17 +125,52 @@ describe('Read total-output cap (boundary matrix)', () => {
     const lastShown = Number(m![1]);
     expect(lastShown).toBeLessThan(2000);
     expect(lastShown).toBeGreaterThanOrEqual(25); // never-empty invariant
-    expect(c).toContain(`Use offset=${lastShown + 1} to continue reading.`);
+    expect(c).toContain(`Call Read with offset=${lastShown + 1} for the next page`);
+    expect(c).toContain('use Grep to find a specific section');
+    expect(c).toContain('Do NOT answer from this page alone');
     // §B consistency: the actual body has exactly `lastShown` numbered rows
     const body = c.split('\n\n(')[0];
     expect(body.split('\n')).toHaveLength(lastShown);
+  });
+
+  // §D, widened 2026-07-27. The hint used to require `truncatedLines > 0` —
+  // a row past the 2000-char per-line cap — on top of the size threshold.
+  // Ordinary source files (TS/Lua/Python) do not have rows that wide, so the
+  // conjunction was practically never true and the hint effectively never
+  // fired: the only route the model was ever shown was "page again". These two
+  // cases pin the new rule (size alone) and the threshold that still bounds it.
+  it('§D: a large file of ORDINARY-width lines now gets the Grep hint', async () => {
+    const dir = await makeSandbox();
+    // 4000 x ~80 chars ~= 320KB > 256KB, every row far below the per-line cap.
+    const file = await writeFileLines(
+      dir,
+      'big-normal.ts',
+      Array.from({ length: 4000 }, (_, i) => `const value${i} = ${'x'.repeat(60)};`),
+    );
+    const c = contentOf(await readTool.execute({ file_path: file }, makeCtx(dir)));
+    expect(c).toContain('This file is large; consider the Grep tool');
+    // The stale precondition must be gone, not merely satisfied by accident.
+    expect(c).not.toContain('very long lines');
+  });
+
+  it('§D: a file under the size threshold still gets no Grep hint', async () => {
+    const dir = await makeSandbox();
+    // ~100KB: over the 50K char cap (so the footer exists) but under 256KB.
+    const file = await writeFileLines(
+      dir,
+      'medium.ts',
+      Array.from({ length: 1200 }, (_, i) => `const v${i} = ${'y'.repeat(60)};`),
+    );
+    const c = contentOf(await readTool.execute({ file_path: file }, makeCtx(dir)));
+    expect(c).toContain('output truncated at');
+    expect(c).not.toContain('consider the Grep tool');
   });
 
   it('§3 case 3: offset continuation reads the window after the cap', async () => {
     const dir = await makeSandbox();
     const file = await writeFileLines(dir, 'wide.txt', Array.from({ length: 2000 }, (_, i) => `${i}:` + 'w'.repeat(500)));
     const first = contentOf(await readTool.execute({ file_path: file }, makeCtx(dir)));
-    const off = Number(first.match(/Use offset=(\d+)/)![1]);
+    const off = Number(first.match(/offset=(\d+) for the next page/)![1]);
     const second = contentOf(await readTool.execute({ file_path: file, offset: off }, makeCtx(dir)));
     // the second read starts exactly where the first stopped
     expect(second).toContain(`${String(off).padStart(6)}\t${off - 1}:`);

--- a/projects/silver-core-sdk/tests/tools-fs.test.ts
+++ b/projects/silver-core-sdk/tests/tools-fs.test.ts
@@ -107,9 +107,13 @@ describe('Read tool', () => {
     expect(content).toContain(catLine(3, 'L3'));
     expect(content).not.toContain('L1');
     expect(content).not.toContain('L4');
-    // Continuation hint names the shown window, the total, and the next offset.
+    // Continuation hint names the shown window, the total, the next offset —
+    // and, since 2026-07-27, the two parts the official 2.1.220 banner carries
+    // that this one used to omit: the Grep alternative and the caution.
     expect(content).toMatch(/lines 2-3 of 5/);
     expect(content).toMatch(/offset=4/);
+    expect(content).toMatch(/use Grep to find a specific section/);
+    expect(content).toMatch(/Do NOT answer from this page alone/);
   });
 
   it('clamps zero/negative offsets to line 1', async () => {
@@ -154,6 +158,8 @@ describe('Read tool', () => {
     expect(content).not.toContain('line-2001');
     expect(content).toMatch(/lines 1-2000 of 2005/);
     expect(content).toMatch(/offset=2001/);
+    expect(content).toMatch(/use Grep to find a specific section/);
+    expect(content).toMatch(/Do NOT answer from this page alone/);
   });
 
   it('returns a system-reminder-style note (not an error) for an empty file', async () => {


### PR DESCRIPTION
## 概述

守密人交付单「Read 截断页脚改为中性提示」。**诊断的现象是真的，理据订正了一半，最终按守密人裁定取官方口径。**

**现象**：一次 Read 读约 1500 行源码后，模型**连发六轮自动翻页**把整档翻完，上下文推到 300K+ 字符。旧页脚只说一句 `Use offset=1301 to continue reading.`，**别的什么都不给**。

**理据订正**：交付单认为官方从不给具体值、只说「the offset parameter」。艾瑞卡从**官方 npm 发行物 2.1.220**（`@anthropic-ai/claude-code-linux-x64`，275MB 原生二进制）提取实测，官方**也给值**：

```
[<file>: showing lines 1-${I} of ${E} total (${tokenCount} tokens, cap ${c}).
 Call Read with offset=${I+1} limit=${I} for the next page,
 or Grep to find a specific section.
 Do NOT answer from this page alone if the answer may be further in the file.]
```

**具体值从不是差别所在**——差别是银芯只给了三件套的**第一件**：一条路、一个动作、没有更便宜的替代、没有告诫。守密人交互裁定「取官方三件套」。

> 小学生比喻：原来的路牌只写「下一站往前 1301 米」，于是人一直往前走。官方那块牌子也写距离，但同时写了「或者查地图找你要的那间屋」和「别只看这一段就下结论」。缺的从来不是把距离擦掉，是另外两行字。

---

## 变更类型

- [x] Bug 修复（页脚只给单一动作 · 大档 Grep 提示条件几乎从不成立）
- [x] 文档完善（COMPAT.md 数值基准段整段订正 + CHANGELOG 记录诊断订正）
- [x] 其他（请说明）：家族锁步版本推进

### ① 两处截断分支均补齐三件套

字符上限分支与行数上限分支现均输出：下一页 offset + `use Grep to find a specific section` + `Do NOT answer from this page alone if the answer may be further in the file`。

最后那句**防的是旧页脚完全没有防备的另一个坏结局**：模型翻一页就当全文作答。

### ② 大档 Grep 提示改为只看体积

原条件是 `truncatedLines > 0 && buf.length > 256KB`——要求存在**超 2000 字符的长行**。TS / Lua / Python 普通源码根本没有那种行，所以合取几乎从不成立，**这条提示实际上从未触发过**；它此前**零测试覆盖**，正与此吻合。现只看体积，256KB 阈值不动，两侧各加一条测试钉死（超阈值必出、未超必不出）。

### ③ 刻意不动 `MAX_READ_OUTPUT_CHARS`

按交付单 §3 保持 50000。问题不在「给多少」，且调小会让**确实需要通读**的场景多翻一倍页。

---

## 顺带：订正 0.80.2 的一处错误结论，并把余项 1 结掉

0.80.2 写着数值基准「须在装有 Claude Code 的机器上才能重新提取」——**这个结论是错的**，且错法值得记：守密人的提取恰好跑在本机 `claude.exe` 上，艾瑞卡就把**那一条路当成了唯一的路**，没验就下了否定结论（正是 lesson #43 那个坑）。

官方二进制是**公开 npm 发行物**：`@anthropic-ai/claude-code` 的平台 `optionalDependency`（`@anthropic-ai/claude-code-linux-x64` 等 8 个）。**本仓一致性作业本来就 `--no-save` 装它作对照臂**，属净室边界①「官方发行渠道产物」明确准许。

已就地提取 2.1.220 并与 0.80.0 所依据的 2.1.141 对账：

| 常量 | 2.1.141（守密人） | 2.1.220（本次实测） | 结论 |
|---|---|---|---|
| Read 输出上限 | 25,000 token | `25000`，env `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS` | 一致 |
| Bash 输出 | 30,000 默认 / 150,000 上限 | `30000` / `150000`，env `BASH_MAX_OUTPUT_LENGTH` | 一致 |
| Grep `head_limit` | 250，三模式统一 | 「Defaults to 250 when unspecified. Pass 0 for unlimited」**逐字** | 一致 |

**79 个版本未变**，0.80.0 那批改动从此立在有佐证的地上，而非单次读数。两条照实保留：WebFetch 的 100000 本轮**未再定位到**（2.1.220 构建未暴露同样符号形态）；本次提取是**一次性核查、不是常设守卫**，没有任何东西会自动重跑它。

---

## 来源声明

- [x] 不涉及游戏数据。对照物为**官方 npm 公开发行物**，符合 `projects/silver-core-sdk/CONTEXT.md` 净室观测边界①（官方发行渠道产物）与②（内容盲纪律 2026-07-05 已解除）；③泄漏衍生禁引本次无涉。

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不上传内部美术资产 / 客户端解包原始文件 / 未公开剧情草稿**（提取物留在临时目录，**未入仓**）。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py --sparse` **全部通过**（exit 0）
- [x] agent SDK **3,245 通过 / 5 跳过（共 3,250）** · Python **3,049 通过 / 51 跳过** · maestro **428** · testbed **37**
- [x] 新增 2 条测试（Grep 提示阈值两侧），改写 4 条断言至三件套口径
- [x] 不引入 emoji
- [x] 未改 `memory/decisions.md` / `memory/lessons-learned.md`

## 家族锁步

两包同步 **0.80.2 → 0.81.0**（minor：页脚属模型可见契约，措辞变化会改变模型行为），maestro 侧 `Lockstep alignment only` 空转条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr

---
_Generated by [Claude Code](https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr)_