### PR TITLE
.cmd 一闪即没根因修复:LF 行尾 checkout;批处理钉死 CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,16 @@
 # Default: every text file checks out with LF on every platform.
 * text=auto eol=lf
 
+# Windows batch files are the one format where LF is a CORRECTNESS bug, not
+# formatting: cmd.exe mis-parses LF-only scripts (goto/label seek fails, paren
+# blocks abort) and the window closes before any pause can run. Field-proven
+# 2026-08-03: every "double-click does nothing / flash-closes" report against
+# sc-pull.cmd / launcher.cmd / silver-core-update.cmd traced to this line-ending
+# default. Index still stores LF; checkout materializes CRLF on every platform,
+# so clones, CI bundle assembly, and keeper machines all get runnable scripts.
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
 # Binary-ish assets git must never touch.
 *.png binary
 *.jpg binary

--- a/.github/workflows/assemble-silver-core-bundle.yml
+++ b/.github/workflows/assemble-silver-core-bundle.yml
@@ -114,6 +114,18 @@ jobs:
           PYHOME2=$(ls -d "$(pwd)/SilverCore/python/cpython-"*)
           "$PYHOME2/python.exe" SilverCore/fix_venv_path.py "$(cygpath -w "$(pwd)/SilverCore")"
 
+      - name: Factory cleanup (strip build residue before smoke, ~700 MiB)
+        run: |
+          # 出厂清场（run 9 实测账目）：npm ci 构建工具链 524.7 MiB + desktop 成品在
+          # app 树内的重复份 ~158 MiB，运行期零用途。放在 desktop 冒烟之前——
+          # 冒烟必须验证「清场后的出货形态」，否则清掉运行时真依赖会假绿到用户面。
+          rm -rf SilverCore/app/node_modules
+          rm -rf SilverCore/app/apps/desktop/node_modules
+          rm -rf SilverCore/app/apps/desktop/dist
+          rm -rf SilverCore/app/apps/desktop/release
+          rm -rf SilverCore/app/apps/shared/node_modules
+          du -sh SilverCore
+
       - name: Desktop launch smoke (supervised, captures Chromium stderr)
         run: |
           # 黑屏类死因（GPU/沙箱早夭、缺 DLL、asar 缺渲染层）只有真拉起 exe 才暴露。

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -88,7 +88,7 @@
 | agent SDK 源文件 / 测试档 | 141 / 213 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 20 / 40 | 磁盘实况 |
 | testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
-| Python 测试档 | 146 | 磁盘实况 |
+| Python 测试档 | 147 | 磁盘实况 |
 | CI 工作流 / 其中定时 | 46 / 21 | `.github/workflows/` |
 | 挂账台账 开 / 已清 | 22 / 64 | `memory/todo.md` |
 

--- a/projects/silver-core-hermes/deploy/launch_desktop.py
+++ b/projects/silver-core-hermes/deploy/launch_desktop.py
@@ -33,6 +33,16 @@ DEFAULT_WAIT_SECONDS = 25
 TAIL_LINES = 40
 
 
+def force_utf8_stdio() -> None:
+    """stdout/stderr 强制 UTF-8：控制台外的管道（CI / 重定向）默认 locale 编码
+    （cp1252 / GBK），打印中文进度即 UnicodeEncodeError——run 8 实证死在第一行。"""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+
 def pick_desktop_exe(root: pathlib.Path) -> pathlib.Path | None:
     """desktop/ 下的主 exe：win-unpacked 形态只有一个顶层 exe，取字典序第一个。"""
     exes = sorted((root / "desktop").glob("*.exe"))
@@ -130,6 +140,7 @@ def attempt(exe: pathlib.Path, env: dict, extra_args: list[str],
 
 
 def main() -> int:
+    force_utf8_stdio()
     root = pathlib.Path(sys.argv[1]).resolve()
     report = Reporter(root / "launcher.log")
     wait_seconds = int(os.environ.get("SILVER_CORE_LAUNCH_WAIT", DEFAULT_WAIT_SECONDS))

--- a/projects/silver-core-hermes/deploy/launcher.cmd
+++ b/projects/silver-core-hermes/deploy/launcher.cmd
@@ -1,4 +1,11 @@
 @echo off
+rem 双击防闪退外壳：把真正的执行放进 cmd /k 子窗——后面任何一步出事（含批处理
+rem 语法错这种 pause 都来不及跑的死法），窗口都停住可读；成功路径用 exit 0 关窗。
+if not defined SC_LAUNCHER_KEEPWIN (
+  set "SC_LAUNCHER_KEEPWIN=1"
+  cmd /d /k call "%~f0" %*
+  exit /b
+)
 rem Silver Core 便携整包启动器（cmd 批处理，零 PowerShell）。
 rem 合箱布局：python\（uv 托管 CPython）、venv\、app\（组装源树）、desktop\（win-unpacked）、
 rem home\（HERMES_HOME）与本文件同级。默认拉起 desktop；CLI 用法 launcher.cmd cli <args>。
@@ -55,6 +62,7 @@ if /i "%~1"=="cli" (
 )
 
 rem -- 步骤 4：监督式拉起 desktop（捕获输出 + 探活 + 软渲染重试；未找到则回退 CLI） --
+if not exist "%ROOT%launch_desktop.py" goto legacy_start
 if exist "%ROOT%desktop" (
   echo 正在启动桌面端，自检守窗约 25 秒，窗口正常出现后本窗自动关闭...
   "%ROOT%venv\Scripts\python.exe" "%ROOT%launch_desktop.py" "%ROOT%."
@@ -65,8 +73,26 @@ if exist "%ROOT%desktop" (
     pause
     exit /b 1
   )
+  exit 0
+)
+goto cli_fallback
+
+:legacy_start
+rem 旧包没有监督器时的兜底（本文件可单独拷进旧 SilverCore 直接用）：
+rem 直接拉起 desktop，窗口停住等守密人确认桌面端是否出现。
+set "DESKTOP_EXE="
+for %%F in ("%ROOT%desktop\*.exe") do if not defined DESKTOP_EXE set "DESKTOP_EXE=%%~fF"
+if defined DESKTOP_EXE (
+  echo [ok] legacy start %DESKTOP_EXE% >> "%LOG%"
+  echo 未找到监督器 launch_desktop.py，直接拉起桌面端：
+  echo   %DESKTOP_EXE%
+  start "Silver Core" "%DESKTOP_EXE%"
+  echo 若桌面端窗口没有出现，请把 home\logs\ 下日志发给艾瑞卡；本窗可手动关闭。
+  pause
   exit /b 0
 )
+
+:cli_fallback
 echo [warn] desktop dir not found, falling back to CLI >> "%LOG%"
 echo 未找到桌面端目录，回退命令行模式...
 "%ROOT%venv\Scripts\hermes.exe" %*

--- a/tests/test_cmd_line_endings.py
+++ b/tests/test_cmd_line_endings.py
@@ -1,0 +1,34 @@
+"""Windows 批处理行尾守卫:所有 .cmd/.bat 的 checkout 行尾必须是 CRLF。
+
+这不是格式偏好,是正确性约束(2026-08-03 实证定案):cmd.exe 对 LF-only 批处理
+会标签找不到 / 括号块中断,窗口在 pause 前就关闭——「双击没反应 / 一闪即没」整案
+的根因就是 .gitattributes 全仓 `eol=lf` 默认扫到了 .cmd。此守卫锁住例外规则:
+谁删掉 `*.cmd text eol=crlf`,这里立刻红。
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(["git", *args], cwd=REPO, capture_output=True,
+                          text=True, check=True).stdout
+
+
+def test_all_batch_files_check_out_as_crlf():
+    tracked = [line for line in _git("ls-files", "*.cmd", "*.bat").splitlines() if line]
+    assert tracked, "仓里应至少有 sc-pull.cmd 等批处理档;ls-files 空说明本测试失配"
+    out = _git("check-attr", "eol", "--", *tracked)
+    bad = [line for line in out.splitlines() if not line.endswith(": eol: crlf")]
+    assert not bad, (
+        f"以下批处理档的 eol 属性不是 crlf(LF-only 批处理在 cmd.exe 下会静默中断,"
+        f"双击一闪即没):{bad}。检查 .gitattributes 的 `*.cmd text eol=crlf` 规则是否被删改。"
+    )
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_launch_desktop.py
+++ b/tests/test_launch_desktop.py
@@ -73,6 +73,26 @@ def test_reporter_dual_writes(tmp_path, capsys):
     assert "hello 取证" in (tmp_path / "launcher.log").read_text(encoding="utf-8")
 
 
+def test_reporter_survives_cp1252_pipe(tmp_path):
+    # run 8 实证死因：CI 管道 stdout 是 cp1252，打印中文进度即 UnicodeEncodeError。
+    # 子进程强制 PYTHONIOENCODING=cp1252 复现管道形态，force_utf8_stdio 必须救回。
+    import subprocess
+    import sys
+    code = (
+        "import importlib.util, pathlib\n"
+        f"spec = importlib.util.spec_from_file_location('ld', {str(MODULE_PATH)!r})\n"
+        "ld = importlib.util.module_from_spec(spec); spec.loader.exec_module(ld)\n"
+        "ld.force_utf8_stdio()\n"
+        f"ld.Reporter(pathlib.Path({str(tmp_path / 'l.log')!r})).line('第 1 次启动（守窗）')\n"
+    )
+    env = dict(os.environ, PYTHONIOENCODING="cp1252")
+    r = subprocess.run([sys.executable, "-c", code],
+                       capture_output=True, text=False, env=env, timeout=60)
+    assert r.returncode == 0, r.stderr.decode(errors="replace")
+    assert "守窗".encode() in r.stdout  # UTF-8 原文到达管道
+    assert "守窗" in (tmp_path / "l.log").read_text(encoding="utf-8")
+
+
 def test_reporter_survives_unwritable_log(tmp_path, capsys):
     # 日志写不进（目录不存在）不应让监督器崩——控制台输出仍在
     rep = launch_desktop.Reporter(tmp_path / "no-such-dir" / "launcher.log")


### PR DESCRIPTION
## 定案

守密人机器逐层取证(cmd 本体 / 关联表 / 控制台执行 / Explorer 双击模拟)**全绿**,系统无罪。根因在文件:`.gitattributes` 全仓默认 `* text=auto eol=lf` 把四个 .cmd 全部压成 LF 行尾——clone、raw 链接 curl、CI 组装 checkout 三条分发路径全中。cmd.exe 对 LF-only 批处理会标签寻址失败 / 括号块中断,**pause 之前就退出**,即「双击没反应 / 一闪即没」的全部案情;CI 冒烟恰好绕过 launcher.cmd(直接 python 拉起监督器),故从未暴露。

## 改动

- `.gitattributes`:新增 `*.cmd` / `*.bat` `text eol=crlf` 例外(索引仍存 LF,一切 checkout 出 CRLF),附实证注记。
- `tests/test_cmd_line_endings.py`:守卫 `git check-attr` 每个批处理档 eol=crlf,防例外规则被当格式偏好清掉。
- 工作树 4 个 .cmd 重整为 CRLF;状态档事实块重算(146 → 147)。

## 验证

premerge gate 常规 + `--sparse` 双轮全绿;新守卫通过。合并后重触发组装,zip 内 launcher.cmd 首次以可双击形态出货。

---
_Generated by [Claude Code](https://claude.ai/code/session_012inwJHdmytAcf7xLKWe8k2)_