### PR TITLE
Fix smoke-step cwd: return to workspace before moving the bundle back

### DIFF
--- a/.github/workflows/assemble-silver-core-bundle.yml
+++ b/.github/workflows/assemble-silver-core-bundle.yml
@@ -93,6 +93,7 @@ jobs:
           cd /c/silver-core-smoke/app
           /c/silver-core-smoke/venv/Scripts/python.exe -c "import agent, hermes_cli; print('runtime imports OK')"
           ls /c/silver-core-smoke/desktop/*.exe
+          cd "$GITHUB_WORKSPACE"
           mv /c/silver-core-smoke SilverCore
           # 回搬后把 home 修回最终打包路径，保证 zip 内初值有效（launcher 首启仍会再自愈）
           PYHOME2=$(ls -d "$(pwd)/SilverCore/python/cpython-"*)


### PR DESCRIPTION
## 概述

组装第二轮（run 30749937257）实质全通：搬移自愈生效（venv home 重指成功）、Python 3.11.14 应答、runtime imports OK、desktop 合箱且 exe 已是品牌名 `Silver Core.exe`。唯一失败是冒烟步自身记账——`cd` 进被搬目录后回搬 `mv` 目标相对解析进了自己内部。一行修复：回搬前 `cd "$GITHUB_WORKSPACE"`。

---

## 变更类型

- [x] Bug 修复（工作流冒烟步 cwd）

---

## 来源声明

- [x] CI run 30749937257 实测日志。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py --with-setup --sparse` 全绿
- [x] 不引入 emoji
- [ ] 合并后点火第三轮，预期首件合箱资产落 Release

---

## 关联 Issue

- 无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY)_