### PR TITLE
launcher.cmd 防闪退外壳:任何失败窗口都停住;可单档拷进旧包

### DIFF
--- a/projects/silver-core-hermes/deploy/launch_desktop.py
+++ b/projects/silver-core-hermes/deploy/launch_desktop.py
@@ -33,6 +33,16 @@ DEFAULT_WAIT_SECONDS = 25
 TAIL_LINES = 40
 
 
+def force_utf8_stdio() -> None:
+    """stdout/stderr 强制 UTF-8：控制台外的管道（CI / 重定向）默认 locale 编码
+    （cp1252 / GBK），打印中文进度即 UnicodeEncodeError——run 8 实证死在第一行。"""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+
 def pick_desktop_exe(root: pathlib.Path) -> pathlib.Path | None:
     """desktop/ 下的主 exe：win-unpacked 形态只有一个顶层 exe，取字典序第一个。"""
     exes = sorted((root / "desktop").glob("*.exe"))
@@ -130,6 +140,7 @@ def attempt(exe: pathlib.Path, env: dict, extra_args: list[str],
 
 
 def main() -> int:
+    force_utf8_stdio()
     root = pathlib.Path(sys.argv[1]).resolve()
     report = Reporter(root / "launcher.log")
     wait_seconds = int(os.environ.get("SILVER_CORE_LAUNCH_WAIT", DEFAULT_WAIT_SECONDS))

--- a/projects/silver-core-hermes/deploy/launcher.cmd
+++ b/projects/silver-core-hermes/deploy/launcher.cmd
@@ -1,4 +1,11 @@
 @echo off
+rem 双击防闪退外壳：把真正的执行放进 cmd /k 子窗——后面任何一步出事（含批处理
+rem 语法错这种 pause 都来不及跑的死法），窗口都停住可读；成功路径用 exit 0 关窗。
+if not defined SC_LAUNCHER_KEEPWIN (
+  set "SC_LAUNCHER_KEEPWIN=1"
+  cmd /d /k call "%~f0" %*
+  exit /b
+)
 rem Silver Core 便携整包启动器（cmd 批处理，零 PowerShell）。
 rem 合箱布局：python\（uv 托管 CPython）、venv\、app\（组装源树）、desktop\（win-unpacked）、
 rem home\（HERMES_HOME）与本文件同级。默认拉起 desktop；CLI 用法 launcher.cmd cli <args>。
@@ -55,6 +62,7 @@ if /i "%~1"=="cli" (
 )
 
 rem -- 步骤 4：监督式拉起 desktop（捕获输出 + 探活 + 软渲染重试；未找到则回退 CLI） --
+if not exist "%ROOT%launch_desktop.py" goto legacy_start
 if exist "%ROOT%desktop" (
   echo 正在启动桌面端，自检守窗约 25 秒，窗口正常出现后本窗自动关闭...
   "%ROOT%venv\Scripts\python.exe" "%ROOT%launch_desktop.py" "%ROOT%."
@@ -65,8 +73,26 @@ if exist "%ROOT%desktop" (
     pause
     exit /b 1
   )
+  exit 0
+)
+goto cli_fallback
+
+:legacy_start
+rem 旧包没有监督器时的兜底（本文件可单独拷进旧 SilverCore 直接用）：
+rem 直接拉起 desktop，窗口停住等守密人确认桌面端是否出现。
+set "DESKTOP_EXE="
+for %%F in ("%ROOT%desktop\*.exe") do if not defined DESKTOP_EXE set "DESKTOP_EXE=%%~fF"
+if defined DESKTOP_EXE (
+  echo [ok] legacy start %DESKTOP_EXE% >> "%LOG%"
+  echo 未找到监督器 launch_desktop.py，直接拉起桌面端：
+  echo   %DESKTOP_EXE%
+  start "Silver Core" "%DESKTOP_EXE%"
+  echo 若桌面端窗口没有出现，请把 home\logs\ 下日志发给艾瑞卡；本窗可手动关闭。
+  pause
   exit /b 0
 )
+
+:cli_fallback
 echo [warn] desktop dir not found, falling back to CLI >> "%LOG%"
 echo 未找到桌面端目录，回退命令行模式...
 "%ROOT%venv\Scripts\hermes.exe" %*

--- a/tests/test_launch_desktop.py
+++ b/tests/test_launch_desktop.py
@@ -73,6 +73,26 @@ def test_reporter_dual_writes(tmp_path, capsys):
     assert "hello 取证" in (tmp_path / "launcher.log").read_text(encoding="utf-8")
 
 
+def test_reporter_survives_cp1252_pipe(tmp_path):
+    # run 8 实证死因：CI 管道 stdout 是 cp1252，打印中文进度即 UnicodeEncodeError。
+    # 子进程强制 PYTHONIOENCODING=cp1252 复现管道形态，force_utf8_stdio 必须救回。
+    import subprocess
+    import sys
+    code = (
+        "import importlib.util, pathlib\n"
+        f"spec = importlib.util.spec_from_file_location('ld', {str(MODULE_PATH)!r})\n"
+        "ld = importlib.util.module_from_spec(spec); spec.loader.exec_module(ld)\n"
+        "ld.force_utf8_stdio()\n"
+        f"ld.Reporter(pathlib.Path({str(tmp_path / 'l.log')!r})).line('第 1 次启动（守窗）')\n"
+    )
+    env = dict(os.environ, PYTHONIOENCODING="cp1252")
+    r = subprocess.run([sys.executable, "-c", code],
+                       capture_output=True, text=False, env=env, timeout=60)
+    assert r.returncode == 0, r.stderr.decode(errors="replace")
+    assert "守窗".encode() in r.stdout  # UTF-8 原文到达管道
+    assert "守窗" in (tmp_path / "l.log").read_text(encoding="utf-8")
+
+
 def test_reporter_survives_unwritable_log(tmp_path, capsys):
     # 日志写不进（目录不存在）不应让监督器崩——控制台输出仍在
     rep = launch_desktop.Reporter(tmp_path / "no-such-dir" / "launcher.log")


### PR DESCRIPTION
守密人的直接痛点:窗口闪没,来不及看任何反馈。

- 整个脚本首次进入时套进 `cmd /k` 子窗:此后任何死法(包括 pause 都来不及跑的批处理语法错)窗口都停住可读;成功路径 `exit 0` 关窗。
- 步骤 4 在 `launch_desktop.py` 缺席时优雅降级为直启 desktop + 停窗——本档可**单独拷进旧 SilverCore 包**直接用,不必重下 1GB 整包。

验证:premerge gate 全绿(13 用例相关守卫通过)。

---
_Generated by [Claude Code](https://claude.ai/code/session_012inwJHdmytAcf7xLKWe8k2)_