### PR TITLE
装配线 Release 说明每轮自愈（修化石路径指针）

### DIFF
--- a/.github/workflows/assemble-black-pool-bundle.yml
+++ b/.github/workflows/assemble-black-pool-bundle.yml
@@ -161,4 +161,5 @@ jobs:
           gh release view "${BUNDLE_TAG}" >/dev/null 2>&1 || \
             gh release create "${BUNDLE_TAG}" --title "Black Pool portable bundle (private edition)" \
               --notes "Black Pool (黑池) v0.1.0 — rolling private-edition portable bundle assembled by CI. See projects/black-pool-agent/deploy/README.md"
+          gh release edit "${BUNDLE_TAG}" --notes "Black Pool (黑池) v0.1.0 — rolling portable bundle assembled by CI. Assets: black-pool-win64.zip (private edition) / black-pool-public-win64.zip (public edition, on demand). See projects/black-pool-agent/deploy/README.md"
           gh release upload "${BUNDLE_TAG}" black-pool-win64.zip --clobber

--- a/.github/workflows/assemble-black-pool-public.yml
+++ b/.github/workflows/assemble-black-pool-public.yml
@@ -162,4 +162,5 @@ jobs:
           gh release view "${BUNDLE_TAG}" >/dev/null 2>&1 || \
             gh release create "${BUNDLE_TAG}" --title "Black Pool portable bundle (private edition)" \
               --notes "Black Pool (黑池) v0.1.0 — rolling private-edition portable bundle assembled by CI. See projects/black-pool-agent/deploy/README.md"
+          gh release edit "${BUNDLE_TAG}" --notes "Black Pool (黑池) v0.1.0 — rolling portable bundle assembled by CI. Assets: black-pool-win64.zip (private edition) / black-pool-public-win64.zip (public edition, on demand). See projects/black-pool-agent/deploy/README.md"
           gh release upload "${BUNDLE_TAG}" black-pool-public-win64.zip --clobber


### PR DESCRIPTION
首个黑池包出炉核验时发现：Release 说明只在建桶时写一次，固化了改名前的 `silver-core-hermes` 路径。两条装配线上传步现追加 `gh release edit --notes`，每轮覆盖说明，指针不再化石化。下轮装配即自愈；不为此单独重跑。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_