### PR TITLE
Supervised desktop launch: capture output, liveness probe, soft-render retry

### DIFF
--- a/.github/workflows/assemble-silver-core-bundle.yml
+++ b/.github/workflows/assemble-silver-core-bundle.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           cp projects/silver-core-hermes/deploy/launcher.cmd SilverCore/
           cp projects/silver-core-hermes/deploy/fix_venv_path.py SilverCore/
+          cp projects/silver-core-hermes/deploy/launch_desktop.py SilverCore/
           # 组装根印章：editable 指针自愈的「旧根」依据（自愈后由脚本滚动更新）
           cygpath -w "$(pwd)/SilverCore" > SilverCore/bundle-root.txt
           {
@@ -112,6 +113,25 @@ jobs:
           # 回搬后把 home 修回最终打包路径，保证 zip 内初值有效（launcher 首启仍会再自愈）
           PYHOME2=$(ls -d "$(pwd)/SilverCore/python/cpython-"*)
           "$PYHOME2/python.exe" SilverCore/fix_venv_path.py "$(cygpath -w "$(pwd)/SilverCore")"
+
+      - name: Desktop launch smoke (supervised, captures Chromium stderr)
+        run: |
+          # 黑屏类死因（GPU/沙箱早夭、缺 DLL、asar 缺渲染层）只有真拉起 exe 才暴露。
+          # 与用户面同一监督器：早夭自动软渲染重试，仍死则 exit 1 并打印取证日志尾部。
+          SILVER_CORE_LAUNCH_WAIT=40 SilverCore/venv/Scripts/python.exe \
+            SilverCore/launch_desktop.py "$(cygpath -w "$(pwd)/SilverCore")"
+          # 冒烟完杀掉 desktop 及其 serve 后端（python.exe），避免句柄占用挡住清理与打包
+          EXE_NAME=$(basename "$(ls SilverCore/desktop/*.exe | head -1)")
+          taskkill //F //IM "$EXE_NAME" 2>/dev/null || true
+          taskkill //F //IM python.exe 2>/dev/null || true
+          sleep 3
+
+      - name: Clean smoke residue before zip
+        run: |
+          # 冒烟在 home\ 与 launcher.log 留下的运行时痕迹不入箱（用户首启应得到干净包）
+          rm -rf SilverCore/home
+          mkdir -p SilverCore/home
+          rm -f SilverCore/launcher.log
 
       - name: Zip (transport container only)
         run: 7z a -mx=3 "silver-core-win64.zip" SilverCore > /dev/null && ls -lh silver-core-win64.zip

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -88,7 +88,7 @@
 | agent SDK 源文件 / 测试档 | 141 / 213 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 20 / 40 | 磁盘实况 |
 | testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
-| Python 测试档 | 145 | 磁盘实况 |
+| Python 测试档 | 146 | 磁盘实况 |
 | CI 工作流 / 其中定时 | 45 / 21 | `.github/workflows/` |
 | 挂账台账 开 / 已清 | 22 / 64 | `memory/todo.md` |
 

--- a/projects/silver-core-hermes/deploy/launch_desktop.py
+++ b/projects/silver-core-hermes/deploy/launch_desktop.py
@@ -1,0 +1,171 @@
+"""便携整包 desktop 监督式启动器（launcher.cmd 步骤 4 后端，stdlib-only）。
+
+治「黑屏结束」类静默失败（守密人 2026-08-02 实机反馈）：旧步骤 4 用 `start`
+fire-and-forget——desktop 进程一经拉起即脱管，Electron / Chromium 级早夭
+（GPU / 沙箱 0x80000003、缺 DLL、策略拦截未签名 exe）没有任何输出留痕，
+用户面 = 黑窗一闪即终。本监督器补三件事：
+
+1. **确定性后端**：注入 HERMES_DESKTOP_HERMES_ROOT / HERMES_DESKTOP_PYTHON
+   直指包内 app/ 源树与 venv 解释器——desktop 六级后端解析阶梯第 1 级即命中，
+   跳过全部冷启动探针（实测单针可达 10 秒级），且绝不落入 PowerShell
+   bootstrap（受限环境的死路）。
+2. **捕获 + 探活**：desktop stdout/stderr 追加落 home/logs/desktop-stdout.log
+   （Chromium FATAL 只上 stderr，`start` 路径下直接丢失）；启动后守窗
+   WAIT_SECONDS 秒，早退即察觉；退出但同名映像仍在（单实例转交 / 沙箱回退
+   自重启）经 tasklist 复核判成功，不误报。
+3. **软渲染重试 + 取证输出**：首试早夭自动带 --disable-gpu --no-sandbox +
+   HERMES_DESKTOP_DISABLE_GPU=1 重试一次（上游 #38216 GPU / 沙箱类死因的
+   已知解）；仍死则把两份日志尾部打印到控制台并非零退出，launcher.cmd 停窗。
+
+用法：python launch_desktop.py <整包根目录>
+环境旋钮：SILVER_CORE_LAUNCH_WAIT（守窗秒数，默认 25）。
+所有输出同时打控制台与 <root>/launcher.log（与 launcher.cmd 共用一本日志）。
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+DEFAULT_WAIT_SECONDS = 25
+TAIL_LINES = 40
+
+
+def pick_desktop_exe(root: pathlib.Path) -> pathlib.Path | None:
+    """desktop/ 下的主 exe：win-unpacked 形态只有一个顶层 exe，取字典序第一个。"""
+    exes = sorted((root / "desktop").glob("*.exe"))
+    return exes[0] if exes else None
+
+
+def build_env(root: pathlib.Path, base_env: dict, disable_gpu: bool = False) -> dict:
+    """desktop 进程环境：HERMES_HOME 指包内 + 确定性后端两针 + venv 前置 PATH。"""
+    env = dict(base_env)
+    env["HERMES_HOME"] = str(root / "home")
+    env["HERMES_DESKTOP_HERMES_ROOT"] = str(root / "app")
+    env["HERMES_DESKTOP_PYTHON"] = str(root / "venv" / "Scripts" / "python.exe")
+    env["PATH"] = str(root / "venv" / "Scripts") + os.pathsep + env.get("PATH", "")
+    if disable_gpu:
+        env["HERMES_DESKTOP_DISABLE_GPU"] = "1"
+    return env
+
+
+def has_motw(path: pathlib.Path) -> bool:
+    """NTFS Zone.Identifier ADS（Mark-of-the-Web）：有则 SmartScreen / 策略可能拦。"""
+    try:
+        with open(f"{path}:Zone.Identifier", encoding="utf-8", errors="ignore"):
+            return True
+    except OSError:
+        return False
+
+
+def tail(path: pathlib.Path, n: int = TAIL_LINES) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    return lines[-n:]
+
+
+def image_running(image_name: str) -> bool:
+    """tasklist 复核同名映像是否存活（单实例转交 / 自重启场景防误报）。"""
+    try:
+        out = subprocess.run(
+            ["tasklist", "/FI", f"IMAGENAME eq {image_name}", "/NH"],
+            capture_output=True, text=True, timeout=30,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return image_name.lower() in out.lower()
+
+
+class Reporter:
+    """控制台 + launcher.log 双写（与 launcher.cmd 共用一本日志）。"""
+
+    def __init__(self, log_path: pathlib.Path):
+        self.log_path = log_path
+
+    def line(self, msg: str) -> None:
+        stamp = time.strftime("%H:%M:%S")
+        text = f"[{stamp}] {msg}"
+        print(text, flush=True)
+        try:
+            with open(self.log_path, "a", encoding="utf-8") as f:
+                f.write(text + "\n")
+        except OSError:
+            pass
+
+
+def attempt(exe: pathlib.Path, env: dict, extra_args: list[str],
+            stdout_log: pathlib.Path, wait_seconds: int, report: Reporter) -> bool:
+    """拉起一次并守窗：存活 / 转交 = True，早夭 = False。"""
+    stdout_log.parent.mkdir(parents=True, exist_ok=True)
+    with open(stdout_log, "a", encoding="utf-8") as sink:
+        sink.write(f"\n===== attempt {time.strftime('%Y-%m-%d %H:%M:%S')} "
+                   f"args={extra_args} =====\n")
+        sink.flush()
+        proc = subprocess.Popen(
+            [str(exe), *extra_args],
+            cwd=str(exe.parent), env=env,
+            stdout=sink, stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        deadline = time.monotonic() + wait_seconds
+        while time.monotonic() < deadline:
+            code = proc.poll()
+            if code is not None:
+                # 早退不等于失败：单实例锁转交 / 沙箱回退 relaunch 都会父退子存，
+                # 以同名映像是否仍在为准。
+                time.sleep(2)
+                if image_running(exe.name):
+                    report.line(f"desktop 进程已转交（父进程退出码 {code}，"
+                                f"同名映像 {exe.name} 仍在运行）")
+                    return True
+                report.line(f"desktop 早夭：退出码 {code}（守窗内退出且无存活映像）")
+                return False
+            time.sleep(1)
+    report.line(f"desktop 存活满 {wait_seconds} 秒，判定启动成功")
+    return True
+
+
+def main() -> int:
+    root = pathlib.Path(sys.argv[1]).resolve()
+    report = Reporter(root / "launcher.log")
+    wait_seconds = int(os.environ.get("SILVER_CORE_LAUNCH_WAIT", DEFAULT_WAIT_SECONDS))
+
+    exe = pick_desktop_exe(root)
+    if exe is None:
+        report.line(f"[FAIL] {root / 'desktop'} 下未找到任何 exe")
+        return 1
+    report.line(f"desktop exe = {exe}")
+
+    if has_motw(exe):
+        report.line("[warn] desktop exe 带 Mark-of-the-Web（来自下载的 zip 解压）。"
+                    "若启动被 SmartScreen / 策略拦截：右键 zip → 属性 → 解除锁定后重新解压。")
+
+    stdout_log = root / "home" / "logs" / "desktop-stdout.log"
+
+    report.line(f"第 1 次启动（守窗 {wait_seconds} 秒）...")
+    if attempt(exe, build_env(root, os.environ), [], stdout_log, wait_seconds, report):
+        return 0
+
+    report.line("首试早夭，带软渲染参数重试（--disable-gpu --no-sandbox，#38216 类死因）...")
+    if attempt(exe, build_env(root, os.environ, disable_gpu=True),
+               ["--disable-gpu", "--no-sandbox"], stdout_log, wait_seconds, report):
+        return 0
+
+    report.line("[FAIL] 两次启动均早夭。以下为取证日志尾部：")
+    for label, p in (("desktop-stdout.log（Chromium/Electron 原始输出）", stdout_log),
+                     ("desktop.log（应用主进程取证）", root / "home" / "logs" / "desktop.log")):
+        report.line(f"---- {label} ----")
+        lines = tail(p)
+        if not lines:
+            report.line("（空 / 不存在）")
+        for line in lines:
+            report.line(f"| {line}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/silver-core-hermes/deploy/launcher.cmd
+++ b/projects/silver-core-hermes/deploy/launcher.cmd
@@ -2,12 +2,14 @@
 rem Silver Core 便携整包启动器（cmd 批处理，零 PowerShell）。
 rem 合箱布局：python\（uv 托管 CPython）、venv\、app\（组装源树）、desktop\（win-unpacked）、
 rem home\（HERMES_HOME）与本文件同级。默认拉起 desktop；CLI 用法 launcher.cmd cli <args>。
-rem 自诊断：全程写 launcher.log；任何一步失败都停窗展示原因（不再闪退吞错）。
+rem 自诊断：全程写 launcher.log；任何一步失败都停窗展示原因（不再闪退吞错）；
+rem desktop 由 launch_desktop.py 监督式拉起（捕获输出 + 探活 + 软渲染重试，治黑屏一闪即终）。
 setlocal EnableExtensions
 chcp 65001 >nul
 set "ROOT=%~dp0"
 set "LOG=%ROOT%launcher.log"
 echo [%date% %time%] launcher start ROOT=%ROOT% > "%LOG%"
+echo Silver Core 启动中，请稍候（本窗会显示进度，失败会停窗给出原因）...
 
 set "HERMES_HOME=%ROOT%home"
 set "PATH=%ROOT%venv\Scripts;%PATH%"
@@ -43,6 +45,7 @@ if errorlevel 1 (
   exit /b 1
 )
 echo [ok] runtime import check passed >> "%LOG%"
+echo 运行时自检通过。
 
 rem -- CLI 模式：launcher.cmd cli <args> --
 if /i "%~1"=="cli" (
@@ -51,14 +54,23 @@ if /i "%~1"=="cli" (
   exit /b %errorlevel%
 )
 
-rem -- 步骤 4：拉起 desktop（未找到则回退 CLI） --
-set "DESKTOP_EXE="
-for %%F in ("%ROOT%desktop\*.exe") do if not defined DESKTOP_EXE set "DESKTOP_EXE=%%~fF"
-if defined DESKTOP_EXE (
-  echo [ok] starting desktop %DESKTOP_EXE% >> "%LOG%"
-  start "Silver Core" "%DESKTOP_EXE%"
+rem -- 步骤 4：监督式拉起 desktop（捕获输出 + 探活 + 软渲染重试；未找到则回退 CLI） --
+if exist "%ROOT%desktop" (
+  echo 正在启动桌面端，自检守窗约 25 秒，窗口正常出现后本窗自动关闭...
+  "%ROOT%venv\Scripts\python.exe" "%ROOT%launch_desktop.py" "%ROOT%."
+  if errorlevel 1 (
+    echo.
+    echo 启动失败：桌面端进程未能存活。上方为取证日志尾部，
+    echo 完整日志见 %LOG% 与 home\logs\ 目录。
+    pause
+    exit /b 1
+  )
   exit /b 0
 )
-echo [warn] desktop exe not found, falling back to CLI >> "%LOG%"
+echo [warn] desktop dir not found, falling back to CLI >> "%LOG%"
+echo 未找到桌面端目录，回退命令行模式...
 "%ROOT%venv\Scripts\hermes.exe" %*
+echo.
+echo 命令行会话已结束。
+pause
 endlocal

--- a/tests/test_launch_desktop.py
+++ b/tests/test_launch_desktop.py
@@ -1,0 +1,85 @@
+"""desktop 监督式启动器（deploy/launch_desktop.py）纯函数守卫。
+
+监督器本体只能在 Windows 实机 / CI 冒烟里全链路验证（tasklist / ADS / 真 exe），
+本档守它的跨平台纯部分：exe 选取、环境注入（确定性后端两针）、日志尾读、双写。
+坏一处即用户面回到「黑屏一闪无痕」——这些函数是取证链的地基。
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MODULE_PATH = REPO / "projects" / "silver-core-hermes" / "deploy" / "launch_desktop.py"
+
+_spec = importlib.util.spec_from_file_location("launch_desktop", MODULE_PATH)
+launch_desktop = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(launch_desktop)
+
+
+def test_pick_desktop_exe_first_sorted(tmp_path):
+    (tmp_path / "desktop").mkdir()
+    (tmp_path / "desktop" / "b tool.exe").touch()
+    (tmp_path / "desktop" / "Silver Core.exe").touch()
+    picked = launch_desktop.pick_desktop_exe(tmp_path)
+    assert picked is not None
+    assert picked.name == "Silver Core.exe"  # 字典序：大写 S < 小写 b
+
+
+def test_pick_desktop_exe_none_when_empty(tmp_path):
+    (tmp_path / "desktop").mkdir()
+    assert launch_desktop.pick_desktop_exe(tmp_path) is None
+    assert launch_desktop.pick_desktop_exe(tmp_path / "absent-root") is None
+
+
+def test_build_env_injects_deterministic_backend(tmp_path):
+    env = launch_desktop.build_env(tmp_path, {"PATH": "/usr/bin", "KEEP": "1"})
+    assert env["HERMES_HOME"] == str(tmp_path / "home")
+    assert env["HERMES_DESKTOP_HERMES_ROOT"] == str(tmp_path / "app")
+    assert env["HERMES_DESKTOP_PYTHON"] == str(
+        tmp_path / "venv" / "Scripts" / "python.exe")
+    assert env["PATH"].startswith(str(tmp_path / "venv" / "Scripts") + os.pathsep)
+    assert env["PATH"].endswith("/usr/bin")
+    assert env["KEEP"] == "1"
+    assert "HERMES_DESKTOP_DISABLE_GPU" not in env
+
+
+def test_build_env_disable_gpu_flag(tmp_path):
+    env = launch_desktop.build_env(tmp_path, {}, disable_gpu=True)
+    assert env["HERMES_DESKTOP_DISABLE_GPU"] == "1"
+
+
+def test_build_env_does_not_mutate_base(tmp_path):
+    base = {"PATH": "x"}
+    launch_desktop.build_env(tmp_path, base)
+    assert base == {"PATH": "x"}
+
+
+def test_tail_missing_and_truncation(tmp_path):
+    assert launch_desktop.tail(tmp_path / "absent.log") == []
+    log = tmp_path / "some.log"
+    log.write_text("\n".join(f"line{i}" for i in range(100)), encoding="utf-8")
+    got = launch_desktop.tail(log, n=40)
+    assert len(got) == 40
+    assert got[0] == "line60" and got[-1] == "line99"
+
+
+def test_reporter_dual_writes(tmp_path, capsys):
+    rep = launch_desktop.Reporter(tmp_path / "launcher.log")
+    rep.line("hello 取证")
+    out = capsys.readouterr().out
+    assert "hello 取证" in out
+    assert "hello 取证" in (tmp_path / "launcher.log").read_text(encoding="utf-8")
+
+
+def test_reporter_survives_unwritable_log(tmp_path, capsys):
+    # 日志写不进（目录不存在）不应让监督器崩——控制台输出仍在
+    rep = launch_desktop.Reporter(tmp_path / "no-such-dir" / "launcher.log")
+    rep.line("still alive")
+    assert "still alive" in capsys.readouterr().out
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## 背景

守密人实测 run 7 整包仍「黑屏结束」。旧 launcher.cmd 步骤 4 用 `start` fire-and-forget 拉起 desktop 后立即退出：Electron / Chromium 级早夭（GPU / 沙箱 0x80000003 类、缺 DLL、策略拦未签名 exe）零留痕；且 desktop 六级后端解析阶梯可能滑入 PowerShell bootstrap（受限环境死路）。控制台本身全程静默重定向，也正是「黑窗」观感的一部分。

## 改动

- **`deploy/launch_desktop.py`（新）**：监督式 desktop 启动器（stdlib-only）。注入 `HERMES_DESKTOP_HERMES_ROOT` / `HERMES_DESKTOP_PYTHON` 令后端解析第 1 级确定性命中（零冷探针、零 bootstrap）；捕获 desktop stdout/stderr 落 `home\logs\desktop-stdout.log`（Chromium FATAL 只上 stderr，原先直接丢失）；守窗探活 + tasklist 复核（单实例转交 / 沙箱回退自重启不误报）；早夭自动带 `--disable-gpu --no-sandbox` 重试一次；两试皆死则打印取证日志尾部并非零退出停窗。附 Mark-of-the-Web 检测提示。
- **`deploy/launcher.cmd`**：步骤 4 改为同步跑监督器并显示进度文字；CLI 回退路径补 pause，不再静默关窗。
- **`assemble-silver-core-bundle.yml`**：监督器入包；新增 CI Windows runner 上的**真拉起 desktop 冒烟**（黑屏类死因唯一能在组装台带 stderr 复现的位置）；冒烟后清进程与 `home\` / `launcher.log` 残留再打包。
- **`tests/test_launch_desktop.py`（新）**：跨平台纯函数守卫（exe 选取 / 环境注入 / 尾读 / 双写）。
- `memory/project-status.md`：事实块重算（Python 测试档 145 → 146）。

## 验证

- `premerge_gate.py --with-setup` 全绿；`--sparse` 轮 pytest 3303 通过（该轮 agent SDK vitest 一步闪烁红，直跑复核 213 档 3460 用例全绿）。
- ruff 全绿；新增守卫 8 用例通过。

---
_Generated by [Claude Code](https://claude.ai/code/session_012inwJHdmytAcf7xLKWe8k2)_