### PR TITLE
Fix cmd trailing-backslash quote trap in sc-pull and launcher

### DIFF
--- a/projects/silver-core-hermes/deploy/launcher.cmd
+++ b/projects/silver-core-hermes/deploy/launcher.cmd
@@ -26,7 +26,7 @@ if not defined PYHOME (
 echo [ok] PYHOME=%PYHOME% >> "%LOG%"
 
 rem -- 步骤 2：venv 自愈（pyvenv.cfg home 指回当前位置；幂等） --
-"%PYHOME%\python.exe" "%ROOT%fix_venv_path.py" "%ROOT%" >> "%LOG%" 2>&1
+"%PYHOME%\python.exe" "%ROOT%fix_venv_path.py" "%ROOT%." >> "%LOG%" 2>&1
 if errorlevel 1 (
   echo [FAIL] fix_venv_path failed >> "%LOG%"
   echo 启动失败：venv 自愈未通过。详情见 %LOG%

--- a/sc-pull.cmd
+++ b/sc-pull.cmd
@@ -3,7 +3,7 @@ rem 银芯仓库一键更新（双击即用；本文件随仓库分发，位于�
 rem 前提：机器装有 Git for Windows。仅快进拉取（--ff-only），本地永远是干净只读镜像。
 chcp 65001 >nul
 echo 正在更新银芯仓库...
-git -C "%~dp0" pull --ff-only
+git -C "%~dp0." pull --ff-only
 if errorlevel 1 (
   echo 更新失败：请检查网络，或本地有未提交改动（本仓应保持只读镜像）。
   pause


### PR DESCRIPTION
## 概述

守密人实测报错 `fatal: cannot change to 'E:\...\BIAV-SC-CODE" pull --ff-only'`——`%~dp0` 尾反斜杠在引号内成转义引号、吞掉后续参数。修法 `"%~dp0."`（同目录、无转义）。同款炸点在 launcher.cmd 的 `"%ROOT%"` 自愈传参处一并拆除（CI 冒烟经 bash 调自愈脚本、未走 launcher 本体故漏网）。合并后重出整包（第七轮）。

---

## 变更类型

- [x] Bug 修复（cmd 引号转义陷阱 ×2）

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `premerge_gate.py --with-setup --sparse` 全绿
- [x] 不引入 emoji

---

## 关联 Issue

- 无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKTVGkT3ykGvfeF8LF17cY)_