### PR TITLE
补 0.92.1 版本升位——#861 让 main 的 version-bump guard 变红

### DIFF
--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,8 +82,8 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.92.0` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.92.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.92.1` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.92.1` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
 | agent SDK 源文件 / 测试档 | 139 / 206 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
@@ -220,6 +220,8 @@
 
 ## Silver Core Maestro SDK（`projects/silver-core-maestro-sdk/`，npm 名 `silver-core-maestro-sdk`，2026-07-18 立项施工，同日定名——曾用 @biav/orchestrator-sdk）
 
+- **v0.92.1（2026-07-28）**：锁步对齐（本包零运行时改动）——agent SDK 0.92.1 修复「被拒绝的控制面覆写仍被留存并重放」；家族版本钟锁步（守密人 2026-07-18 裁定），本包同步升位。
+
 > **一句话**：银芯编排 SDK——持有分子（钟 / 跨会话状态 / 会话装配），把「活得比一次调用久」的
 > agent 脏活做成可复用零件交宿主装配；与代理 SDK 分界 = 代理持原子（一次结构化调用）、编排持分子。
 > 需求裁定书 `Public-Info-Pool/Resource/repo-engineering/scs-req-orchestrator-sdk-20260717.md`。
@@ -339,6 +341,7 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.92.1（2026-07-28）**：修自动续跑时「被拒绝的控制面覆写仍被留存并重放」（全仓缺陷扫描 PR #861，TS 侧首次 lint 扫描查出）——包裹层先记账后返回可能拒绝的 Promise，加上 `replayControlPlane` 三个 setter 全不 await，叠加成悬空 Promise（Node ≥ 15 下未处理 rejection 直接终止进程）。改为「内层成功才记账」+ 调用点 await；两条均已证伪验证。次序竞态目前不可触发，按潜伏记。详见 CHANGELOG。
 - **v0.84.0（2026-07-27）**：记忆索引纪律 + 整理规程——修的是「SDK 给了常驻索引机制却没规定索引条目该长什么样，且会话收尾提示词命令模型把进度卡写进索引档」这个自伤缺口（守密人 BPT 现场反馈：开工要好几回工具调用才找得到东西）。进度卡改落 `/memories/progress/`、索引只留指针；新增索引纪律片段（两模式注入、前提不成立即跳过）；写侧超限反压（读写共用同一度量，明说尾部已不可见）；`buildConsolidationPrompt()` + 四阶段整理规程，由 `assessMemoryStoreHealth()` 结果渲染待办。**层界守住**：只给「该不该整理 / 怎么整理」，不给调度（N1 未破，零新进程）。新增测试 28。
 - **v0.87.0（2026-07-27）**：截断纪律全家对齐——任何上限砍内容须答三问（丢多少/为何/怎么拿回）、流式保尾。后台 shell 流永久失聪缺陷修复（保尾保留窗 + 丢弃计数 + gap 标记）；Bash/WebFetch/Glob/workflow 标记补齐；注册表测试逼新截断点登记；cards 校验两层豁免索引档（修 0.84.0 自种 P4 矛盾）。另修哨兵两档制 + test.yml push 盲区 + 门禁 hooksPath 警告（仓侧）。
 - **v0.92.0（2026-07-27）**：**Workflow 改为真异步启动**（守密人「1 改」）——**对调用方是行为破坏性变更**：工具不再返回跑完的结果。官方后台启动、立即返回 `{status:'async_launched', taskId}`；本工具原先把整个工作流跑在工具调用里。**类型层调和不了，而假装对齐比留缺口更坏**——同步跑完再交那个字面量，等于给一张「货已在你手上」的取件凭证，调用方会去找一个在凭证打印前就结束的任务。**改的是行为**。**接进既有后台 id 空间**（新增 `ShellManager.registerTask`，`TaskOutput` 读 / `TaskStop` 停，不另立注册表也不另加工具；id 与 `bash_N` 共用计数器永不撞号，`pid: undefined` 对 promise 是实话）。**新增 `ToolContext.lifeSignal`**（查询级信号）：`ctx.signal` 是**按回合**的，挂在它上面是这里最坏的一种错——回执照发、回合边界静默死掉、调用方永远等不到；回归测试**做了反向对照**（接回 `ctx.signal` 确实转红，首跑就绿的竞态测试不算证据）。**语法错保持同步**（新增只编译不执行的 `checkWorkflowSyntax`：官方同时要求「立即返回」与「语法错抛出」，只有脱手前拿到判词才同时成立）。**停止优先于完成**（被停报 `killed` 不报 `completed`）。**三件刻意不声称**：无 `<task-notification>` 推送（引擎对工具发起的后台工作没有这条通道，回执改指 `TaskOutput`）· 无 `transcriptDir` · **没宿主就不谎称异步**（`query()` 外无 `lifeSignal`，就地跑完并明说）。`WorkflowOutput` 由此真填充、Workflow 移出零产出台账——0.91.0 那道守卫的**陈条检查**改动后首跑即抓到毕业。另清陈账：`'TaskStop'` 早已发货却仍挂在描述红线禁提清单上（红线是「绝不提未发货的」，把已发货的留着会反转成「绝不提我们有的」）。
@@ -349,7 +352,6 @@
 - **v0.87.1（2026-07-27）**：**嵌套路径普查（三扫）**（守密人「1 继续」）——前两轮比顶层键，本轮摊成**点号路径**再比，专抓两类前两轮**结构上看不见**的差异。**挖出一条真缺陷、是银芯自己的**：`timedOutAfterMs` 官方在**基类** `BashOutput`，0.85.0 却加在银芯**扩展类型**上——交集相同、没坏东西，但**顶层键比对永远发现不了**（键两边都有、待错了地方），已移回基类。其余全属平台绑定只登记：`gitOperation.*`（官方解析 git/gh 输出成结构化 VCS 事实）· `artifactRead.*` · `blobSavedTo` 等。~~九个类型逐层完全一致~~（**已由 v0.89.0 工具化重跑推翻**：Glob / Grep / Workflow 并不一致，本轮手搓展平器只比联合类型第一支、不匹配带引号的键，覆盖被高估）。**方法边界**：展平器不解析 TS 语义，故同时报键总数，数量级不对即解析飞了。
 
 - **v0.88.0（2026-07-27）**：处方卡型（A1）+ sessions 体检面（P1-S1）——cards 模式增处方卡（意图/步骤/结果/适用边界，按字段集判型、混用按名拒绝；进度卡映射处方型，解 P1-3）；`assessSessionStoreHealth()` 照 memory 体检成例补 sessions 域「机制无规程」缺口（会话数/字节/腐化/孤儿 checkpoint，外部店报 unavailable）；blob 上限挂 T74 待裁。审计报告补 sessions 节。
-- **v0.87.1（2026-07-27）**：**嵌套路径普查（三扫）**（守密人「1 继续」）——前两轮比顶层键，本轮摊成**点号路径**再比，专抓两类前两轮**结构上看不见**的差异。**挖出一条真缺陷、是银芯自己的**：`timedOutAfterMs` 官方在**基类** `BashOutput`，0.85.0 却加在银芯**扩展类型**上——交集相同、没坏东西，但**顶层键比对永远发现不了**（键两边都有、待错了地方），已移回基类。其余全属平台绑定只登记：`gitOperation.*`（官方解析 git/gh 输出成结构化 VCS 事实）· `artifactRead.*` · `blobSavedTo` 等。**九个类型逐层完全一致**。**方法边界**：展平器不解析 TS 语义，故同时报键总数，数量级不对即解析飞了。
 - **v0.86.0（2026-07-27）**：**主循环提示词补回开篇句 + 输出类型普查（续）**（守密人「1 对齐官方 4 续」）——① 补回官方「Text you write between tool calls may not be shown to the user.」——银芯只搬了结论没搬**理由**，缺前提的规则是模型最先绕过的那条；字节金样有意重生成、差异经核实只有这一句（四个工具集各一处）。**官方 `# Focus mode` 整块刻意不复刻**（为进不去的 UI 模式发指令 = 描述未发货能力）。② **15 个 `*Output` 逐字段比完：9 个完全一致**（FileEdit / Task 五件 / EnterWorktree / TodoWrite / Monitor）；6 个有官方独有字段，守密人裁「逐条再看」，**这一类并不齐整**——`ReadMcpResourceOutput.error` **加了并真产出**（非 UI 绑定，调用方此前分不清「读失败」与「读到空」）；`WebSearchOutput` **整体补产出**（原议题 `searchCount` 是伪命题、恒为 1，真缺口是它根本没有结构化结果；报**过滤后**命中免得与文本对不上）；其余四条**只登记不声明**（Workflow 的真障碍不在可选字段，而在必填判别式 `status:'async_launched'`——本 SDK 同步跑工作流，填它等于断言一次没发生的启动）。**射程边界**：本次为**顶层字段**比对，嵌套差异首轮漏看（`contents[].blobSavedTo` 靠人工复读才发现）。测试 3,295 → **3,297**。
 - **v0.85.0（2026-07-27）**：**GoalVerdict 家族统一（本包零行为改动）**——本包 `{status, reason?}` 判词升格家族**正典**，maestro 0.85.0 将 GoalChaser 评审判词迁为同形，一个宿主评审器同时服务引擎 `options.goal` Stop 门与跨 query 追逐两缝。留档背景：两形并存期产出真实消费者陷阱——maestro 形判词喂进 `options.goal` 被引擎判 malformed、fail-open 放行停止（防评审器坏死锁死代理的既定失败方向），症状即 BPT 2026-07-27 所报「接了 goal 模型照样停」。`options.goal` 语义与评审器契约未动，仅 `GoalVerdict` 注释补正典地位声明。
 - **v0.85.0（2026-07-27）**：**工具真正产出结构化结果 + MCP 接受列表扩容**（偏离普查轴一/轴四裁定）——**先订正普查自己的结论**：首轮只 grep `outputSchema` 就报「银芯零输出面」是**错的**，`types/tools.ts` 里官方形状的输出类型**早已齐备**，缺的是**从来没人产出**（typed-not-populated）；故改为**复用既有类型**、只补真缺的两三个。`ToolResultPayload.structuredOutput` + 引擎 **WeakMap 侧信道**（不往 Anthropic 线格式上加字段）+ `query()` 发 `toolUseResult`（**tool_use_id 为键的 record**，因本引擎一轮批处理、官方一消息一结果）。Read/Glob/Grep/Bash/WebFetch 每条终态分支均产出。MCP 接受列表加 `2024-10-07`；**提议版本仍留 `2025-06-18`**——官方的 `2025-11-25` 新增异步任务面（`tasks/*`）本包未实现，宣告它等于描述未发货能力。测试 3,254 → **3,267**。
@@ -361,7 +363,6 @@
 - **v0.79.1（2026-07-27）**：内部去重，零表面/行为变化——重试退避与 JSON-RPC 两族重复实现分别收敛为 `transport/http-retry.ts` / `mcp/protocol.ts`，六档净 −288 行。随 #835 合并时漏 bump 致版本门禁在 main 红约一小时，本版为补票（详见 CHANGELOG）。
 - **v0.79.0（2026-07-26，锁步对齐）**：本包**零代码改动**；随 maestro 0.79.0 前进，同批订正本包 0.72.0/0.70.0 两条空转条目措辞（内容未变）。
 - **v0.78.1（2026-07-26，锁步对齐）**：本包**零代码改动**；家族版本钟随 maestro 0.78.1（产品审视四裁，含删除其对本包的无支撑 peerDependency）整体前进。
-- **v0.78.0（2026-07-26，锁步对齐）**：本包**零代码改动**；家族版本钟随 maestro 0.78.0（设计审视四缝全修）整体前进，详见 maestro CHANGELOG。
 - **v0.77.0（2026-07-26，Windows 正确性清扫——家族史上首次非 Linux CI 实跑 + 守密人现场反馈
   「SDK 在 windows 环境工具调用经常犯蠢」）**：3200+ 测试一直全绿却一条都看不见，因为全部跑在
   POSIX 宿主的 POSIX 方言下。三条真缺陷——① **路径域权限规则双向皆坏**：POSIX 写法 deny

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,6 +12,12 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
+## 0.92.1 — 2026-07-28
+
+**锁步对齐**（无本包运行时改动）。agent SDK 0.92.1 修复了自动续跑时「被拒绝的
+控制面覆写仍被留存并重放」——见 silver-core-sdk CHANGELOG。家族版本钟锁步
+（守密人 2026-07-18 裁定），故本包同步升位。
+
 ## 0.92.0 — 2026-07-27
 
 Lockstep alignment only — no changes to this package. The family clock advanced

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,11 +36,13 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.92.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-agent-sdk` = `0.92.0`
+**当前版本 `0.92.1`** · 发布日 2026-07-28 · 家族锁步对端 `silver-core-agent-sdk` = `0.92.1`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.92.1（2026-07-28）：锁步对齐**（本包零运行时改动）——agent SDK 0.92.1 修复自动续跑时「被拒绝的控制面覆写仍被留存并重放」；家族版本钟锁步（守密人 2026-07-18 裁定），本包同步升位。
 
 **v0.92.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.92.0（Workflow 改真异步启动，对该工具调用方为行为破坏性变更）前进。
 

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.92.0",
+  "version": "0.92.1",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.92.0';
+export const MAESTRO_SDK_VERSION = '0.92.1';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,30 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.92.1 — 2026-07-28
+
+**修复：自动续跑时，被拒绝的控制面覆写仍被留存并重放。** 全仓缺陷扫描（#861）在
+TypeScript 侧首次 lint 扫描中查出，两条互相咬合、均已证伪验证：
+
+1. `session-manager` 的包裹层**先记账、后返回可能拒绝的 Promise**。
+   `setPermissionMode('bypassPermissions')` 未解锁时会 REJECT，但该模式已被写进
+   `pending` —— 一次被 query 拒绝、且被消费方正确 catch 的调用，照样污染了重放
+   状态，下一次透明自动续跑就把这个被拒绝的模式重放上去。重放一个被拒绝的覆写
+   本身就错。现改为 `await` 内层 setter 成功后才记账：失败的设置不留任何痕迹。
+
+2. `replayControlPlane` 声明为 `(): void`，调用三个返回 `Promise<void>` 的 setter
+   全不 await。叠加缺陷 1 后，那个必然拒绝的重放成了悬空 Promise —— Node ≥ 15 下
+   未处理的 rejection 默认**直接终止进程**，而 SDK 消费方连捕获的接缝都没有。
+   现改为 `async` 并在调用点 `await`。
+
+诚实边界：次序竞态目前**不可触发**（已核实四个 setter 体内首个 `await` 之前即完成
+赋值），按「潜伏」记；可触发的是拒绝路径。await 同时把「重放先于续跑被泵动」从
+**巧合**变成**结构保证**——将来任何人在 setter 顶部加一个 await，都不会再悄悄复活
+WV3-1 那个「续跑后工具调用仍跑在基础权限模式」的洞。
+
+新增回归 `WV3-1: a REFUSED control-plane override leaves no trace to replay`，
+同时钉住被接受的覆写仍须跨续跑存活。
+
 ## 0.92.0 — 2026-07-27
 
 **Workflow launches asynchronously** (keeper ruling 2026-07-27, "1 改").

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -71,11 +71,13 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.92.0`** · 发布日 2026-07-27 · 家族锁步对端 `silver-core-maestro-sdk` = `0.92.0`
+**当前版本 `0.92.1`** · 发布日 2026-07-28 · 家族锁步对端 `silver-core-maestro-sdk` = `0.92.1`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.92.1（2026-07-28）：自动续跑时被拒绝的控制面覆写仍被留存并重放**（全仓缺陷扫描 #861，TypeScript 侧首次 lint 扫描查出）——两条互相咬合：① 包裹层**先记账、后返回可能拒绝的 Promise**，`setPermissionMode('bypassPermissions')` 未解锁时会 REJECT，但该模式已写进 `pending`，一次被 query 拒绝、且被消费方正确 catch 的调用照样污染了重放状态；② `replayControlPlane` 声明 `(): void`、三个返回 Promise 的 setter 全不 await，叠加①后那个必然拒绝的重放成了悬空 Promise——Node ≥ 15 下未处理的 rejection **直接终止进程**，SDK 消费方连捕获的接缝都没有。改为「内层成功才记账」+ 调用点 await。**诚实边界**：次序竞态目前不可触发（四个 setter 首个 await 之前即完成赋值），按潜伏记；可触发的是拒绝路径。await 同时把「重放先于续跑被泵动」从**巧合**变成**结构保证**。两条均已证伪验证（回退任一，新增用例即红）。
 
 **v0.88.0（2026-07-27）：处方卡型（A1）+ sessions 体检面（P1-S1）**——cards 模式增第二卡型
 **处方卡**（意图/步骤/结果/适用边界，按字段集判型；单卡混用两型按名拒绝，结构化错误重述两模板；

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.92.0",
+  "version": "0.92.1",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.92.0';
+export const SDK_VERSION = '0.92.1';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;


### PR DESCRIPTION
## 概述

#861（全仓缺陷扫描）修了 `session-manager` 的两条缺陷，但**没有升版本号**，合并进 main 后 required 检查 `Silver Core Agent SDK / unit tests` 的 Version-bump guard 当场变红。本 PR 补上升位，使 main 转绿。

守卫的判词是对的：消费方按版本 pin `npm pack` tarball，**同版本不同内容的构建无法 pin、无法回滚、也无从审计**。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [x] 文档完善（两包 CONTEXT.md + `memory/project-status.md` 版本叙述）
- [x] Bug 修复（版本台账修复：使 main 的 required 检查转绿）
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [ ] 其他

---

## 来源声明

- [x] 本 PR **不涉及数据补全**，无外部数据引入。

---

## 安全声明（强制）

- [x] **不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不含游戏图片 / 解包原始文件 / 未公开剧情文本。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] Python 全量 **3084 通过 / 51 跳过**
- [x] Agent SDK **3345 通过**、Maestro SDK **429 通过**
- [x] `node scripts/check-version-bump.mjs` 三方对账（package.json / src/version.ts / CHANGELOG）一致
- [x] `tests/test_status_facts.py::test_family_lockstep_holds`、`tests/test_status_doc_facts.py`、`tests/test_claude_md_size.py` 全绿
- [x] 不引入 emoji
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 内容

- agent SDK `0.92.0` → `0.92.1`（package.json / `src/version.ts` / CHANGELOG 三处同步——guard 的三方对账要求，缺一即红）；
- maestro SDK 同步 `0.92.1`——家族版本钟**锁步**（守密人 2026-07-18 裁定，`test_family_lockstep_holds` 执法），本包零运行时改动；
- 两包 `CONTEXT.md` 与 `memory/project-status.md` 补版本叙述（`test_status_doc_facts.py` 守的是「叙述有没有跟上台账」）；
- `project-status.md` 因此超 520 行上限，按该守卫给的补救判词（逐版叙述交给各包 CHANGELOG）删去一条**重复登记的 v0.87.1** 与最老一条 v0.78.0 锁步空条——**不抬上限**。

---

## 记一条教训

这正是 CLAUDE.md §7.6 记的那条差集——`pytest` / `vitest` 跑绿覆盖不到这类检查，而 required 检查在本仓**不是物理门禁**（2026-07-27 实测三连 PR 均在检查 `in_progress` 时合并成功）。#861 合并前确实跑了 `premerge_gate.py` 并全绿，但那是在**分支基底**上跑的；合并瞬间 main 已前进到 0.92.0（#860），版本冲突只在**合并后的组合态**才成立。

**教训**：跨版本推进的分支，合并前门禁应在**合并后的组合态**再复跑一次，而不只在分支基底上跑。

---

## 关联 Issue

- Refs #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bibkq7CFodLUNveL7RBihf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bibkq7CFodLUNveL7RBihf)_