### PR TITLE
fix(retag-release): idempotent publish repair; retry publish past draft race

### DIFF
--- a/.github/workflows/retag-release.yml
+++ b/.github/workflows/retag-release.yml
@@ -77,7 +77,10 @@ jobs:
         run: |
           set -euo pipefail
           release_id=$(cat /tmp/release_id)
-          if [ -n "$(git ls-remote origin "refs/tags/$TAG" | cut -f1)" ]; then
+          current=$(git ls-remote origin "refs/tags/$TAG" | cut -f1)
+          if [ "$current" = "$NEW_SHA" ]; then
+            echo "tag 已在目标位，跳过删建，仅确保发布状态"
+          elif [ -n "$current" ]; then
             gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG"
             echo "旧 tag 已删除（Release 随之退草稿，下一步重新发布）"
           fi
@@ -92,17 +95,15 @@ jobs:
             [ -n "$moved" ] && break
             sleep 5
           done
-          if [ -z "$moved" ]; then
-            echo "发布未自建 tag，做一次 draft 循环重试"
-            gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" -F draft=true > /dev/null
-            publish
-            for i in 1 2 3 4 5 6; do
-              moved=$(git ls-remote origin "refs/tags/$TAG" | cut -f1)
-              [ -n "$moved" ] && break
-              sleep 5
-            done
-          fi
           [ "$moved" = "$NEW_SHA" ] || { echo "::error::移锚后远端为 '${moved:-空}'，非目标 $NEW_SHA"; exit 1; }
+          # 「删 tag 退草稿」与「PATCH 发布」存在竞态（run5/6 实测：tag 建成而
+          # draft 未翻回），发布态单独重试收敛
+          for i in 1 2 3 4 5 6; do
+            [ "$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" --jq .draft)" = "false" ] && break
+            echo "Release 仍为草稿，重试发布（第 $i 次）"
+            publish
+            sleep 3
+          done
           echo "tag $TAG 已移至 $NEW_SHA"
 
       - name: Verify release intact


### PR DESCRIPTION
## 概述

run5/6 实测竞态：删 tag 使 Release 退草稿，发布 PATCH 把 tag 建到了目标位但 draft 标志未翻回，验收步如实拦下。本 PR 两点修正：tag 已在目标位时跳过删建只修发布态（幂等可重跑）；tag 落位后对发布态单独重试环收敛。用于补发布 community-assets / unpacked-assets 两个草稿态 Release。

---

## 变更类型

- [x] Bug 修复

---

## 来源声明

- [x] 无数据引入；证据为本仓 Actions run 30763170550 / 30763209859 日志

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **仅引用公开素材。**
- [x] **同意按 [MIT License](../LICENSE) 提交贡献。**

---

## 验证清单

- [x] YAML 语法校验通过（单工作流文件改动）
- [x] 不引入 emoji
- [x] 不动决策/踩坑档案

---

## 关联 Issue

- Refs #907 #908 #910

---
_Generated by [Claude Code](https://claude.ai/code/session_0155Nwq4muACuRRaaVdsBWW5)_