### PR TITLE
Heal editable pointers instead of fighting upstream's no-wheel stance

### DIFF
--- a/.github/workflows/assemble-silver-core-bundle.yml
+++ b/.github/workflows/assemble-silver-core-bundle.yml
@@ -56,10 +56,11 @@ jobs:
         working-directory: SilverCore/app
         run: |
           uv venv --relocatable --python "${PYTHON_VERSION}" "${UV_PROJECT_ENVIRONMENT}"
-          # --no-editable：项目自身装成实体包而非 editable .pth 指针——editable 指针
-          # 钉死组装机绝对路径，整包搬走即 ModuleNotFoundError（run 4 实证，
-          # 亦即守密人实测 launcher 失败的真因链源头）。
-          uv sync --locked --no-editable --extra all --extra anthropic --extra mistral --extra fal \
+          # 项目自身保持 editable（上游构建后端刻意禁 wheel——run 5 实证「wheels not
+          # supported, use editable」）；editable 指针钉组装机绝对路径的搬移问题
+          #（run 4 实证 ModuleNotFoundError）由 fix_venv_path.py 的指针自愈治：
+          # bundle-root.txt 记组装根，启动时把 site-packages 的 editable 指针改写到当前根。
+          uv sync --locked --extra all --extra anthropic --extra mistral --extra fal \
             --extra modal --extra daytona --extra hindsight --extra parallel-web
 
       - name: Setup Node
@@ -80,6 +81,8 @@ jobs:
         run: |
           cp projects/silver-core-hermes/deploy/launcher.cmd SilverCore/
           cp projects/silver-core-hermes/deploy/fix_venv_path.py SilverCore/
+          # 组装根印章：editable 指针自愈的「旧根」依据（自愈后由脚本滚动更新）
+          cygpath -w "$(pwd)/SilverCore" > SilverCore/bundle-root.txt
           {
             echo "Silver Core portable bundle (win64, merged single directory)"
             echo "pin: $(grep -m1 'pin tag' projects/silver-core-hermes/UPSTREAM.md || true)"

--- a/projects/silver-core-hermes/deploy/fix_venv_path.py
+++ b/projects/silver-core-hermes/deploy/fix_venv_path.py
@@ -1,16 +1,30 @@
 """便携整包 venv 自愈（launcher.cmd 每次启动前调用，幂等）。
 
-坑（2026-08-02 首跑实证，run 30748746543）：uv `--relocatable` 只让 venv 的脚本
-入口相对化，`pyvenv.cfg` 的 `home =` 仍是组装机绝对路径——整包搬移后 venv 找不到
-基座解释器（exit 103 "No Python at ..."）。基座 CPython 本身完全便携，故用它把
-home 指回当前包内位置即自愈。用法：python fix_venv_path.py <整包根目录>
+治两类「组装机绝对路径钉死」问题（CI run 1 / run 4 实证，run 5 定形态）：
+1. `venv/pyvenv.cfg` 的 `home =` 指基座 CPython——搬移后 venv 找不到解释器
+   （exit 103 "No Python at ..."）。
+2. site-packages 里项目自身的 **editable 指针**（`.pth` / `__editable__*.py`）指
+   组装机的 app 源树——搬移后 `ModuleNotFoundError: No module named 'hermes_cli'`。
+   上游构建后端刻意禁 wheel（「use an editable install instead」），故指针自愈是
+   便携化的正解而非绕道。
+
+「旧根」来自 `bundle-root.txt`（组装期落章，本脚本自愈后滚动更新为当前根），
+新根 = argv[1]。两根相同即幂等直通。用法：python fix_venv_path.py <整包根目录>
 """
 import pathlib
 import sys
 
 
+def _variants(root: str) -> list[str]:
+    """同一路径的三种书写形态（原样 / 双反斜杠转义 / 正斜杠）。"""
+    back = root.replace("/", "\\")
+    return [back, back.replace("\\", "\\\\"), back.replace("\\", "/")]
+
+
 def main() -> int:
     root = pathlib.Path(sys.argv[1]).resolve()
+
+    # -- 1) pyvenv.cfg home --
     py_home = next((root / "python").glob("cpython-*"), None)
     if py_home is None:
         print(f"no managed cpython under {root / 'python'}", file=sys.stderr)
@@ -23,6 +37,32 @@ def main() -> int:
         out.append(f"home = {py_home}" if key == "home" else line)
     cfg.write_text("\n".join(out) + "\n", encoding="utf-8")
     print(f"venv home -> {py_home}")
+
+    # -- 2) editable 指针改写（旧根 -> 当前根） --
+    stamp = root / "bundle-root.txt"
+    if not stamp.is_file():
+        print("no bundle-root.txt stamp; skip editable heal", file=sys.stderr)
+        return 0
+    old_root = stamp.read_text(encoding="utf-8").strip()
+    new_root = str(root)
+    if old_root and old_root.rstrip("\\/") != new_root.rstrip("\\/"):
+        site = root / "venv" / "Lib" / "site-packages"
+        pairs = list(zip(_variants(old_root.rstrip("\\/")), _variants(new_root), strict=True))
+        touched = 0
+        for pattern in ("*.pth", "__editable__*.py"):
+            for f in site.glob(pattern):
+                try:
+                    text = f.read_text(encoding="utf-8")
+                except (UnicodeDecodeError, OSError):
+                    continue
+                new_text = text
+                for old_v, new_v in pairs:
+                    new_text = new_text.replace(old_v, new_v)
+                if new_text != text:
+                    f.write_text(new_text, encoding="utf-8")
+                    touched += 1
+        print(f"editable pointers healed: {touched} file(s) ({old_root} -> {new_root})")
+    stamp.write_text(new_root + "\n", encoding="utf-8")
     return 0
 
 


### PR DESCRIPTION
## 概述

第五轮实证上游构建后端**刻意禁 wheel**（「use an editable install instead」）——venv 装依赖 + 源码树当应用是上游钦定布局。撤回 `--no-editable`，改为**自愈模式推广**：包内落 `bundle-root.txt` 组装根印章，`fix_venv_path.py` v3 每次启动把 site-packages 的 editable 指针（`.pth` / `__editable__*.py`，三种路径写法全覆盖）由章上旧根改写到当前根并滚动更新印章——与 pyvenv.cfg home 自愈同一幂等模式。ruff B905 补 `strict=True`。

---

## 变更类型

- [x] Bug 修复（便携整包 editable 指针搬移自愈）

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `premerge_gate.py --with-setup --sparse` 全绿
- [ ] 第六轮组装实证（合并后点火；冒烟为中立目录导入 + hermes.exe 真启动 + 搬移自愈全链）
- [x] 不引入 emoji

---

## 关联 Issue

- 无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY)_