### PR TITLE
feat(sdk): 四工具补结构化产出 + 零产出面立台账（v0.90.0）

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,10 +82,10 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.90.0` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.90.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.91.0` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.91.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
-| agent SDK 源文件 / 测试档 | 139 / 203 | 磁盘实况 |
+| agent SDK 源文件 / 测试档 | 139 / 205 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
 | testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
 | Python 测试档 | 137 | 磁盘实况 |
@@ -249,6 +249,8 @@
 > schedule 错过补偿核对（已实现有测试，免补）+ 质量切换：棘轮五族全靶（新增 delivery-channel 100 /
 > workflow-load 100，CI 矩阵六靶）、四份 e2e 全部假钟化（三连稳、秒级降毫秒级）；测试 171→180。
 >
+> **v0.91.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.91.0（四工具补结构化产出 + 零产出面台账守卫）前进。
+
 > **v0.90.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.90.0（checkpoint blob 上限，T74 甲案）前进。
 > **v0.89.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.89.0（类型面漂移检测工具化，首跑挖出四条「发货了却没声明」的类型缺陷）前进。
 > **v0.88.0（2026-07-27，锁步对齐）**：本包零代码改动；随 agent SDK 0.88.0（处方卡型 + sessions 体检面）前进。
@@ -338,6 +340,8 @@
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
 - **v0.84.0（2026-07-27）**：记忆索引纪律 + 整理规程——修的是「SDK 给了常驻索引机制却没规定索引条目该长什么样，且会话收尾提示词命令模型把进度卡写进索引档」这个自伤缺口（守密人 BPT 现场反馈：开工要好几回工具调用才找得到东西）。进度卡改落 `/memories/progress/`、索引只留指针；新增索引纪律片段（两模式注入、前提不成立即跳过）；写侧超限反压（读写共用同一度量，明说尾部已不可见）；`buildConsolidationPrompt()` + 四阶段整理规程，由 `assessMemoryStoreHealth()` 结果渲染待办。**层界守住**：只给「该不该整理 / 怎么整理」，不给调度（N1 未破，零新进程）。新增测试 28。
 - **v0.87.0（2026-07-27）**：截断纪律全家对齐——任何上限砍内容须答三问（丢多少/为何/怎么拿回）、流式保尾。后台 shell 流永久失聪缺陷修复（保尾保留窗 + 丢弃计数 + gap 标记）；Bash/WebFetch/Glob/workflow 标记补齐；注册表测试逼新截断点登记；cards 校验两层豁免索引档（修 0.84.0 自种 P4 矛盾）。另修哨兵两档制 + test.yml push 盲区 + 门禁 hooksPath 警告（仓侧）。
+- **v0.91.0（2026-07-27）**：**四个工具补上结构化产出 + 零产出面立台账**（守密人「全补」+「整体记档并入白名单」两裁）——**暴露的是 type-parity 的射程边界**：它比**声明的形状**、不问**有没有人产出**，首跑遂一本正经报 `AgentOutput` 差 20 个字段——实情是本 SDK **从没有代码填过 `AgentOutput`**，等于精确地量一个空盒子。顺线做工具层普查又揪出**四个「声明了官方形状、一行没填」**的类型，事实全都只能靠解析人话字符串拿到：**Write**（`type`/`filePath`/`content`/`bytes` + 有 checkpoint 时的 `originalFile`；`bytes` **早就算好了**、拼进句子扔掉，全批最刺眼）· **Edit**（含 `replacedCount`，前像不额外花钱）· **TodoWrite**（`oldTodos`/`newTodos` 完整，为此把上一版单子存进 session-key WeakMap，调用方才看得到**迁移**）· **EnterWorktree**（三字段完整）。`structuredPatch`/`gitDiff` 不填——无差分引擎与 git 管线，空数组会被读成「没有改动」。**缺就报缺**：Write 的 `originalFile` 没抓到前像时**省略**而非 `null`（`null` 已表示「原本没这个文件」，把「不知道」塌缩成「不存在」是主动误导）。**立台账不立规矩**：`tests/structured-output-census.test.ts` 钉住刻意不产出的名单+理由，新工具静默上线红、陈条也红——「所有工具都必须产出」是错规矩（会再造 typed-not-populated），真正出事的是**静默增长**。**18 条并入白名单**，漂移报告归零。**Workflow 仍开着**（必填 `status:'async_launched'` 与同步执行冲突，守密人已裁改行为对齐，另轮跟进）。
+
 - **v0.90.0（2026-07-27）**：checkpoint blob 上限（T74 甲案）——超 10MB 前像不存字节、标 `oversized`（刻意不复用 `blob: null`——那意味「新建」，rewind 会删档；`readIndex()` 往返保留标记，丢即致命）；rewind 对超限档原样不动、点名不可恢复并整体报 `canRewind: false`。销 T74。
 - **v0.89.0（2026-07-27）**：**类型面漂移检测工具化——只报「新的」**（守密人「按你建议继续」）——同日三轮普查全是跑完即弃的手搓脚本，「上次扫到哪、哪些已裁过」全靠人记，这正是漂移反复回来的原因（第三轮挖到的恰是第二轮当天引入的）。收成 `projects/silver-core-sdk/scripts/type-parity.mjs`：**价值不在重跑比对，在于自动扣除已裁定项、只把新长出来的摆上台**（`RULED` 白名单，一条裁定吸收整棵子树）——每次都吐同样四十条已知差异的报告，人第二次就不看了。恒 exit 0（尺子不是门禁：红线纪律禁止声明未发货能力，机械拉平等于逼类型面承诺做不到的事）。**首跑挖出四条真缺陷，三条同一种「发货了却没声明」**：`GrepInput` 未声明 `-o`（实现早在，前几轮漏因不匹配带引号键）· `WorkflowInput` 未声明 `title`/`description`（都在发货 schema 里）· `GlobOutput` 空着 `totalMatches`/`countIsComplete`（本引擎先枚举全集再切片，数得准）。**声明面少报代码实际接受的东西 = typed-not-populated 的镜像**。解析器出的是**假发现**不是响亮失败，故 `tests/type-parity.test.ts` 钉住历次真踩过的坑（单行 `{}` 吞下一块、纯别名伸进邻居花括号、带引号短横线键、索引签名造幽灵字段、官方 `@minItems` 元组展开挂错父节点）。**三项待守密人裁**：`AgentOutput` 官方遥测/worktree 字段 · `AgentInput.team_name` · `FileReadOutput.source`（缺的是整条 `file_unchanged` 分支）——**故意不自行并入白名单**。
 - **v0.87.1（2026-07-27）**：**嵌套路径普查（三扫）**（守密人「1 继续」）——前两轮比顶层键，本轮摊成**点号路径**再比，专抓两类前两轮**结构上看不见**的差异。**挖出一条真缺陷、是银芯自己的**：`timedOutAfterMs` 官方在**基类** `BashOutput`，0.85.0 却加在银芯**扩展类型**上——交集相同、没坏东西，但**顶层键比对永远发现不了**（键两边都有、待错了地方），已移回基类。其余全属平台绑定只登记：`gitOperation.*`（官方解析 git/gh 输出成结构化 VCS 事实）· `artifactRead.*` · `blobSavedTo` 等。~~九个类型逐层完全一致~~（**已由 v0.89.0 工具化重跑推翻**：Glob / Grep / Workflow 并不一致，本轮手搓展平器只比联合类型第一支、不匹配带引号的键，覆盖被高估）。**方法边界**：展平器不解析 TS 语义，故同时报键总数，数量级不对即解析飞了。

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,9 +12,14 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
-## 0.90.0 — 2026-07-27
+## 0.91.0 — 2026-07-27
 
 Lockstep alignment only — no changes to this package. The family clock advanced
+for silver-core-agent-sdk 0.91.0 (Write / Edit / TodoWrite / EnterWorktree
+produce structured results; the zero-producer set gets a census guard).
+
+## 0.90.0 — 2026-07-27
+
 for silver-core-agent-sdk 0.90.0 (checkpoint blob cap, T74 option 甲).
 
 ## 0.89.0 — 2026-07-27

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,11 +36,13 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.90.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.90.0`
+**当前版本 `0.91.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.91.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.91.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.91.0（Write/Edit/TodoWrite/EnterWorktree 补结构化产出 + 零产出面立台账守卫）前进。
 
 **v0.90.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.90.0
 （checkpoint blob 上限，T74 甲案）前进。

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.90.0';
+export const MAESTRO_SDK_VERSION = '0.91.0';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,63 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.91.0 — 2026-07-27
+
+Four more tools produce structured results, and the zero-producer set gets a
+census (keeper rulings 2026-07-27: "全补" + "整体记档并入白名单").
+
+**What the type-parity command could not see.** It compares DECLARED shapes and
+never asks whether anything EMITS them, and its first run walked straight into
+the consequence: it reported `AgentOutput` as missing twenty official fields
+when the truth is that nothing in this SDK has ever populated `AgentOutput` at
+all. A census of the tool layer then found four MORE types declared,
+official-shaped, and never filled — Write, Edit, TodoWrite, EnterWorktree —
+with every fact reachable only by parsing the human-facing sentence.
+
+- **Write** emits `type` / `filePath` / `content` / `bytes`, plus
+  `originalFile` when checkpointing captured a pre-image. `bytes` is the
+  sharpest case in the whole batch: the number was already computed, then spent
+  on string interpolation and thrown away.
+- **Edit** emits `filePath` / `oldString` / `newString` / `originalFile` /
+  `replaceAll` / `replacedCount`. The pre-image is free here — Edit had to read
+  the file to apply the replacement.
+- **TodoWrite** emits `oldTodos` / `newTodos`, COMPLETE. This needed one new
+  thing: the tool kept no state (the model resends the whole list), so
+  `oldTodos` did not exist to report. The previous list now persists on the
+  session-key WeakMap — the sanctioned per-query pattern — which is what lets a
+  caller see the TRANSITION instead of diffing against a copy it was never
+  handed.
+- **EnterWorktree** emits `worktreePath` / `worktreeBranch` / `message`,
+  COMPLETE.
+
+`structuredPatch` and `gitDiff` stay absent (no diff engine, no git plumbing);
+an empty patch array would read as "no changes".
+
+**Absence is reported as absence.** Write's `originalFile` is OMITTED, not
+`null`, when no pre-image was captured — `null` already means "there was no
+prior file", so collapsing "unknown" into "did not exist" would make the field
+actively misleading. Two tests pin exactly this, because it is the kind of
+distinction that quietly erodes.
+
+**A census, not a rule.** `tests/structured-output-census.test.ts` pins the
+roster of tools that deliberately emit nothing, each with its reason, and fails
+on a new tool that ships silent OR on a stale entry whose tool started emitting.
+"Every tool must emit" would be the wrong rule — several genuinely have no
+machine-readable fact beyond their sentence, and forcing a shape onto them
+recreates typed-not-populated. What actually goes wrong is SILENT growth: four
+tools sat unpopulated for many versions because nothing was counting.
+
+**Adjudicated unshipped**, now deducted by `type-parity.mjs` (18 new `RULED`
+entries): `AgentOutput`'s telemetry / worktree / remote-task fields,
+`AgentInput.team_name`, `FileReadOutput.source`. The Agent row is recorded
+rather than filled on purpose — arguing over individual fields before the tool
+has any structured producer is backwards. The drift report is back to clean.
+
+`Workflow` remains open: official's `WorkflowOutput` requires
+`status: 'async_launched'` and this engine runs workflows synchronously, so
+emitting that literal would hand the caller a claim ticket for goods it is
+already holding. Being closed by making the behaviour match, tracked separately.
+
 ## 0.90.0 — 2026-07-27
 
 Checkpoint blob cap with honest degradation (todo T74, keeper ruling: option

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -71,7 +71,7 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.90.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.90.0`
+**当前版本 `0.91.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.91.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
@@ -89,6 +89,8 @@ unavailable、触界标 lower bound、零进程零调度（N1）。blob 上限�
 Bash/WebFetch/Glob/workflow 标记补齐；注册表测试逼新截断点登记；cards 校验两层豁免索引档
 （修 0.84.0 自种 P4 矛盾）。详见 CHANGELOG。
 **v0.87.1（2026-07-27）：嵌套路径普查（三扫）**（守密人「1 继续」）——前两轮普查比的都是**顶层键**，本轮把两边摊成**点号路径**（`contents[].blobSavedTo`、`gitOperation.commit.sha`）再比，专抓两类前两轮**结构上看不见**的差异：嵌在双方都声明的形状**里面**的字段，以及**两边都有、却待在不同类型里**的字段。**挖出一条真缺陷，而且是银芯自己的**：`timedOutAfterMs` 官方在**基类** `BashOutput` 里，0.85.0 却把它加在了银芯的**扩展类型**上。交出来的交集完全相同、没坏任何东西，而**任何顶层键比对都不可能发现它**——键在两边都存在，只是待错了地方。已移入基类。**其余全属平台绑定，只登记不声明**：`BashOutput.gitOperation.*`（官方**解析 git/gh 命令输出**成结构化 VCS 事实，银芯只跑 shell、不解析其输出，为填字段现造一个解析器不是对齐）· `ghRateLimitHint`/`staleReadFileStateHint`/`backgroundCwdHint`/`noOutputExpected` · `WebFetchOutput.artifactRead.*` · `gitDiff.repository`（在一个银芯声明了但从不产出的形状里）· `contents[].blobSavedTo` · AskUserQuestion 权限 UI 路径。~~九个类型逐层完全一致~~**（2026-07-27 由 v0.88.0 工具化重跑推翻：Glob / Grep / Workflow 三个并不一致——本轮手搓展平器只比了联合类型的第一支、也不匹配带引号的键，覆盖被高估了）**。**方法边界**：展平器只跟花括号深度与键名、不解析 TS 语义，故逐类型同时报**键总数**——数量级不对说明解析飞了，而不是类型真有差异。
+
+**v0.91.0（2026-07-27）：四个工具补上结构化产出 + 零产出面立台账**（守密人「全补」+「整体记档并入白名单」两裁）——**这一轮暴露的是 type-parity 那把尺子的射程边界**：它比的是**声明的形状**，不问**有没有人产出**，于是首跑一本正经地报 `AgentOutput` 差 20 个字段——而实情是本 SDK **从来没有任何代码填过 `AgentOutput`**，等于在很精确地量一个空盒子。顺着这条线做工具层普查，又揪出**四个「声明了官方形状、一行没填」**的类型，且每个的事实都**只能靠解析人话字符串**才拿得到。**Write** 补 `type`/`filePath`/`content`/`bytes`（+ 有 checkpoint 时的 `originalFile`）——`bytes` 是全批最刺眼的一个：数字**早就算好了**，然后拼进句子里扔掉了；**Edit** 补 `filePath`/`oldString`/`newString`/`originalFile`/`replaceAll`/`replacedCount`（前像不额外花钱——Edit 本来就得读全文才能替换）；**TodoWrite** 补 `oldTodos`/`newTodos`**完整**，为此新增一件东西：该工具原本零状态（模型每次重发整张单），`oldTodos` 根本不存在，现把上一版单子存进 **session-key WeakMap**（既定的按查询状态模式），调用方这才看得到**迁移**而不是只看到新单子；**EnterWorktree** 补三字段**完整**。`structuredPatch`/`gitDiff` 仍不填——没有差分引擎与 git 管线，填个空数组会被读成「没有改动」。**缺就报缺**：Write 的 `originalFile` 在没抓到前像时是**省略**而非 `null`——`null` 已经表示「原本没有这个文件」，把「不知道」塌缩成「不存在」会让字段主动误导（两条测试专钉这一点）。**立的是台账不是规矩**：`tests/structured-output-census.test.ts` 钉住「刻意不产出」的名单+逐条理由，新工具静默上线会红、名单里已经开始产出的陈条也会红。「所有工具都必须产出」是错的规矩——有些工具确实没有超出那句话之外的机器可读事实，硬套形状就是再造 typed-not-populated；真正会出事的是**静默增长**（四个工具躺了很多版没人数）。**18 条并入白名单**：`AgentOutput` 遥测/worktree/远程任务字段、`AgentInput.team_name`、`FileReadOutput.source`；Agent 那行**刻意只记档不补**——在工具连产出方都没有时争论补哪个字段是顺序反了。漂移报告已归零。**Workflow 仍开着**：官方 `WorkflowOutput` 必填 `status:'async_launched'`，本引擎同步跑完才返回，交这个字面量等于给一张「货已在你手上」的取件凭证；守密人已裁定改行为对齐，另轮跟进。
 
 **v0.90.0（2026-07-27）：checkpoint blob 上限（T74 甲案）**——`record()` 原对每个被改文件存完整
 前像、无上限（sessions 补审 P1-S2）。超 10MB（可配）前像**不存字节、标 `oversized`**——刻意不复用

--- a/projects/silver-core-sdk/docs/COMPAT.md
+++ b/projects/silver-core-sdk/docs/COMPAT.md
@@ -638,6 +638,66 @@ concludes a shipped feature is absent.
 | `AgentInput.team_name` | Official teams; no such concept here. |
 | `FileReadOutput.source` | Sits on official's `file_unchanged` result arm — a startup-seeded CLAUDE.md dedup path this SDK does not ship at all. The gap is the whole arm, not the field. |
 
+## Zero-producer output types — the census (2026-07-27)
+
+`type-parity.mjs` compares DECLARED shapes. It never asks whether anything
+EMITS them, and its first run walked straight into the consequence: it reported
+`AgentOutput` as missing twenty official fields when the truth is that nothing
+in this SDK has ever populated `AgentOutput` at all. Measuring the shape of an
+empty box very precisely.
+
+A census of the tool layer found **four types declared, official-shaped, and
+never filled**, with every fact reachable only by parsing the sentence. All
+four are now producers (keeper ruling, "全补"):
+
+| Tool | Now emits | Still absent, and why |
+|---|---|---|
+| Write | `type` / `filePath` / `content` / `bytes`, plus `originalFile` when checkpointing captured a pre-image | `structuredPatch` (no diff engine), `gitDiff` (no git plumbing). `originalFile` is optional here and required in official: Write does not otherwise read the file it replaces, and forcing a read to fill a field would tax every write |
+| Edit | `filePath` / `oldString` / `newString` / `originalFile` / `replaceAll` / `replacedCount` | `structuredPatch`, `gitDiff`, `userModified` (official editor integration) |
+| TodoWrite | `oldTodos` / `newTodos` — **complete** | — (required adding per-session state; see below) |
+| EnterWorktree | `worktreePath` / `worktreeBranch` / `message` — **complete** | — |
+
+`Write.bytes` is the sharpest illustration of the whole class: the number was
+already computed, then spent on string interpolation and discarded.
+
+TodoWrite needed one new thing. It kept no state — the model resends the whole
+list each call — so `oldTodos` did not exist to report. It now persists the
+previous list on the session-key WeakMap (the sanctioned per-query pattern),
+which is what lets a caller see the TRANSITION instead of diffing against a
+copy it was never handed. A session's first call honestly reports `[]`.
+
+**Absence is reported as absence.** Write's `originalFile` is omitted, not
+`null`, when no pre-image was captured — `null` already means "there was no
+prior file", and collapsing "unknown" into "did not exist" would make the field
+actively misleading. Same reasoning as `truncatedByCharCap` vs official's
+`truncatedByTokenCap`: a field that reads as parity and behaves as drift is
+worse than an honestly different one.
+
+Tools that deliberately emit nothing are on a named ledger in
+`tests/structured-output-census.test.ts`, each with its reason, and the test
+fails on a new tool that ships silent OR on a stale entry whose tool started
+emitting. The rule is not "every tool must emit" — several genuinely have no
+machine-readable fact beyond their sentence, and forcing a shape onto them
+recreates typed-not-populated. The rule is that nothing joins the silent set
+without someone writing down why.
+
+**Adjudicated unshipped (keeper ruling 2026-07-27, "整体记档并入白名单"), now
+deducted by `type-parity.mjs`:**
+
+| Surface | Ruling |
+|---|---|
+| `AgentOutput.toolStats.*`, `usage.inference_geo` / `.speed` / `.iterations`, `worktreePath` / `worktreeBranch`, `agentType`, `modelsUsed`, `content.citations`, `isAsync` / `sessionUrl` / `taskId` | The Agent tool has no structured producer at all. Arguing over individual fields before there is a producer is backwards: stand up the producer first, and the fields follow. Recorded, not added |
+| `AgentInput.team_name` | Official teams; no such concept here. Pure scope |
+| `FileReadOutput.source` | Sits on official's `file_unchanged` arm (startup-seeded CLAUDE.md dedup). This SDK lacks the WHOLE ARM — the flattener surfaces only the one field unique to it, which is that method's blind spot, stated here so the row is not misread as a one-field gap |
+| `Monitor`, `ExitPlanMode`, `AskUserQuestion` outputs | Official background-task ids / multi-agent approval chain / permission-component UI. No honest source |
+
+**Open**: `Workflow`. Official's `WorkflowOutput` requires
+`status: 'async_launched'`, and this engine runs workflows synchronously — the
+result is already in hand when the tool returns. Emitting that literal would
+hand the caller a claim ticket for goods it is already holding, which is worse
+than handing it nothing. The keeper has ruled to close this by making the
+behaviour match (真异步), tracked separately; until then the tool returns text.
+
 ## Tool-description ↔ implementation fidelity (audit r4, 2026-07-18)
 
 The model-side tool descriptions in `src/tools/descriptions.ts` are FAITHFUL

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/scripts/type-parity.mjs
+++ b/projects/silver-core-sdk/scripts/type-parity.mjs
@@ -79,6 +79,21 @@ const RULED = new Set([
   // 官方靠这对字段报「截断前共多少」；本引擎的 rg 流式读到上限即停，
   // 拿不到未截断总数，填即编造（理由全文见 src/types/tool-outputs.ts 头注）。
   'GrepOutput:totalFiles', 'GrepOutput:totalLines',
+  // ---- 守密人 2026-07-27 第二批裁定（「整体记档并入白名单」）----
+  // 官方子代理遥测 / worktree 会计 / 远程任务模型。本 SDK 的 Agent 工具连结构化
+  // 产出方都还没有（见 docs/COMPAT.md「零产出 Output 类型台账」），在没有产出方的
+  // 前提下讨论补哪个字段是顺序反了；要动先立产出方。
+  'AgentOutput:agentType', 'AgentOutput:modelsUsed', 'AgentOutput:content.citations',
+  'AgentOutput:toolStats', 'AgentOutput:usage.inference_geo',
+  'AgentOutput:usage.speed', 'AgentOutput:usage.iterations',
+  'AgentOutput:worktreePath', 'AgentOutput:worktreeBranch',
+  'AgentOutput:isAsync', 'AgentOutput:sessionUrl', 'AgentOutput:taskId',
+  // 官方 teams，本 SDK 无此设施。
+  'AgentInput:team_name',
+  // 挂在官方 `file_unchanged` 结果分支上（启动期预置 CLAUDE.md 去重）。本 SDK
+  // 没有那条分支，缺的是**整条分支**而非一个字段——展平比对只露出该分支独有的
+  // 那个字段，此为其固有盲区，已在 COMPAT.md 写明。
+  'FileReadOutput:source',
 ]);
 
 /** 官方名 -> 本 SDK 名（同物异名）。 */

--- a/projects/silver-core-sdk/src/tools/edit.ts
+++ b/projects/silver-core-sdk/src/tools/edit.ts
@@ -30,6 +30,7 @@ import {
   resolveAbs,
 } from './fsutil.js';
 import { EDIT_DESCRIPTION } from './descriptions.js';
+import type { EditStructuredOutput } from '../types/tool-outputs.js';
 
 /** Context lines shown around the first edit site in the success snippet. */
 const SNIPPET_CONTEXT_LINES = 2;
@@ -271,6 +272,17 @@ export const editTool: BuiltinTool = {
         content:
           `Replaced ${replaced} occurrence${replaced === 1 ? '' : 's'} of old_string in "${abs}".\n` +
           `Snippet around the first edit site:\n${snippet}`,
+        // `text` IS the original content — Edit had to read it to apply the
+        // replacement, so `originalFile` costs nothing extra here (unlike
+        // Write, which does not otherwise read what it replaces).
+        structuredOutput: {
+          filePath: abs,
+          oldString: effOld,
+          newString: effNew,
+          originalFile: text,
+          replaceAll,
+          replacedCount: replaced,
+        } satisfies EditStructuredOutput,
       };
     } catch (e) {
       if (isAbortError(e)) {

--- a/projects/silver-core-sdk/src/tools/enterworktree.ts
+++ b/projects/silver-core-sdk/src/tools/enterworktree.ts
@@ -54,6 +54,7 @@ import {
   worktreeBranch,
 } from '../internal/worktree.js';
 import { ENTERWORKTREE_DESCRIPTION } from './descriptions.js';
+import type { EnterWorktreeStructuredOutput } from '../types/tool-outputs.js';
 
 /** Worktree-session state for one query. */
 export type WorktreeSession = {
@@ -111,7 +112,15 @@ function renderOutput(
   const lines = [`worktreePath: ${worktreePath}`];
   if (branch !== undefined) lines.push(`worktreeBranch: ${branch}`);
   lines.push(message);
-  return { content: lines.join('\n') };
+  return {
+    content: lines.join('\n'),
+    // Complete: every field of the official shape is a fact already in hand.
+    structuredOutput: {
+      worktreePath,
+      ...(branch !== undefined ? { worktreeBranch: branch } : {}),
+      message,
+    } satisfies EnterWorktreeStructuredOutput,
+  };
 }
 
 export const enterWorktreeTool: BuiltinTool = {

--- a/projects/silver-core-sdk/src/tools/todo.ts
+++ b/projects/silver-core-sdk/src/tools/todo.ts
@@ -1,10 +1,18 @@
 /**
  * Built-in TodoWrite tool: maintain a structured task checklist.
  *
- * Stateless by design - the model resends the complete list on every call, so
- * the tool simply validates the payload and renders a markdown checklist plus a
- * one-line count summary back as the tool_result. A dedicated SDK message
- * variant is deferred (see docs/COMPAT.md).
+ * Stateless from the MODEL's side by design - it resends the complete list on
+ * every call, and the tool validates the payload and renders a markdown
+ * checklist plus a one-line count summary back as the tool_result. A dedicated
+ * SDK message variant is deferred (see docs/COMPAT.md).
+ *
+ * The tool does keep ONE piece of per-session state: the previous list, so the
+ * structured result can report the TRANSITION (`oldTodos` -> `newTodos`) the
+ * way official does. Without it a caller sees the new list and has to diff it
+ * against a copy it was never given — which is the whole reason official
+ * carries both halves. Stored on the session-key WeakMap (the sanctioned
+ * per-query state pattern, contracts.ts `sessionKey`) so it dies with the
+ * query and never leaks between sessions.
  */
 
 import type {
@@ -14,6 +22,7 @@ import type {
 } from '../internal/contracts.js';
 import { AbortError } from '../errors.js';
 import { TODOWRITE_DESCRIPTION } from './descriptions.js';
+import type { TodoWriteStructuredOutput } from '../types/tool-outputs.js';
 
 type TodoStatus = 'pending' | 'in_progress' | 'completed';
 const STATUSES: readonly TodoStatus[] = ['pending', 'in_progress', 'completed'];
@@ -26,6 +35,20 @@ type TodoItem = {
 
 function errorResult(message: string): ToolResultPayload {
   return { content: message, isError: true };
+}
+
+/** Previous list per query. WeakMap on the session key: no cleanup hook needed,
+ *  and a context with no sessionKey (bare tool use in a unit test) simply gets
+ *  an empty previous list rather than sharing one process-wide. */
+const previousTodos = new WeakMap<object, TodoItem[]>();
+const NO_SESSION_KEY: TodoItem[] = [];
+
+function takePrevious(ctx: ToolContext, next: TodoItem[]): TodoItem[] {
+  const key = ctx.sessionKey;
+  if (key === undefined) return NO_SESSION_KEY;
+  const prior = previousTodos.get(key) ?? [];
+  previousTodos.set(key, next);
+  return prior;
 }
 
 export const todoWriteTool: BuiltinTool = {
@@ -120,6 +143,10 @@ export const todoWriteTool: BuiltinTool = {
 
     const summary = `Todos: ${pending} pending, ${inProgress} in progress, ${completed} completed.`;
     const content = lines.length > 0 ? `${summary}\n${lines.join('\n')}` : summary;
-    return { content };
+    const oldTodos = takePrevious(ctx, todos);
+    return {
+      content,
+      structuredOutput: { oldTodos, newTodos: todos } satisfies TodoWriteStructuredOutput,
+    };
   },
 };

--- a/projects/silver-core-sdk/src/tools/write.ts
+++ b/projects/silver-core-sdk/src/tools/write.ts
@@ -27,6 +27,7 @@ import type {
 import { AbortError, isAbortError } from '../errors.js';
 import { looksBinary, resolveAbs } from './fsutil.js';
 import { WRITE_DESCRIPTION } from './descriptions.js';
+import type { WriteStructuredOutput } from '../types/tool-outputs.js';
 
 function errorResult(message: string): ToolResultPayload {
   return { content: message, isError: true };
@@ -73,6 +74,9 @@ export const writeTool: BuiltinTool = {
 
       // Determine created-vs-overwritten before writing; reject directories.
       let existedBefore = false;
+      // Kept when checkpointing captured a lossless pre-image; feeds
+      // `originalFile` on the structured result (never re-read just for it).
+      let preImage: string | null | undefined;
       let priorMode: number | undefined;
       try {
         const st = await stat(abs);
@@ -125,6 +129,7 @@ export const writeTool: BuiltinTool = {
       // file whose pre-image we never captured.
       if (ctx.recordFileChange !== undefined) {
         if (!existedBefore) {
+          preImage = null;
           ctx.recordFileChange(abs, null);
         } else {
           let buf: Buffer | undefined;
@@ -137,6 +142,7 @@ export const writeTool: BuiltinTool = {
             const asText = buf.toString('utf8');
             const roundTrips = Buffer.from(asText, 'utf8').equals(buf);
             if (roundTrips && !looksBinary(buf)) {
+              preImage = asText;
               ctx.recordFileChange(abs, asText);
             } else {
               // Non-UTF-8 / binary existing file: cannot capture losslessly
@@ -205,6 +211,15 @@ export const writeTool: BuiltinTool = {
         content: existedBefore
           ? `Overwrote existing file "${abs}" (${bytes} bytes written).`
           : `Created new file "${abs}" (${bytes} bytes written).`,
+        // `bytes` was already computed for the sentence above; a caller should
+        // not have to parse that sentence back apart to learn it.
+        structuredOutput: {
+          type: existedBefore ? 'update' : 'create',
+          filePath: abs,
+          content,
+          bytes,
+          ...(preImage !== undefined ? { originalFile: preImage } : {}),
+        } satisfies WriteStructuredOutput,
       };
     } catch (e) {
       if (isAbortError(e)) {

--- a/projects/silver-core-sdk/src/types/tool-outputs.ts
+++ b/projects/silver-core-sdk/src/types/tool-outputs.ts
@@ -33,9 +33,13 @@
 
 import type {
   BashOutput,
+  EnterWorktreeOutput,
+  FileEditOutput,
   FileReadOutput,
+  FileWriteOutput,
   GlobOutput,
   GrepOutput,
+  TodoWriteOutput,
   WebFetchOutput,
 } from './tools.js';
 
@@ -78,6 +82,63 @@ export type BashStructuredOutput = BashOutput & {
   exitCode: number | null;
   truncated: boolean;
 };
+
+/**
+ * Write / Edit / TodoWrite / EnterWorktree — the second batch of producers
+ * (keeper ruling 2026-07-27, "全补").
+ *
+ * These four were found by `scripts/type-parity.mjs`'s first run and the
+ * follow-up producer census: each already DECLARED an official-shaped output
+ * type in `types/tools.ts`, none had ever populated it, and every fact a
+ * caller wanted was reachable only by parsing the human-facing sentence —
+ * `Overwrote existing file "/x" (1234 bytes written).` is not an interface.
+ * Write is the sharpest case: `bytes` was already computed and then spent on
+ * string interpolation.
+ *
+ * What stays absent, and why absence is the honest answer:
+ * - `structuredPatch` (Write, Edit) needs a diff algorithm this SDK does not
+ *   ship. An empty array would read as "no changes".
+ * - `gitDiff` (Write, Edit) needs git plumbing this SDK does not ship.
+ * - `userModified` (Edit) is official's editor-integration signal; adjudicated
+ *   unshipped, see docs/COMPAT.md.
+ * - `originalFile` (Write) is captured only when file checkpointing is on —
+ *   Write does not otherwise read the file it is about to replace, and forcing
+ *   a read to fill a field would make every write pay for it. Optional here,
+ *   required in official: a documented divergence, not a silent one.
+ */
+export type WriteStructuredOutput = Omit<
+  FileWriteOutput,
+  'structuredPatch' | 'originalFile' | 'gitDiff'
+> & {
+  /** Present when file checkpointing captured a lossless pre-image. */
+  originalFile?: string | null;
+  /** UTF-8 byte length actually written. Not an official field; this engine
+   *  computes it for its own message and a caller should not have to re-derive
+   *  it from `content`. */
+  bytes: number;
+};
+
+export type EditStructuredOutput = Omit<
+  FileEditOutput,
+  'structuredPatch' | 'gitDiff' | 'userModified'
+> & {
+  /** How many occurrences were actually replaced (1 unless `replace_all`).
+   *  Official carries this only inside `structuredPatch`, which this engine
+   *  cannot build. */
+  replacedCount: number;
+};
+
+/** Complete — every field is a fact this tool already holds. */
+export type EnterWorktreeStructuredOutput = EnterWorktreeOutput;
+
+/**
+ * Complete, but note what had to be built to make it so: `oldTodos` demanded
+ * per-session state the tool never kept (it validated the incoming list and
+ * rendered it). The list now persists on the session-key WeakMap — the sanctioned
+ * per-query state pattern — so a caller can see the TRANSITION rather than just
+ * the new list. A first call in a session honestly reports `oldTodos: []`.
+ */
+export type TodoWriteStructuredOutput = TodoWriteOutput;
 
 /** The per-message map described in the module header. */
 export type ToolUseResults = Record<string, unknown>;

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.90.0';
+export const SDK_VERSION = '0.91.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/structured-output-census.test.ts
+++ b/projects/silver-core-sdk/tests/structured-output-census.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Census guard for the structured-output surface.
+ *
+ * Why a census and not a rule: "every tool must emit `structuredOutput`" would
+ * be the wrong rule — several tools genuinely have no fact to report beyond the
+ * sentence they already return, and forcing a shape onto them produces
+ * typed-not-populated, the failure this whole line of work exists to undo.
+ *
+ * What actually goes wrong is SILENT growth. Four tools (Write, Edit,
+ * TodoWrite, EnterWorktree) each declared an official-shaped output type and
+ * never populated it, and nobody noticed for many versions because nothing was
+ * counting. `scripts/type-parity.mjs` cannot catch this class either: it
+ * compares DECLARED shapes and never asks whether anything emits them.
+ *
+ * So this pins the roster. A new tool that ships without a structured result
+ * fails here and its author writes down why — the reason lands in the ledger
+ * instead of in nobody's head.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const TOOLS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'tools');
+
+/**
+ * Tool modules that deliberately emit no `structuredOutput`, each with the
+ * reason. Removing a name from here is how a tool graduates; adding one
+ * requires stating why the tool has no machine-readable fact worth reporting.
+ */
+const NO_STRUCTURED_OUTPUT: Record<string, string> = {
+  askuserquestion:
+    'the answer map is official permission-component UI state; adjudicated unshipped (COMPAT.md)',
+  enterplanmode: 'official declares no output type for this tool',
+  exitplanmode:
+    'official fields are its multi-agent approval chain (awaitingLeaderApproval / requestId)',
+  monitor: "MonitorOutput.taskId is official's background-task id space; this Monitor is a subset",
+  sendmessage: 'official declares no output type for this tool',
+  task: 'the task-ledger quintet returns its rows as text; no official output shape diverges from it',
+  workflow:
+    "official's WorkflowOutput requires status:'async_launched'; emitting it would assert a launch this engine never made (open item, COMPAT.md)",
+  // Not tools — module-level helpers that merely contain a `name:` literal.
+  descriptions: 'not a tool module (description constants)',
+  shells: 'declares BashOutput/KillShell/TaskOutput/TaskStop, whose facts ride the shell records',
+  'workflow-engine': 'not a tool module (the sandboxed runner behind Workflow)',
+};
+
+function toolModules(): string[] {
+  return readdirSync(TOOLS_DIR)
+    .filter((f) => f.endsWith('.ts'))
+    .filter((f) => readFileSync(join(TOOLS_DIR, f), 'utf8').includes("name: '"))
+    .map((f) => f.replace(/\.ts$/, ''))
+    .sort();
+}
+
+function emitsStructuredOutput(mod: string): boolean {
+  return readFileSync(join(TOOLS_DIR, `${mod}.ts`), 'utf8').includes('structuredOutput');
+}
+
+describe('structured-output census', () => {
+  it('every non-emitting tool module is on the ledger with a stated reason', () => {
+    const silent = toolModules().filter((m) => !emitsStructuredOutput(m));
+    const unexplained = silent.filter((m) => !(m in NO_STRUCTURED_OUTPUT));
+    expect(unexplained, `无理由的零产出工具：${unexplained.join(', ')}`).toEqual([]);
+  });
+
+  it('the ledger carries no stale entry', () => {
+    // A tool that started emitting must LEAVE the ledger, or the ledger drifts
+    // into a list of excuses for things that were fixed long ago.
+    const stale = Object.keys(NO_STRUCTURED_OUTPUT)
+      .filter((m) => toolModules().includes(m))
+      .filter((m) => emitsStructuredOutput(m));
+    expect(stale, `已产出却仍挂在豁免清单上：${stale.join(', ')}`).toEqual([]);
+  });
+
+  it('every reason is a real sentence, not a placeholder', () => {
+    for (const [mod, reason] of Object.entries(NO_STRUCTURED_OUTPUT)) {
+      expect(reason.length, `${mod} 的理由太短`).toBeGreaterThan(20);
+    }
+  });
+
+  it('the four tools ruled in on 2026-07-27 do emit', () => {
+    for (const mod of ['write', 'edit', 'todo', 'enterworktree']) {
+      expect(emitsStructuredOutput(mod), `${mod} 应当产出结构化结果`).toBe(true);
+    }
+  });
+});

--- a/projects/silver-core-sdk/tests/tool-structured-output-batch2.test.ts
+++ b/projects/silver-core-sdk/tests/tool-structured-output-batch2.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Structured results for Write / Edit / TodoWrite / EnterWorktree — the second
+ * batch of producers (keeper ruling 2026-07-27, "全补").
+ *
+ * Same discipline as the first batch: each case asserts the structured field
+ * DIRECTLY, never by re-reading the sentence. The whole point of the surface is
+ * that `Overwrote existing file "/x" (1234 bytes written).` stops being an
+ * interface, so a test that parsed that sentence would be testing the thing
+ * being retired.
+ *
+ * Two cases below exist because the honest answer is "absent", not "zero":
+ * Write's `originalFile` when no checkpoint recorder is wired, and TodoWrite's
+ * `oldTodos` on a session's first call. A field that quietly reads `null` or
+ * `[]` when the truth is "never captured" is worse than a missing one — the
+ * caller cannot tell the difference between "unchanged" and "unknown".
+ */
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { writeTool } from '../src/tools/write.js';
+import { editTool } from '../src/tools/edit.js';
+import { todoWriteTool } from '../src/tools/todo.js';
+import type { ToolContext } from '../src/internal/contracts.js';
+import type {
+  EditStructuredOutput,
+  TodoWriteStructuredOutput,
+  WriteStructuredOutput,
+} from '../src/types/tool-outputs.js';
+
+let sandboxes: string[] = [];
+async function makeSandbox(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'scs-structured2-'));
+  sandboxes.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(sandboxes.map((d) => rm(d, { recursive: true, force: true })));
+  sandboxes = [];
+});
+
+function makeCtx(cwd: string, extra: Partial<ToolContext> = {}): ToolContext {
+  return {
+    cwd,
+    additionalDirectories: [],
+    env: {},
+    signal: new AbortController().signal,
+    debug: () => {},
+    readFilePaths: new Set<string>(),
+    ...extra,
+  };
+}
+
+describe('Write structured result', () => {
+  it('reports create vs update, path and byte count without parsing the sentence', async () => {
+    const dir = await makeSandbox();
+    const file = path.join(dir, 'new.txt');
+    const res = await writeTool.execute({ file_path: file, content: 'héllo' }, makeCtx(dir));
+    const s = res.structuredOutput as WriteStructuredOutput;
+    expect(s.type).toBe('create');
+    expect(s.filePath).toBe(file);
+    expect(s.content).toBe('héllo');
+    // 6, not 5: é is two bytes in UTF-8. The count is of BYTES WRITTEN, which
+    // is exactly the fact a caller cannot recover from `content.length`.
+    expect(s.bytes).toBe(6);
+  });
+
+  it('flips to update on an overwrite', async () => {
+    const dir = await makeSandbox();
+    const file = path.join(dir, 'x.txt');
+    await writeFile(file, 'old', 'utf8');
+    const ctx = makeCtx(dir);
+    ctx.readFilePaths?.add(file); // satisfy the read-before-write gate
+    const res = await writeTool.execute({ file_path: file, content: 'new' }, ctx);
+    expect((res.structuredOutput as WriteStructuredOutput).type).toBe('update');
+  });
+
+  it('carries originalFile only when a checkpoint recorder captured it', async () => {
+    const dir = await makeSandbox();
+    const file = path.join(dir, 'y.txt');
+    await writeFile(file, 'previous', 'utf8');
+
+    const bare = makeCtx(dir);
+    bare.readFilePaths?.add(file);
+    const noRecorder = (await writeTool.execute({ file_path: file, content: 'a' }, bare))
+      .structuredOutput as WriteStructuredOutput;
+    // ABSENT, not null — Write never read the old bytes, so "unknown" is the
+    // truth. `null` would mean "the file did not exist", a different claim.
+    expect('originalFile' in noRecorder).toBe(false);
+
+    await writeFile(file, 'previous', 'utf8');
+    const withRecorder = makeCtx(dir, { recordFileChange: () => {} });
+    withRecorder.readFilePaths?.add(file);
+    const recorded = (await writeTool.execute({ file_path: file, content: 'b' }, withRecorder))
+      .structuredOutput as WriteStructuredOutput;
+    expect(recorded.originalFile).toBe('previous');
+  });
+
+  it('reports originalFile as null for a newly created file under a recorder', async () => {
+    const dir = await makeSandbox();
+    const res = await writeTool.execute(
+      { file_path: path.join(dir, 'fresh.txt'), content: 'z' },
+      makeCtx(dir, { recordFileChange: () => {} }),
+    );
+    // null is the honest value here: there was no prior file.
+    expect((res.structuredOutput as WriteStructuredOutput).originalFile).toBeNull();
+  });
+});
+
+describe('Edit structured result', () => {
+  it('reports the replacement count, which the caller previously had to read out of prose', async () => {
+    const dir = await makeSandbox();
+    const file = path.join(dir, 'e.txt');
+    await writeFile(file, 'a\na\na\n', 'utf8');
+    const ctx = makeCtx(dir);
+    ctx.readFilePaths?.add(file);
+    const res = await editTool.execute(
+      { file_path: file, old_string: 'a', new_string: 'b', replace_all: true },
+      ctx,
+    );
+    const s = res.structuredOutput as EditStructuredOutput;
+    expect(s.replacedCount).toBe(3);
+    expect(s.replaceAll).toBe(true);
+    expect(s.oldString).toBe('a');
+    expect(s.newString).toBe('b');
+    // Edit had to read the file to apply the edit, so the pre-image is free.
+    expect(s.originalFile).toBe('a\na\na\n');
+    expect(await readFile(file, 'utf8')).toBe('b\nb\nb\n');
+  });
+
+  it('counts a single replacement when replace_all is off', async () => {
+    const dir = await makeSandbox();
+    const file = path.join(dir, 'e2.txt');
+    await writeFile(file, 'x\nx\n', 'utf8');
+    const ctx = makeCtx(dir);
+    ctx.readFilePaths?.add(file);
+    const res = await editTool.execute(
+      { file_path: file, old_string: 'x\nx', new_string: 'y' },
+      ctx,
+    );
+    const s = res.structuredOutput as EditStructuredOutput;
+    expect(s.replacedCount).toBe(1);
+    expect(s.replaceAll).toBe(false);
+  });
+});
+
+describe('TodoWrite structured result', () => {
+  const list = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      content: `task ${i}`,
+      status: 'pending' as const,
+      activeForm: `doing ${i}`,
+    }));
+
+  it('reports the transition, not just the new list', async () => {
+    const dir = await makeSandbox();
+    const ctx = makeCtx(dir, { sessionKey: {} });
+
+    const first = (await todoWriteTool.execute({ todos: list(1) }, ctx))
+      .structuredOutput as TodoWriteStructuredOutput;
+    // First call in a session: empty is the truth, and it is a truth the
+    // caller can act on (nothing was replaced).
+    expect(first.oldTodos).toEqual([]);
+    expect(first.newTodos).toHaveLength(1);
+
+    const second = (await todoWriteTool.execute({ todos: list(3) }, ctx))
+      .structuredOutput as TodoWriteStructuredOutput;
+    expect(second.oldTodos).toHaveLength(1);
+    expect(second.newTodos).toHaveLength(3);
+  });
+
+  it('keeps sessions apart', async () => {
+    const dir = await makeSandbox();
+    const a = makeCtx(dir, { sessionKey: {} });
+    const b = makeCtx(dir, { sessionKey: {} });
+    await todoWriteTool.execute({ todos: list(2) }, a);
+    const fromB = (await todoWriteTool.execute({ todos: list(1) }, b))
+      .structuredOutput as TodoWriteStructuredOutput;
+    // Session B must not inherit A's list — the state is per-query, and a
+    // process-wide store would silently cross-contaminate concurrent queries.
+    expect(fromB.oldTodos).toEqual([]);
+  });
+
+  it('does not share state between contexts that carry no session key', async () => {
+    const dir = await makeSandbox();
+    const bare = makeCtx(dir);
+    await todoWriteTool.execute({ todos: list(2) }, bare);
+    const again = (await todoWriteTool.execute({ todos: list(1) }, bare))
+      .structuredOutput as TodoWriteStructuredOutput;
+    // No session key (bare tool use, e.g. a unit test): report empty rather
+    // than inventing a shared global bucket.
+    expect(again.oldTodos).toEqual([]);
+  });
+});

--- a/projects/silver-core-sdk/tests/tools-planmode-worktree-monitor.test.ts
+++ b/projects/silver-core-sdk/tests/tools-planmode-worktree-monitor.test.ts
@@ -281,6 +281,28 @@ describe('EnterWorktree', () => {
     });
   });
 
+  it('reports path and branch as a structured result, not only as prose', async () => {
+    // The three facts EnterWorktree returns were previously reachable only by
+    // splitting `worktreePath: …\nworktreeBranch: …\n<message>` back apart.
+    // This is the one output type in the 2026-07-27 batch that comes out
+    // COMPLETE — every official field is a fact the tool already holds.
+    const repo = makeGitRepo();
+    const ctx = makeCtx({ cwd: repo, readFilePaths: new Set() });
+    const r = await enterWorktreeTool.execute({ name: 'structured-wt' }, ctx);
+    expect(r.isError, text(r)).toBeUndefined();
+    const s = r.structuredOutput as {
+      worktreePath: string;
+      worktreeBranch?: string;
+      message: string;
+    };
+    expect(s.worktreePath).toBe(join(repo, '.claude', 'worktrees', 'structured-wt'));
+    expect(s.worktreeBranch).toBe('structured-wt');
+    expect(s.message.length).toBeGreaterThan(0);
+    // The structured path must be the one the session actually switched to —
+    // the two disagreeing is the failure mode that makes the surface harmful.
+    expect(s.worktreePath).toBe(ctx.cwd);
+  });
+
   it('generates a random name when none is given', async () => {
     const repo = makeGitRepo();
     const ctx = makeCtx({ cwd: repo, readFilePaths: new Set() });


### PR DESCRIPTION
守密人两裁的落地：甲档「全补」+ 乙档「整体记档并入白名单」。

## 这一轮暴露的是上一把尺子的射程边界

`type-parity.mjs` 比的是**声明的形状**，不问**有没有人产出**。首跑于是一本正经地报 `AgentOutput` 差 20 个字段——而实情是本 SDK **从来没有任何代码填过 `AgentOutput`**。等于在很精确地量一个空盒子。

顺这条线做工具层普查，又揪出**四个「声明了官方形状、一行没填」**的类型，事实全都只能靠解析人话字符串拿到。

## 四个新产出方

| 工具 | 补上 | 仍不填，为什么 |
|---|---|---|
| **Write** | `type` / `filePath` / `content` / `bytes`，+ 抓到前像时的 `originalFile` | `structuredPatch`（无差分引擎）· `gitDiff`（无 git 管线）。`originalFile` 本包可选、官方必填：Write 本来不读它要覆盖的文件，为填一个字段逼每次写入都多读一遍不合算 |
| **Edit** | `filePath` / `oldString` / `newString` / `originalFile` / `replaceAll` / `replacedCount` | 同上，另 `userModified` 属官方编辑器集成 |
| **TodoWrite** | `oldTodos` / `newTodos` —— **完整** | —— |
| **EnterWorktree** | `worktreePath` / `worktreeBranch` / `message` —— **完整** | —— |

`Write.bytes` 是全批最刺眼的一条：数字**早就算好了**，然后拼进句子里扔掉了。

**TodoWrite 需要新加一件东西**：它原本零状态（模型每次重发整张单），`oldTodos` 根本不存在。现把上一版单子存进 **session-key WeakMap**（既定的按查询状态模式），调用方这才看得到**迁移**，而不是拿着新单子去跟一份从没给过他的副本做差。会话首次调用诚实报 `[]`。

## 缺就报缺，不塌缩

Write 的 `originalFile` 在没抓到前像时是**省略**而非 `null`——`null` 已经表示「原本没有这个文件」，把「不知道」塌缩成「不存在」会让字段主动误导。两条测试专钉这一点。同一条道理上一轮已经用过：`truncatedByCharCap` 不叫 `truncatedByTokenCap`。

## 立的是台账，不是规矩

`tests/structured-output-census.test.ts` 钉住「刻意不产出」的名单 + 逐条理由：新工具静默上线会红，名单里已开始产出的陈条也会红。

**「所有工具都必须产出」是错的规矩**——有些工具确实没有超出那句话之外的机器可读事实，硬套形状就是再造 typed-not-populated，正是这条线要消灭的东西。真正会出事的是**静默增长**：四个工具躺了很多版没人发现，因为没人在数。

## 18 条并入白名单，漂移报告归零

`AgentOutput` 遥测 / worktree / 远程任务字段 · `AgentInput.team_name` · `FileReadOutput.source`（挂在官方 `file_unchanged` 分支上，缺的是**整条分支**，展平比对只露出该分支独有的那个字段——这是该方法的固有盲区，已在 COMPAT.md 写明）。

Agent 那行**刻意只记档不补**：在工具连结构化产出方都没有的前提下，争论补哪个字段是顺序反了。

## 仍开着：Workflow

官方 `WorkflowOutput` 必填 `status: 'async_launched'`，本引擎同步跑完才返回——交这个字面量等于给调用方一张「货已在你手上」的取件凭证，比不给更坏。守密人已裁定改行为对齐（真异步，接入既有 `TaskOutput`/`TaskStop` id 空间），另轮跟进。

## 验证

`python3 scripts/premerge_gate.py` 全绿。新增测试 14 条（batch2 结构化 9 + 普查守卫 4 + EnterWorktree 1）。家族锁步 0.89.0 → **0.90.0**。

---
_Generated by [Claude Code](https://claude.ai/code/session_011Xo79YqGJLJfjtiGygK8jr)_