### PR TITLE
feat(sdk): Read 通读 >256KB 改为拒绝（v0.82.0）+ 首次对官方二进制做偏离普查

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,8 +82,8 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.81.0` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.81.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.82.0` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.82.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
 | agent SDK 源文件 / 测试档 | 134 / 198 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
@@ -249,6 +249,8 @@
 > schedule 错过补偿核对（已实现有测试，免补）+ 质量切换：棘轮五族全靶（新增 delivery-channel 100 /
 > workflow-load 100，CI 矩阵六靶）、四份 e2e 全部假钟化（三连稳、秒级降毫秒级）；测试 171→180。
 >
+> **v0.82.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.82.0（Read 通读 >256KB 拒绝）前进。
+>
 > **v0.81.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.81.0（Read 截断页脚补齐官方三件套）前进。
 >
 > **v0.80.2（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.80.2（对齐 2.1.216 快照基准）前进。
@@ -324,6 +326,7 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.82.0（2026-07-27）**：**Read 通读 >256KB 改为拒绝 + 首次对官方二进制做偏离普查**（守密人问「还能查到有哪些我们与官方不一致」）——第一次拿**官方发行物本体**（npm 平台包 + `sdk-tools.d.ts`）而非第三方重建档做四轴对照。**工具集**：官方 18 个工具银芯没有（多为绑定 Anthropic 云侧服务）。**输入 schema**：Bash/Read/Write/Edit/Glob/**Grep 15 字段**/WebFetch/WebSearch/Task 五件/Workflow/两个 PlanMode/EnterWorktree **全部一致**；真差异仅 `AskUserQuestion` 缺三个**回程字段**（守密人裁「只登记不改」——它们服务官方权限组件 UI，本 SDK 无那套组件）。**数值**：Read 25000 token / Bash 30000·150000 / **Glob 100** / Grep 250 均一致，唯一缺口 = 官方 `maxSizeBytes`=262144 拒通读，银芯此前只有 50MB OOM 守卫（松 200 倍）——**已按守密人裁定补上**，只拦通读、带 offset/limit 放行。**两条经复核是假象、如实记档**（`EnterPlanModeInput` 官方就是 `{}`；Grep 短横线键与 `TaskListInput` 亦一致）。未扫轴照实标注：官方 `*Output` 37 个 / 主循环提示词 / 权限钩子层 / MCP 协议层 / WebFetch 的 100000。
 - **v0.81.0（2026-07-27）**：**Read 截断页脚补齐官方三件套 + 数值基准获独立佐证**——守密人报「一次 Read 后模型连发六轮自动翻页、上下文推到 300K+ 字符」，旧页脚只给一句「Use offset=N to continue reading.」别无他物。**交付单诊断对了一半**：它认为官方从不给具体值，实测**官方 2.1.220 也给值**，且同时给 **Grep 替代路径**与**「不要单凭本页作答」告诫**——差别从不在那个值，在银芯只给了三件套的第一件。守密人裁定取官方口径，两处截断分支均补齐；大档 Grep 提示改为**只看体积**（原还要求有超 2000 字符长行，普通源码没有那种行，故几乎从未触发、且零测试覆盖）。**同批订正 0.80.2 的错误结论**——「数值基准须在装有 Claude Code 的机器上才能提取」是错的：官方二进制是**公开 npm 发行物**（平台 optionalDependency），本仓一致性作业本就装它作对照臂。已提取 2.1.220：Read **25000 token** / Bash **30000 默认 · 150000 上限** / Grep **「Defaults to 250」逐字**，与 2.1.141 三项全部一致（79 版未变）。
 - **v0.80.2（2026-07-27）**：**对齐 2.1.216 快照基准**（守密人裁「3 也直接对齐基准」）——① 手工挖出**第三条指空 slug**（`SendMessage` 引用被快照改名），真因是**缺档检查搭在锚点检查里、而锚点检查跳过 adapted 条目**，现拆为独立测试 faithful/adapted 一视同仁；② 新增 `projects/silver-core-sdk/scripts/description-coverage.mjs`——把「散文基准漂没漂」变成一条命令，**报告体恒 exit 0**（吻合度本就不该满分：红线纪律禁止描述未发货能力）。实测 30 档 18 档 100%，低分端全是已登记改编。**射程边界**：0.80.0 那批**数值上限对不了**（重建档把数字模板化、grep 档无参数级文档），仍只靠一次 2.1.141 二进制提取支撑，重新核验须在装有 Claude Code 的机器上再提取。
 - **v0.80.1（2026-07-27）**：**两条提示词溯源 slug 改锚 + 给刷新 cron 补自检**（守密人 2026-07-27 交互裁「一并修 + 给 cron 补自检」）——上游快照 2.1.173 → 2.1.216（今日 cron 76fe5e6 带 `[skip ci]` 直推 main）改名 24 档 / 删 5 档，SDK 侧两条 slug 指空、两条 corpus-sync 守卫在 main 上报红。① `COORDINATOR_WORKER_PROVENANCE.slug` → `agent-prompt-coordinator-worker-instructions`（纯改名，守卫抽出的 15 个锚点句逐字仍在）· ② `MAIN_LOOP_INTRO.slug` → `system-prompt-harness-instructions`（上游把三个 intro 小档合并进它，原句未变、现居开篇模板的「无 output style」分支；`faithful` 仍成立，注释写明 faithful 于**分支**非整档）。**零 shipped 提示词文本改动**。同批给 `refresh-claude-code-prompts.yml` 补自检：刷新后、提交前跑这两条守卫，**红则不提交不直推**，第二道网是 dead-man-switch 按「最近一次成功超时」抓持续失败。

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,6 +12,12 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
+## 0.82.0 — 2026-07-27
+
+Lockstep alignment only — no changes to this package. The family clock advanced
+for silver-core-agent-sdk 0.82.0 (Read refuses whole-file reads past 256KB, per
+official parity found in a divergence sweep of the 2.1.220 binary).
+
 ## 0.81.0 — 2026-07-27
 
 Lockstep alignment only — no changes to this package. The family clock advanced

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,11 +36,13 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.81.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.81.0`
+**当前版本 `0.82.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.82.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.82.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.82.0（Read 通读 >256KB 改为拒绝，源自首次对官方 2.1.220 二进制的偏离普查）前进。
 
 **v0.81.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.81.0（Read 截断页脚补齐官方三件套 + 大档 Grep 提示改为只看体积 + 数值基准经官方 npm 发行物获独立佐证）前进。
 

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.81.0",
+  "version": "0.82.0",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.81.0';
+export const MAESTRO_SDK_VERSION = '0.82.0';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,45 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.82.0 — 2026-07-27
+
+Read refuses a whole-file read past 256KB, matching official Claude Code. Found
+by a divergence sweep of the official 2.1.220 binary (keeper: "你还能从
+claude.exe 查到有哪些我们与官方不一致"), and ruled in by the keeper.
+
+Official refuses at `maxSizeBytes` = 262144 (`QLi=262144`, `FileTooLargeError`,
+remote-overridable via the `tengu_amber_wren` gate, which this SDK has no
+equivalent of). This SDK's only size limit was the 50MB OOM guard — 200x looser,
+so nothing stopped a 30MB log from being pulled into memory and then almost
+entirely discarded by the character cap. The two limits now coexist with
+distinct jobs: 256KB STEERS ("that is not what Read is for"), 50MB SURVIVES
+("this would kill the process").
+
+- The refusal applies ONLY to unbounded reads. A read carrying `offset` or
+  `limit` proceeds, which is the escape hatch the official text names in both
+  places it appears: the error ("Use offset and limit parameters to read
+  specific portions of the file") and the tool description ("use offset and
+  limit for larger files"). HONEST LIMIT: official's throw site is gated on an
+  internal `truncateOnByteLimit` flag whose per-call-path wiring was not pinned
+  down here, so the exemption is reproduced from the stated contract, not from
+  the observed branch.
+- Read's description gains the official sentence about the 256KB error.
+- **Breaking for a consumer that reads 256KB–50MB files whole.** The fix is
+  mechanical (add `offset`/`limit`, or use Grep) and the error says so.
+
+Interaction worth knowing: the large-file Grep hint (0.81.0) fires at the same
+256KB, so it is now reachable only on a BOUNDED read — which is precisely the
+caller it is for, someone already paging a file too big to page.
+
+Also from the same sweep, recorded in docs/COMPAT.md rather than changed:
+`AskUserQuestion` omits official's three round-trip fields (`answers`,
+`annotations`, `metadata.source`) — they exist to carry the official permission
+component's UI回填 and telemetry, and this SDK routes the tool to a host
+callback with no such component (keeper ruling: log, do not add). Two divergences
+the sweep first reported turned out to be parser artifacts and are NOT real:
+`EnterPlanModeInput` is `{}` upstream (matches), and Grep's dash-prefixed flags
+plus `TaskListInput` also match.
+
 ## 0.81.0 — 2026-07-27
 
 Read's truncation footer now carries all THREE parts of the official banner

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -70,11 +70,15 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.81.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.81.0`
+**当前版本 `0.82.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.82.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.82.0（2026-07-27）：Read 通读 >256KB 改为拒绝 + 首次对官方二进制做偏离普查**——守密人问「还能查到有哪些我们与官方不一致」，遂第一次拿**官方发行物本体**（npm 平台包 + `sdk-tools.d.ts`）而非第三方重建档做四轴对照。**唯一改代码的一条**：官方 `maxSizeBytes`=262144 拒通读，银芯此前只有 50MB OOM 守卫（松 200 倍，于是 30MB 日志会被真读进内存再几乎全丢）。现两条上限各司其职——256KB **导向**（「这不是 Read 该干的事」）、50MB **保命**（「这会撑死进程」）；**只拦通读**，带 offset/limit 放行（官方错误文案与工具描述两处都写明这是逃生口）。**属破坏性变更**：读 256KB–50MB 档的消费方会突然报错，修法机械（加 offset/limit 或改 Grep）且错误文案已写明。
+**同批查出但按守密人裁定只登记不改**：`AskUserQuestion` 缺官方三个**回程字段**（`answers`/`annotations`/`metadata.source`）——它们服务于官方权限组件 UI 回填与遥测，本 SDK 是宿主回调、无那套组件，加了就是描述未发货能力。**另有两条经复核是假象、如实记档**：`EnterPlanModeInput` 官方就是 `{}`（一致），Grep 的 `-i/-A/-B/-C/-o` 与 `TaskListInput` 亦一致——首轮正则不认带引号键、且被单行 `{}` 接口串块骗了三次。
+详见 `docs/COMPAT.md`「Divergence sweep」。
 
 **v0.81.0（2026-07-27）：Read 截断页脚补齐官方三件套 + 数值基准获独立佐证**——守密人报的现象：一次 Read 读约 1500 行源码后，模型**连发六轮自动翻页**把整档翻完、上下文推到 300K+ 字符。旧页脚只说一句「Use offset=1301 to continue reading.」，**别的什么都不给**。**交付单的诊断对了一半，错的那一半值得记**：它认为官方从不给具体值，只说「the offset parameter」；对着**官方 npm 发行物 2.1.220** 提取实测，官方**也给值**——「…Call Read with offset=${I+1} limit=${I} for the next page, **or Grep to find a specific section**. **Do NOT answer from this page alone** if the answer may be further in the file.」。可见具体值从不是差别，差别是银芯只给了三件套的**第一件**：一条路、一个动作、没有更便宜的替代、没有告诫。守密人裁定取官方口径。两处截断分支（字符上限 / 行数上限）现均补齐三件套；大档 Grep 提示改为**只看体积**（原还要求存在超 2000 字符的长行，而 TS/Lua/Python 普通源码根本没有那种行，故该提示**几乎从未触发过**——它此前零测试覆盖，正与此吻合），256KB 阈值不动。`MAX_READ_OUTPUT_CHARS` 刻意不动。
 **同批订正 0.80.2 的一处错误结论**：那条说数值基准「须在装有 Claude Code 的机器上才能重新提取」——**错了**。官方二进制是**公开 npm 发行物**（`@anthropic-ai/claude-code` 的平台 optionalDependency），本仓一致性作业本就`--no-save` 装它作对照臂，属净室边界①「官方发行渠道产物」。已就地提取 2.1.220 实测：Read 输出上限 **25000 token**、Bash 输出 **30000 默认 / 150000 上限**、Grep `head_limit` **「Defaults to 250 when unspecified」逐字**——与 0.80.0 所依据的 2.1.141 三项**全部一致**，79 个版本未变。WebFetch 的 100000 本轮未再定位到，照实记。

--- a/projects/silver-core-sdk/docs/COMPAT.md
+++ b/projects/silver-core-sdk/docs/COMPAT.md
@@ -474,6 +474,57 @@ was not re-located in this pass (the 2.1.220 build does not expose the same
 symbol shape), and the extraction is a point-in-time check, not a standing
 guard — nothing re-runs it automatically.
 
+## Divergence sweep vs the official 2.1.220 binary (2026-07-27)
+
+First systematic comparison against the OFFICIAL ARTIFACT rather than the
+third-party reconstruction: the npm platform package
+(`@anthropic-ai/claude-code-linux-x64`) plus the `sdk-tools.d.ts` type
+definitions shipped in the wrapper package. Four axes swept; two of the four
+findings turned out to be parser artifacts and are recorded as such, because a
+divergence list that quietly carries phantoms is worse than none.
+
+**Tool set.** 18 official tools this SDK does not ship: `Artifact`,
+`ClaudeDesign`, `CronCreate`/`CronDelete`/`CronList`, `ExitWorktree`, `Mcp`,
+`NotebookEdit`, `Projects`, `ProposeSkills`, `PushNotification`, `REPL`,
+`RefreshMcpTools`, `RemoteTrigger`, `ReportFindings`, `ScheduleWakeup`,
+`SendFeedback`, `ShowOnboardingRolePicker`. Most are bound to Anthropic-side
+services this SDK has no counterpart for. Three tools go the other way:
+`BashOutput` and `KillShell` (upstream replaced them with
+`TaskOutput`/`TaskStop`, which this SDK also ships — both pairs are kept) and
+`SendMessage` (not exported in the official d.ts).
+
+**Input schemas — one real gap.** Field-for-field, `Bash`, `Read`, `Write`,
+`Edit`, `Glob`, `Grep` (all 15 fields), `WebFetch`, `WebSearch`, the Task
+quintet, `Workflow`, `ExitPlanMode`, `EnterPlanMode` and `EnterWorktree` MATCH.
+
+- `AskUserQuestion` — official also carries `answers` ("User answers collected
+  by the permission component"), `annotations` (per-question `preview`/`notes`)
+  and `metadata.source` (analytics). All three are ROUND-TRIP fields written
+  back by the official permission-component UI; this SDK routes the tool to a
+  host callback and has no such component. **Keeper ruling 2026-07-27: log, do
+  not add** — declaring fields nothing populates would describe an unshipped
+  capability, which the red-line discipline forbids.
+- `Monitor` — official also carries `ws`/`url`/`protocols` (the WebSocket
+  source). Already documented above as an honest subset.
+
+**Numeric constants.** Read output cap 25,000 tokens, Bash output
+30,000/150,000, Glob `maxResults ?? 100` and Grep's "Defaults to 250 when
+unspecified" all match this SDK (Read's is 50,000 CHARACTERS by the
+documented measure divergence). One gap found and CLOSED in v0.82.0: official
+refuses a whole-file read past `maxSizeBytes` = 262144 (256KB) with
+`FileTooLargeError`, while this SDK's only size limit was the 50MB OOM guard.
+
+**Recorded as NOT divergences** (first-pass regex artifacts, corrected on
+re-check with a brace-balanced parse): `EnterPlanModeInput` is `{}` upstream and
+here — the four fields first attributed to it belong to the adjacent
+`TaskCreateInput`; `TaskListInput` is likewise `{}` on both sides; and Grep's
+`-i`/`-n`/`-A`/`-B`/`-C`/`-o` exist upstream too (the first parser did not match
+quoted keys).
+
+**Not swept, stated so the coverage is not overread**: official `*Output` types
+(37 of them), the main-loop system prompt, the permission/hook layer, the MCP
+protocol layer, and WebFetch's 100,000 (not re-located in the 2.1.220 build).
+
 ## Tool-description ↔ implementation fidelity (audit r4, 2026-07-18)
 
 The model-side tool descriptions in `src/tools/descriptions.ts` are FAITHFUL

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.81.0",
+  "version": "0.82.0",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/tools/descriptions.ts
+++ b/projects/silver-core-sdk/src/tools/descriptions.ts
@@ -218,6 +218,7 @@ Usage:
 - The file_path parameter must be an absolute path, not a relative path
 - By default, it reads up to 2000 lines starting from the beginning of the file
 - Any lines longer than 2000 characters will be truncated
+- Files larger than 256KB will return an error; use offset and limit for larger files, or Grep to find what you need
 - Output is also capped at ~50000 characters total; when truncated, a footer shows the exact line range returned, the offset for the next page, and a reminder to consider Grep instead of paging - do not answer from one page alone if the answer may be further in the file
 - Results are returned using cat -n format, with line numbers starting at 1
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters

--- a/projects/silver-core-sdk/src/tools/read.ts
+++ b/projects/silver-core-sdk/src/tools/read.ts
@@ -40,6 +40,29 @@ const MAX_PDF_PAGES_PER_READ = 20;
 const MAX_READ_BYTES = 50 * 1024 * 1024;
 
 /**
+ * Refuse a WHOLE-FILE read past this size and steer the caller to a bounded
+ * read or to Grep — official Claude Code's `maxSizeBytes`, 262144 (256KB),
+ * verified in the 2.1.220 binary (`QLi=262144`, `FileTooLargeError`; the
+ * official value is additionally overridable by the `tengu_amber_wren` remote
+ * feature gate, which this SDK has no equivalent of).
+ *
+ * Distinct from MAX_READ_BYTES above, which is an OOM guard at 50MB — 200x
+ * looser, and therefore never the thing that stops a 30MB log from being pulled
+ * into memory and then thrown away by the character cap. The two coexist on
+ * purpose: this one is a STEERING limit ("that is not what Read is for"), that
+ * one is a SURVIVAL limit ("this would kill the process").
+ *
+ * Bounded reads are exempt, which is the escape hatch the official text itself
+ * names: the error says "Use offset and limit parameters to read specific
+ * portions of the file", and the official tool description says "use offset and
+ * limit for larger files". HONEST LIMIT on the reproduction: the official throw
+ * site is gated on an internal `truncateOnByteLimit` flag whose exact wiring
+ * per call path was not established here, so "offset or limit ⇒ allowed" is
+ * reproduced from the stated contract rather than from the observed branch.
+ */
+const MAX_READ_FILE_BYTES = 262144;
+
+/**
  * Read `abs` while enforcing `maxBytes` DURING the read, not just before it:
  * the stat-based pre-check races a concurrent writer (TOCTOU — the file can
  * grow past the cap between stat and read, audit 2026-07-17 L22). Chunked fd
@@ -245,6 +268,23 @@ export function createReadTool(limits?: ReadLimits): BuiltinTool {
             `Read failed: "${abs}" is ${st.size} bytes, larger than the ${MAX_READ_BYTES}-byte (${Math.floor(
               MAX_READ_BYTES / (1024 * 1024),
             )}MB) read cap. Reading it whole would exhaust memory. Use the Grep tool to search it, or split the file into smaller pieces.`,
+          );
+        }
+        // Whole-file read of an oversized file: refuse and steer, as official
+        // Claude Code does at the same 256KB. Checked ONLY when neither offset
+        // nor limit was given — a bounded read is the escape hatch the refusal
+        // text itself names, so gating on the caller's intent (not on the
+        // file's size alone) is what makes the advice actionable.
+        if (
+          offsetRaw === undefined &&
+          limitRaw === undefined &&
+          st.size > MAX_READ_FILE_BYTES
+        ) {
+          return errorResult(
+            `Read failed: file content (${st.size} bytes) exceeds maximum allowed size ` +
+              `(${MAX_READ_FILE_BYTES} bytes). Use offset and limit parameters to read ` +
+              `specific portions of the file, or search for specific content with Grep ` +
+              `instead of reading the whole file.`,
           );
         }
       } catch (e) {

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.81.0';
+export const SDK_VERSION = '0.82.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/read-output-cap.test.ts
+++ b/projects/silver-core-sdk/tests/read-output-cap.test.ts
@@ -114,16 +114,18 @@ describe('Read total-output cap (boundary matrix)', () => {
 
   it('§3 case 2: char cap hits first -> footer reports truncated at cap + offset', async () => {
     const dir = await makeSandbox();
-    // 2000 lines x 500 chars ~= 1MB: the 50K char cap bounds it near line ~90.
-    const file = await writeFileLines(dir, 'wide.txt', Array.from({ length: 2000 }, () => 'w'.repeat(500)));
+    // 400 lines x 500 chars ~= 200KB: over the 50K char cap, but UNDER the
+    // 256KB whole-file refusal added in 0.82.0 — this case is about the char
+    // cap, so it must stay on the side of the size limit that still reads.
+    const file = await writeFileLines(dir, 'wide.txt', Array.from({ length: 400 }, () => 'w'.repeat(500)));
     const res = await readTool.execute({ file_path: file }, makeCtx(dir));
     const c = contentOf(res);
     expect(c).toContain(`output truncated at ${MAX_READ_OUTPUT_CHARS} chars`);
     // footer must name the REAL last line (< 2000), not claim all 2000
-    const m = c.match(/Showing lines 1-(\d+) of 2000/);
+    const m = c.match(/Showing lines 1-(\d+) of 400/);
     expect(m).not.toBeNull();
     const lastShown = Number(m![1]);
-    expect(lastShown).toBeLessThan(2000);
+    expect(lastShown).toBeLessThan(400);
     expect(lastShown).toBeGreaterThanOrEqual(25); // never-empty invariant
     expect(c).toContain(`Call Read with offset=${lastShown + 1} for the next page`);
     expect(c).toContain('use Grep to find a specific section');
@@ -147,7 +149,10 @@ describe('Read total-output cap (boundary matrix)', () => {
       'big-normal.ts',
       Array.from({ length: 4000 }, (_, i) => `const value${i} = ${'x'.repeat(60)};`),
     );
-    const c = contentOf(await readTool.execute({ file_path: file }, makeCtx(dir)));
+    // A whole-file read of this size is now REFUSED (256KB, 0.82.0), so the
+    // hint is reachable only on a bounded read — which is exactly the caller
+    // the hint is for: someone already paging a file too big to page.
+    const c = contentOf(await readTool.execute({ file_path: file, offset: 1 }, makeCtx(dir)));
     expect(c).toContain('This file is large; consider the Grep tool');
     // The stale precondition must be gone, not merely satisfied by accident.
     expect(c).not.toContain('very long lines');
@@ -166,9 +171,65 @@ describe('Read total-output cap (boundary matrix)', () => {
     expect(c).not.toContain('consider the Grep tool');
   });
 
+  // 0.82.0: whole-file reads past 256KB are refused, matching official Claude
+  // Code's maxSizeBytes (QLi=262144, FileTooLargeError). The 50MB cap that used
+  // to be the only size limit is an OOM guard — 200x looser, so it never
+  // stopped a 30MB log from being read into memory and then mostly discarded.
+  describe('whole-file size refusal (official maxSizeBytes parity)', () => {
+    it('refuses an unbounded read past 256KB and names both escapes', async () => {
+      const dir = await makeSandbox();
+      const file = await writeFileLines(
+        dir,
+        'huge.log',
+        Array.from({ length: 6000 }, (_, i) => `${i} ${'z'.repeat(60)}`),
+      );
+      const res = await readTool.execute({ file_path: file }, makeCtx(dir));
+      expect(res.isError).toBe(true);
+      const c = contentOf(res);
+      expect(c).toContain('exceeds maximum allowed size');
+      expect(c).toContain('offset and limit');
+      expect(c).toContain('Grep');
+    });
+
+    it('allows the same file when offset is given (the documented escape hatch)', async () => {
+      const dir = await makeSandbox();
+      const file = await writeFileLines(
+        dir,
+        'huge.log',
+        Array.from({ length: 6000 }, (_, i) => `${i} ${'z'.repeat(60)}`),
+      );
+      const res = await readTool.execute({ file_path: file, offset: 10 }, makeCtx(dir));
+      expect(res.isError).toBeFalsy();
+      expect(contentOf(res)).not.toContain('exceeds maximum allowed size');
+    });
+
+    it('allows the same file when only limit is given', async () => {
+      const dir = await makeSandbox();
+      const file = await writeFileLines(
+        dir,
+        'huge.log',
+        Array.from({ length: 6000 }, (_, i) => `${i} ${'z'.repeat(60)}`),
+      );
+      const res = await readTool.execute({ file_path: file, limit: 20 }, makeCtx(dir));
+      expect(res.isError).toBeFalsy();
+    });
+
+    it('a file just under the threshold still reads whole', async () => {
+      const dir = await makeSandbox();
+      // ~200KB, under 256KB: unchanged behaviour, no refusal.
+      const file = await writeFileLines(
+        dir,
+        'ok.ts',
+        Array.from({ length: 3000 }, (_, i) => `const a${i} = ${'q'.repeat(50)};`),
+      );
+      const res = await readTool.execute({ file_path: file }, makeCtx(dir));
+      expect(res.isError).toBeFalsy();
+    });
+  });
+
   it('§3 case 3: offset continuation reads the window after the cap', async () => {
     const dir = await makeSandbox();
-    const file = await writeFileLines(dir, 'wide.txt', Array.from({ length: 2000 }, (_, i) => `${i}:` + 'w'.repeat(500)));
+    const file = await writeFileLines(dir, 'wide.txt', Array.from({ length: 400 }, (_, i) => `${i}:` + 'w'.repeat(500)));
     const first = contentOf(await readTool.execute({ file_path: file }, makeCtx(dir)));
     const off = Number(first.match(/offset=(\d+) for the next page/)![1]);
     const second = contentOf(await readTool.execute({ file_path: file, offset: off }, makeCtx(dir)));


### PR DESCRIPTION
## 概述

守密人问「还能从 claude.exe 查到有哪些我们与官方不一致」。艾瑞卡第一次拿**官方发行物本体**（npm 平台包 `@anthropic-ai/claude-code-linux-x64@2.1.220` + wrapper 包里的 `sdk-tools.d.ts` 官方工具类型定义）而非第三方重建档，做了四轴对照，守密人就两条真差异各下一裁。

---

## 变更类型

- [x] Bug 修复（Read 缺少导向性大小上限）
- [x] 文档完善（COMPAT.md 新增「Divergence sweep」整节）
- [x] 其他（请说明）：**破坏性行为变更** + 家族锁步版本推进

## 一、守密人裁定「向官方看齐」：Read 通读 >256KB 拒绝

官方 `maxSizeBytes` = **262144**（二进制内 `QLi=262144`，抛 `FileTooLargeError`，且可经远端 feature gate `tengu_amber_wren` 覆盖——本 SDK 无对应旋钮）。银芯此前**唯一**的大小上限是 50MB OOM 守卫，**松 200 倍**，于是一个 30MB 日志档会被真读进内存、再被 50K 字符上限几乎全丢。

现两条上限各司其职：

| 上限 | 值 | 职责 |
|---|---|---|
| `MAX_READ_FILE_BYTES` | 256KB | **导向**——「这不是 Read 该干的事」 |
| `MAX_READ_BYTES` | 50MB | **保命**——「这会撑死进程」 |

**只拦通读**：带 `offset` 或 `limit` 的定点读放行。这是官方在**两处**都写明的逃生口——错误文案（"Use offset and limit parameters to read specific portions of the file"）与工具描述（"use offset and limit for larger files"，见 `prompt()` 内 `includeMaxSizeInPrompt` 分支）。

**射程边界照实写**：官方抛出点被内部 `truncateOnByteLimit` 旗门控，其**逐调用路径的接线本次未钉死**，故「带 offset/limit 即放行」是照**明示契约**复现，不是照观测到的分支复现。

⚠ **属破坏性变更**：读 256KB–50MB 档的消费方会突然报错。修法机械（加 `offset`/`limit` 或改 Grep），错误文案已写明。

**顺带的语义交互**：0.81.0 那条大档 Grep 提示阈值同为 256KB，故它现在**只在有界读时可达**——而那正是它服务的对象：已经在翻一个不该翻的档的人。

> 小学生比喻：门口原来只有一条规矩「超过 50 米长的东西不许进」，等于没规矩。现在加了一条「整箱超过 256KB 的别整箱搬，拆开拿你要的那件，或者直接去查目录」——但你要是本来就只拿其中一件（带 offset/limit），照进不误。

## 二、守密人裁定「只登记不改」：`AskUserQuestion` 三个回程字段

官方另有 `answers`（注：「User answers collected by the permission component」）、`annotations`（逐问 `preview`/`notes`）、`metadata.source`（遥测来源标）。这三个**不是模型填的**，是官方权限组件 UI 回填后回写进工具输入的。本 SDK 走宿主回调、无那套组件——**加了就是描述未发货能力，撞红线纪律**。已记入 COMPAT.md。

## 三、两条经复核是假象，如实记档

首轮正则报了三条差异，复核后**只剩一条真的**：

| 首轮报告 | 复核结论 |
|---|---|
| `EnterPlanMode` 缺 4 字段 | ❌ 假象——官方原文就是 `export interface EnterPlanModeInput {}`，那 4 字段属紧邻的 `TaskCreateInput` |
| Grep 银芯独有 `-i/-A/-B/-C/-o` | ❌ 假象——官方**也有**，首轮正则不认带引号的键 |
| `TaskList` 缺 3 字段 | ❌ 假象——官方亦为 `{}` |
| `AskUserQuestion` 缺 3 字段 | ✅ **真** |

同一个惰性匹配缺陷（单行 `{}` 接口让 `[\s\S]*?\n\}` 串进下一块）**骗了艾瑞卡三次**，改用括号配平重解才见底。**一份夹带幻影的偏离清单比没有更坏**，故三条假象与真差异并列入档。

## 四、扫过的与没扫的

**扫过**：工具集（官方 18 个银芯没有，多为绑定 Anthropic 云侧服务；银芯独有 3 个）· 输入 schema 逐字段（Bash/Read/Write/Edit/Glob/**Grep 15 字段**/WebFetch/WebSearch/Task 五件/Workflow/两个 PlanMode/EnterWorktree **全部一致**）· 数值常量（Read 25000 token · Bash 30000/150000 · **Glob `maxResults ?? 100`** · Grep 250 均一致）。

**没扫，照实标注**：官方 `*Output` 类型 37 个 · 主循环系统提示词 · 权限 / 钩子层 · MCP 协议层 · WebFetch 的 100000（2.1.220 构建两次都未定位到）。

---

## 来源声明

- [x] 不涉及游戏数据。对照物为**官方 npm 公开发行物**，符合净室观测边界①（官方发行渠道产物）与②（内容盲纪律 2026-07-05 已解除）；③泄漏衍生禁引无涉。提取物留在临时目录、**未入仓**。

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不上传内部美术资产 / 客户端解包原始文件 / 未公开剧情草稿。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py --sparse` **全部通过**（exit 0）
- [x] agent SDK **3,249 通过 / 5 跳过（共 3,254）** · Python **3,049 通过 / 51 跳过** · maestro **428** · testbed **37**
- [x] 新增 **4 条**测试（拒读生效 · offset 放行 · limit 放行 · 阈值下不受影响），另调整 3 条既有用例至新语义
- [x] 不引入 emoji · 未改 `memory/decisions.md` / `memory/lessons-learned.md`

## 家族锁步

两包 **0.81.0 → 0.82.0**（minor：行为变更且对部分消费方破坏），maestro 侧 `Lockstep alignment only` 空转条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr

---
_Generated by [Claude Code](https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr)_