### PR TITLE
fix(sdk): 嵌套路径普查（三扫）——timedOutAfterMs 移回基类（v0.87.1）

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,8 +82,8 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.87.0` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.87.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.87.1` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.87.1` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
 | agent SDK 源文件 / 测试档 | 138 / 201 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
@@ -250,6 +250,7 @@
 > workflow-load 100，CI 矩阵六靶）、四份 e2e 全部假钟化（三连稳、秒级降毫秒级）；测试 171→180。
 >
 > **v0.87.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.87.0（截断纪律全家对齐 + cards 索引豁免）前进。
+> **v0.86.1（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.87.1（嵌套路径普查：timedOutAfterMs 移回基类）前进。
 > **v0.86.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.86.0（主循环提示词补回开篇句 + 输出类型普查续：ReadMcpResource 错误字段 + WebSearch 结构化结果）前进。
 > **v0.84.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.84.0（记忆索引纪律 + 整理规程）前进。
 > **v0.85.0（2026-07-27，goal 判词家族统一）**：**BREAKING（实验面）**——`GoalVerdict` 迁移为与 agent SDK 逐字同形的 `{status: 'achieved'|'not_achieved'|'impossible', reason?}`（原 `{achieved, feedback, impossible?}`）。起因：BPT 接入后报「goal 没效果、模型照样停」，排查定位两包**同名不同形**判词——评审器误用另一包形状时引擎按设计 fail-open 把 malformed verdict 放行为允许停止，goal 无声失效。守密人裁「统一判词类型」：agent 侧 `{status}` 为正典（BPT 实接层不动），Maestro goal 族（零调用点实验面）赶在 GoalChaser 首次接线前迁移；声明式重复不跨包 import（硬性质 §1.2），一个宿主评审器经结构类型同时服务两缝；`GoalRoundPayload.feedback` 字段名保留、改承载 `reason`。迁移映射见 CHANGELOG 0.85.0。
@@ -334,6 +335,7 @@
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
 - **v0.84.0（2026-07-27）**：记忆索引纪律 + 整理规程——修的是「SDK 给了常驻索引机制却没规定索引条目该长什么样，且会话收尾提示词命令模型把进度卡写进索引档」这个自伤缺口（守密人 BPT 现场反馈：开工要好几回工具调用才找得到东西）。进度卡改落 `/memories/progress/`、索引只留指针；新增索引纪律片段（两模式注入、前提不成立即跳过）；写侧超限反压（读写共用同一度量，明说尾部已不可见）；`buildConsolidationPrompt()` + 四阶段整理规程，由 `assessMemoryStoreHealth()` 结果渲染待办。**层界守住**：只给「该不该整理 / 怎么整理」，不给调度（N1 未破，零新进程）。新增测试 28。
 - **v0.87.0（2026-07-27）**：截断纪律全家对齐——任何上限砍内容须答三问（丢多少/为何/怎么拿回）、流式保尾。后台 shell 流永久失聪缺陷修复（保尾保留窗 + 丢弃计数 + gap 标记）；Bash/WebFetch/Glob/workflow 标记补齐；注册表测试逼新截断点登记；cards 校验两层豁免索引档（修 0.84.0 自种 P4 矛盾）。另修哨兵两档制 + test.yml push 盲区 + 门禁 hooksPath 警告（仓侧）。
+- **v0.87.1（2026-07-27）**：**嵌套路径普查（三扫）**（守密人「1 继续」）——前两轮比顶层键，本轮摊成**点号路径**再比，专抓两类前两轮**结构上看不见**的差异。**挖出一条真缺陷、是银芯自己的**：`timedOutAfterMs` 官方在**基类** `BashOutput`，0.85.0 却加在银芯**扩展类型**上——交集相同、没坏东西，但**顶层键比对永远发现不了**（键两边都有、待错了地方），已移回基类。其余全属平台绑定只登记：`gitOperation.*`（官方解析 git/gh 输出成结构化 VCS 事实）· `artifactRead.*` · `blobSavedTo` 等。**九个类型逐层完全一致**。**方法边界**：展平器不解析 TS 语义，故同时报键总数，数量级不对即解析飞了。
 - **v0.86.0（2026-07-27）**：**主循环提示词补回开篇句 + 输出类型普查（续）**（守密人「1 对齐官方 4 续」）——① 补回官方「Text you write between tool calls may not be shown to the user.」——银芯只搬了结论没搬**理由**，缺前提的规则是模型最先绕过的那条；字节金样有意重生成、差异经核实只有这一句（四个工具集各一处）。**官方 `# Focus mode` 整块刻意不复刻**（为进不去的 UI 模式发指令 = 描述未发货能力）。② **15 个 `*Output` 逐字段比完：9 个完全一致**（FileEdit / Task 五件 / EnterWorktree / TodoWrite / Monitor）；6 个有官方独有字段，守密人裁「逐条再看」，**这一类并不齐整**——`ReadMcpResourceOutput.error` **加了并真产出**（非 UI 绑定，调用方此前分不清「读失败」与「读到空」）；`WebSearchOutput` **整体补产出**（原议题 `searchCount` 是伪命题、恒为 1，真缺口是它根本没有结构化结果；报**过滤后**命中免得与文本对不上）；其余四条**只登记不声明**（Workflow 的真障碍不在可选字段，而在必填判别式 `status:'async_launched'`——本 SDK 同步跑工作流，填它等于断言一次没发生的启动）。**射程边界**：本次为**顶层字段**比对，嵌套差异首轮漏看（`contents[].blobSavedTo` 靠人工复读才发现）。测试 3,295 → **3,297**。
 - **v0.85.0（2026-07-27）**：**GoalVerdict 家族统一（本包零行为改动）**——本包 `{status, reason?}` 判词升格家族**正典**，maestro 0.85.0 将 GoalChaser 评审判词迁为同形，一个宿主评审器同时服务引擎 `options.goal` Stop 门与跨 query 追逐两缝。留档背景：两形并存期产出真实消费者陷阱——maestro 形判词喂进 `options.goal` 被引擎判 malformed、fail-open 放行停止（防评审器坏死锁死代理的既定失败方向），症状即 BPT 2026-07-27 所报「接了 goal 模型照样停」。`options.goal` 语义与评审器契约未动，仅 `GoalVerdict` 注释补正典地位声明。
 - **v0.85.0（2026-07-27）**：**工具真正产出结构化结果 + MCP 接受列表扩容**（偏离普查轴一/轴四裁定）——**先订正普查自己的结论**：首轮只 grep `outputSchema` 就报「银芯零输出面」是**错的**，`types/tools.ts` 里官方形状的输出类型**早已齐备**，缺的是**从来没人产出**（typed-not-populated）；故改为**复用既有类型**、只补真缺的两三个。`ToolResultPayload.structuredOutput` + 引擎 **WeakMap 侧信道**（不往 Anthropic 线格式上加字段）+ `query()` 发 `toolUseResult`（**tool_use_id 为键的 record**，因本引擎一轮批处理、官方一消息一结果）。Read/Glob/Grep/Bash/WebFetch 每条终态分支均产出。MCP 接受列表加 `2024-10-07`；**提议版本仍留 `2025-06-18`**——官方的 `2025-11-25` 新增异步任务面（`tasks/*`）本包未实现，宣告它等于描述未发货能力。测试 3,254 → **3,267**。

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,12 +12,17 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
+## 0.87.1 — 2026-07-27
+
+Lockstep alignment only — no changes to this package. The family clock advanced
+for silver-core-agent-sdk 0.87.1 (nested-path sweep: `timedOutAfterMs` moved to
+the base BashOutput type where official carries it).
+
 ## 0.87.0 — 2026-07-27
 
 Lockstep alignment only — no changes to this package. The family clock advanced
 for silver-core-agent-sdk 0.87.0 (truncation discipline family-wide + cards
 mode index exemption).
-
 ## 0.86.0 — 2026-07-27
 
 Lockstep alignment only — no changes to this package. The family clock advanced

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,7 +36,7 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.87.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.87.0`
+**当前版本 `0.87.1`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.87.1`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
@@ -44,6 +44,7 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 **v0.87.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.87.0
 （截断纪律全家对齐 + cards 索引豁免）前进，详见该包 CHANGELOG。
+**v0.87.1（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.87.1（嵌套路径普查：`timedOutAfterMs` 移回官方所在的基类 `BashOutput`）前进。
 
 **v0.86.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.86.0（主循环提示词补回开篇句 + 输出类型普查续：ReadMcpResource 错误字段 + WebSearch 结构化结果）前进。
 

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.87.0",
+  "version": "0.87.1",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.87.0';
+export const MAESTRO_SDK_VERSION = '0.87.1';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,36 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.87.1 — 2026-07-27
+
+Nested-path sweep against official 2.1.220 — the third and last axis of the
+divergence work (keeper: "1 继续"). The two earlier sweeps compared TOP-LEVEL
+keys; this one flattens both sides into dotted paths and diffs those.
+
+**One real defect, and it was ours.** `timedOutAfterMs` lives in official's BASE
+`BashOutput`; 0.85.0 put it on this SDK's EXTENSION type instead. The resulting
+intersection is identical — nothing broke, no consumer could tell — and NO
+top-level key diff could ever have flagged it, because the key was present on
+both sides. It was in the wrong place, which is a shape a key-set comparison is
+structurally blind to. Moved to the base type; the extension keeps only
+`exitCode` and `truncated`, which official genuinely lacks.
+
+Everything else the sweep found is platform-bound and recorded in
+docs/COMPAT.md rather than declared: `BashOutput.gitOperation.*` (official
+parses git/gh command OUTPUT into structured VCS facts — this SDK has no such
+parser), `ghRateLimitHint` / `staleReadFileStateHint` / `backgroundCwdHint` /
+`noOutputExpected`, `WebFetchOutput.artifactRead.*`, `gitDiff.repository` inside
+a shape this SDK declares but never populates, `contents[].blobSavedTo`, and the
+AskUserQuestion permission-UI paths already ruled on.
+
+Nine types are identical at EVERY depth: Glob, Grep, WebSearch, Monitor, the
+Task quintet, TodoWrite, EnterWorktree, ExitPlanMode, Workflow.
+
+Method limit stated in COMPAT rather than implied: the flattener tracks brace
+depth and key names, not TypeScript semantics. Per-type key counts are reported
+next to each diff so a mis-parse shows up as a wrong order of magnitude instead
+of masquerading as a divergence.
+
 ## 0.87.0 — 2026-07-27
 
 Truncation discipline, family-wide (keeper ruling, same-day review batch) — any
@@ -51,7 +81,6 @@ family to the same line, plus one review-found contradiction fix.
 - **`tests/truncation-discipline.test.ts`**: pins the repaired notices AND
   carries a registry test — any new truncation site in `src/tools/` must
   register and cover its message, or the suite reds.
-
 ## 0.86.0 — 2026-07-27
 
 Prompt alignment + the second half of the output-type sweep (keeper: "1 对齐官方

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -70,7 +70,7 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.87.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.87.0`
+**当前版本 `0.87.1`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.87.1`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
@@ -80,6 +80,7 @@ src/
 怎么拿回）、流式保尾。后台 shell 流「命中 500K 即永久失聪」改保尾保留窗（丢弃计数入契约 + gap 标记）；
 Bash/WebFetch/Glob/workflow 标记补齐；注册表测试逼新截断点登记；cards 校验两层豁免索引档
 （修 0.84.0 自种 P4 矛盾）。详见 CHANGELOG。
+**v0.87.1（2026-07-27）：嵌套路径普查（三扫）**（守密人「1 继续」）——前两轮普查比的都是**顶层键**，本轮把两边摊成**点号路径**（`contents[].blobSavedTo`、`gitOperation.commit.sha`）再比，专抓两类前两轮**结构上看不见**的差异：嵌在双方都声明的形状**里面**的字段，以及**两边都有、却待在不同类型里**的字段。**挖出一条真缺陷，而且是银芯自己的**：`timedOutAfterMs` 官方在**基类** `BashOutput` 里，0.85.0 却把它加在了银芯的**扩展类型**上。交出来的交集完全相同、没坏任何东西，而**任何顶层键比对都不可能发现它**——键在两边都存在，只是待错了地方。已移入基类。**其余全属平台绑定，只登记不声明**：`BashOutput.gitOperation.*`（官方**解析 git/gh 命令输出**成结构化 VCS 事实，银芯只跑 shell、不解析其输出，为填字段现造一个解析器不是对齐）· `ghRateLimitHint`/`staleReadFileStateHint`/`backgroundCwdHint`/`noOutputExpected` · `WebFetchOutput.artifactRead.*` · `gitDiff.repository`（在一个银芯声明了但从不产出的形状里）· `contents[].blobSavedTo` · AskUserQuestion 权限 UI 路径。**九个类型逐层完全一致**：Glob / Grep / WebSearch / Monitor / Task 五件 / TodoWrite / EnterWorktree / ExitPlanMode / Workflow。**方法边界**：展平器只跟花括号深度与键名、不解析 TS 语义，故逐类型同时报**键总数**——数量级不对说明解析飞了，而不是类型真有差异。
 
 **v0.86.0（2026-07-27）：主循环提示词补回开篇句 + 输出类型普查（续）**（守密人「1 对齐官方 4 续」+ 逐条裁定）——① **补回官方那句 “Text you write between tool calls may not be shown to the user.”**：银芯此前只搬了结论、没搬**理由**；缺了前提，整段就从「事实的后果」退化成「风格偏好」，而**前提缺失的规则是模型最先绕过的那条**。已对官方 2.1.220 逐字核实；字节金样**有意重生成**，差异经核实**只有这一句**（四个工具集各一处）。**官方 `# Focus mode` 整块刻意不复刻**——它为「用户只看得到最终消息」这一 UI 模式覆盖沟通行为，本 SDK 无此模式，为进不去的模式发指令，与描述未发货工具是同一条红线。② **15 个 `*Output` 逐字段比完**：**9 个完全一致**（FileEdit / Task 五件 / EnterWorktree / TodoWrite / Monitor）；6 个有官方独有字段，守密人裁「逐条再看」——**这一类并不齐整**：`ReadMcpResourceOutput.error` **加了并真产出**（非 UI 绑定：工具本有失败路径，调用方此前分不清「读失败」与「读到空」）；`WebSearchOutput` **整体补产出**（原议题 `searchCount` 其实是伪命题——每次调用只打一次后端、恒为 1；真缺口是它**根本没有结构化结果**，而 `query`/`results`/`durationSeconds` 全能填；报的是**过滤后**命中，免得结构化数字与文本对不上）；其余四条**只登记不声明**（`FileWrite.userModified`、`ExitPlanMode.planWasEdited`、`AskUserQuestion.afkTimeoutMs`/`annotations`、`Workflow` 远程任务字段——Workflow 的真障碍**不在可选字段**，而在官方**必填**判别式 `status: 'async_launched'`，本 SDK 同步跑工作流，填它等于断言一次没发生的启动）。**射程边界照实写**：本次是**顶层字段**比对，嵌套差异首轮漏看（`contents[].blobSavedTo` 是人工复读才发现的），其余嵌套字段可能仍未扫。
 
@@ -91,110 +92,5 @@ Bash/WebFetch/Glob/workflow 标记补齐；注册表测试逼新截断点登记�
 **v0.85.0（2026-07-27）：工具真正产出结构化结果 + MCP 接受列表扩容**（偏离普查轴一 / 轴四守密人裁定）——**先订正普查自己的一处结论**：首轮只 grep `outputSchema`、没找到就报「银芯零输出面」，**错了**——`types/tools.ts` 里 `GlobOutput`/`GrepOutput`/`WebFetchOutput`/`FileReadOutput`/`BashOutput`/Task 五件**早已按官方形状声明**，缺的是**从来没人产出**（typed-not-populated）。于是改动比原先设想的小得多也好得多：**复用既有类型、不另造一套**。① `ToolResultPayload.structuredOutput` 承载机器可读结果，Read/Glob/Grep/Bash/WebFetch 在**每条终态分支**都产出（含空结果与失败——调用方不该需要区分「没有结构化结果」与「没有匹配」）；② 引擎按 tool_use_id 收集整批，经 **WeakMap 侧信道**（`engine/tool-use-results.ts`）挂到用户轮而**不是加字段**——`APIMessageParam` 是**Anthropic 线格式**，多挂一个属性要么发去 API、要么逼后来每个调用点都记得先剥掉；③ `query()` 读回并以`toolUseResult` 发给消费方。**形状差异（有意）**：官方是裸对象（它一消息一 tool_result），本引擎一轮批处理，故为 **tool_use_id 为键的 record**。新增可直接读到的事实：Glob `truncated` · Grep `appliedLimit`/`appliedOffset`/`truncated` · Bash `exitCode`/`interrupted`/`timedOutAfterMs`/`truncated` · Read `truncatedByCharCap`（**按本 SDK 的字符度量命名**，官方 `truncatedByTokenCap` 数的是 token，同名不同单位读起来像对齐、跑起来是漂移）。13 条测试，含一条**跑真引擎**的接缝测试（工具级绿说明不了值有没有传出去）。
 **MCP 接受列表**加 `2024-10-07`（官方接受 5 个、银芯只接受 3 个，钉在最老修订的服务器在官方能连、在银芯被拒）；**提议版本仍留 `2025-06-18`**——官方提议 `2025-11-25`，其新增是**异步任务面**（`tasks/get`·`list`·`status`·`result`·`cancel`）与 `related-task`/`skills` 两扩展，本包一个都没实现；**宣告一个语义未发货的版本号，与描述未发货能力是同一条红线**。
 
-**v0.82.0（2026-07-27）：Read 通读 >256KB 改为拒绝 + 首次对官方二进制做偏离普查**——守密人问「还能查到有哪些我们与官方不一致」，遂第一次拿**官方发行物本体**（npm 平台包 + `sdk-tools.d.ts`）而非第三方重建档做四轴对照。**唯一改代码的一条**：官方 `maxSizeBytes`=262144 拒通读，银芯此前只有 50MB OOM 守卫（松 200 倍，于是 30MB 日志会被真读进内存再几乎全丢）。现两条上限各司其职——256KB **导向**（「这不是 Read 该干的事」）、50MB **保命**（「这会撑死进程」）；**只拦通读**，带 offset/limit 放行（官方错误文案与工具描述两处都写明这是逃生口）。**属破坏性变更**：读 256KB–50MB 档的消费方会突然报错，修法机械（加 offset/limit 或改 Grep）且错误文案已写明。
-**同批查出但按守密人裁定只登记不改**：`AskUserQuestion` 缺官方三个**回程字段**（`answers`/`annotations`/`metadata.source`）——它们服务于官方权限组件 UI 回填与遥测，本 SDK 是宿主回调、无那套组件，加了就是描述未发货能力。**另有两条经复核是假象、如实记档**：`EnterPlanModeInput` 官方就是 `{}`（一致），Grep 的 `-i/-A/-B/-C/-o` 与 `TaskListInput` 亦一致——首轮正则不认带引号键、且被单行 `{}` 接口串块骗了三次。
-详见 `docs/COMPAT.md`「Divergence sweep」。
-
-**v0.81.0（2026-07-27）：Read 截断页脚补齐官方三件套 + 数值基准获独立佐证**——守密人报的现象：一次 Read 读约 1500 行源码后，模型**连发六轮自动翻页**把整档翻完、上下文推到 300K+ 字符。旧页脚只说一句「Use offset=1301 to continue reading.」，**别的什么都不给**。**交付单的诊断对了一半，错的那一半值得记**：它认为官方从不给具体值，只说「the offset parameter」；对着**官方 npm 发行物 2.1.220** 提取实测，官方**也给值**——「…Call Read with offset=${I+1} limit=${I} for the next page, **or Grep to find a specific section**. **Do NOT answer from this page alone** if the answer may be further in the file.」。可见具体值从不是差别，差别是银芯只给了三件套的**第一件**：一条路、一个动作、没有更便宜的替代、没有告诫。守密人裁定取官方口径。两处截断分支（字符上限 / 行数上限）现均补齐三件套；大档 Grep 提示改为**只看体积**（原还要求存在超 2000 字符的长行，而 TS/Lua/Python 普通源码根本没有那种行，故该提示**几乎从未触发过**——它此前零测试覆盖，正与此吻合），256KB 阈值不动。`MAX_READ_OUTPUT_CHARS` 刻意不动。
-**同批订正 0.80.2 的一处错误结论**：那条说数值基准「须在装有 Claude Code 的机器上才能重新提取」——**错了**。官方二进制是**公开 npm 发行物**（`@anthropic-ai/claude-code` 的平台 optionalDependency），本仓一致性作业本就`--no-save` 装它作对照臂，属净室边界①「官方发行渠道产物」。已就地提取 2.1.220 实测：Read 输出上限 **25000 token**、Bash 输出 **30000 默认 / 150000 上限**、Grep `head_limit` **「Defaults to 250 when unspecified」逐字**——与 0.80.0 所依据的 2.1.141 三项**全部一致**，79 个版本未变。WebFetch 的 100000 本轮未再定位到，照实记。
-
-**v0.80.2（2026-07-27）：对齐 2.1.216 快照基准**（守密人裁「3 也直接对齐基准」）——基准同时从两个方向陈旧了，且只有一个方向能在仓内修，两者都记进 `docs/COMPAT.md`「Baseline realignment」。① **手工挖出第三条指空 slug**：`SendMessage` 引用的 `tool-description-sendmessagetool` 被快照改名，却因**缺档检查搭在锚点检查里、而锚点检查跳过 adapted 条目**而长期报绿——现把「引用的档案必须存在」拆成独立测试，faithful / adapted 一视同仁。同一次快照造了三条指空 slug：两条让 main 红了六小时（0.80.1），这条根本没守卫在看。② 新增 `scripts/description-coverage.mjs`，把「散文基准漂没漂」从人工比对变成一条命令（逐档报还剩多少逐字吻合 + 该档 ccVersion）。**报告体恒 exit 0**：吻合度本就不该是 100%——红线纪律禁止描述未发货能力，硬拉满等于逼描述去吹本包做不到的事。实测 30 档里 18 档 100%（Grep 对 2.1.217、Glob 对 2.1.215），低分端全是已登记改编（SendMessage 11% / EnterWorktree 25%）。**射程边界照实写**：0.80.0 那批**数值上限对不了**——重建档把数字模板化（`${MAX_LINES_CONSTANT}`）、grep 档没有参数级文档，故 250 / 25,000 / 30,000 / 100,000 仍只靠那一次 2.1.141 二进制提取支撑，仓内无任何东西能独立佐证，重新核验需在装有 Claude Code 的机器上再提取一次。发货运行时改动仅一个 slug 字符串及其注释，**描述文本未动**，提示词字节与缓存键不变。
-
-**v0.80.1（2026-07-27）：两条提示词溯源 slug 改锚 + 给刷新 cron 补自检**——上游快照
-2.1.173 → 2.1.216（今日 cron 76fe5e6 直推 main）改名 24 档、删 5 档，两条 slug 指空，
-两条 corpus-sync 守卫在 main 上报红。① `COORDINATOR_WORKER_PROVENANCE.slug` 随上游命名
-规范化改指 `agent-prompt-coordinator-worker-instructions`（守卫抽出的 15 个锚点句在
-shipped 文本里逐字仍在，只动 slug）；② `MAIN_LOOP_INTRO.slug` 改指
-`system-prompt-harness-instructions`——上游把三个 intro 小档合并进它，那句话逐字未变、
-现居该档开篇模板的「无 output style」分支，故 `faithful: true` 仍成立，但注释里写明它
-faithful 于**模板档的一个分支**而非整档。**零 shipped 提示词文本改动**。
-包外同批：`refresh-claude-code-prompts.yml` 刷新后、提交前就地跑这两条守卫，**红则不提交
-不直推**——该 cron 带 `[skip ci]` 直推 main，此前它捅的破绽要等下一个不相干 PR 跑门禁才
-暴露（本次正是这么被发现的）。
-
-**v0.80.0（2026-07-27）：工具输出上限对齐 Claude Code 2.1.141**——守密人交付单三处独立改动
-（常量取自 `claude.exe` 内含明文 JS）。① **WebFetch 上限 100_000 → 复用 Read 的 50_000**：
-官方那个数管的是「喂给摘要小模型的输入」、主上下文只收摘要，本 SDK 直连无摘要层，同一个数字
-在这里变成「原文直灌主上下文」，反让 WebFetch 成为唯一能塞进两倍 Read 额度的工具，而它拉的
-还是最不可控的外部网页；现改为引用 `MAX_READ_OUTPUT_CHARS` 常量，两道闸门从此无法各自漂移
-（`fsutil.ts` 注释里「~50K aligns with the WebFetch cap」的本意终于对上代码）。
-② **Grep `head_limit` 三种 output_mode 统一默认 250**（原 `count` / `files_with_matches` 默认无限，
-OPT-1 v0.13.0）：OPT-1 担忧的「截断的 count 是错的 count」已由同批落地的「每种模式都追加截断提示」
-解决，无限默认不再多买到诚实，却让一次宽泛检索能吐几千条；要可证完整仍显式传 `head_limit=0`。
-③ **Bash 输出截断改保尾去头**，标记移到开头（`[truncated: earlier output dropped]`）：长命令的
-结论在末尾——构建成败 / 测试汇总 / 最终报错，原保头恰好切掉要看的、留下编译噪音；新增
-`sliceTailSurrogateSafe` 镜像 helper（尾切要丢的是**开头低位**代理，与头切相反）。
-**刻意不改**：Read 的计量单位仍按字符（官方按 token 25,000 + 256KB 拒读），对齐需引入 tokenizer
-运行时依赖，且字符计量在中文场景反而更宽（50K 中文字符 ≈ 50K token，是官方两倍）。
-
-**v0.79.1（2026-07-27）：内部去重，零表面变化**——重试/退避/错误体/流错误/空闲看门狗从
-`transport/anthropic.ts` 与 `transport/openai.ts` 各抄一份收敛为 `transport/http-retry.ts`；
-JSON-RPC 报文形状/结果解析/分页/版本协商从 `mcp/http.ts` 与 `mcp/stdio.ts` 收敛为
-`mcp/protocol.ts`。六个 src 档净 −288 行，3,214 测试与 api-surface 守卫原样通过即表面未动的证据。
-**照实记**：该改动随 #835 合并时**未 bump**，版本门禁在 main 上红了约一小时——本条是补票，
-故 0.79.0 标签在那段窗口里同时对应了改动前后两份内容，见 CHANGELOG 同条。
-
-**v0.79.0（2026-07-26）：锁步对齐**——本包**零代码改动**。家族版本钟随 maestro 0.79.0（重开语义 + CONCURRENCY 文档 + 棘轮 cadence 分档）前进；同批订正本档 0.72.0 / 0.70.0 两条空转条目的措辞（内容未变，改为机器可识别的规范开头）。
-
-**v0.78.1（2026-07-26）：锁步对齐**——本包**零代码改动**。家族版本钟因 maestro 0.78.1（产品审视四裁：删除其对本包的无支撑 peerDependency / 六族两级成熟度标注 / 首份 ONBOARDING 文档 / 判别式补维）整体前进，详见该包 CHANGELOG。
-
-**v0.78.0（2026-07-26）：锁步对齐**——本包**零代码改动**。家族版本钟因 silver-core-maestro-sdk 0.78.0（设计审视四缝全修：`cancelled` 终态穿透场景层 / 驱动器并发上限 / 台账保留缝 / 长跑组件中止缝）整体前进，详见该包 CHANGELOG。
-
-**v0.77.0（2026-07-26）：Windows 正确性清扫（家族史上第一次非 Linux CI 实跑 + 守密人现场反馈
-「SDK 在 windows 环境工具调用经常犯蠢」）**——3200+ 测试一直全绿，却**一条都看不见**这些问题：
-它们全部跑在 POSIX 宿主的 POSIX 方言下。三条真缺陷：
-① **路径域权限规则在 Windows 上两个方向都坏**——POSIX 写法的 deny（`Read(//etc/**)`）匹配**不到任何东西**
-（`path.resolve` 出 `C:\etc\a`，规则与 glob 说 `/`），是**在黑池唯一发货平台上 fail-open 的 deny**；
-Windows 写法的 deny 则**过度匹配**（单 `*` 的字符类 `[^/]*` 不在 `\` 处停，`*` 跨了目录边界）；
-且大小写敏感，`C:/Secret/**` 的 deny 用 `c:\secret\x` 就绕开。三者在同一规范空间（`/` 分隔 + 小写）
-下一起消失，**只在 win32 生效**——POSIX 上反斜杠是合法文件名字符、路径大小写敏感，折叠任一都是新洞。
-**明写代价**：规则语法里打头的 `//` 是「绝对路径」写法，win32 下会先折叠再解析，故 UNC 域规则在
-win32 不可表达（此前它同样什么都匹配不到）。
-② **宿主传受控 env 时 Bash 工具整个消失**——Git-for-Windows 安装根只从 `options.env` 读，硬化宿主
-（Electron 正是如此）只传 `{PATH, HOME}` 即得空候选表，每次 Bash 调用都死于「No POSIX shell found」。
-安装根是**宿主装机事实**、不是会话配置，现回落 `process.env`（调用方给的根仍优先，且不往子进程环境泄漏
-任何新变量）；候选表同时去重（64 位机上 `ProgramFiles` 与 `ProgramW6432` 同目录，此前每条探两遍）。
-③ **Glob / Grep 与 SDK 其余部分说不同的路径方言**——`fast-glob` 恒出 POSIX 分隔符，于是 Windows 上
-它们报 `C:/Users/x/a.txt`，而 Read/Write/Edit、错误信息、`cwd` 都说 `C:\Users\x`；同一会话里一条路径
-两种拼写，模型据此犯蠢。现统一归一为宿主原生分隔符（`toNativePath`）——既有 Glob/Grep 测试本就按
-`path.join` 断言，**原本就是这个契约，只是实现悄悄漂了**。
-**测试侧**：`MatchContext.platform` 让路径方言可注入，`tests/windows-path-semantics.test.ts`（20 例，
-含证明修复 win32-scoped 的 POSIX 负控）在任意宿主上断言 win32 行为——**这套本可在没有 Windows 机器时
-就抓住该缺陷**；vitest 插件剥 `scripts/*.mjs` 的 shebang（四个守卫脚本 import 在 Windows 上死于
-SyntaxError，两个无 shebang 的对照组全过，相关性精确）；Windows 拆卸 `rmSync` 重试越过 EBUSY、
-worktree 套件把 `os.tmpdir()` 的 8.3 短名归一为 git 报的长名、sandbox / file-store 停用硬编码 POSIX 分隔符。
-**Linux/macOS 行为零变化**：全量 3236 通过 + 5 skipped。**maestro 侧同轮 362/362 全绿、零改动**。
-
-### 更早的版本叙述已下沉（2026-07-26 瘦身，守密人裁定）
-
-本节曾是一部**三周的发布编年史**——27 个版本条目、405 行，占全档 86%，与
-[`CHANGELOG.md`](CHANGELOG.md) 职责重复。而 CHANGELOG 自己开篇就写着它是
-**consumer-facing build ledger**、每次改 shipped 代码必加一行、并有 `check-version-bump.mjs`
-守着——**发布史的唯一权威在那边，这里再抄一份只会两边分叉**。
-
-- **想知道某一版做了什么** → [`CHANGELOG.md`](CHANGELOG.md)，逐版全文；
-- **想知道现在能不能动手** → 上方生成块（版本 / 发布日 / 锁步对端）+ 紧邻的最近版叙述；
-- **想知道为什么这么设计** → [`docs/POSITIONING.md`](docs/POSITIONING.md)（定位与三缝）、
-  [`docs/COMPAT.md`](docs/COMPAT.md)（对标差异）、[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)。
-
-本节今后**只留最近版叙述 + 下方长期纪律**；新版本进来时，把上一版的叙述交给 CHANGELOG，
-不再在此累积。行数上限由 `tests/test_claude_md_size.py` 守（上限 500，撞线即下沉、不抬上限）。
-
-### 长期纪律（非发布史，动手前必读）
-
-**官方裸对比的黑箱纪律**（守密人 2026-07-04 裁定，v0.5+ 起生效）：`silver-core-sdk.yml` 的
-`vs-official` job 同模型同 7 任务两引擎对跑，**只比客观两轴**——响应速度（墙钟 / API ms / TTFT）
-与输出正确性（同 `check()` 通过率）；**质量不评判**（该轴被专有系统提示词混淆，属 POSITIONING
-§2/§4 结构性天花板）。官方包 `npm i --no-save` 仅本次装，**绝不进 package.json / lockfile、
-绝不成为本包依赖**；官方引擎当**纯黑箱**——读其输入输出行为计时判分，**绝不读其提示词文本**。
-官方 SDK 靠 spawn Claude Code CLI，无头 CI 起不来则官方臂跳过（exit 2）——
-「官方引擎无头起不来」本身即结论（那正是黑池换引擎的动机）。
-
-
-## 旧「v0.2 候选」清单已作废（2026-07-26 核实）
-
-该节列的候选——subagents / 上下文压缩（compact_boundary）/ WebFetch / 设置文件 hooks /
-会话管理全量 API / defer 权限决策——在 0.79.0 时代**全部早已实装**（逐条核到 `src/subagents/`、
-`src/engine/compaction.ts`、`src/tools/webfetch.ts`、`src/hooks/`、`src/sessions/`、
-`src/permissions/`）。一份**每条都已完成的待办清单**留在必读档里，只会让下一个会话
-把已有能力当成缺口去「补」。能力现状以 [`docs/COMPAT.md`](docs/COMPAT.md) 对标矩阵为准。
+> 更早版本的发布叙述已下沉 `CHANGELOG.md`（本档有 200 行封顶，`tests/test_claude_md_size.py` 守——
+> 路由器不许长成目录；撞线时的正确动作是下沉，不是抬上限）。

--- a/projects/silver-core-sdk/docs/COMPAT.md
+++ b/projects/silver-core-sdk/docs/COMPAT.md
@@ -559,6 +559,42 @@ content was saved) is one, found only on a manual re-read, and it stays
 unshipped because this SDK does not spill blobs to disk. Other nested fields
 may remain unswept.
 
+## Nested-path sweep vs official 2.1.220 (2026-07-27, 三扫)
+
+The previous two sweeps compared TOP-LEVEL keys. This one flattens both sides
+into dotted paths (`contents[].blobSavedTo`, `gitOperation.commit.sha`) and
+diffs those, which surfaces two classes the earlier passes were structurally
+blind to: fields nested inside a shape both sides declare, and fields present
+on both sides but living in DIFFERENT types.
+
+**One real defect, and it was this SDK's own.** `timedOutAfterMs` sits in
+official's BASE `BashOutput`; 0.85.0 added it to this SDK's EXTENSION type
+instead. The resulting intersection is identical, so nothing broke and no
+top-level key diff could ever have flagged it — the key existed on both sides.
+Moved to the base type. A sweep that only compares key SETS cannot see a field
+in the wrong place.
+
+**Everything else nested is platform-bound**, recorded not added:
+
+| Path | Why unshipped |
+|---|---|
+| `BashOutput.gitOperation.*` (9 paths: commit sha/kind, pr number/url/action, push branch, branch action/ref) | Official parses git / gh command OUTPUT to report structured VCS operations. This SDK runs the shell and reports what it printed; it has no git-output parser and inventing one to fill a field is not a parity fix. |
+| `BashOutput.ghRateLimitHint`, `staleReadFileStateHint`, `backgroundCwdHint`, `noOutputExpected` | Official heuristics over its own session state. |
+| `WebFetchOutput.artifactRead.slug` / `.ver` | Anthropic artifacts, a surface this SDK does not have. |
+| `FileWriteOutput` / `FileEditOutput` `.gitDiff.repository` | Inside the `gitDiff` shape this SDK declares but never populates (no git plumbing). Completing an unpopulated shape adds nothing a caller can read. |
+| `ReadMcpResourceOutput.contents[].blobSavedTo` | This SDK does not spill binary blobs to disk. |
+| `AskUserQuestionOutput.answers.*` / `annotations.*` | Official permission-component UI, same ruling as the input side. |
+
+**Nine types are identical at every depth**: Glob, Grep, WebSearch, Monitor,
+the Task quintet, TodoWrite, EnterWorktree, ExitPlanMode, Workflow.
+
+**Method limit, stated because it bounds what "swept" means here**: the
+comparison uses a brace-depth flattener, not a TypeScript parser — it tracks
+key names and nesting, so it agrees with itself on both sides but would mis-read
+exotic constructs (conditional types, deep generics). Key COUNTS per type are
+printed alongside the diff for exactly this reason: a count in the wrong order
+of magnitude means the parse went wrong, not that the types diverged.
+
 ## Tool-description ↔ implementation fidelity (audit r4, 2026-07-18)
 
 The model-side tool descriptions in `src/tools/descriptions.ts` are FAITHFUL

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.87.0",
+  "version": "0.87.1",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/types/tool-outputs.ts
+++ b/projects/silver-core-sdk/src/types/tool-outputs.ts
@@ -76,7 +76,6 @@ export type ReadOutput = ReadTextOutputWithCap | Exclude<FileReadOutput, { type:
  */
 export type BashStructuredOutput = BashOutput & {
   exitCode: number | null;
-  timedOutAfterMs?: number;
   truncated: boolean;
 };
 

--- a/projects/silver-core-sdk/src/types/tools.ts
+++ b/projects/silver-core-sdk/src/types/tools.ts
@@ -344,6 +344,12 @@ export type BashOutput = {
   stderr: string;
   rawOutputPath?: string;
   interrupted: boolean;
+  /** How long the command ran before a timeout killed it. Official carries
+   *  this in the BASE type; it was added to this SDK's extension type instead
+   *  (0.85.0) and moved here 2026-07-27 by the NESTED-path sweep — a field in
+   *  the wrong type is a divergence a top-level key diff cannot see, because
+   *  the key existed on both sides, just not in the same place. */
+  timedOutAfterMs?: number;
   isImage?: boolean;
   backgroundTaskId?: string;
   backgroundedByUser?: boolean;

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.87.0';
+export const SDK_VERSION = '0.87.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;


### PR DESCRIPTION
## 概述

偏离普查第三轴，也是最后一轴（守密人「1 继续」）。前两轮比的都是**顶层键**；本轮把两边摊成**点号路径**（`contents[].blobSavedTo`、`gitOperation.commit.sha`）再比，专抓两类前两轮**结构上看不见**的差异：

1. 嵌在双方都声明的形状**里面**的字段；
2. **两边都有、却待在不同类型里**的字段。

---

## 变更类型

- [x] Bug 修复（`timedOutAfterMs` 待错了类型）
- [x] 文档完善（COMPAT.md 新增「嵌套路径普查」整节 + CONTEXT 撞封顶后下沉）
- [x] 其他：家族锁步版本推进

## 挖出一条真缺陷，而且是银芯自己的

`timedOutAfterMs` 官方在**基类** `BashOutput` 里；0.85.0 却把它加在了银芯的**扩展类型**上。

交出来的交集**完全相同**——没坏任何东西，没有任何消费方能察觉。而**任何顶层键比对都不可能发现它**：键在两边都存在，只是待错了地方。已移入基类；扩展类型只留 `exitCode` 与 `truncated`（这两个官方确实没有）。

> 小学生比喻：两家书架上都有同一本书，清点书目时对得上；但一家放在「参考书」格、另一家放在「课外读物」格。只数书名永远看不出来，得连格子一起看。

## 其余嵌套差异：全属平台绑定，只登记不声明

| 路径 | 为何不实现 |
|---|---|
| `BashOutput.gitOperation.*`（9 条：commit sha/kind、pr number/url/action、push branch、branch action/ref）| 官方**解析 git / gh 命令的输出**，把它变成结构化 VCS 事实。银芯只跑 shell、报告它打印了什么；**为填字段现造一个 git 输出解析器不是对齐** |
| `ghRateLimitHint` · `staleReadFileStateHint` · `backgroundCwdHint` · `noOutputExpected` | 官方对自身会话状态的启发式 |
| `WebFetchOutput.artifactRead.slug` / `.ver` | Anthropic artifacts，本 SDK 无此面 |
| `FileWrite` / `FileEdit` 的 `.gitDiff.repository` | 在一个银芯**声明了但从不产出**的形状里；补全一个没人填的形状，调用方读不到任何东西 |
| `ReadMcpResourceOutput.contents[].blobSavedTo` | 银芯不把二进制落盘 |
| `AskUserQuestionOutput.answers.*` / `annotations.*` | 官方权限组件 UI，与输入侧同一裁定 |

**九个类型逐层完全一致**：Glob · Grep · WebSearch · Monitor · Task 五件 · TodoWrite · EnterWorktree · ExitPlanMode · Workflow。

## 方法边界（写明而非暗示）

展平器只跟**花括号深度与键名**，不解析 TypeScript 语义——它对两边用同一套规则，故系统性偏差在差集里互相抵消；真正的风险是**某一侧解析飞了**。因此逐类型同时报**键总数**：数量级不对说明解析出问题，而不是类型真有差异。奇异构造（条件类型、深泛型）它会读错。

## 顺带：CONTEXT.md 撞 200 行封顶

该测试自己的失败信息就写着「**不要抬上限**——发布叙述交给 CHANGELOG.md」。照办：下沉 10 条旧版本段（CHANGELOG 里逐字都有），保留最新四条 + 一行指针，**201 行 → 96 行**。

---

## 来源声明

- [x] 不涉及游戏数据。对照物为**官方 npm 公开发行物**的 `sdk-tools.d.ts`（净室边界①）。提取物未入仓，已清理。

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不上传内部美术资产 / 客户端解包原始文件 / 未公开剧情草稿。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py --sparse` **全部通过**（exit 0），且已变基到并行会话 #854 之后重跑
- [x] agent SDK **3,299 通过 / 5 跳过（共 3,304）** · Python **3,056 通过 / 51 跳过** · maestro **429** · testbed **37**
- [x] 不引入 emoji · 未改 `memory/decisions.md` / `memory/lessons-learned.md`

## 家族锁步

并行会话 #854 已把家族推到 0.87.0，本改动让号顺延 **0.87.1**（patch：类型字段归位，运行时行为零变化），maestro 侧 `Lockstep alignment only` 空转条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr

---
_Generated by [Claude Code](https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr)_