### PR TITLE
Ship keeper convenience scripts: repo puller at root, bundle updater archived

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,7 @@ git commit = 数据归档提交 / git push = 同步至远端存储 /
 ```
 brain-in-a-vat/
 ├── CLAUDE.md / README.md          # AI 统一入口 / 人 + AI 共用入口
+├── sc-pull.cmd                    # 守密人本地一键更新本仓（双击 --ff-only 拉取，2026-08-02）
 ├── assets/                        # 事实圣经层（只读引用源）
 │   ├── data/                      # 角色卡 / 采访 / 叙事 / 设计决策 JSON（见 §5.1）
 │   └── images/                    # 立绘 / CG 等公开图像资产

--- a/projects/silver-core-hermes/deploy/launcher.cmd
+++ b/projects/silver-core-hermes/deploy/launcher.cmd
@@ -4,6 +4,7 @@ rem 合箱布局：python\（uv 托管 CPython）、venv\、app\（组装源树�
 rem home\（HERMES_HOME）与本文件同级。默认拉起 desktop；CLI 用法 launcher.cmd cli <args>。
 rem 自诊断：全程写 launcher.log；任何一步失败都停窗展示原因（不再闪退吞错）。
 setlocal EnableExtensions
+chcp 65001 >nul
 set "ROOT=%~dp0"
 set "LOG=%ROOT%launcher.log"
 echo [%date% %time%] launcher start ROOT=%ROOT% > "%LOG%"

--- a/projects/silver-core-hermes/deploy/silver-core-update.cmd
+++ b/projects/silver-core-hermes/deploy/silver-core-update.cmd
@@ -1,0 +1,19 @@
+@echo off
+rem Silver Core 整包一键更新器（部署件归档；使用时复制到桌面等 SilverCore 外的位置双击）。
+rem 逻辑：下载最新整包 -> 旧版改名 SilverCore.old 留作回滚 -> 解压新版 ->
+rem 迁回 home\（个人记忆与配置，更新不丢）-> 自动启动。零安装器零 PowerShell
+rem （curl.exe / tar.exe 均为 Windows 10+ 自带）。
+chcp 65001 >nul
+cd /d %USERPROFILE%\Desktop
+echo 正在下载最新 Silver Core 整包（约 1GB，请稍候）...
+curl.exe -L -o silver-core-win64.zip https://github.com/lightproud/BIAV-SC-CODE/releases/download/silver-core-bundle/silver-core-win64.zip || goto :fail
+if exist SilverCore.old rd /s /q SilverCore.old
+if exist SilverCore move SilverCore SilverCore.old >nul
+tar -xf silver-core-win64.zip || goto :fail
+if exist SilverCore.old\home xcopy /e /i /y SilverCore.old\home SilverCore\home >nul
+start "" "%USERPROFILE%\Desktop\SilverCore\launcher.cmd"
+exit /b 0
+:fail
+echo 更新失败，请检查网络后重试。
+pause
+exit /b 1

--- a/sc-pull.cmd
+++ b/sc-pull.cmd
@@ -1,0 +1,13 @@
+@echo off
+rem 银芯仓库一键更新（双击即用；本文件随仓库分发，位于仓根）。
+rem 前提：机器装有 Git for Windows。仅快进拉取（--ff-only），本地永远是干净只读镜像。
+chcp 65001 >nul
+echo 正在更新银芯仓库...
+git -C "%~dp0" pull --ff-only
+if errorlevel 1 (
+  echo 更新失败：请检查网络，或本地有未提交改动（本仓应保持只读镜像）。
+  pause
+  exit /b 1
+)
+echo 银芯仓库已是最新。
+pause


### PR DESCRIPTION
## 概述

守密人要求「更新仓库的批处理放仓根」：`sc-pull.cmd` 入仓根（双击 `--ff-only` 拉取，响亮报错，UTF-8 代码页）；整包更新器 `deploy/silver-core-update.cmd` 归档为版本化部署件（下载最新 zip / 旧版留 SilverCore.old 回滚 / `home\` 迁移保记忆 / 自启动，纯 Windows 自带 curl.exe + tar.exe）；launcher.cmd 补 `chcp 65001` 防中文乱码；CLAUDE.md 目录树登记。

---

## 变更类型

- [x] 其他（请说明）：部署便利脚本 ×2 + launcher 代码页加固 + 目录树登记

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `premerge_gate.py --with-setup --sparse` 全绿
- [x] 不引入 emoji

---

## 关联 Issue

- 无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY)_