### PR TITLE
改名审计轮：userData 脑裂 / 更新轮询 / Billing / relay 默认名（守密人派发）

### DIFF
--- a/projects/silver-core-hermes/BRANDING.md
+++ b/projects/silver-core-hermes/BRANDING.md
@@ -20,6 +20,7 @@
 | **About 页出身声明 + 自更新区 / Danger zone 隐藏**（守密人 2026-08-02 三裁：①直接说明「B.I.A.V. Studio 基于 Hermes <版本> 的定制版本」②不再展示自更新区——便携包生产禁用 `hermes update`（文书 §2.4），该区只会报 git checkout 错误误导③Danger zone 整区不必要——便携包无安装器，卸载文案「reopen the installer」失实） | 后置全文规则锚定 about-settings.tsx：插入声明（版本动态渲染）+ `{false && …}` 帘子包裹两区（非删除，移 pin 冲突面最小）；哨兵防静默复活（charter 守卫） | 3 处 |
 | CLI 命令名 | `deploy/bin/silver-core` 别名包裹（零侵入） | 1 件 |
 | 钉钉显示名 | 钉钉应用后台配置（内网侧） | 部署说明 |
+| **改名审计轮（守密人 2026-08-02 派发「查改名 bug + 不再必要功能」）** | 后置规则四条：① APP_NAME 兜底 `'Hermes'`→`'Silver Core'`（productName 已换而兜底未换 = electron userData 按两个名字解析，绕过 launcher 直启 exe 时配置脑裂）② 后台更新轮询整只 no-op（挂载 + 每 30 分钟 + 聚焦触发，便携包里每次注定报「isn't a git checkout」错误噪音）③ Billing 设置入口隐藏（Hermes Cloud 订阅页，内网自有 Providers 无对象）④ 钉钉 relay 默认名抑制两名并收（旧持久化配置存 `Hermes Agent` 时漏抑制、回复前缀泄漏旧名）；哨兵 `test_rebrand_portable_fit_rules_alive` | 4 处 |
 
 ## 刻意不碰（红线，守卫 `tests/test_hermes_charter.py`）
 

--- a/projects/silver-core-hermes/deploy/rebrand.py
+++ b/projects/silver-core-hermes/deploy/rebrand.py
@@ -122,6 +122,59 @@ POST_RULES = [
         "        {/* 便携包无安装器——Danger zone 整区隐藏（守密人 2026-08-02 裁定） */}\n"
         "        {false && <UninstallSection />}\n",
     ),
+    # ---- 2026-08-02 改名审计轮（守密人「继续检查改名 bug + 不再必要功能」派发） ----
+    # (1) APP_NAME 兜底统一：该行含 HERMES_ 被跳线保留，兜底值 'Hermes' 与已换装的
+    # productName（'Silver Core'）分裂——electron userData 路径在 app.setName 前后
+    # 按不同名字解析，绕过 launcher 直启 exe 时配置会写进两个目录（脑裂）。
+    # 环境变量名原样保留，只统一兜底字面量。
+    (
+        "const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME || 'Hermes'\n",
+        "const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME || 'Silver Core'\n",
+    ),
+    # (2) 后台更新轮询整只 no-op：便携包更新通道 = 换 tag 重测（文书 §2.4），
+    # 轮询（挂载 + 每 30 分钟 + 窗口聚焦）只会反复报「isn't a git checkout」。
+    (
+        "export function startUpdatePoller(): void {\n"
+        "  if (pollerStarted || typeof window === 'undefined') {\n",
+        "export function startUpdatePoller(): void {\n"
+        "  // 便携包禁自更新（文书 §2.4）——后台轮询只产错误噪音，整只 no-op。\n"
+        "  if (true as boolean) {\n"
+        "    return\n"
+        "  }\n"
+        "\n"
+        "  if (pollerStarted || typeof window === 'undefined') {\n",
+    ),
+    # (3) Billing 入口隐藏：Hermes Cloud 订阅/额度页，内网便携包用自有 Providers，
+    # 该页无对象。spread-空数组帘子，保留代码结构。
+    (
+        "      {\n"
+        "        active: activeView === 'billing',\n"
+        "        icon: BarChart3,\n"
+        "        id: 'billing',\n"
+        "        label: t.settings.nav.billing,\n"
+        "        onSelect: () => setActiveView('billing')\n"
+        "      },\n",
+        "      // 内网便携包无 Hermes Cloud 订阅——Billing 入口隐藏（2026-08-02 审计轮）\n"
+        "      ...(false\n"
+        "        ? [\n"
+        "            {\n"
+        "              active: activeView === 'billing',\n"
+        "              icon: BarChart3,\n"
+        "              id: 'billing',\n"
+        "              label: t.settings.nav.billing,\n"
+        "              onSelect: () => setActiveView('billing')\n"
+        "            }\n"
+        "          ]\n"
+        "        : []),\n",
+    ),
+    # (4) 钉钉 relay 默认名抑制加固：旧持久化配置里存的可能仍是换装前的
+    # "Hermes Agent"，只比对新名会漏抑制、回复前缀泄漏旧品牌名。两名并收。
+    (
+        '        if value == "Silver Core":\n'
+        '            value = ""\n',
+        '        if value in ("Silver Core", "Hermes Agent"):\n'
+        '            value = ""\n',
+    ),
 ]
 
 # 二进制品牌资产覆盖（2026-08-02 补漏：图标是二进制，文本规则到不了）：

--- a/projects/silver-core-hermes/patches/silver-core-rebrand.patch
+++ b/projects/silver-core-hermes/patches/silver-core-rebrand.patch
@@ -19665,7 +19665,7 @@ index e671dc2..04197d8 100644
      )
    }
 diff --git a/apps/desktop/electron/main.ts b/apps/desktop/electron/main.ts
-index f485e5a..1e6c05f 100644
+index f485e5a..c15d74c 100644
 --- a/apps/desktop/electron/main.ts
 +++ b/apps/desktop/electron/main.ts
 @@ -346,7 +346,7 @@ if (IS_WINDOWS) {
@@ -19686,6 +19686,15 @@ index f485e5a..1e6c05f 100644
  // local backend as. When set, startHermes() passes `hermes --profile <name>
  // dashboard …`, which deterministically pins HERMES_HOME (see
  // _apply_profile_override in hermes_cli/main.py) and bypasses the sticky
+@@ -659,7 +659,7 @@ const BOOT_FAKE_STEP_MS = (() => {
+   return Math.max(120, raw)
+ })()
+ 
+-const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME || 'Hermes'
++const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME || 'Silver Core'
+ const TITLEBAR_HEIGHT = 34
+ const MACOS_TRAFFIC_LIGHTS_HEIGHT = 14
+ 
 @@ -960,7 +960,7 @@ if (IS_WINDOWS) {
    app.setAppUserModelId('com.nousresearch.hermes')
  }
@@ -35334,6 +35343,36 @@ index 30afd2d..c71ab22 100644
            whose selection drives the silent per-agent cascade + a cloud
            connection. Replaces the URL/token form while in cloud mode. */}
        {state.mode === 'cloud' && !state.envOverride ? (
+diff --git a/apps/desktop/src/app/settings/index.tsx b/apps/desktop/src/app/settings/index.tsx
+index 8dccf3a..9f9e016 100644
+--- a/apps/desktop/src/app/settings/index.tsx
++++ b/apps/desktop/src/app/settings/index.tsx
+@@ -161,13 +161,18 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
+         label: t.settings.nav.notifications,
+         onSelect: () => setActiveView('notifications')
+       },
+-      {
+-        active: activeView === 'billing',
+-        icon: BarChart3,
+-        id: 'billing',
+-        label: t.settings.nav.billing,
+-        onSelect: () => setActiveView('billing')
+-      },
++      // 内网便携包无 Hermes Cloud 订阅——Billing 入口隐藏（2026-08-02 审计轮）
++      ...(false
++        ? [
++            {
++              active: activeView === 'billing',
++              icon: BarChart3,
++              id: 'billing',
++              label: t.settings.nav.billing,
++              onSelect: () => setActiveView('billing')
++            }
++          ]
++        : []),
+       {
+         active: activeView === 'providers',
+         children: [
 diff --git a/apps/desktop/src/app/settings/memory/provider-config-panel.test.tsx b/apps/desktop/src/app/settings/memory/provider-config-panel.test.tsx
 index ac4fe9c..b6a0af5 100644
 --- a/apps/desktop/src/app/settings/memory/provider-config-panel.test.tsx
@@ -40051,6 +40090,22 @@ index 9dd1cbe..e6c1d10 100644
      })
  
      const result = await applyUpdates()
+diff --git a/apps/desktop/src/store/updates.ts b/apps/desktop/src/store/updates.ts
+index 0b46920..b4295da 100644
+--- a/apps/desktop/src/store/updates.ts
++++ b/apps/desktop/src/store/updates.ts
+@@ -667,6 +667,11 @@ let lastConnectionMode: string | undefined
+ 
+ /** Wire up background polling + progress streaming. Idempotent. */
+ export function startUpdatePoller(): void {
++  // 便携包禁自更新（文书 §2.4）——后台轮询只产错误噪音，整只 no-op。
++  if (true as boolean) {
++    return
++  }
++
+   if (pollerStarted || typeof window === 'undefined') {
+     return
+   }
 diff --git a/apps/desktop/src/store/wake-word.test.ts b/apps/desktop/src/store/wake-word.test.ts
 index 1d09a92..e66a9d0 100644
 --- a/apps/desktop/src/store/wake-word.test.ts
@@ -40362,7 +40417,7 @@ index 70f77b2..ea9009d 100644
      _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[\u200b\u2060\u2063\ufeff]")
      _OUTBOUND_ODD_SPACE_RE = re.compile(r"[\u00a0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]")
 diff --git a/gateway/relay/__init__.py b/gateway/relay/__init__.py
-index 77481d8..18b480f 100644
+index 77481d8..c2cd3c2 100644
 --- a/gateway/relay/__init__.py
 +++ b/gateway/relay/__init__.py
 @@ -284,10 +284,10 @@ def relay_display_name() -> Optional[str]:
@@ -40374,7 +40429,7 @@ index 77481d8..18b480f 100644
          # shadowing the connector's linked-owner fallback, which actually
          # disambiguates. Only a deliberately customized name is forwarded.
 -        if value == "Hermes Agent":
-+        if value == "Silver Core":
++        if value in ("Silver Core", "Hermes Agent"):
              value = ""
      # Mirror the connector's ingest sanitization (trim + 64-char cap) so what
      # we send is what gets stored.

--- a/tests/test_hermes_charter.py
+++ b/tests/test_hermes_charter.py
@@ -89,6 +89,19 @@ def test_rebrand_hides_about_updates_section():
     )
 
 
+def test_rebrand_portable_fit_rules_alive():
+    """改名审计轮四规则（2026-08-02）不得因移 pin 锚点失配而无声失效。"""
+    text = (SUB / "patches" / "silver-core-rebrand.patch").read_text(encoding="utf-8")
+    sentinels = {
+        "APP_NAME 兜底统一（userData 脑裂）": "|| 'Silver Core'",
+        "后台更新轮询 no-op": "便携包禁自更新",
+        "Billing 入口隐藏": "Billing 入口隐藏",
+        "relay 默认名两名并收": 'value in ("Silver Core", "Hermes Agent")',
+    }
+    missing = [k for k, v in sentinels.items() if v not in text]
+    assert not missing, f"审计轮规则从补丁消失（POST_RULES 锚点失配）: {missing}"
+
+
 def test_charter_skeleton_present():
     for name in ["plugins", "skills", "deploy"]:
         assert (SUB / name).is_dir(), f"§2.2 骨架目录缺失: {name}/"


### PR DESCRIPTION
守密人派发「继续检查改名可能导致的 bug + 显然不再必要的功能」的审计产出，四条后置规则：

**改名诱发 bug（2 条）**
1. **electron userData 脑裂**：productName 已换 `Silver Core`，而 `APP_NAME` 兜底行因含 `HERMES_` 被跳线保留仍是 `'Hermes'`——`app.setName` 前后 userData 按两个名字解析，绕过 launcher 直启 exe 时配置写进两个目录。兜底字面量统一为 `'Silver Core'`（环境变量名原样保留）。
2. **钉钉 relay 默认名抑制漏网**：抑制条件只比对新名，旧持久化配置里存过 `Hermes Agent` 时回复前缀会泄漏旧品牌名。两名并收。

**显然不再必要的功能（2 条）**
3. **后台更新轮询整只 no-op**：挂载 + 每 30 分钟 + 窗口聚焦三路触发，便携包里每次注定报「isn't a git checkout」（更新通道 = 换 tag 重测，文书 §2.4）。
4. **Billing 设置入口隐藏**：Hermes Cloud 订阅/额度页，内网自有 Providers 无对象。

哨兵 `test_rebrand_portable_fit_rules_alive` 守四锚点防移 pin 静默失效。验证：全量 pytest 3,281 通过，charter 守卫 7 例绿。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_