### PR TITLE
整包二阶瘦身:剔文档站源码与测试集,压缩升 -mx=9

### DIFF
--- a/.github/workflows/assemble-silver-core-bundle.yml
+++ b/.github/workflows/assemble-silver-core-bundle.yml
@@ -124,6 +124,11 @@ jobs:
           rm -rf SilverCore/app/apps/desktop/dist
           rm -rf SilverCore/app/apps/desktop/release
           rm -rf SilverCore/app/apps/shared/node_modules
+          # 二阶清场（守密人 2026-08-03 继续压缩指示）：文档站源码与测试集运行期零用途。
+          # docs/ 与 mcp-research-data/ 刻意保留——运行时是否消费未证伪，宁胖勿断。
+          rm -rf SilverCore/app/website
+          rm -rf SilverCore/app/tests
+          rm -rf SilverCore/app/tests-js
           du -sh SilverCore
 
       - name: Desktop launch smoke (supervised, captures Chromium stderr)
@@ -146,7 +151,7 @@ jobs:
           rm -f SilverCore/launcher.log
 
       - name: Zip (transport container only)
-        run: 7z a -mx=3 "silver-core-win64.zip" SilverCore > /dev/null && ls -lh silver-core-win64.zip
+        run: 7z a -mx=9 "silver-core-win64.zip" SilverCore > /dev/null && ls -lh silver-core-win64.zip
 
       - name: Upload to Release
         env:


### PR DESCRIPTION
守密人指示继续压缩。二阶清场:`app/website`(文档站源码)、`app/tests` / `app/tests-js`(测试集)运行期零用途,剔除;`docs/` 与 `mcp-research-data/` 刻意保留(运行时是否消费未证伪,宁胖勿断)。压缩级别 `-mx=3` → `-mx=9`(组装耗时已非瓶颈)。预期 433 → 约 350–390 MiB。清场步骤仍在 desktop 冒烟之前,冒烟验证出货形态。

验证:premerge gate 全绿。

---
_Generated by [Claude Code](https://claude.ai/code/session_012inwJHdmytAcf7xLKWe8k2)_