### PR TITLE
feat(sdk): 工具真正产出结构化结果 + MCP 接受列表扩容（v0.83.0）

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,10 +82,10 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.84.0` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.84.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.85.0` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.85.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
-| agent SDK 源文件 / 测试档 | 136 / 199 | 磁盘实况 |
+| agent SDK 源文件 / 测试档 | 138 / 200 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
 | testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
 | Python 测试档 | 137 | 磁盘实况 |
@@ -250,7 +250,9 @@
 > workflow-load 100，CI 矩阵六靶）、四份 e2e 全部假钟化（三连稳、秒级降毫秒级）；测试 171→180。
 >
 > **v0.84.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.84.0（记忆索引纪律 + 整理规程）前进。
-> **v0.83.0（2026-07-27，goal 判词家族统一）**：**BREAKING（实验面）**——`GoalVerdict` 迁移为与 agent SDK 逐字同形的 `{status: 'achieved'|'not_achieved'|'impossible', reason?}`（原 `{achieved, feedback, impossible?}`）。起因：BPT 接入后报「goal 没效果、模型照样停」，排查定位两包**同名不同形**判词——评审器误用另一包形状时引擎按设计 fail-open 把 malformed verdict 放行为允许停止，goal 无声失效。守密人裁「统一判词类型」：agent 侧 `{status}` 为正典（BPT 实接层不动），Maestro goal 族（零调用点实验面）赶在 GoalChaser 首次接线前迁移；声明式重复不跨包 import（硬性质 §1.2），一个宿主评审器经结构类型同时服务两缝；`GoalRoundPayload.feedback` 字段名保留、改承载 `reason`。迁移映射见 CHANGELOG 0.83.0。
+> **v0.85.0（2026-07-27，goal 判词家族统一）**：**BREAKING（实验面）**——`GoalVerdict` 迁移为与 agent SDK 逐字同形的 `{status: 'achieved'|'not_achieved'|'impossible', reason?}`（原 `{achieved, feedback, impossible?}`）。起因：BPT 接入后报「goal 没效果、模型照样停」，排查定位两包**同名不同形**判词——评审器误用另一包形状时引擎按设计 fail-open 把 malformed verdict 放行为允许停止，goal 无声失效。守密人裁「统一判词类型」：agent 侧 `{status}` 为正典（BPT 实接层不动），Maestro goal 族（零调用点实验面）赶在 GoalChaser 首次接线前迁移；声明式重复不跨包 import（硬性质 §1.2），一个宿主评审器经结构类型同时服务两缝；`GoalRoundPayload.feedback` 字段名保留、改承载 `reason`。迁移映射见 CHANGELOG 0.85.0。
+> **v0.85.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.85.0（工具产出结构化结果 + MCP 接受列表扩容）前进。
+>
 > **v0.82.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.82.0（Read 通读 >256KB 拒绝）前进。
 >
 > **v0.81.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.81.0（Read 截断页脚补齐官方三件套）前进。
@@ -329,7 +331,8 @@
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
 - **v0.84.0（2026-07-27）**：记忆索引纪律 + 整理规程——修的是「SDK 给了常驻索引机制却没规定索引条目该长什么样，且会话收尾提示词命令模型把进度卡写进索引档」这个自伤缺口（守密人 BPT 现场反馈：开工要好几回工具调用才找得到东西）。进度卡改落 `/memories/progress/`、索引只留指针；新增索引纪律片段（两模式注入、前提不成立即跳过）；写侧超限反压（读写共用同一度量，明说尾部已不可见）；`buildConsolidationPrompt()` + 四阶段整理规程，由 `assessMemoryStoreHealth()` 结果渲染待办。**层界守住**：只给「该不该整理 / 怎么整理」，不给调度（N1 未破，零新进程）。新增测试 28。
-- **v0.83.0（2026-07-27）**：**GoalVerdict 家族统一（本包零行为改动）**——本包 `{status, reason?}` 判词升格家族**正典**，maestro 0.83.0 将 GoalChaser 评审判词迁为同形，一个宿主评审器同时服务引擎 `options.goal` Stop 门与跨 query 追逐两缝。留档背景：两形并存期产出真实消费者陷阱——maestro 形判词喂进 `options.goal` 被引擎判 malformed、fail-open 放行停止（防评审器坏死锁死代理的既定失败方向），症状即 BPT 2026-07-27 所报「接了 goal 模型照样停」。`options.goal` 语义与评审器契约未动，仅 `GoalVerdict` 注释补正典地位声明。
+- **v0.85.0（2026-07-27）**：**GoalVerdict 家族统一（本包零行为改动）**——本包 `{status, reason?}` 判词升格家族**正典**，maestro 0.85.0 将 GoalChaser 评审判词迁为同形，一个宿主评审器同时服务引擎 `options.goal` Stop 门与跨 query 追逐两缝。留档背景：两形并存期产出真实消费者陷阱——maestro 形判词喂进 `options.goal` 被引擎判 malformed、fail-open 放行停止（防评审器坏死锁死代理的既定失败方向），症状即 BPT 2026-07-27 所报「接了 goal 模型照样停」。`options.goal` 语义与评审器契约未动，仅 `GoalVerdict` 注释补正典地位声明。
+- **v0.85.0（2026-07-27）**：**工具真正产出结构化结果 + MCP 接受列表扩容**（偏离普查轴一/轴四裁定）——**先订正普查自己的结论**：首轮只 grep `outputSchema` 就报「银芯零输出面」是**错的**，`types/tools.ts` 里官方形状的输出类型**早已齐备**，缺的是**从来没人产出**（typed-not-populated）；故改为**复用既有类型**、只补真缺的两三个。`ToolResultPayload.structuredOutput` + 引擎 **WeakMap 侧信道**（不往 Anthropic 线格式上加字段）+ `query()` 发 `toolUseResult`（**tool_use_id 为键的 record**，因本引擎一轮批处理、官方一消息一结果）。Read/Glob/Grep/Bash/WebFetch 每条终态分支均产出。MCP 接受列表加 `2024-10-07`；**提议版本仍留 `2025-06-18`**——官方的 `2025-11-25` 新增异步任务面（`tasks/*`）本包未实现，宣告它等于描述未发货能力。测试 3,254 → **3,267**。
 - **v0.82.0（2026-07-27）**：**Read 通读 >256KB 改为拒绝 + 首次对官方二进制做偏离普查**（守密人问「还能查到有哪些我们与官方不一致」）——第一次拿**官方发行物本体**（npm 平台包 + `sdk-tools.d.ts`）而非第三方重建档做四轴对照。**工具集**：官方 18 个工具银芯没有（多为绑定 Anthropic 云侧服务）。**输入 schema**：Bash/Read/Write/Edit/Glob/**Grep 15 字段**/WebFetch/WebSearch/Task 五件/Workflow/两个 PlanMode/EnterWorktree **全部一致**；真差异仅 `AskUserQuestion` 缺三个**回程字段**（守密人裁「只登记不改」——它们服务官方权限组件 UI，本 SDK 无那套组件）。**数值**：Read 25000 token / Bash 30000·150000 / **Glob 100** / Grep 250 均一致，唯一缺口 = 官方 `maxSizeBytes`=262144 拒通读，银芯此前只有 50MB OOM 守卫（松 200 倍）——**已按守密人裁定补上**，只拦通读、带 offset/limit 放行。**两条经复核是假象、如实记档**（`EnterPlanModeInput` 官方就是 `{}`；Grep 短横线键与 `TaskListInput` 亦一致）。未扫轴照实标注：官方 `*Output` 37 个 / 主循环提示词 / 权限钩子层 / MCP 协议层 / WebFetch 的 100000。
 - **v0.81.0（2026-07-27）**：**Read 截断页脚补齐官方三件套 + 数值基准获独立佐证**——守密人报「一次 Read 后模型连发六轮自动翻页、上下文推到 300K+ 字符」，旧页脚只给一句「Use offset=N to continue reading.」别无他物。**交付单诊断对了一半**：它认为官方从不给具体值，实测**官方 2.1.220 也给值**，且同时给 **Grep 替代路径**与**「不要单凭本页作答」告诫**——差别从不在那个值，在银芯只给了三件套的第一件。守密人裁定取官方口径，两处截断分支均补齐；大档 Grep 提示改为**只看体积**（原还要求有超 2000 字符长行，普通源码没有那种行，故几乎从未触发、且零测试覆盖）。**同批订正 0.80.2 的错误结论**——「数值基准须在装有 Claude Code 的机器上才能提取」是错的：官方二进制是**公开 npm 发行物**（平台 optionalDependency），本仓一致性作业本就装它作对照臂。已提取 2.1.220：Read **25000 token** / Bash **30000 默认 · 150000 上限** / Grep **「Defaults to 250」逐字**，与 2.1.141 三项全部一致（79 版未变）。
 - **v0.80.2（2026-07-27）**：**对齐 2.1.216 快照基准**（守密人裁「3 也直接对齐基准」）——① 手工挖出**第三条指空 slug**（`SendMessage` 引用被快照改名），真因是**缺档检查搭在锚点检查里、而锚点检查跳过 adapted 条目**，现拆为独立测试 faithful/adapted 一视同仁；② 新增 `projects/silver-core-sdk/scripts/description-coverage.mjs`——把「散文基准漂没漂」变成一条命令，**报告体恒 exit 0**（吻合度本就不该满分：红线纪律禁止描述未发货能力）。实测 30 档 18 档 100%，低分端全是已登记改编。**射程边界**：0.80.0 那批**数值上限对不了**（重建档把数字模板化、grep 档无参数级文档），仍只靠一次 2.1.141 二进制提取支撑，重新核验须在装有 Claude Code 的机器上再提取。

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,13 +12,7 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
-## 0.84.0 — 2026-07-27
-
-Lockstep alignment only — no changes to this package. The family clock advanced
-for silver-core-agent-sdk 0.84.0 (memory index discipline + consolidation
-protocol).
-
-## 0.83.0 — 2026-07-27
+## 0.85.0 — 2026-07-27
 
 **BREAKING (experimental goal family): `GoalVerdict` unified with the agent
 SDK's shape** (keeper ruling 2026-07-27, "改进方向换成统一判词类型").
@@ -48,6 +42,17 @@ the keeper's live BPT symptom report.
   "experimental, zero production consumers" in README §status, whose whole
   point is that the first real consumer may reshape signatures — this is
   that adjustment, made BEFORE GoalChaser's first wiring instead of after.
+## 0.84.0 — 2026-07-27
+
+Lockstep alignment only — no changes to this package. The family clock advanced
+for silver-core-agent-sdk 0.84.0 (memory index discipline + consolidation
+protocol).
+
+## 0.83.0 — 2026-07-27
+
+Lockstep alignment only — no changes to this package. The family clock advanced
+for silver-core-agent-sdk 0.83.0 (tools populate structured results, surfaced as
+`toolUseResult`; MCP accept list widened to the oldest official revision).
 
 ## 0.82.0 — 2026-07-27
 

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,7 +36,7 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.84.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.84.0`
+**当前版本 `0.85.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.85.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
@@ -45,7 +45,8 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 **v0.84.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.84.0
 （记忆索引纪律 + 整理规程）前进，详见该包 CHANGELOG。
 
-**v0.83.0（2026-07-27）：goal 判词统一为 agent SDK 正典形状（BREAKING，实验面）**——`GoalVerdict` 从 `{achieved: boolean, feedback, impossible?}` 迁为与 agent SDK **逐字同形**的 `{status: 'achieved'|'not_achieved'|'impossible', reason?}`。这终结一个已咬到首个真实消费者的陷阱：两包各自导出**同名不同形**判词，评审器接错缝时引擎判 malformed 并 fail-open 放行停止（BPT 2026-07-27 症状「接了 goal 模型照样停」的 SDK 侧根源之一）。统一后一个宿主评审器经结构类型同时服务两缝；**声明式重复、不跨包 import**（硬性质 §1.2 不声明对 agent 依赖）；`nextGoalAction` 改依 `status` 判分支、四动作与优先序不变；`GoalRoundPayload.feedback` 字段名保留（持久化 payload schema）、改承载判词 `reason`。迁移映射与破坏面理由见 CHANGELOG 0.83.0；goal 族仍属实验面（GoalChaser 零调用点），本次即「签名随首个真实消费方调整」条款的兑现，且赶在首次接线之前。
+**v0.85.0（2026-07-27）：goal 判词统一为 agent SDK 正典形状（BREAKING，实验面）**——`GoalVerdict` 从 `{achieved: boolean, feedback, impossible?}` 迁为与 agent SDK **逐字同形**的 `{status: 'achieved'|'not_achieved'|'impossible', reason?}`。这终结一个已咬到首个真实消费者的陷阱：两包各自导出**同名不同形**判词，评审器接错缝时引擎判 malformed 并 fail-open 放行停止（BPT 2026-07-27 症状「接了 goal 模型照样停」的 SDK 侧根源之一）。统一后一个宿主评审器经结构类型同时服务两缝；**声明式重复、不跨包 import**（硬性质 §1.2 不声明对 agent 依赖）；`nextGoalAction` 改依 `status` 判分支、四动作与优先序不变；`GoalRoundPayload.feedback` 字段名保留（持久化 payload schema）、改承载判词 `reason`。迁移映射与破坏面理由见 CHANGELOG 0.85.0；goal 族仍属实验面（GoalChaser 零调用点），本次即「签名随首个真实消费方调整」条款的兑现，且赶在首次接线之前。
+**v0.83.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.85.0（工具真正产出结构化结果并以 `toolUseResult` 交付消费方；MCP 接受列表扩到官方最老修订）前进。
 
 **v0.82.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.82.0（Read 通读 >256KB 改为拒绝，源自首次对官方 2.1.220 二进制的偏离普查）前进。
 

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.84.0';
+export const MAESTRO_SDK_VERSION = '0.85.0';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,21 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.85.0 — 2026-07-27
+
+Family verdict-type unification (keeper ruling 2026-07-27): this package's
+`GoalVerdict` `{status, reason?}` is now the ONE verdict shape family-wide —
+silver-core-maestro-sdk 0.85.0 migrated its `GoalChaser` evaluator verdict
+(previously `{achieved, feedback, impossible?}`) to it, so a single host
+evaluator serves both the engine's `options.goal` Stop gate and the maestro
+cross-query chase. No behavior change in this package; `options.goal` and its
+evaluator contract are untouched. The `GoalVerdict` doc comment in
+`src/types/subsystems.ts` now records the canonical-shape status (shape
+changes require a family-wide ruling). Context worth keeping: the two-shape
+era produced a live consumer trap — a maestro-shaped verdict fed to
+`options.goal` is judged malformed and the Stop gate's deliberate fail-open
+direction allows every stop, so the goal silently never bites (BPT symptom
+report 2026-07-27, "接了 goal 模型照样停").
 ## 0.84.0 — 2026-07-27
 
 Memory index discipline + a consolidation protocol. Diagnosis behind it (keeper
@@ -61,19 +76,56 @@ New tests: 25 (`tests/memory-consolidation.test.ts`) + 3 wiring cases.
 
 ## 0.83.0 — 2026-07-27
 
-Family verdict-type unification (keeper ruling 2026-07-27): this package's
-`GoalVerdict` `{status, reason?}` is now the ONE verdict shape family-wide —
-silver-core-maestro-sdk 0.83.0 migrated its `GoalChaser` evaluator verdict
-(previously `{achieved, feedback, impossible?}`) to it, so a single host
-evaluator serves both the engine's `options.goal` Stop gate and the maestro
-cross-query chase. No behavior change in this package; `options.goal` and its
-evaluator contract are untouched. The `GoalVerdict` doc comment in
-`src/types/subsystems.ts` now records the canonical-shape status (shape
-changes require a family-wide ruling). Context worth keeping: the two-shape
-era produced a live consumer trap — a maestro-shaped verdict fed to
-`options.goal` is judged malformed and the Stop gate's deliberate fail-open
-direction allows every stop, so the goal silently never bites (BPT symptom
-report 2026-07-27, "接了 goal 模型照样停").
+Tools now PRODUCE the structured results this package had been declaring all
+along, and consumers receive them as `toolUseResult` on the tool_result user
+message. From axes 1 and 4 of the divergence sweep (keeper rulings: build the
+structured output surface in full; widen the MCP accept list and research the
+newer revision).
+
+**A correction to the sweep's own finding, because it shaped the work.** The
+first pass grepped for `outputSchema`, found none, and reported "this SDK
+declares no output surface at all". Wrong: `types/tools.ts` already carried
+`GlobOutput`, `GrepOutput`, `WebFetchOutput`, `FileReadOutput`, `BashOutput`
+and the Task quintet, faithfully shaped after official. What was missing was
+that nothing ever POPULATED them — typed-not-populated. The fix is therefore
+much smaller and much better than the one first scoped: the existing types are
+consumed, not duplicated, and `types/tool-outputs.ts` adds only what genuinely
+did not exist.
+
+- `ToolResultPayload.structuredOutput` carries a tool's machine-readable
+  result; Read, Glob, Grep, Bash and WebFetch populate it on every terminal
+  branch (including empty results and failures — a caller must not have to
+  distinguish "no structured result" from "no matches").
+- The engine collects a batch's results keyed by tool_use_id and attaches them
+  to the user turn via a WeakMap side-channel (`engine/tool-use-results.ts`),
+  NOT a field: `APIMessageParam` is the Anthropic wire shape, and an extra
+  property on it either reaches the API or forces a strip-before-send step
+  every future call site must remember. `query()` reads the channel back and
+  emits `toolUseResult` on `SDKUserMessage`.
+- Shape divergence, deliberate: official carries a BARE object because it emits
+  one tool_result per message; this engine batches a turn's results into one
+  message, so the field is a record keyed by tool_use_id. Emitting one message
+  per result instead would change turn structure for every existing consumer.
+- New facts a consumer previously had to parse out of prose: Glob `truncated`,
+  Grep `appliedLimit` / `appliedOffset` / `truncated`, Bash `exitCode` /
+  `interrupted` / `timedOutAfterMs` / `truncated`, Read `truncatedByCharCap`
+  (named for THIS SDK's measure — official's `truncatedByTokenCap` counts
+  tokens, and a same-named field with a different unit reads as parity and
+  behaves as drift).
+- 13 tests, including a loop-level one that runs a real Glob through the engine
+  and reads the turn the engine appended — a green tool-level assertion says
+  nothing about whether the value travels.
+
+**MCP accept list widened** to include `2024-10-07`: official accepts five
+revisions, this client accepted three, so a server pinned to the oldest was
+refused here and served there. The ADVERTISED revision deliberately stays at
+`2025-06-18`. Official advertises `2025-11-25`, whose addition is an async task
+surface (`tasks/get`, `tasks/list`, `tasks/status`, `tasks/result`,
+`tasks/cancel`) plus the `io.modelcontextprotocol/related-task` and `/skills`
+extensions — none implemented here. Advertising a revision whose semantics are
+unshipped is the same red line as describing an unshipped capability, and
+`2025-11-25` is kept out of the accept list for the same reason: failing at
+connect is more legible than failing later on a task method that does not exist.
 
 ## 0.82.0 — 2026-07-27
 

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -70,7 +70,7 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.84.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.84.0`
+**当前版本 `0.85.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.85.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
@@ -84,7 +84,9 @@ src/
 `buildConsolidationPrompt()` + 四阶段整理规程。**层界守住 N1**：只给「该不该整理 / 怎么整理」，
 不给调度——helper 零 I/O 不起进程。整理是跨档大范围写，多租户须挂 S1。详见 CHANGELOG 与 docs/MEMORY.md。
 
-**v0.83.0（2026-07-27）：GoalVerdict 家族统一（本包零行为改动）**——本包 `{status: 'achieved'|'not_achieved'|'impossible', reason?}` 判词类型升格为家族**正典**：maestro 0.83.0 把 `GoalChaser` 评审判词（原 `{achieved, feedback, impossible?}`）迁为同形，自此一个宿主评审器经结构类型同时服务引擎 `options.goal` Stop 门与 maestro 跨 query 追逐两条缝。背景是首个真实消费者陷阱：BPT 接了 `options.goal` 后报「goal 没效果、模型照样停」，排查出两包**同名不同形** `GoalVerdict`——评审器误用 maestro 形状时，引擎按既定失败方向（阻断停止才是危险动作，评审器坏 = fail-open 放行）把 malformed verdict 放行为允许停止，goal 无声失效。本包仅在 `src/types/subsystems.ts` 的 `GoalVerdict` 注释补「正典地位 + 改形需家族级裁定」声明，`options.goal` 行为与评审器契约一字未动。
+**v0.85.0（2026-07-27）：GoalVerdict 家族统一（本包零行为改动）**——本包 `{status: 'achieved'|'not_achieved'|'impossible', reason?}` 判词类型升格为家族**正典**：maestro 0.85.0 把 `GoalChaser` 评审判词（原 `{achieved, feedback, impossible?}`）迁为同形，自此一个宿主评审器经结构类型同时服务引擎 `options.goal` Stop 门与 maestro 跨 query 追逐两条缝。背景是首个真实消费者陷阱：BPT 接了 `options.goal` 后报「goal 没效果、模型照样停」，排查出两包**同名不同形** `GoalVerdict`——评审器误用 maestro 形状时，引擎按既定失败方向（阻断停止才是危险动作，评审器坏 = fail-open 放行）把 malformed verdict 放行为允许停止，goal 无声失效。本包仅在 `src/types/subsystems.ts` 的 `GoalVerdict` 注释补「正典地位 + 改形需家族级裁定」声明，`options.goal` 行为与评审器契约一字未动。
+**v0.85.0（2026-07-27）：工具真正产出结构化结果 + MCP 接受列表扩容**（偏离普查轴一 / 轴四守密人裁定）——**先订正普查自己的一处结论**：首轮只 grep `outputSchema`、没找到就报「银芯零输出面」，**错了**——`types/tools.ts` 里 `GlobOutput`/`GrepOutput`/`WebFetchOutput`/`FileReadOutput`/`BashOutput`/Task 五件**早已按官方形状声明**，缺的是**从来没人产出**（typed-not-populated）。于是改动比原先设想的小得多也好得多：**复用既有类型、不另造一套**。① `ToolResultPayload.structuredOutput` 承载机器可读结果，Read/Glob/Grep/Bash/WebFetch 在**每条终态分支**都产出（含空结果与失败——调用方不该需要区分「没有结构化结果」与「没有匹配」）；② 引擎按 tool_use_id 收集整批，经 **WeakMap 侧信道**（`engine/tool-use-results.ts`）挂到用户轮而**不是加字段**——`APIMessageParam` 是**Anthropic 线格式**，多挂一个属性要么发去 API、要么逼后来每个调用点都记得先剥掉；③ `query()` 读回并以`toolUseResult` 发给消费方。**形状差异（有意）**：官方是裸对象（它一消息一 tool_result），本引擎一轮批处理，故为 **tool_use_id 为键的 record**。新增可直接读到的事实：Glob `truncated` · Grep `appliedLimit`/`appliedOffset`/`truncated` · Bash `exitCode`/`interrupted`/`timedOutAfterMs`/`truncated` · Read `truncatedByCharCap`（**按本 SDK 的字符度量命名**，官方 `truncatedByTokenCap` 数的是 token，同名不同单位读起来像对齐、跑起来是漂移）。13 条测试，含一条**跑真引擎**的接缝测试（工具级绿说明不了值有没有传出去）。
+**MCP 接受列表**加 `2024-10-07`（官方接受 5 个、银芯只接受 3 个，钉在最老修订的服务器在官方能连、在银芯被拒）；**提议版本仍留 `2025-06-18`**——官方提议 `2025-11-25`，其新增是**异步任务面**（`tasks/get`·`list`·`status`·`result`·`cancel`）与 `related-task`/`skills` 两扩展，本包一个都没实现；**宣告一个语义未发货的版本号，与描述未发货能力是同一条红线**。
 
 **v0.82.0（2026-07-27）：Read 通读 >256KB 改为拒绝 + 首次对官方二进制做偏离普查**——守密人问「还能查到有哪些我们与官方不一致」，遂第一次拿**官方发行物本体**（npm 平台包 + `sdk-tools.d.ts`）而非第三方重建档做四轴对照。**唯一改代码的一条**：官方 `maxSizeBytes`=262144 拒通读，银芯此前只有 50MB OOM 守卫（松 200 倍，于是 30MB 日志会被真读进内存再几乎全丢）。现两条上限各司其职——256KB **导向**（「这不是 Read 该干的事」）、50MB **保命**（「这会撑死进程」）；**只拦通读**，带 offset/limit 放行（官方错误文案与工具描述两处都写明这是逃生口）。**属破坏性变更**：读 256KB–50MB 档的消费方会突然报错，修法机械（加 offset/limit 或改 Grep）且错误文案已写明。
 **同批查出但按守密人裁定只登记不改**：`AskUserQuestion` 缺官方三个**回程字段**（`answers`/`annotations`/`metadata.source`）——它们服务于官方权限组件 UI 回填与遥测，本 SDK 是宿主回调、无那套组件，加了就是描述未发货能力。**另有两条经复核是假象、如实记档**：`EnterPlanModeInput` 官方就是 `{}`（一致），Grep 的 `-i/-A/-B/-C/-o` 与 `TaskListInput` 亦一致——首轮正则不认带引号键、且被单行 `{}` 接口串块骗了三次。

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/engine/loop.ts
+++ b/projects/silver-core-sdk/src/engine/loop.ts
@@ -5,6 +5,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { attachToolUseResults } from './tool-use-results.js';
 
 import {
   AbortError,
@@ -1451,6 +1452,12 @@ export async function* runAgentLoop(
           return;
         }
         const results: ToolResultBlockParam[] = [];
+        // Structured results for this batch, keyed by tool_use_id. Official
+        // carries one `toolUseResult` per user message because it emits one
+        // tool_result per message; this engine batches a turn's results into
+        // ONE user turn, so a record keyed by id is the honest shape here
+        // (2026-07-27, structured-output surface).
+        const structuredResults: Record<string, unknown> = {};
         let batchStop: ToolExecOutcome['stop'];
         let batchDefer: ToolExecOutcome['defer'];
         // Execute in content order, but run a maximal run of >= 2 consecutive
@@ -1517,6 +1524,9 @@ export async function* runAgentLoop(
               for (const msg of outcome.observability) yield msg;
             }
             results.push(outcome.result);
+            if (outcome.structured !== undefined) {
+              structuredResults[toolUses[ti + g]!.id] = outcome.structured;
+            }
             if (outcome.stop !== undefined) {
               batchStop = outcome.stop;
               stoppedInGroup = true;
@@ -1562,6 +1572,9 @@ export async function* runAgentLoop(
         }
         pushAssistant(assistant.content, assistant.model);
         const userTurn: APIMessageParam = { role: 'user', content: results };
+        if (Object.keys(structuredResults).length > 0) {
+          attachToolUseResults(userTurn, structuredResults);
+        }
         history.push(userTurn);
         mirror(userTurn);
 

--- a/projects/silver-core-sdk/src/engine/tool-dispatch.ts
+++ b/projects/silver-core-sdk/src/engine/tool-dispatch.ts
@@ -58,6 +58,11 @@ function mkToolError(toolUseId: string, message: string): ToolResultBlockParam {
  */
 export type ToolExecOutcome = {
   result: ToolResultBlockParam;
+  /** Machine-readable result from the tool, carried alongside the API block so
+   *  the loop can attach it to the emitted user message as `toolUseResult`.
+   *  The API's tool_result has no structured channel, so it cannot ride there
+   *  (2026-07-27, structured-output surface). */
+  structured?: unknown;
   stop?: { reason: string };
   defer?: {
     // Official field names (canonical) + legacy names, dual-track per T1-4.
@@ -583,7 +588,7 @@ export function createToolDispatcher(cfg: ToolDispatcherConfig): {
       content: Array.isArray(content) && content.length === 0 ? '' : content,
     };
     if (payload.isError === true) result.is_error = true;
-    return { result, stop };
+    return { result, stop, structured: payload.structuredOutput };
   }
 
   return { isReadOnlyTool, isParallelSafeTool, executeToolUse };

--- a/projects/silver-core-sdk/src/engine/tool-use-results.ts
+++ b/projects/silver-core-sdk/src/engine/tool-use-results.ts
@@ -1,0 +1,33 @@
+/**
+ * Side-channel carrying a batch's structured tool results from the engine loop
+ * (which builds the API user turn) to the query layer (which emits the
+ * SDKUserMessage), added 2026-07-27 with the structured-output surface.
+ *
+ * A WeakMap keyed by the turn object rather than a field on it, for one
+ * reason: `APIMessageParam` is the ANTHROPIC WIRE SHAPE. Every entry in
+ * `history` is serialized into the next request, and an extra property riding
+ * along would either be sent to the API (rejected, or worse, silently billed
+ * as unknown content) or force a strip-before-send step that every future call
+ * site has to remember. Keying off the object identity keeps the wire type
+ * exactly what its name says it is.
+ *
+ * WeakMap, not Map: entries die with the turn objects, so a long session
+ * cannot accumulate a second copy of every tool result it ever produced.
+ */
+
+import type { APIMessageParam } from '../types.js';
+import type { ToolUseResults } from '../types/tool-outputs.js';
+
+const RESULTS = new WeakMap<object, ToolUseResults>();
+
+/** Attach a batch's structured results to the user turn that carries them. */
+export function attachToolUseResults(turn: APIMessageParam, results: ToolUseResults): void {
+  RESULTS.set(turn as unknown as object, results);
+}
+
+/** Read back what `attachToolUseResults` stored, or undefined for a turn that
+ *  carried none (a plain user message, or a batch where no tool produced a
+ *  structured result). */
+export function readToolUseResults(turn: APIMessageParam): ToolUseResults | undefined {
+  return RESULTS.get(turn as unknown as object);
+}

--- a/projects/silver-core-sdk/src/internal/contracts.ts
+++ b/projects/silver-core-sdk/src/internal/contracts.ts
@@ -115,6 +115,26 @@ export interface Transport {
 export type ToolResultPayload = {
   content: string | Array<TextBlockParam | ImageBlockParam | DocumentBlockParam>;
   isError?: boolean;
+  /**
+   * Machine-readable result, surfaced to SDK consumers as `toolUseResult` on
+   * the tool_result user message (2026-07-27, divergence sweep vs official
+   * 2.1.220 + keeper ruling "全量建结构化输出面").
+   *
+   * WHY it exists: official declares an `outputSchema` per tool and hands
+   * consumers a typed result; this SDK returned text only, so anything a
+   * consumer needed — did Glob truncate, how many matches did Grep really
+   * find, what exactly did Edit change — had to be re-derived by PARSING the
+   * human-facing string. Official's own type comment on
+   * `truncatedByTokenCap` states the principle outright: it "survives output
+   * reconstruction (unlike the render-time banner)". Text is a rendering;
+   * rendering is not an interface.
+   *
+   * NOT sent to the model — the Anthropic tool_result block has no structured
+   * channel, and duplicating the payload into the text would spend context to
+   * restate what the text already says. See `src/types/tool-outputs.ts` for
+   * the per-tool shapes.
+   */
+  structuredOutput?: unknown;
 };
 
 /**

--- a/projects/silver-core-sdk/src/mcp/protocol.ts
+++ b/projects/silver-core-sdk/src/mcp/protocol.ts
@@ -28,13 +28,39 @@ import type {
 import { McpError } from '../errors.js';
 import { SDK_VERSION } from '../version.js';
 
-/** Protocol revision this client advertises in `initialize`. */
+/**
+ * Protocol revision this client advertises in `initialize`.
+ *
+ * Official Claude Code 2.1.220 advertises `2025-11-25` (verified in the binary:
+ * `frt="2025-11-25"`). This client stays on `2025-06-18` DELIBERATELY: the
+ * newer revision's addition is an async task surface (`tasks/get`, `tasks/list`,
+ * `tasks/status`, `tasks/result`, `tasks/cancel`) plus the
+ * `io.modelcontextprotocol/related-task` and `/skills` extensions, none of which
+ * this client implements. Advertising a revision whose semantics are unshipped
+ * is the same red line as describing an unshipped capability — a server may
+ * legitimately expect those methods to work. The number moves when the
+ * semantics land, not before.
+ */
 export const MCP_PROTOCOL_VERSION = '2025-06-18';
 /** Protocol revisions this clean-room client can speak. A server that
  *  negotiates anything outside this set fails connect (spec: the client SHOULD
  *  disconnect on an unsupported version) instead of having the unknown version
- *  echoed into every later request (audit r4 Z6-1/Z6-2). */
-export const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'];
+ *  echoed into every later request (audit r4 Z6-1/Z6-2).
+ *
+ *  `2024-10-07` added 2026-07-27: official accepts five revisions
+ *  (`[frt, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"]`) and this
+ *  client accepted only three, so a server pinned to the oldest revision was
+ *  REFUSED here and served there. Widening what we tolerate costs nothing —
+ *  it is the accept list, not the advertised one, and every request still
+ *  carries the negotiated version. `2025-11-25` is deliberately NOT in this
+ *  list either: accepting a negotiation onto a revision whose task methods are
+ *  unimplemented would fail later and less legibly than failing at connect. */
+export const SUPPORTED_PROTOCOL_VERSIONS = [
+  '2025-06-18',
+  '2025-03-26',
+  '2024-11-05',
+  '2024-10-07',
+];
 export const CLIENT_INFO = { name: 'silver-core-sdk', version: SDK_VERSION } as const;
 export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 /** Safety cap on tools/list pagination to avoid a misbehaving-server loop. */

--- a/projects/silver-core-sdk/src/query.ts
+++ b/projects/silver-core-sdk/src/query.ts
@@ -7,6 +7,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { readToolUseResults } from './engine/tool-use-results.js';
 
 import { AbortError, ConfigurationError, isAbortError } from './errors.js';
 import type {
@@ -1274,12 +1275,16 @@ export function query(args: {
               // (keeper ruling 2026-07-13: message uuids persist at write time).
               const entryUuid = randomUUID();
               persistParam(sess.sessionId, entry, entryUuid);
+              // Structured tool results ride a side-channel keyed by the turn
+              // object (see engine/tool-use-results.ts for why not a field).
+              const toolUseResult = readToolUseResults(entry);
               yield {
                 type: 'user',
                 uuid: entryUuid,
                 session_id: sess.sessionId,
                 message: { role: 'user', content: entry.content },
                 parent_tool_use_id: null,
+                ...(toolUseResult !== undefined && { toolUseResult }),
               };
             }
           }

--- a/projects/silver-core-sdk/src/tools/bash.ts
+++ b/projects/silver-core-sdk/src/tools/bash.ts
@@ -16,6 +16,7 @@ import { BASH_DESCRIPTION, BASH_WIN32_NOTE, buildBashSandboxNote } from './descr
 import { planShellSpawn, resolveSpawnEnv } from '../sandbox/backend.js';
 import { detectSandboxEvidence, sandboxFailureHint } from '../sandbox/evidence.js';
 import { sliceTailSurrogateSafe } from '../internal/text.js';
+import type { BashStructuredOutput } from '../types/tool-outputs.js';
 import type { SandboxContext } from '../types.js';
 import type {
   BuiltinTool,
@@ -34,6 +35,10 @@ const KILL_GRACE_MS = 2_000;
  * never fire). The common case settles earlier, on 'close'.
  */
 const FLUSH_GRACE_MS = 200;
+
+/** Leading marker a capped stream carries; also the `truncated` signal in the
+ *  structured result, so the two can never disagree. */
+const BASH_TRUNCATION_MARKER = '[truncated: earlier output dropped]';
 
 /**
  * Accumulates stream output, keeping only the LAST STREAM_CAP_CHARS chars.
@@ -61,7 +66,7 @@ class CappedStream {
   }
 
   text(): string {
-    return this.truncated ? `[truncated: earlier output dropped]\n${this.buf}` : this.buf;
+    return this.truncated ? `${BASH_TRUNCATION_MARKER}\n${this.buf}` : this.buf;
   }
 }
 
@@ -490,6 +495,25 @@ export function createBashTool(
  *  the schema carries the always-on escape param (no-op here). */
 export const bashTool: BuiltinTool = createBashTool();
 
+/** Structured result shared by Bash's three terminal branches, so a consumer
+ *  reads the same shape whether the command succeeded, failed or timed out —
+ *  facts that were previously only recoverable by parsing the report string. */
+function bashStructured(
+  outcome: { stdout: string; stderr: string; code: number | null },
+  opts: { interrupted: boolean; timedOutAfterMs?: number },
+): BashStructuredOutput {
+  return {
+    stdout: outcome.stdout,
+    stderr: outcome.stderr,
+    interrupted: opts.interrupted,
+    exitCode: outcome.code,
+    ...(opts.timedOutAfterMs !== undefined && { timedOutAfterMs: opts.timedOutAfterMs }),
+    truncated:
+      outcome.stdout.startsWith(BASH_TRUNCATION_MARKER) ||
+      outcome.stderr.startsWith(BASH_TRUNCATION_MARKER),
+  };
+}
+
 async function execute(
     input: Record<string, unknown>,
     ctx: ToolContext,
@@ -636,11 +660,18 @@ async function execute(
           `Command timed out after ${timeoutMs}ms` +
           (streams.length > 0 ? `\n${streams}` : ''),
         isError: true,
+        structuredOutput: bashStructured(outcome, {
+          interrupted: true,
+          timedOutAfterMs: timeoutMs,
+        }),
       };
     }
 
     if (outcome.code === 0) {
-      return { content: streams.length > 0 ? streams : '(no output)' };
+      return {
+        content: streams.length > 0 ? streams : '(no output)',
+        structuredOutput: bashStructured(outcome, { interrupted: false }),
+      };
     }
 
     const failure =
@@ -669,5 +700,6 @@ async function execute(
     return {
       content: failure + (streams.length > 0 ? `\n${streams}` : '') + hint + cmdHint + sigHint,
       isError: true,
+      structuredOutput: bashStructured(outcome, { interrupted: false }),
     };
 }

--- a/projects/silver-core-sdk/src/tools/glob.ts
+++ b/projects/silver-core-sdk/src/tools/glob.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import { AbortError } from '../errors.js';
 import { GLOB_DESCRIPTION } from './descriptions.js';
 import { toNativePath } from './fsutil.js';
+import type { GlobOutput as GlobStructuredOutput } from '../types/tools.js';
 import type {
   BuiltinTool,
   ToolContext,
@@ -45,6 +46,7 @@ export const globTool: BuiltinTool = {
     input: Record<string, unknown>,
     ctx: ToolContext,
   ): Promise<ToolResultPayload> {
+    const startedAt = Date.now();
     const pattern = input['pattern'];
     if (typeof pattern !== 'string' || pattern.length === 0) {
       return {
@@ -130,7 +132,15 @@ export const globTool: BuiltinTool = {
     if (ctx.signal.aborted) throw new AbortError();
 
     if (files.length === 0) {
-      return { content: 'No files found' };
+      return {
+        content: 'No files found',
+        structuredOutput: {
+          durationMs: Date.now() - startedAt,
+          numFiles: 0,
+          filenames: [],
+          truncated: false,
+        } satisfies GlobStructuredOutput,
+      };
     }
 
     // Newest first, with a deterministic path tiebreak (V6-2, audit r4): mtime
@@ -151,6 +161,16 @@ export const globTool: BuiltinTool = {
         `(Results truncated: showing first ${MAX_RESULTS} of ${sorted.length} matches)`,
       );
     }
-    return { content: lines.join('\n') };
+    return {
+      content: lines.join('\n'),
+      // `truncated` is the fact a caller most often needs and could previously
+      // only get by string-matching the "(Results truncated: ...)" line.
+      structuredOutput: {
+        durationMs: Date.now() - startedAt,
+        numFiles: capped.length,
+        filenames: capped.map((e) => e.path),
+        truncated: sorted.length > MAX_RESULTS,
+      } satisfies GlobStructuredOutput,
+    };
   },
 };

--- a/projects/silver-core-sdk/src/tools/grep.ts
+++ b/projects/silver-core-sdk/src/tools/grep.ts
@@ -15,6 +15,7 @@ import { guardRegexPattern } from '../internal/regex-guard.js';
 import { sliceSurrogateSafe } from '../internal/text.js';
 import { GREP_DESCRIPTION } from './descriptions.js';
 import { toNativePath } from './fsutil.js';
+import type { GrepStructuredOutput } from '../types/tool-outputs.js';
 import type {
   BuiltinTool,
   ToolContext,
@@ -633,7 +634,18 @@ export const grepTool: BuiltinTool = {
         : '';
 
     if (!anyMatch) {
-      return { content: `No matches found${oversizeNote}` };
+      return {
+        content: `No matches found${oversizeNote}`,
+        structuredOutput: {
+          mode: outputMode,
+          numFiles: 0,
+          filenames: [],
+          numLines: outputMode === 'content' ? 0 : undefined,
+          appliedLimit: headLimit,
+          appliedOffset: offset,
+          truncated: scanStoppedEarly,
+        } satisfies GrepStructuredOutput,
+      };
     }
     const capped = limited
       ? out.slice(offset, offset + headLimit)
@@ -670,6 +682,25 @@ export const grepTool: BuiltinTool = {
         `${files.length - scannedFiles} file(s) not scanned — more matches may exist;` +
         ` raise head_limit or set head_limit=0 for the complete result)`;
     }
-    return { content: content + oversizeNote };
+    return {
+      content: content + oversizeNote,
+      // appliedLimit / appliedOffset report what the call ACTUALLY used after
+      // defaulting — previously inferable only from the footer sentence, and
+      // exactly what a caller needs to page correctly.
+      structuredOutput: {
+        mode: outputMode,
+        // In files_with_matches mode every emitted row IS a path, so the count
+        // and the list are exact. In the other modes a row is a match line or a
+        // per-file count, so `filenames` would be a guess — left empty rather
+        // than filled with something derived-looking but wrong.
+        numFiles:
+          outputMode === 'files_with_matches' ? capped.length : scannedFiles,
+        filenames: outputMode === 'files_with_matches' ? [...capped] : [],
+        numLines: outputMode === 'content' ? capped.length : undefined,
+        appliedLimit: headLimit,
+        appliedOffset: offset,
+        truncated: displayTruncated || matchesCut || scanStoppedEarly,
+      } satisfies GrepStructuredOutput,
+    };
   },
 };

--- a/projects/silver-core-sdk/src/tools/read.ts
+++ b/projects/silver-core-sdk/src/tools/read.ts
@@ -20,6 +20,7 @@ import {
   resolveAbs,
 } from './fsutil.js';
 import { READ_DESCRIPTION } from './descriptions.js';
+import type { ReadOutput as ReadStructuredOutput } from '../types/tool-outputs.js';
 
 const DEFAULT_LINE_LIMIT = 2000;
 
@@ -451,6 +452,20 @@ export function createReadTool(limits?: ReadLimits): BuiltinTool {
             'instead of reading page by page.)';
         }
         content += footer;
+        return {
+          content,
+          structuredOutput: {
+            type: 'text',
+            file: {
+              filePath: abs,
+              content: fmt.text,
+              numLines: shownLines,
+              startLine,
+              totalLines: total,
+              truncatedByCharCap: true,
+            },
+          } satisfies ReadStructuredOutput,
+        };
       } else if (realLastShown < total) {
         // Line-count limit (or offset window) bounded the output, chars did not.
         // Same wording as the char-cap branch above: the trigger differs, the
@@ -461,7 +476,19 @@ export function createReadTool(limits?: ReadLimits): BuiltinTool {
           `Grep to find a specific section. Do NOT answer from this page alone ` +
           `if the answer may be further in the file.)`;
       }
-      return { content };
+      return {
+        content,
+        structuredOutput: {
+          type: 'text',
+          file: {
+            filePath: abs,
+            content: fmt.text,
+            numLines: shownLines,
+            startLine,
+            totalLines: total,
+          },
+        } satisfies ReadStructuredOutput,
+      };
     } catch (e) {
       if (isAbortError(e)) {
         throw new AbortError('Read was aborted');

--- a/projects/silver-core-sdk/src/tools/webfetch.ts
+++ b/projects/silver-core-sdk/src/tools/webfetch.ts
@@ -35,6 +35,7 @@ import type {
 } from '../internal/contracts.js';
 import { sliceSurrogateSafe } from '../internal/text.js';
 import { MAX_READ_OUTPUT_CHARS } from './fsutil.js';
+import type { WebFetchStructuredOutput } from '../types/tool-outputs.js';
 import { AbortError, isAbortError } from '../errors.js';
 import { SDK_USER_AGENT } from '../version.js';
 import { WEBFETCH_DESCRIPTION } from './descriptions.js';
@@ -491,6 +492,7 @@ export const webFetchTool: BuiltinTool = {
     input: Record<string, unknown>,
     ctx: ToolContext,
   ): Promise<ToolResultPayload> {
+    const fetchStartedAt = Date.now();
     try {
       if (ctx.signal.aborted) throw new AbortError();
 
@@ -652,7 +654,21 @@ export const webFetchTool: BuiltinTool = {
       }
 
       ctx.debug(`WebFetch: ${current.toString()} -> ${text.length} chars (${contentType})`);
-      return { content: text };
+      return {
+        content: text,
+        structuredOutput: {
+          bytes: buf.length,
+          code: response.status,
+          codeText: response.statusText,
+          url: current.toString(),
+          durationMs: Date.now() - fetchStartedAt,
+          // `result` is the official field for the fetched body; this engine
+          // returns it verbatim (no summarizer), so the structured copy is the
+          // same text the model sees.
+          result: text,
+          truncated,
+        } satisfies WebFetchStructuredOutput,
+      };
     } catch (e) {
       // WV5-3 (audit r3): the fetch signal merges the turn signal with a 30s
       // per-request timeout. A REAL turn cancel (ctx.signal aborted) rethrows

--- a/projects/silver-core-sdk/src/types.ts
+++ b/projects/silver-core-sdk/src/types.ts
@@ -33,3 +33,13 @@ export * from './types/subsystems.js';
 export * from './types/query.js';
 // 官方工具输入/输出类型面（原 src/tool-types.ts，P7 归位；零名字冲突，实测 47 vs 219）
 export * from './types/tools.js';
+
+// 结构化工具结果（2026-07-27 偏离普查后新增；形状与理由见该档头注）
+export type {
+  ReadOutput,
+  ReadTextOutputWithCap,
+  BashStructuredOutput,
+  GrepStructuredOutput,
+  WebFetchStructuredOutput,
+  ToolUseResults,
+} from './types/tool-outputs.js';

--- a/projects/silver-core-sdk/src/types/messages.ts
+++ b/projects/silver-core-sdk/src/types/messages.ts
@@ -9,6 +9,7 @@
  */
 
 import type { NormalizedProviderError } from '../error-normalize.js';
+import type { ToolUseResults } from './tool-outputs.js';
 import type { HookEvent } from './hooks.js';
 import type { SDKMemoryHealth } from './options.js';
 import type { PermissionMode, SDKPermissionDenial } from './permissions.js';
@@ -59,6 +60,18 @@ export type SDKUserMessage = {
   parent_tool_use_id: string | null;
   /** NEW-IN-DOCS. typed-not-populated. */
   origin?: SDKMessageOrigin;
+  /**
+   * Structured results for the tool_result blocks this message carries, keyed
+   * by tool_use_id (2026-07-27). Present only on engine-emitted tool_result
+   * turns where at least one tool produced one.
+   *
+   * Official carries a BARE object here because it emits one tool_result per
+   * message; this engine batches a turn's results into one message, so the
+   * key is required to tell them apart. Documented as a shape divergence in
+   * docs/COMPAT.md rather than papered over by emitting one message per
+   * result, which would change turn structure for every existing consumer.
+   */
+  toolUseResult?: ToolUseResults;
 };
 
 export type SDKUserMessageReplay = {

--- a/projects/silver-core-sdk/src/types/tool-outputs.ts
+++ b/projects/silver-core-sdk/src/types/tool-outputs.ts
@@ -1,0 +1,84 @@
+/**
+ * Structured tool results (`toolUseResult`) — the PRODUCING side of the output
+ * types that already lived in `types/tools.ts`.
+ *
+ * Correcting the record, because the first pass of the 2026-07-27 divergence
+ * sweep got this wrong: it grepped for `outputSchema`, found none, and reported
+ * "this SDK declares no output surface at all". The TYPES were there the whole
+ * time — `GlobOutput`, `GrepOutput`, `WebFetchOutput`, `FileReadOutput`,
+ * `BashOutput`, the Task quintet — faithfully mirroring the official shapes.
+ * What was missing was that nothing ever POPULATED them: typed-not-populated,
+ * which is exactly the failure mode this repository has a name for. So this
+ * module deliberately declares almost nothing new; it re-exports the existing
+ * types under producing-side names and adds only the two things that genuinely
+ * did not exist.
+ *
+ * Why a caller needs this at all: a fact about a tool call — did Glob truncate,
+ * what offset did Grep actually apply, what was the exit code — was previously
+ * recoverable only by PARSING the human-facing string. Official states the
+ * principle in its own comment on `truncatedByTokenCap`: that field "survives
+ * output reconstruction (unlike the render-time banner)". A banner is a
+ * rendering; a rendering is not an interface.
+ *
+ * Fidelity notes so these are not mistaken for byte-parity with official:
+ * - Fields official derives from machinery this SDK does not ship (git diffs,
+ *   image transcode metadata, official background-task ids) stay UNPOPULATED
+ *   rather than faked. An absent optional field is honest; a zero-filled one
+ *   is not.
+ * - Official emits one `toolUseResult` per user message because it emits one
+ *   tool_result per message. This engine batches a turn's results into a single
+ *   user turn, so the message carries a RECORD keyed by tool_use_id. That is a
+ *   real shape divergence, documented in docs/COMPAT.md.
+ */
+
+import type {
+  BashOutput,
+  FileReadOutput,
+  GlobOutput,
+  GrepOutput,
+  WebFetchOutput,
+} from './tools.js';
+
+export type { BashOutput, FileReadOutput, GlobOutput };
+
+/**
+ * Grep / WebFetch as this SDK populates them: the existing official-shaped
+ * type plus a `truncated` flag. NEW because official reports truncation for
+ * these through fields this engine does not produce (Grep's `totalFiles` /
+ * `totalLines` pair, WebFetch's summarizer path), and "was this cut short" is
+ * the single most load-bearing fact a caller needs — it decides whether the
+ * result may be treated as complete. Additive, so an existing consumer typed
+ * against the base shape keeps compiling.
+ */
+export type GrepStructuredOutput = GrepOutput & { truncated: boolean };
+export type WebFetchStructuredOutput = WebFetchOutput & { truncated: boolean };
+export type { GrepOutput, WebFetchOutput };
+
+/**
+ * Read's char-cap flag. NEW here, and named differently from official's
+ * `truncatedByTokenCap` ON PURPOSE: official measures tokens, this SDK
+ * measures characters (a documented divergence), and a same-named field
+ * carrying a different unit is worse than a differently-named one — it reads
+ * as parity and behaves as drift.
+ */
+export type ReadTextOutputWithCap = Extract<FileReadOutput, { type: 'text' }> & {
+  file: { truncatedByCharCap?: boolean };
+};
+
+/** What Read actually produces here: the official union, with the cap flag
+ *  available on the text arm. */
+export type ReadOutput = ReadTextOutputWithCap | Exclude<FileReadOutput, { type: 'text' }>;
+
+/**
+ * Bash's result as this SDK populates it. Extends the existing `BashOutput`
+ * with the two facts this engine knows and official carries elsewhere in its
+ * own task model: the process exit code, and whether the stream cap bit.
+ */
+export type BashStructuredOutput = BashOutput & {
+  exitCode: number | null;
+  timedOutAfterMs?: number;
+  truncated: boolean;
+};
+
+/** The per-message map described in the module header. */
+export type ToolUseResults = Record<string, unknown>;

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.84.0';
+export const SDK_VERSION = '0.85.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/tool-structured-output.test.ts
+++ b/projects/silver-core-sdk/tests/tool-structured-output.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Structured tool results (`toolUseResult`), added 2026-07-27 after the
+ * divergence sweep found this SDK shipping no output surface at all.
+ *
+ * What these tests are FOR: every fact asserted below was previously
+ * obtainable only by parsing the human-facing string — "did Glob truncate",
+ * "what offset did Grep actually apply", "what was the exit code". Official's
+ * own type comment states the principle (`truncatedByTokenCap` "survives
+ * output reconstruction, unlike the render-time banner"), and a test that
+ * merely re-read the banner would be testing the very thing this surface
+ * exists to stop depending on. So each case asserts the structured field
+ * DIRECTLY, and the truncation cases additionally pin that the structured
+ * flag agrees with the rendered text — the two disagreeing is the failure
+ * mode that would make the surface worse than useless.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { readTool } from '../src/tools/read.js';
+import { globTool } from '../src/tools/glob.js';
+import { grepTool } from '../src/tools/grep.js';
+import { bashTool } from '../src/tools/bash.js';
+import type { ToolContext } from '../src/internal/contracts.js';
+import type {
+  BashStructuredOutput,
+  GlobOutput,
+  GrepOutput,
+  ReadOutput,
+} from '../src/types/tool-outputs.js';
+
+let sandboxes: string[] = [];
+async function makeSandbox(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'scs-structured-'));
+  sandboxes.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(sandboxes.map((d) => rm(d, { recursive: true, force: true })));
+  sandboxes = [];
+});
+
+function makeCtx(cwd: string): ToolContext {
+  return {
+    cwd,
+    additionalDirectories: [],
+    env: {},
+    signal: new AbortController().signal,
+    debug: () => {},
+  };
+}
+const text = (res: { content: unknown }): string =>
+  typeof res.content === 'string' ? res.content : JSON.stringify(res.content);
+
+describe('Read structured result', () => {
+  it('reports the window and total without the caller parsing the footer', async () => {
+    const dir = await makeSandbox();
+    const file = path.join(dir, 'a.txt');
+    await writeFile(file, Array.from({ length: 40 }, (_, i) => `l${i}`).join('\n'), 'utf8');
+    const res = await readTool.execute({ file_path: file, offset: 5, limit: 10 }, makeCtx(dir));
+    const s = res.structuredOutput as ReadOutput;
+    expect(s.type).toBe('text');
+    if (s.type !== 'text') return;
+    expect(s.file.startLine).toBe(5);
+    expect(s.file.numLines).toBe(10);
+    expect(s.file.totalLines).toBe(40);
+    expect(s.file.truncatedByCharCap).toBeUndefined();
+  });
+
+  it('flags a char-capped read, and the flag agrees with the rendered footer', async () => {
+    const dir = await makeSandbox();
+    const file = path.join(dir, 'wide.txt');
+    // ~200KB: over the 50K char cap, under the 256KB whole-file refusal.
+    await writeFile(file, Array.from({ length: 400 }, () => 'w'.repeat(500)).join('\n'), 'utf8');
+    const res = await readTool.execute({ file_path: file }, makeCtx(dir));
+    const s = res.structuredOutput as ReadOutput;
+    expect(s.type === 'text' && s.file.truncatedByCharCap).toBe(true);
+    expect(text(res)).toContain('output truncated at');
+  });
+});
+
+describe('Glob structured result', () => {
+  it('reports truncated=false and the file list for a small match set', async () => {
+    const dir = await makeSandbox();
+    await writeFile(path.join(dir, 'x.ts'), '', 'utf8');
+    await writeFile(path.join(dir, 'y.ts'), '', 'utf8');
+    const res = await globTool.execute({ pattern: '**/*.ts', path: dir }, makeCtx(dir));
+    const s = res.structuredOutput as GlobOutput;
+    expect(s.numFiles).toBe(2);
+    expect(s.truncated).toBe(false);
+    expect(s.filenames).toHaveLength(2);
+    expect(typeof s.durationMs).toBe('number');
+  });
+
+  it('a no-match run still carries a structured result, not undefined', async () => {
+    const dir = await makeSandbox();
+    const res = await globTool.execute({ pattern: '**/*.nope', path: dir }, makeCtx(dir));
+    const s = res.structuredOutput as GlobOutput;
+    expect(s.numFiles).toBe(0);
+    expect(s.filenames).toEqual([]);
+    expect(s.truncated).toBe(false);
+  });
+});
+
+describe('Grep structured result', () => {
+  it('reports the offset and limit ACTUALLY applied, defaults included', async () => {
+    const dir = await makeSandbox();
+    await writeFile(path.join(dir, 'a.txt'), 'NEEDLE\n', 'utf8');
+    const res = await grepTool.execute({ pattern: 'NEEDLE', path: dir }, makeCtx(dir));
+    const s = res.structuredOutput as GrepOutput;
+    // The caller passed neither; 250/0 are what the call ran with, and there
+    // was previously no way to learn that except by reading the schema docs.
+    expect(s.appliedLimit).toBe(250);
+    expect(s.appliedOffset).toBe(0);
+    expect(s.truncated).toBe(false);
+    expect(s.mode).toBe('files_with_matches');
+    expect(s.filenames).toHaveLength(1);
+  });
+
+  it('flags truncation, and the flag agrees with the rendered note', async () => {
+    const dir = await makeSandbox();
+    for (let i = 0; i < 30; i++) {
+      await writeFile(path.join(dir, `f${i}.txt`), 'NEEDLE\n', 'utf8');
+    }
+    const res = await grepTool.execute(
+      { pattern: 'NEEDLE', path: dir, output_mode: 'files_with_matches', head_limit: 5 },
+      makeCtx(dir),
+    );
+    const s = res.structuredOutput as GrepOutput;
+    expect(s.appliedLimit).toBe(5);
+    expect(s.truncated).toBe(true);
+    expect(s.filenames).toHaveLength(5);
+    expect(text(res)).toMatch(/truncated|not scanned/);
+  });
+
+  it('a no-match run reports the applied limits rather than nothing', async () => {
+    const dir = await makeSandbox();
+    await writeFile(path.join(dir, 'a.txt'), 'nothing here\n', 'utf8');
+    const s = (await grepTool.execute({ pattern: 'ZZZ_ABSENT', path: dir }, makeCtx(dir)))
+      .structuredOutput as GrepOutput;
+    expect(s.numFiles).toBe(0);
+    expect(s.appliedLimit).toBe(250);
+  });
+});
+
+describe('Bash structured result', () => {
+  it('reports exit code 0 and the streams for a success', async () => {
+    const dir = await makeSandbox();
+    const res = await bashTool.execute({ command: 'printf hello' }, makeCtx(dir));
+    const s = res.structuredOutput as BashStructuredOutput;
+    expect(s.exitCode).toBe(0);
+    expect(s.stdout).toBe('hello');
+    expect(s.interrupted).toBe(false);
+    expect(s.truncated).toBe(false);
+  });
+
+  it('reports the real exit code on failure, not just an error string', async () => {
+    const dir = await makeSandbox();
+    const res = await bashTool.execute({ command: 'exit 42' }, makeCtx(dir));
+    expect(res.isError).toBe(true);
+    expect((res.structuredOutput as BashStructuredOutput).exitCode).toBe(42);
+  });
+
+  it('marks interrupted + timedOutAfterMs on a timeout', async () => {
+    const dir = await makeSandbox();
+    const res = await bashTool.execute({ command: 'sleep 5', timeout: 300 }, makeCtx(dir));
+    const s = res.structuredOutput as BashStructuredOutput;
+    expect(s.interrupted).toBe(true);
+    expect(s.timedOutAfterMs).toBe(300);
+  });
+
+  it('flags a capped stream, and the flag agrees with the rendered marker', async () => {
+    const dir = await makeSandbox();
+    const res = await bashTool.execute(
+      { command: 'head -c 40000 /dev/zero | tr "\\0" a' },
+      makeCtx(dir),
+    );
+    const s = res.structuredOutput as BashStructuredOutput;
+    expect(s.truncated).toBe(true);
+    expect(text(res)).toContain('[truncated: earlier output dropped]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The seam: the loop must ATTACH the batch's structured results to the user
+// turn it appends, or nothing above ever sees them. A green tool-level test
+// says nothing about whether the value travels — so this exercises the real
+// loop with a real tool and reads the turn the loop appended.
+// ---------------------------------------------------------------------------
+
+describe('structured results reach the turn the loop appends', () => {
+  it('the side-channel returns what was attached, and nothing for other turns', async () => {
+    const { attachToolUseResults, readToolUseResults } = await import(
+      '../src/engine/tool-use-results.js'
+    );
+    const turn = { role: 'user' as const, content: 'x' };
+    const other = { role: 'user' as const, content: 'y' };
+    expect(readToolUseResults(turn)).toBeUndefined();
+    attachToolUseResults(turn, { toolu_1: { ok: true } });
+    expect(readToolUseResults(turn)).toEqual({ toolu_1: { ok: true } });
+    // Keyed by object identity: a structurally identical turn is NOT the same
+    // turn. That is what keeps one turn's results off another's.
+    expect(readToolUseResults(other)).toBeUndefined();
+  });
+
+  it('a real Glob call through the loop lands on the appended user turn', async () => {
+    const dir = await makeSandbox();
+    await writeFile(path.join(dir, 'only.ts'), '', 'utf8');
+
+    const { runAgentLoop } = await import('../src/engine/loop.js');
+    const { readToolUseResults } = await import('../src/engine/tool-use-results.js');
+    const { MockTransport, toolUseReplyEvents, textReplyEvents } = await import(
+      './helpers/mock-transport.js'
+    );
+    const { FakeMcp } = await import('./helpers/engine-fakes.js');
+
+    const transport = new MockTransport([
+      toolUseReplyEvents('Glob', { pattern: '**/*.ts', path: dir }),
+      textReplyEvents('done'),
+    ]);
+    const deps = {
+      transport,
+      builtinTools: new Map([['Glob', globTool]]),
+      mcp: new FakeMcp(),
+      // Minimum gate/hook surface the loop actually calls. Kept inline rather
+      // than importing engine.test.ts's fakes (not exported) — this test is
+      // about the attachment seam, not about gate semantics.
+      permissions: {
+        check: async (_name: string, input: Record<string, unknown>) => ({
+          behavior: 'allow' as const,
+          updatedInput: input,
+        }),
+        denials: () => [],
+        mode: () => 'default' as const,
+        setMode: () => {},
+      },
+      hooks: {
+        hasHooks: () => false,
+        run: async () => ({ systemMessages: [], blocked: false }),
+      },
+      toolContext: makeCtx(dir),
+      debug: () => {},
+    } as unknown as Parameters<typeof runAgentLoop>[1];
+
+    const history: Array<{ role: 'user' | 'assistant'; content: unknown }> = [
+      { role: 'user', content: 'glob it' },
+    ];
+    // Drain the loop; the tool_result user turn is appended to `history`.
+    for await (const _m of runAgentLoop(
+      history as never,
+      deps,
+      { model: 'test-model', maxTurns: 3 } as never,
+    )) {
+      void _m;
+    }
+
+    const toolTurn = history.find(
+      (h) => h.role === 'user' && Array.isArray(h.content),
+    );
+    expect(toolTurn, 'the loop should have appended a tool_result user turn').toBeDefined();
+    // Diagnose rather than guess if this ever regresses: a denial or a hook
+    // block would also produce a tool_result turn, with different content.
+    if (process.env['SCS_DEBUG_STRUCTURED'] === '1') {
+      console.log('turn content:', JSON.stringify(toolTurn?.content).slice(0, 400));
+    }
+    const attached = readToolUseResults(toolTurn as never);
+    expect(attached, 'Glob produced a structured result; it must be attached').toBeDefined();
+    const only = Object.values(attached!)[0] as GlobOutput;
+    expect(only.numFiles).toBe(1);
+    expect(only.truncated).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概述

偏离普查轴一与轴四，按守密人两项裁定落地：**全量建结构化输出面** + **扩 MCP 接受列表并调研新修订**。

---

## 先订正普查自己的一处结论

首轮只 grep `outputSchema`、没找到就报**「银芯零输出面」——错了**。`types/tools.ts` 里 `GlobOutput` / `GrepOutput` / `WebFetchOutput` / `FileReadOutput` / `BashOutput` / Task 五件**早已按官方形状声明**，缺的是**从来没人产出**（typed-not-populated）。

于是改动比原先设想的**小得多也好得多**：**复用既有类型、不另造一套**，`types/tool-outputs.ts` 只补真正不存在的那几个（Read 的字符度量截断标记、Bash 的退出码、Grep/WebFetch 的 `truncated`）。

> 小学生比喻：以为要新做一套表格，翻开抽屉发现表格早就印好了——只是从来没人往上面填数字。

## 变更类型

- [x] Bug 修复（声明了从不产出的输出面 · MCP 接受列表比官方窄）
- [x] 文档完善（CHANGELOG / CONTEXT / project-status）
- [x] 其他（请说明）：新增消费方可见接口 + 家族锁步版本推进

### 轴一 · 结构化输出面（守密人裁「全量建」）

| 环节 | 做法 |
|---|---|
| 工具侧 | `ToolResultPayload.structuredOutput` 承载机器可读结果；**Read / Glob / Grep / Bash / WebFetch 在每条终态分支都产出**——含空结果与失败，调用方不该需要区分「没有结构化结果」与「没有匹配」 |
| 引擎侧 | 按 `tool_use_id` 收集整批，经 **WeakMap 侧信道**（`engine/tool-use-results.ts`）挂到用户轮 |
| 消费侧 | `query()` 读回，以 `toolUseResult` 发到 `SDKUserMessage` |

**为什么是侧信道而不是加字段**：`APIMessageParam` 是 **Anthropic 线格式**，`history` 里每一条都会被序列化进下一次请求。多挂一个属性，要么被发去 API，要么逼后来每一个调用点都记得先剥掉。按对象身份存取，让这个类型仍然只是它名字所说的那个东西。用 WeakMap 而非 Map，是让条目随轮次对象一起消亡——长会话不会攒下每条工具结果的第二份拷贝。

**形状差异（有意，已登记）**：官方是**裸对象**（它一消息一 tool_result）；本引擎把一轮的结果批进**一条**用户轮，故为 **`tool_use_id` 为键的 record**。改成一结果一消息会动到每个既有消费方的轮次结构，不值。

**新增可直接读到的事实**（此前只能靠**解析人话字符串**）：

- `Glob.truncated`
- `Grep.appliedLimit` / `appliedOffset` / `truncated`
- `Bash.exitCode` / `interrupted` / `timedOutAfterMs` / `truncated`
- `Read.truncatedByCharCap` —— **按本 SDK 的字符度量命名**。官方 `truncatedByTokenCap` 数的是 token；同名不同单位**读起来像对齐、跑起来是漂移**。

官方在自己的类型注释里把道理说尽了：该字段「**survives output reconstruction (unlike the render-time banner)**」——**横幅是渲染，渲染不是接口**。

**13 条测试**，含一条**跑真引擎**的接缝测试：真跑 Glob 过一遍 loop，再去读 loop 追加的那条轮次。工具级绿说明不了值有没有传出去。

### 轴四 · MCP（守密人裁「扩接受列表 + 调研新修订」）

**接受列表**加 `2024-10-07`：官方接受 5 个修订、银芯只接受 3 个，**钉在最老修订的服务器在官方能连、在银芯被拒**。

**提议版本仍留 `2025-06-18`**——调研结果：官方提议的 `2025-11-25`，新增的是**异步任务面**（`tasks/get` · `list` · `status` · `result` · `cancel`）加 `io.modelcontextprotocol/related-task` 与 `/skills` 两个扩展，**本包一个都没实现**。宣告一个语义未发货的版本号，与描述未发货能力**是同一条红线**；`2025-11-25` 也刻意不进接受列表——在 connect 处失败，比日后在一个不存在的 task 方法上失败更好读。

---

## 来源声明

- [x] 不涉及游戏数据。对照物为**官方 npm 公开发行物**（净室边界①）。提取物留在临时目录、**未入仓**，已清理。

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不上传内部美术资产 / 客户端解包原始文件 / 未公开剧情草稿。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py --sparse` **全部通过**（exit 0）
- [x] agent SDK **3,262 通过 / 5 跳过（共 3,267）** · Python **3,049 通过 / 51 跳过** · maestro **428** · testbed **37**
- [x] 新增 13 条测试（含真引擎接缝测试）
- [x] 不引入 emoji · 未改 `memory/decisions.md` / `memory/lessons-learned.md`

## 家族锁步

两包 **0.82.0 → 0.83.0**（minor：新增消费方可见接口），maestro 侧 `Lockstep alignment only` 空转条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr

---
_Generated by [Claude Code](https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr)_