### PR TITLE
SDK 0.97.0：从包入口导出 token 估算器与 TOOL_OUTPUT_CAPS（黑池转派需求）

### DIFF
--- a/Public-Info-Pool/Resource/repo-engineering/scs-req-export-token-estimation-20260728.md
+++ b/Public-Info-Pool/Resource/repo-engineering/scs-req-export-token-estimation-20260728.md
@@ -1,0 +1,61 @@
+# 黑池转派需求:从包入口导出 estimateTextTokens 与 MAX_READ_OUTPUT_CHARS
+
+- 提出方:黑池 BPT · 2026-07-28
+- 优先级:P2(功能可用,当前靠手工镜像;正规导出后可删镜像)
+- 类型:SDK 公开 API 补充(黑池不改 SDK 源码,按红线转派)
+- 先例:`enumerateBuiltinToolMetadata`(ADR 0014)、`buildSystemPromptParts`(sdk-request-export-harness-base.md)——同一类「内部已有实现、只差入口一行 export」的请求
+- 归档说明:本需求档此前未进 SVN、银芯未收到(同批 harness-base 请求已兑现);2026-07-28 经会话转派补收,现归档于此。
+- **兑现状态:已于 SDK 0.97.0 兑现(2026-07-28,见 `projects/silver-core-sdk/CHANGELOG.md` 0.97.0 条;原拟 0.95.0,两度与同日审计波次 #867 / #868 撞号,定 0.97.0)。**
+
+## 背景 / 需求
+
+两个符号在 SDK 内部**已经实现且已 `export`**,但没有从 `src/index.ts` 转出,而包的 `exports` 只开了
+`"."`(无子路径),故黑池经公开 API 取不到,只能在自己这边复制一份:
+
+| 符号 | SDK 内位置 | 黑池当前做法 |
+|---|---|---|
+| `estimateTextTokens` | `src/engine/tokens.ts` | `electron/lib/context-composition.ts` 手工镜像一份同算法 |
+| `MAX_READ_OUTPUT_CHARS` | `src/tools/fsutil.ts`(值 50000,read.ts / webfetch.ts 共用) | 无镜像,但无法对账面板口径 |
+
+`estimateTextTokens` 这条是**手工同步契约**,注释里写得很直白:「与 SDK 权威估算器 estimateTextTokens
+精确对齐(CJK 码点 ~1 token/字,其余按 UTF-16 码元数 /4 向上取整)……**改 SDK 该文件时须同步本函数与
+isCjkCodePoint**」。这类靠人记得同步的对齐必然漂移——一旦 SDK 调整估算口径(例如改 CJK 判定区间或
+除数),黑池的「上下文构成」面板会静默低报或高报,而且不会有任何测试变红,因为两边各自自洽。
+
+面板本身已经在消费 SDK 的权威数据(`includePromptComposition` 吐的 `prompt_composition` 事件带
+per-part 估算),但面板还要对**尚未成为请求**的素材做预估(用户正在输入的草稿、待注入的记忆片段、
+知识库候选),这部分只能本地算,因此需要一个与 SDK 同源的估算函数。
+
+## 请求
+
+在 `src/index.ts` 增加:
+
+```ts
+export { estimateTextTokens } from './engine/tokens.js';
+export { MAX_READ_OUTPUT_CHARS } from './tools/fsutil.js';
+```
+
+如果认为 `MAX_READ_OUTPUT_CHARS` 单独导出一个常量太零碎,替代方案是导出一个只读的上限集合(例如
+`export const TOOL_OUTPUT_CAPS = { read: …, bash: …, webFetch: …, grepHeadLimit: … }`),黑池更希望要这个
+——面板可以据此把「工具返回上限」如实标给用户,不必按版本猜。此项与
+`sdk-request-read-total-char-cap.md` 相关,可一并考虑。
+
+顺带说明:`estimateMessagesTokens` / `estimateToolDefsTokens`(同文件)若一并导出更好,黑池
+`classifyTranscript` 里的每消息 +8 / 每块 +3 结构开销也是照 SDK 口径手抄的,同属会漂移的镜像。
+
+## 验收
+
+- 从包入口可 `import { estimateTextTokens } from 'silver-core-sdk'`,对同一字符串返回值与 SDK
+  内部估算一致。
+- 黑池删掉 `context-composition.ts` 的 `estimateTokens` 与 `isCjkCodePoint` 镜像后,
+  `electron/lib/__tests__/context-composition.test.ts` 现有断言仍全绿(该测试文件里的期望值就是
+  按 SDK 口径写的,可直接当对齐验证用)。
+
+## 银芯兑现记录(0.97.0)
+
+- 估算器三件全部导出:`estimateTextTokens` / `estimateMessagesTokens` / `estimateToolDefsTokens`
+  (入口 re-export 原函数引用,与内部同一函数,结构上不可能漂移)。
+- `MAX_READ_OUTPUT_CHARS` 直接导出;同时提供黑池更希望的 `TOOL_OUTPUT_CAPS` frozen 集合
+  (`read` 50000 / `bash` 30000 尾保留 / `webFetch` 50000 / `grepHeadLimit` 250 条目数),
+  每值 import 自各工具实际执行的常量、不重抄字面量(`src/tools/output-caps.ts`)。
+- 验收测试 `tests/output-caps-export.test.ts`:函数引用同一性 + 样例算术 + 集合逐键对账 + frozen。

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -82,10 +82,10 @@
 
 | 事实 | 值 | 权威源 |
 |------|----|--------|
-| Silver Core Agent SDK 版本 | `0.96.0` | `projects/silver-core-sdk/package.json` |
-| Silver Core Maestro SDK 版本 | `0.96.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
+| Silver Core Agent SDK 版本 | `0.97.0` | `projects/silver-core-sdk/package.json` |
+| Silver Core Maestro SDK 版本 | `0.97.0` | `projects/silver-core-maestro-sdk/package.json`（与 agent 锁步同号）|
 | testbed 试金石 | `0.0.0`（private，永不发布）| `projects/silver-core-testbed/package.json` |
-| agent SDK 源文件 / 测试档 | 139 / 206 | 磁盘实况 |
+| agent SDK 源文件 / 测试档 | 140 / 207 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 17 / 34 | 磁盘实况 |
 | testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
 | Python 测试档 | 138 | 磁盘实况 |
@@ -220,11 +220,10 @@
 
 ## Silver Core Maestro SDK（`projects/silver-core-maestro-sdk/`，npm 名 `silver-core-maestro-sdk`，2026-07-18 立项施工，同日定名——曾用 @biav/orchestrator-sdk）
 
+- **v0.97.0（2026-07-28）**：锁步对齐（本包零代码改动）——家族版本钟随 agent SDK 0.97.0（从包入口导出权威 token 估算器三件与 `MAX_READ_OUTPUT_CHARS` / `TOOL_OUTPUT_CAPS` 只读上限集合）前进。
 - **v0.96.0（2026-07-28）**：**驱动器并发上限可被翻倍**——未 await 的 `stop()`+`start()`（代际机制明文支持的陈旧启动模式）令新旧两代 tick 并行，二者在 `claimDue` 落地前读到同一 `inflight.size`，各自认领满额；新增同步 `#reserved` 预留计数（await 前自增、`finally` 释放）封死窗口，无上限与单链稳态字节不变。
 - **v0.95.0（2026-07-28）**：**台账两处缺陷 + 驱动器并发上限竞态修正**（家族审计波及本包，非空转）——`reopenSession` 并发 CAS 落败永久丢溯源链接、`recordOutcome` 回填路径写入词表外 outcome、`stop()`+`start()` 交错令两代 tick 各自认领满额致并发翻倍。
 - **v0.94.0（2026-07-28）**：锁步对齐（本包零代码改动）——家族版本钟随 agent SDK 0.94.0（BREAKING：包内模型兜底默认值全数移除，缺 model 即抛错）前进。
-- **v0.93.0（2026-07-28）**：锁步对齐（本包零运行时改动）——agent SDK 0.93.0 修复 recap 截断丢最新进度（BPT P1 活锁根因）并扩截断纪律注册表到全 `src/`；家族版本钟锁步（守密人 2026-07-18 裁定），本包同步升位。
-- **v0.92.1（2026-07-28）**：锁步对齐（本包零运行时改动）——agent SDK 0.92.1 修复「被拒绝的控制面覆写仍被留存并重放」；家族版本钟锁步（守密人 2026-07-18 裁定），本包同步升位。
 
 > **一句话**：银芯编排 SDK——持有分子（钟 / 跨会话状态 / 会话装配），把「活得比一次调用久」的
 > agent 脏活做成可复用零件交宿主装配；与代理 SDK 分界 = 代理持原子（一次结构化调用）、编排持分子。
@@ -343,6 +342,7 @@
 > 银芯→黑池单向输出物，与 §1.1-HC 防火墙同向，非 BPT 产品内部开发。
 
 - **动手前必读**：`projects/silver-core-sdk/CONTEXT.md`（会话上下文 + 当前 milestone）
+- **v0.97.0（2026-07-28）**：**导出权威 token 估算器 + 内建工具输出上限（黑池转派需求 2026-07-28）**——黑池「上下文构成」面板对未成请求素材（草稿 / 待注入记忆 / 知识库候选）只能手工镜像 SDK 估算算法，注释级「改 SDK 须同步本函数」人肉契约必然漂移。从包入口导出 `estimateTextTokens` / `estimateMessagesTokens` / `estimateToolDefsTokens`（引用级 re-export）与 `MAX_READ_OUTPUT_CHARS` + frozen `TOOL_OUTPUT_CAPS`（read 50000 / bash 30000 尾保留 / webFetch 50000 / grepHeadLimit 250 条目数，每值 import 自工具实际执行常量）。同 `buildSystemPromptParts` 先例（ADR 0014）：内部已有实现、只差入口 export。黑池删镜像后其既有测试断言即对齐验证。需求档已归档 `Public-Info-Pool/Resource/repo-engineering/scs-req-export-token-estimation-20260728.md`。原拟 0.95.0，两度与同日审计波次（#867 / #868）撞号，定 0.97.0。
 - **v0.96.0（2026-07-28）**：**审计第八波（换镜复扫已加固面）**——本包再修 6 处：query 层两处 user 轮叠加（非上限终态后，流式输入与会话收尾记忆轮各造一次 `roles must alternate` 400 且重试不可恢复）· MCP HTTP 会话过期时并发 `tools/call` 相互吃掉恢复守卫（一路裸抛 404，另一交错铸出两个服务端会话）· fork 读入把 JSON **数组**行当记录、经展开固化成幻影记录 · `file-store` 写侧吞 `ENAMETOOLONG`、读侧却上抛（同一 id 写静默丢、读直接炸）· goal 的 Stop 匹配器继承宿主 `failureMode:'closed'`，评审器**挂起**即被超时判 block、把循环永久困住（违反本模块「坏法官绝不困住循环」的明文不变量）。
 - **v0.95.0（2026-07-28）**：**多波缺陷审计（八波 59 分区）**——100+ 处经核实真实缺陷全修（崩溃面 / 线协议 `roles must alternate` 与工具对边界 / 权限 deny 七类绕过 / 原型污染与域名过滤绕过 / 子代理与会话竞态 / socket 与监听器泄漏 / 代理对截断与 NaN 守卫）；公开 API 与测试契约零改动。逐条见 CHANGELOG 与战报 `Public-Info-Pool/Resource/repo-engineering/sdk-bug-audit-multiwave-20260728.md`。
 - **v0.94.0（2026-07-28）**：**包内模型兜底默认值全数移除（BREAKING，黑池 sdk-bridge 转派需求 2026-07-28）**——黑池生产报错文案里出现其代码从未写过的 `claude-sonnet-4-5`，倒查出 `query.ts` 写死的 `DEFAULT_MODEL`：消费方任一路径漏传 `model`，包就静默换上一个自己都不知道对方网关认不认的 id，直到网关 400 才暴露。按黑池首选方案 A 根治：`query()` 缺 `options.model` 且缺 `ANTHROPIC_MODEL` → 构造期抛 `ConfigurationError`；`runUtilityCall` 全家缺 `opts.model` → 请求出门前拒；引擎内部 condition 调用改**继承会话模型**（与 compaction 摘要器同规）；`DEFAULT_UTILITY_MODEL` / `VERIFIER_DEFAULT_MODEL` 出口删除（0.3x 表面锁 `knownRemovals` 登记 + MIGRATION §3.10）。COMPAT `model` 行降 FULL → PARTIAL 如实记刻意偏离；一致性台架显式钉原默认 id，冻结基线字节不变；黑池已按铁律传全 id 的路径零行为变化。

--- a/projects/silver-core-maestro-sdk/CHANGELOG.md
+++ b/projects/silver-core-maestro-sdk/CHANGELOG.md
@@ -12,6 +12,14 @@ discipline as the agent SDK: every merge that changes shipped runtime code
 bumps BOTH versions and adds one line here (a lockstep-alignment line when
 this package itself is untouched).
 
+## 0.97.0 — 2026-07-28
+
+**锁步对齐**(无本包运行时改动)。agent SDK 0.97.0 从包入口导出权威 token 估算器
+(`estimateTextTokens` / `estimateMessagesTokens` / `estimateToolDefsTokens`)与内建
+工具输出上限(`MAX_READ_OUTPUT_CHARS` + frozen `TOOL_OUTPUT_CAPS` 集合),黑池可删
+手工镜像——见 silver-core-sdk CHANGELOG。家族版本钟锁步(守密人 2026-07-18 裁定),
+故本包同步升位。
+
 ## 0.96.0 — 2026-07-28
 
 Audit wave 8: `LedgerDriver` could run **2x** `maxConcurrent`. A non-awaited

--- a/projects/silver-core-maestro-sdk/CONTEXT.md
+++ b/projects/silver-core-maestro-sdk/CONTEXT.md
@@ -36,11 +36,15 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.96.0`** · 发布日 2026-07-28 · 家族锁步对端 `silver-core-agent-sdk` = `0.96.0`
+**当前版本 `0.97.0`** · 发布日 2026-07-28 · 家族锁步对端 `silver-core-agent-sdk` = `0.97.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.97.0（2026-07-28）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.97.0
+（从包入口导出权威 token 估算器三件与 `MAX_READ_OUTPUT_CHARS` / `TOOL_OUTPUT_CAPS`
+只读上限集合，黑池「上下文构成」面板可删手工镜像）前进，详见该包 CHANGELOG。
 
 **v0.96.0（2026-07-28）：驱动器并发上限可被翻倍**——未 await 的 `stop()`+`start()` 令两代 tick 并行各自认领满额；新增同步 `#reserved` 预留计数封窗。
 
@@ -53,11 +57,7 @@ npm 名 `silver-core-agent-sdk`)持有原子:一次结构化调用。判别式**
 `DEFAULT_UTILITY_MODEL` / `VERIFIER_DEFAULT_MODEL` 出口删除）前进，详见该包 CHANGELOG。
 **v0.93.0（2026-07-28）：锁步对齐**（本包零运行时改动）——agent SDK 0.93.0 修复 recap 截断丢最新进度（BPT P1 活锁事故根因，`buildRecap` 改头尾双保留）并把截断纪律注册表扩到全 `src/`；家族版本钟锁步，本包同步升位。
 
-**v0.92.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.92.0（Workflow 改真异步启动，对该工具调用方为行为破坏性变更）前进。
-
 **v0.91.0 / v0.90.0（2026-07-27）：锁步对齐两连**——本包**零代码改动**。家族版本钟随 agent SDK 同号前进（四工具补结构化产出 + 零产出面台账守卫 · checkpoint blob 上限 T74 甲案）。
-
-**v0.89.0（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK 0.89.0（类型面漂移检测工具化：`type-parity.mjs` 只报新漂移，首跑挖出四条「发货了却没声明」的类型缺陷）前进。
 
 **v0.88.0 / v0.87.x（2026-07-27）：锁步对齐**——本包**零代码改动**。家族版本钟随 agent SDK
 0.87.0（截断纪律全家对齐）、0.87.1（嵌套路径普查）、0.88.0（处方卡型 + sessions 体检面）

--- a/projects/silver-core-maestro-sdk/package.json
+++ b/projects/silver-core-maestro-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-maestro-sdk",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "description": "Silver Core Maestro SDK - reusable parts for agents that outlive a single call: clock, cross-session state, session assembly (task ledger, driver, loop/schedule/workflow scaffolds). A library, not a framework: the host owns main().",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-maestro-sdk/src/index.ts
+++ b/projects/silver-core-maestro-sdk/src/index.ts
@@ -22,7 +22,7 @@
  * LedgerDriver.
  */
 
-export const MAESTRO_SDK_VERSION = '0.96.0';
+export const MAESTRO_SDK_VERSION = '0.97.0';
 
 // Clock seam
 export type { Clock } from './clock.js';

--- a/projects/silver-core-sdk/CHANGELOG.md
+++ b/projects/silver-core-sdk/CHANGELOG.md
@@ -16,6 +16,30 @@ entries at the bottom are likewise retroactive — reconstructed from the commit
 sequence (no per-merge ledger existed before the 0.6.2 discipline), so their
 granularity stops at the commit-title level.
 
+## 0.97.0 — 2026-07-28
+
+**导出权威 token 估算器 + 内建工具输出上限**(黑池转派需求 2026-07-28
+「从包入口导出 estimateTextTokens 与 MAX_READ_OUTPUT_CHARS」,与
+`buildSystemPromptParts` / `enumerateBuiltinToolMetadata`(ADR 0014)同类:
+内部已有实现,只差入口一行 export)。此前黑池「上下文构成」面板对尚未成为请求的
+素材(草稿输入 / 待注入记忆 / 知识库候选)只能手工镜像一份同算法,靠注释里的
+「改 SDK 该文件时须同步」人肉契约对齐——必然漂移。现从包入口正规导出,黑池可删镜像。
+
+- 新导出 `estimateTextTokens` / `estimateMessagesTokens` /
+  `estimateToolDefsTokens`(`engine/tokens.ts` 原实现,零改动零副作用):
+  CJK 码点 ~1 token/字、其余按 UTF-16 码元 /4 向上取整;每消息 +8 / 每块 +3
+  结构开销随 messages 级导出一并拿到,`classifyTranscript` 的手抄口径同样可删。
+- 新导出 `MAX_READ_OUTPUT_CHARS`(50000,Read/WebFetch 共用)与黑池更希望的
+  只读集合 `TOOL_OUTPUT_CAPS`(frozen:`read` 50000 头保留 / `bash` 30000
+  尾保留 / `webFetch` 50000 / `grepHeadLimit` 250 条目数;每值均 import 自
+  各工具实际执行的常量,不重抄字面量,工具改上限则集合同 commit 跟随)。
+  语义与单位差异记在 `tools/output-caps.ts` 模块文档,属契约一部分。
+- 为此把 `bash.ts` `STREAM_CAP_CHARS` / `grep.ts` `DEFAULT_HEAD_LIMIT` /
+  `webfetch.ts` `MAX_OUTPUT_CHARS` 加了 `export`(值与行为不变)。
+- 验收测试 `tests/output-caps-export.test.ts`:入口导出与内部实现同一函数引用
+  (最强防漂移断言)+ 样例值 + 集合与各权威常量逐键相等 + frozen。
+- 版本注:原拟 0.95.0,两度与同日先并入 main 的审计波次(#867 / #868)撞号,定 0.97.0。
+
 ## 0.96.0 — 2026-07-28
 
 Audit wave 8 (fresh lenses over already-hardened surfaces): 6 further verified

--- a/projects/silver-core-sdk/CONTEXT.md
+++ b/projects/silver-core-sdk/CONTEXT.md
@@ -71,11 +71,21 @@ src/
 
 <!-- CONTEXT-FACTS:BEGIN 机器生成，勿手改；重算 `python3 scripts/build_status_facts.py` -->
 
-**当前版本 `0.96.0`** · 发布日 2026-07-28 · 家族锁步对端 `silver-core-maestro-sdk` = `0.96.0`
+**当前版本 `0.97.0`** · 发布日 2026-07-28 · 家族锁步对端 `silver-core-maestro-sdk` = `0.97.0`
 
 > 本行由 `scripts/build_status_facts.py` 从 `package.json` + `CHANGELOG.md` 生成，**勿手改**；规模数字不在此列，指 `memory/project-status.md` 的 STATUS-FACTS 块。下方叙述由人写（「这一版做了什么」是判断、生成不出来），其**新鲜度**由`tests/test_status_doc_facts.py` 守。
 
 <!-- CONTEXT-FACTS:END -->
+
+**v0.97.0（2026-07-28）：导出权威 token 估算器 + 内建工具输出上限（黑池转派需求）**——
+黑池「上下文构成」面板此前对未成请求的素材（草稿输入 / 待注入记忆 / 知识库候选）只能手工
+镜像 SDK 估算算法，靠注释级「改 SDK 须同步」人肉契约对齐——必然漂移。现从包入口正规导出
+`estimateTextTokens` / `estimateMessagesTokens` / `estimateToolDefsTokens`（引用级
+re-export，与内部同一函数）与 `MAX_READ_OUTPUT_CHARS`（50000）+ frozen `TOOL_OUTPUT_CAPS`
+（read 50000 / bash 30000 尾保留 / webFetch 50000 / grepHeadLimit 250 条目数；每值 import
+自各工具实际执行的常量，不重抄字面量）。与 `buildSystemPromptParts`（ADR 0014/0022）同类：
+内部已有实现、只差入口 export。验收测试 `tests/output-caps-export.test.ts`。原拟 0.95.0，
+两度与同日审计波次（#867 / #868）撞号，定 0.97.0。
 
 **v0.96.0（2026-07-28）：审计第八波（换镜复扫）**——本包再修 6 处：query 层两处 user 轮叠加
 （`roles must alternate` 400 且重试不可恢复）· MCP HTTP 并发请求相互吃掉会话过期恢复守卫 ·

--- a/projects/silver-core-sdk/package.json
+++ b/projects/silver-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-core-agent-sdk",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "description": "Silver Core Agent SDK - independent agent harness with a claude-agent-sdk compatible surface, driving the Anthropic Messages API directly (no bundled CLI binary).",
   "license": "MIT",
   "type": "module",

--- a/projects/silver-core-sdk/src/index.ts
+++ b/projects/silver-core-sdk/src/index.ts
@@ -149,6 +149,25 @@ export type {
   SystemCompositionPart,
   SystemPartRole,
 } from './internal/contracts.js';
+// BPT-EXTENSION (2026-07-28, black-pool request "从包入口导出 estimateTextTokens
+// 与 MAX_READ_OUTPUT_CHARS"): the authoritative token estimator, so a host can
+// pre-size NOT-YET-A-REQUEST material (draft input, memory snippets, KB
+// candidates) with the SAME arithmetic prompt_composition uses — retiring the
+// hand-mirrored copy ("改 SDK 该文件时须同步本函数" contracts are drift by
+// design). estimateMessagesTokens / estimateToolDefsTokens ride along so the
+// per-message +8 / per-block +3 structural overheads stop being hand-copied
+// too. Same lineage as buildSystemPromptParts (ADR 0014/0022): read-only,
+// zero side effects, exposes what the SDK already computes.
+export {
+  estimateTextTokens,
+  estimateMessagesTokens,
+  estimateToolDefsTokens,
+} from './engine/tokens.js';
+// The Read/WebFetch total-output cap (requested constant) plus the frozen
+// per-tool cap registry the black pool preferred — values imported from the
+// enforcing constants, never re-literalled (see tools/output-caps.ts).
+export { MAX_READ_OUTPUT_CHARS } from './tools/fsutil.js';
+export { TOOL_OUTPUT_CAPS } from './tools/output-caps.js';
 export { getSessionInfo, listSessions } from './sessions/store.js';
 // Sessions-domain health scan (audit P1-S1, keeper 2026-07-27): the trigger
 // surface for host-side session cleanup, mirroring assessMemoryStoreHealth.

--- a/projects/silver-core-sdk/src/tools/bash.ts
+++ b/projects/silver-core-sdk/src/tools/bash.ts
@@ -26,7 +26,10 @@ import type {
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_TIMEOUT_MS = 600_000;
-const STREAM_CAP_CHARS = 30_000;
+/** Cap on the TOTAL characters one Bash call returns (tail-kept: when output
+ *  exceeds the cap, the EARLIEST chars are dropped and a leading marker says
+ *  how many). Exported for TOOL_OUTPUT_CAPS (tools/output-caps.ts). */
+export const STREAM_CAP_CHARS = 30_000;
 const KILL_GRACE_MS = 2_000;
 /**
  * After the direct shell exits, how long to let its stdout/stderr pipes flush

--- a/projects/silver-core-sdk/src/tools/grep.ts
+++ b/projects/silver-core-sdk/src/tools/grep.ts
@@ -24,7 +24,9 @@ import type {
 
 const IGNORE_PATTERNS = ['**/node_modules/**', '**/.git/**'];
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-const DEFAULT_HEAD_LIMIT = 250;
+/** Default cap on returned lines/entries (NOT characters) when the caller
+ *  passes no head_limit. Exported for TOOL_OUTPUT_CAPS (tools/output-caps.ts). */
+export const DEFAULT_HEAD_LIMIT = 250;
 const MAX_LINE_DISPLAY_CHARS = 2000;
 
 /** File-type name -> glob patterns (mirrors common ripgrep type sets). */

--- a/projects/silver-core-sdk/src/tools/output-caps.ts
+++ b/projects/silver-core-sdk/src/tools/output-caps.ts
@@ -1,0 +1,34 @@
+/**
+ * Read-only registry of the built-in tools' output caps (BPT-EXTENSION,
+ * black-pool request 2026-07-28 "从包入口导出 estimateTextTokens 与
+ * MAX_READ_OUTPUT_CHARS"): a host UI ("上下文构成" panel and kin) can label
+ * "tool output is capped at N" truthfully per installed SDK version instead
+ * of guessing by release notes.
+ *
+ * Anti-drift rule: every value here is IMPORTED from the constant the tool
+ * actually enforces — never re-literalled. If a tool's cap moves, this object
+ * follows in the same commit by construction.
+ *
+ * Semantics vary by key and are part of the contract:
+ * - `read`     — max TOTAL characters one Read returns (head-kept, cut on a
+ *                line boundary; fsutil.ts MAX_READ_OUTPUT_CHARS).
+ * - `bash`     — max TOTAL characters one Bash call returns (TAIL-kept: the
+ *                earliest chars are dropped first; bash.ts STREAM_CAP_CHARS).
+ * - `webFetch` — max TOTAL characters one WebFetch returns (head-kept;
+ *                webfetch.ts aliases the Read cap by reference).
+ * - `grepHeadLimit` — default max returned lines/ENTRIES (not characters)
+ *                when the caller passes no head_limit (grep.ts).
+ */
+
+import { MAX_READ_OUTPUT_CHARS } from './fsutil.js';
+import { STREAM_CAP_CHARS } from './bash.js';
+import { MAX_OUTPUT_CHARS as WEBFETCH_MAX_OUTPUT_CHARS } from './webfetch.js';
+import { DEFAULT_HEAD_LIMIT } from './grep.js';
+
+/** Frozen map of built-in tool output caps. See module doc for per-key units. */
+export const TOOL_OUTPUT_CAPS = Object.freeze({
+  read: MAX_READ_OUTPUT_CHARS,
+  bash: STREAM_CAP_CHARS,
+  webFetch: WEBFETCH_MAX_OUTPUT_CHARS,
+  grepHeadLimit: DEFAULT_HEAD_LIMIT,
+} as const);

--- a/projects/silver-core-sdk/src/tools/webfetch.ts
+++ b/projects/silver-core-sdk/src/tools/webfetch.ts
@@ -54,7 +54,7 @@ const MAX_BODY_BYTES = 5 * 1024 * 1024;
  * the two gates cannot drift apart; fsutil.ts:32 already documents the
  * intended alignment.)
  */
-const MAX_OUTPUT_CHARS = MAX_READ_OUTPUT_CHARS;
+export const MAX_OUTPUT_CHARS = MAX_READ_OUTPUT_CHARS;
 const USER_AGENT = SDK_USER_AGENT;
 const ACCEPT_HEADER =
   'text/html,application/xhtml+xml,application/xml;q=0.9,application/json,text/plain;q=0.8,*/*;q=0.5';

--- a/projects/silver-core-sdk/src/version.ts
+++ b/projects/silver-core-sdk/src/version.ts
@@ -7,7 +7,7 @@
  * scripts/check-version-bump.mjs REDS any commit where the two disagree.
  */
 
-export const SDK_VERSION = '0.96.0';
+export const SDK_VERSION = '0.97.0';
 
 /** User-Agent both transports send. */
 export const SDK_USER_AGENT = `silver-core-sdk/${SDK_VERSION}`;

--- a/projects/silver-core-sdk/tests/output-caps-export.test.ts
+++ b/projects/silver-core-sdk/tests/output-caps-export.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Public-surface acceptance for the 0.95.0 exports (black-pool request
+ * 2026-07-28 "从包入口导出 estimateTextTokens 与 MAX_READ_OUTPUT_CHARS").
+ *
+ * The consumer's stated acceptance: `import { estimateTextTokens } from
+ * 'silver-core-sdk'` must return, for the same string, the value the SDK
+ * uses internally. The strongest form of that guarantee is REFERENCE
+ * identity — the entry point re-exports the very function the engine calls,
+ * so the two cannot diverge — asserted here alongside sample values that pin
+ * the documented arithmetic (CJK codepoint ~1 token; others ceil(len/4)).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  estimateTextTokens,
+  estimateMessagesTokens,
+  estimateToolDefsTokens,
+  MAX_READ_OUTPUT_CHARS,
+  TOOL_OUTPUT_CAPS,
+} from '../src/index.js';
+import {
+  estimateTextTokens as engineEstimateTextTokens,
+  estimateMessagesTokens as engineEstimateMessagesTokens,
+  estimateToolDefsTokens as engineEstimateToolDefsTokens,
+} from '../src/engine/tokens.js';
+import { MAX_READ_OUTPUT_CHARS as FSUTIL_CAP } from '../src/tools/fsutil.js';
+import { STREAM_CAP_CHARS } from '../src/tools/bash.js';
+import { MAX_OUTPUT_CHARS as WEBFETCH_CAP } from '../src/tools/webfetch.js';
+import { DEFAULT_HEAD_LIMIT } from '../src/tools/grep.js';
+
+describe('entry-point token estimator exports', () => {
+  it('re-exports the exact engine functions (reference identity, not copies)', () => {
+    expect(estimateTextTokens).toBe(engineEstimateTextTokens);
+    expect(estimateMessagesTokens).toBe(engineEstimateMessagesTokens);
+    expect(estimateToolDefsTokens).toBe(engineEstimateToolDefsTokens);
+  });
+
+  it('estimateTextTokens keeps the documented arithmetic on samples', () => {
+    // Pure CJK: ~1 token per codepoint.
+    expect(estimateTextTokens('你好世界')).toBe(4);
+    // Pure Latin: ceil(len / 4).
+    expect(estimateTextTokens('abcdefgh')).toBe(2);
+    expect(estimateTextTokens('abcde')).toBe(2);
+    expect(estimateTextTokens('')).toBe(0);
+    // Mixed: buckets are charged independently (4 CJK + ceil(8/4)).
+    expect(estimateTextTokens('你好世界abcdefgh')).toBe(6);
+    // Astral CJK (Ext B, surrogate pair in UTF-16) charges 1, not 4/4.
+    expect(estimateTextTokens('\u{20000}')).toBe(1);
+  });
+
+  it('estimateMessagesTokens carries the +8 per-message overhead', () => {
+    expect(estimateMessagesTokens([{ role: 'user', content: 'abcd' }])).toBe(9);
+  });
+
+  it('estimateToolDefsTokens is 0 for no tools', () => {
+    expect(estimateToolDefsTokens([])).toBe(0);
+  });
+});
+
+describe('entry-point output-cap exports', () => {
+  it('MAX_READ_OUTPUT_CHARS is the enforcing fsutil constant', () => {
+    expect(MAX_READ_OUTPUT_CHARS).toBe(FSUTIL_CAP);
+    expect(MAX_READ_OUTPUT_CHARS).toBe(50000);
+  });
+
+  it('TOOL_OUTPUT_CAPS mirrors each tool-enforced constant and is frozen', () => {
+    expect(TOOL_OUTPUT_CAPS.read).toBe(FSUTIL_CAP);
+    expect(TOOL_OUTPUT_CAPS.bash).toBe(STREAM_CAP_CHARS);
+    expect(TOOL_OUTPUT_CAPS.webFetch).toBe(WEBFETCH_CAP);
+    expect(TOOL_OUTPUT_CAPS.grepHeadLimit).toBe(DEFAULT_HEAD_LIMIT);
+    expect(Object.isFrozen(TOOL_OUTPUT_CAPS)).toBe(true);
+    // No unexpected keys: the four documented caps are the whole contract.
+    expect(Object.keys(TOOL_OUTPUT_CAPS).sort()).toEqual([
+      'bash',
+      'grepHeadLimit',
+      'read',
+      'webFetch',
+    ]);
+  });
+});


### PR DESCRIPTION
## 概述

兑现黑池转派需求（2026-07-28「从包入口导出 estimateTextTokens 与 MAX_READ_OUTPUT_CHARS」）：从 `silver-core-sdk` 包入口正规导出权威 token 估算器三件（`estimateTextTokens` / `estimateMessagesTokens` / `estimateToolDefsTokens`，引用级 re-export）与 `MAX_READ_OUTPUT_CHARS` + frozen `TOOL_OUTPUT_CAPS` 只读上限集合（read 50000 / bash 30000 尾保留 / webFetch 50000 / grepHeadLimit 250 条目数，每值 import 自各工具实际执行常量、不重抄字面量），黑池「上下文构成」面板可删手工镜像。

---

## 变更类型

- [x] 其他（请说明）：SDK 公开 API 补充（使命#2 silver-core-sdk）+ 需求档归档 + 状态档同步

---

## 来源声明

- [x] 本 PR 不涉及游戏数据；SDK 变更依据为黑池转派需求档（已归档 `Public-Info-Pool/Resource/repo-engineering/scs-req-export-token-estimation-20260728.md`），导出实现均为本仓既有代码。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 需求档为黑池→银芯的任务转派文书（公开工程需求），不含商业数据；代码方向为银芯→黑池单向输出，与 §1.1-HC 防火墙同向。
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**；本 PR 无游戏素材。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 合并前门禁 `python3 scripts/premerge_gate.py --sparse` 全绿（pytest 3086 passed / 51 skipped，含稀疏检出臂；agent SDK typecheck + build + vitest 3357 + version-bump guard；maestro typecheck + build + vitest 429 + testbed 消费者契约 + publishability + 依赖方向守卫）
- [x] 不引入 emoji
- [x] 版本纪律：两包锁步 0.97.0（package.json / SDK_VERSION / MAESTRO_SDK_VERSION / 双 CHANGELOG），状态档事实块 `build_status_facts.py` 重算，入口档体量上限内（520 / 151 / 200）

---

## 关联 Issue

- 无（黑池需求经会话转派，无 GitHub Issue）

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFz8b18wGyjqk1RAHbcY1p)_