### PR TITLE
Fix bundle relocatability: self-heal venv home path at launch

### DIFF
--- a/.github/workflows/assemble-silver-core-bundle.yml
+++ b/.github/workflows/assemble-silver-core-bundle.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Launcher + bundle notes
         run: |
           cp projects/silver-core-hermes/deploy/launcher.cmd SilverCore/
+          cp projects/silver-core-hermes/deploy/fix_venv_path.py SilverCore/
           {
             echo "Silver Core portable bundle (win64, merged single directory)"
             echo "pin: $(grep -m1 'pin tag' projects/silver-core-hermes/UPSTREAM.md || true)"
@@ -82,14 +83,20 @@ jobs:
             echo "config: endpoints/credentials are injected on the intranet side (never bundled)"
           } > SilverCore/BUNDLE-INFO.txt
 
-      - name: Relocatability + merge smoke test (moved path)
+      - name: Relocatability + merge smoke test (moved path, launcher self-heal flow)
         run: |
           mv SilverCore /c/silver-core-smoke
+          # 与 launcher.cmd 同一自愈机制：基座 CPython 修 pyvenv.cfg home 后 venv 方可用
+          PYHOME=$(ls -d /c/silver-core-smoke/python/cpython-*)
+          "$PYHOME/python.exe" /c/silver-core-smoke/fix_venv_path.py 'C:\silver-core-smoke'
           /c/silver-core-smoke/venv/Scripts/python.exe --version
           cd /c/silver-core-smoke/app
           /c/silver-core-smoke/venv/Scripts/python.exe -c "import agent, hermes_cli; print('runtime imports OK')"
           ls /c/silver-core-smoke/desktop/*.exe
           mv /c/silver-core-smoke SilverCore
+          # 回搬后把 home 修回最终打包路径，保证 zip 内初值有效（launcher 首启仍会再自愈）
+          PYHOME2=$(ls -d "$(pwd)/SilverCore/python/cpython-"*)
+          "$PYHOME2/python.exe" SilverCore/fix_venv_path.py "$(cygpath -w "$(pwd)/SilverCore")"
 
       - name: Zip (transport container only)
         run: 7z a -mx=3 "silver-core-win64.zip" SilverCore > /dev/null && ls -lh silver-core-win64.zip

--- a/projects/silver-core-hermes/deploy/fix_venv_path.py
+++ b/projects/silver-core-hermes/deploy/fix_venv_path.py
@@ -1,0 +1,30 @@
+"""便携整包 venv 自愈（launcher.cmd 每次启动前调用，幂等）。
+
+坑（2026-08-02 首跑实证，run 30748746543）：uv `--relocatable` 只让 venv 的脚本
+入口相对化，`pyvenv.cfg` 的 `home =` 仍是组装机绝对路径——整包搬移后 venv 找不到
+基座解释器（exit 103 "No Python at ..."）。基座 CPython 本身完全便携，故用它把
+home 指回当前包内位置即自愈。用法：python fix_venv_path.py <整包根目录>
+"""
+import pathlib
+import sys
+
+
+def main() -> int:
+    root = pathlib.Path(sys.argv[1]).resolve()
+    py_home = next((root / "python").glob("cpython-*"), None)
+    if py_home is None:
+        print(f"no managed cpython under {root / 'python'}", file=sys.stderr)
+        return 1
+    cfg = root / "venv" / "pyvenv.cfg"
+    lines = cfg.read_text(encoding="utf-8").splitlines()
+    out = []
+    for line in lines:
+        key = line.split("=", 1)[0].strip().lower()
+        out.append(f"home = {py_home}" if key == "home" else line)
+    cfg.write_text("\n".join(out) + "\n", encoding="utf-8")
+    print(f"venv home -> {py_home}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/silver-core-hermes/deploy/launcher.cmd
+++ b/projects/silver-core-hermes/deploy/launcher.cmd
@@ -9,6 +9,10 @@ set "ROOT=%~dp0"
 set "HERMES_HOME=%ROOT%home"
 set "PATH=%ROOT%venv\Scripts;%PATH%"
 if not exist "%HERMES_HOME%" mkdir "%HERMES_HOME%"
+rem venv 自愈：pyvenv.cfg 的 home 是绝对路径，包被复制/搬移后须指回当前位置
+rem （基座 CPython 自身便携，用它跑修复脚本；幂等毫秒级）。
+for /d %%D in ("%ROOT%python\cpython-*") do set "PYHOME=%%~fD"
+"%PYHOME%\python.exe" "%ROOT%fix_venv_path.py" "%ROOT%" >nul
 for %%F in ("%ROOT%desktop\*.exe") do (
   start "Silver Core" "%%~fF"
   goto :eof


### PR DESCRIPTION
## 概述

组装首跑（run 30748746543）抓到便携化核心坑：uv `--relocatable` 只让 venv 脚本入口相对化，`pyvenv.cfg` 的 `home =` 仍钉组装机绝对路径——整包搬移后 venv 报 "No Python at ..."（exit 103）。修复：包内自带 `fix_venv_path.py`，launcher 启动前用基座便携 CPython 幂等修 home 指针（毫秒级，复制到任何位置自愈）；冒烟测试改走同一自愈流程并在回搬后把 home 修回打包路径。desktop 腿首跑已全绿。

---

## 变更类型

- [x] Bug 修复（便携整包搬移自愈）

---

## 来源声明

- [x] CI run 30748746543 实测日志（exit 103 "No Python at ..."）。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py --with-setup --sparse` 全绿
- [x] 不引入 emoji
- [ ] 合并后重新 dispatch 组装、验证首个合箱资产落 Release

---

## 关联 Issue

- 无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY)_