### PR TITLE
About 页隐藏自更新区（守密人裁定）

### DIFF
--- a/projects/silver-core-hermes/BRANDING.md
+++ b/projects/silver-core-hermes/BRANDING.md
@@ -17,7 +17,7 @@
 | **窗口标题 `<title>`**（desktop / web / bootstrap-installer 的 index.html——任务栏 / Alt-Tab 显示名实际来源，2026-08-02 补漏 #3） | `.html` 扩入扫描后缀 | 3 档 |
 | **应用显示名 APP_NAME**（About 面板 / 菜单标签 / `app.setName`；其兜底行含 `HERMES_` 被跳线保留，2026-08-02 补漏 #3） | 上游官方环境针 `HERMES_DESKTOP_APP_NAME=Silver Core`（launcher.cmd + launch_desktop.py 双设，零侵入） | 2 件 |
 | **应用图标 / 品牌图像**（win exe · 任务栏 · 托盘 · 窗口图标 · favicon · About 页 BrandMark，2026-08-02 补漏 #2） | 二进制覆盖 `deploy/brand-assets/`（`gen_brand_assets.py` 单源图生成全套；rebrand.py `ASSET_OVERLAYS` 组装期覆盖 + 补丁 `--binary` 段等效承载）。**现为艾瑞卡立绘占位**——守密人 2026-08-02 裁定另行供图，正式图落 `deploy/brand-assets/source.png` 后重跑两生成器即换装 | 4 件 |
-| **About 页出身声明**（守密人 2026-08-02 裁定：直接说明「B.I.A.V. Studio 基于 Hermes <版本> 的定制版本」） | 后置全文规则锚定 about-settings.tsx 插入，版本号动态渲染 | 1 处 |
+| **About 页出身声明 + 自更新区隐藏**（守密人 2026-08-02 两裁：①直接说明「B.I.A.V. Studio 基于 Hermes <版本> 的定制版本」②不再展示自更新区——便携包生产禁用 `hermes update`（文书 §2.4），该区只会报 git checkout 错误误导） | 后置全文规则锚定 about-settings.tsx：插入声明（版本动态渲染）+ `{false && (<>...</>)}` 包裹自更新区；哨兵防移 pin 静默复活（charter 守卫） | 2 处 |
 | CLI 命令名 | `deploy/bin/silver-core` 别名包裹（零侵入） | 1 件 |
 | 钉钉显示名 | 钉钉应用后台配置（内网侧） | 部署说明 |
 

--- a/projects/silver-core-hermes/deploy/rebrand.py
+++ b/projects/silver-core-hermes/deploy/rebrand.py
@@ -98,6 +98,29 @@ POST_RULES = [
         " + ' 的定制版本'}\n"
         "          </p>\n",
     ),
+    # About 自更新区整块隐藏（守密人 2026-08-02 裁定；与文书 §2.4「生产禁用
+    # hermes update、更新只有换 tag 重测」同向——便携包里该区只会报 git checkout
+    # 错误误导用户）。{false && (<>...</>)} 包裹而非删除：对上游 diff 最小、
+    # 移 pin 冲突面最小。哨兵防静默复活见 tests/test_hermes_charter.py。
+    (
+        "      <div className=\"mx-auto mt-4 w-full max-w-2xl\">\n"
+        "        <SectionHeading icon={RefreshCw} title={a.updates} />\n",
+        "      <div className=\"mx-auto mt-4 w-full max-w-2xl\">\n"
+        "        {/* 便携包生产禁用自更新（文书 §2.4）——About 隐藏该区（2026-08-02 裁定） */}\n"
+        "        {false && (<>\n"
+        "        <SectionHeading icon={RefreshCw} title={a.updates} />\n",
+    ),
+    (
+        "          title={a.automaticUpdates}\n"
+        "        />\n"
+        "\n"
+        "        <UninstallSection />\n",
+        "          title={a.automaticUpdates}\n"
+        "        />\n"
+        "        </>)}\n"
+        "\n"
+        "        <UninstallSection />\n",
+    ),
 ]
 
 # 二进制品牌资产覆盖（2026-08-02 补漏：图标是二进制，文本规则到不了）：

--- a/projects/silver-core-hermes/patches/silver-core-rebrand.patch
+++ b/projects/silver-core-hermes/patches/silver-core-rebrand.patch
@@ -33788,10 +33788,10 @@ index bcc6ffc..d0770aa 100644
      })
    })
 diff --git a/apps/desktop/src/app/settings/about-settings.tsx b/apps/desktop/src/app/settings/about-settings.tsx
-index fa0ca76..a883bc7 100644
+index fa0ca76..51b73b5 100644
 --- a/apps/desktop/src/app/settings/about-settings.tsx
 +++ b/apps/desktop/src/app/settings/about-settings.tsx
-@@ -102,6 +102,9 @@ export function AboutSettings() {
+@@ -102,10 +102,15 @@ export function AboutSettings() {
            <p className="mt-1 text-xs text-muted-foreground">
              {version?.appVersion ? a.version(version.appVersion) : a.versionUnavailable}
            </p>
@@ -33801,6 +33801,20 @@ index fa0ca76..a883bc7 100644
          </div>
        </div>
  
+       <div className="mx-auto mt-4 w-full max-w-2xl">
++        {/* 便携包生产禁用自更新（文书 §2.4）——About 隐藏该区（2026-08-02 裁定） */}
++        {false && (<>
+         <SectionHeading icon={RefreshCw} title={a.updates} />
+ 
+         <div
+@@ -175,6 +180,7 @@ export function AboutSettings() {
+           hint={a.branchCommit(status?.branch ?? 'unknown', status?.currentSha?.slice(0, 7) ?? 'unknown')}
+           title={a.automaticUpdates}
+         />
++        </>)}
+ 
+         <UninstallSection />
+       </div>
 diff --git a/apps/desktop/src/app/settings/billing/errors.ts b/apps/desktop/src/app/settings/billing/errors.ts
 index 0357bf4..3469aae 100644
 --- a/apps/desktop/src/app/settings/billing/errors.ts

--- a/tests/test_hermes_charter.py
+++ b/tests/test_hermes_charter.py
@@ -72,6 +72,19 @@ def test_rebrand_never_breaks_functional_identifiers():
     assert not bad, f"连字符标识符被换装打断: {bad[:3]}"
 
 
+def test_rebrand_hides_about_updates_section():
+    """About 自更新区隐藏（守密人 2026-08-02 裁定）不得因移 pin 锚点失配而静默复活。
+
+    POST_RULES 是纯文本锚定替换——上游改了 about-settings.tsx 结构时替换会无声
+    no-op，补丁里的隐藏 hunk 随之消失。哨兵：补丁必须仍含包裹标记。
+    """
+    text = (SUB / "patches" / "silver-core-rebrand.patch").read_text(encoding="utf-8")
+    assert "{false && (<>" in text and "</>)}" in text, (
+        "About 自更新区隐藏 hunk 从补丁消失——多半是移 pin 后 POST_RULES 锚点"
+        "失配无声 no-op，去 deploy/rebrand.py 修锚点"
+    )
+
+
 def test_charter_skeleton_present():
     for name in ["plugins", "skills", "deploy"]:
         assert (SUB / name).is_dir(), f"§2.2 骨架目录缺失: {name}/"


### PR DESCRIPTION
守密人 2026-08-02 裁定：About 内不再展示自更新内容。便携包生产禁用 `hermes update`（文书 §2.4），该区块只会报「isn't a git checkout」错误误导用户。

- POST_RULES 以 `{false && (<>...</>)}` 包裹整个 Updates 区（状态卡 / Check now / Release notes / Automatic updates 行）——对上游 diff 最小、移 pin 冲突面最小。
- charter 守卫新增哨兵：移 pin 后锚点失配导致隐藏 hunk 无声消失时响亮变红，防区块静默复活。
- BRANDING.md 覆盖面台账同步。

验证：charter 守卫 7 例绿 + premerge 相关套件绿；`rebrand.py --check` 同步。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_