### PR TITLE
Fix supervisor crash on non-UTF8 stdio (run 8 forensics)

### DIFF
--- a/projects/silver-core-hermes/deploy/launch_desktop.py
+++ b/projects/silver-core-hermes/deploy/launch_desktop.py
@@ -33,6 +33,16 @@ DEFAULT_WAIT_SECONDS = 25
 TAIL_LINES = 40
 
 
+def force_utf8_stdio() -> None:
+    """stdout/stderr 强制 UTF-8：控制台外的管道（CI / 重定向）默认 locale 编码
+    （cp1252 / GBK），打印中文进度即 UnicodeEncodeError——run 8 实证死在第一行。"""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+
 def pick_desktop_exe(root: pathlib.Path) -> pathlib.Path | None:
     """desktop/ 下的主 exe：win-unpacked 形态只有一个顶层 exe，取字典序第一个。"""
     exes = sorted((root / "desktop").glob("*.exe"))
@@ -130,6 +140,7 @@ def attempt(exe: pathlib.Path, env: dict, extra_args: list[str],
 
 
 def main() -> int:
+    force_utf8_stdio()
     root = pathlib.Path(sys.argv[1]).resolve()
     report = Reporter(root / "launcher.log")
     wait_seconds = int(os.environ.get("SILVER_CORE_LAUNCH_WAIT", DEFAULT_WAIT_SECONDS))

--- a/tests/test_launch_desktop.py
+++ b/tests/test_launch_desktop.py
@@ -73,6 +73,26 @@ def test_reporter_dual_writes(tmp_path, capsys):
     assert "hello 取证" in (tmp_path / "launcher.log").read_text(encoding="utf-8")
 
 
+def test_reporter_survives_cp1252_pipe(tmp_path):
+    # run 8 实证死因：CI 管道 stdout 是 cp1252，打印中文进度即 UnicodeEncodeError。
+    # 子进程强制 PYTHONIOENCODING=cp1252 复现管道形态，force_utf8_stdio 必须救回。
+    import subprocess
+    import sys
+    code = (
+        "import importlib.util, pathlib\n"
+        f"spec = importlib.util.spec_from_file_location('ld', {str(MODULE_PATH)!r})\n"
+        "ld = importlib.util.module_from_spec(spec); spec.loader.exec_module(ld)\n"
+        "ld.force_utf8_stdio()\n"
+        f"ld.Reporter(pathlib.Path({str(tmp_path / 'l.log')!r})).line('第 1 次启动（守窗）')\n"
+    )
+    env = dict(os.environ, PYTHONIOENCODING="cp1252")
+    r = subprocess.run([sys.executable, "-c", code],
+                       capture_output=True, text=False, env=env, timeout=60)
+    assert r.returncode == 0, r.stderr.decode(errors="replace")
+    assert "守窗".encode() in r.stdout  # UTF-8 原文到达管道
+    assert "守窗" in (tmp_path / "l.log").read_text(encoding="utf-8")
+
+
 def test_reporter_survives_unwritable_log(tmp_path, capsys):
     # 日志写不进（目录不存在）不应让监督器崩——控制台输出仍在
     rep = launch_desktop.Reporter(tmp_path / "no-such-dir" / "launcher.log")


### PR DESCRIPTION
## 背景

组装台 run 8 首跑新监督器冒烟即败,取证明确:`launch_desktop.py` 在打印第一行中文进度时 `UnicodeEncodeError` 崩溃——管道形态的 stdout(CI / 任何重定向)默认 locale 编码(runner 上 cp1252,中文实机 GBK),desktop 冒烟根本没跑到。

## 改动

- `deploy/launch_desktop.py`:入口新增 `force_utf8_stdio()`,stdout/stderr 一律 reconfigure 为 UTF-8 + `errors=replace`。
- `tests/test_launch_desktop.py`:子进程强制 `PYTHONIOENCODING=cp1252` 复现管道形态,钉住修复(9 用例全绿)。

## 验证

`premerge_gate.py` 全绿;ruff 全绿。合并后将重触发组装台 run 9。

---
_Generated by [Claude Code](https://claude.ai/code/session_012inwJHdmytAcf7xLKWe8k2)_