### PR TITLE
Fix bundle root-package install: --no-editable, neutral-cwd smoke

### DIFF
--- a/.github/workflows/assemble-silver-core-bundle.yml
+++ b/.github/workflows/assemble-silver-core-bundle.yml
@@ -56,7 +56,10 @@ jobs:
         working-directory: SilverCore/app
         run: |
           uv venv --relocatable --python "${PYTHON_VERSION}" "${UV_PROJECT_ENVIRONMENT}"
-          uv sync --locked --extra all --extra anthropic --extra mistral --extra fal \
+          # --no-editable：项目自身装成实体包而非 editable .pth 指针——editable 指针
+          # 钉死组装机绝对路径，整包搬走即 ModuleNotFoundError（run 4 实证，
+          # 亦即守密人实测 launcher 失败的真因链源头）。
+          uv sync --locked --no-editable --extra all --extra anthropic --extra mistral --extra fal \
             --extra modal --extra daytona --extra hindsight --extra parallel-web
 
       - name: Setup Node
@@ -93,7 +96,8 @@ jobs:
           PYHOME=$(ls -d /c/silver-core-smoke/python/cpython-*)
           "$PYHOME/python.exe" /c/silver-core-smoke/fix_venv_path.py 'C:\silver-core-smoke'
           /c/silver-core-smoke/venv/Scripts/python.exe --version
-          cd /c/silver-core-smoke/app
+          # 中立目录跑导入检查——绝不允许 cwd 兜底假绿（前三轮的假绿正是 cwd=app 兜出来的）
+          cd /c
           /c/silver-core-smoke/venv/Scripts/python.exe -c "import agent, hermes_cli; print('runtime imports OK')"
           # 真启动检查：console-script 入口壳（hermes.exe）在搬移后的路径必须能跑起来
           /c/silver-core-smoke/venv/Scripts/hermes.exe --help > /dev/null 2>&1 || \


### PR DESCRIPTION
## 概述

第四轮新加的真启动冒烟精确复现守密人实测失败：`hermes.exe → ModuleNotFoundError: No module named 'hermes_cli'`。真因：`uv sync` 默认把项目装成 editable .pth 指针（钉死组装机绝对路径），整包搬走即失忆；desktop 解析梯 PATH 级探测同样撞死 → 跌落 bootstrap（install.ps1 / PowerShell 被禁）。前三轮假绿系冒烟 cwd=app 兜底所致。修复：`--no-editable` 实体安装 + 冒烟改中立目录跑（cwd 永不再兜底）。

---

## 变更类型

- [x] Bug 修复（便携整包实体安装）

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `premerge_gate.py --with-setup --sparse` 全绿
- [ ] 第五轮组装实证（合并后点火）
- [x] 不引入 emoji

---

## 关联 Issue

- 无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY)_