### PR TITLE
默认语言设为简体中文（守密人裁定）

### DIFF
--- a/projects/black-pool-agent/BRANDING.md
+++ b/projects/black-pool-agent/BRANDING.md
@@ -33,6 +33,7 @@
 | 钉钉显示名 | 钉钉应用后台配置（内网侧） | 部署说明 |
 | **改名审计轮（守密人 2026-08-02 派发「查改名 bug + 不再必要功能」）** | 后置规则四条：① APP_NAME 兜底 `'Hermes'`→`'Silver Core'`（productName 已换而兜底未换 = electron userData 按两个名字解析，绕过 launcher 直启 exe 时配置脑裂）② 后台更新轮询整只 no-op（挂载 + 每 30 分钟 + 聚焦触发，便携包里每次注定报「isn't a git checkout」错误噪音）③ Billing 设置入口隐藏（Hermes Cloud 订阅页，内网自有 Providers 无对象）④ 钉钉 relay 默认名抑制两名并收（旧持久化配置存 `Hermes Agent` 时漏抑制、回复前缀泄漏旧名）；哨兵 `test_rebrand_portable_fit_rules_alive` | 4 处 |
 | **审计轮二（2026-08-03 Sonnet 七断面动态编排 + 主循环终审）** | 后置规则八条：① `hermes update` 便携硬门禁（无 .git 的 win32 ZIP 兜底会拉未换装上游整树覆盖——字面撤销全部品牌补丁；文书 §2.4 从文档纪律升格代码门禁）② Billing 深路由封死（`?tab=billing` + 计费故障自动跳转两条暗道，从 `SETTINGS_VIEWS` 摘除）③ Help > Check for Updates 菜单整项摘除（三处自更新入口最后一处）④ Gateway Cloud 连接模式卡隐藏（portal.nousresearch.com OAuth 无对象）⑤ Telegram Quick setup 列隐藏（托管 Bot 固定代理 Nous 自营 SaaS，内网不可达却挂 recommended）⑥⑦ AUMID + appId 中性化 `com.biav.silvercore`（全小写躲过裸词规则，Windows 通知设置直接显示原始串）⑧ 唤醒词帮助文案中性化（裸词规则教出 "Hey Silver Core" 但声学模型只认 "hey hermes"）+ CLI `⚕ Hermes` 面板残留收尾；哨兵 `test_rebrand_audit_round2_rules_alive` | 8 条 |
+| **默认语言简体中文（守密人 2026-08-03 裁定）** | 基座层后置规则：desktop 缺省 locale 单一真相源 `DEFAULT_LOCALE` `'en'`→`'zh'`（无系统语言探测，配置未设时生效；已设用户不受影响）；公私两版同得（语言偏好属产品定制非内网适配）；哨兵入 `test_brand_patch_sentinels` | 1 处 |
 
 **审计轮二观察项（未处理，供守密人裁夺）**：`hermes uninstall` 的桌面产物探测硬编码 `Hermes` 目录名、换装后找不到 `Silver Core` 实际产物（便携形态卸载 = 删目录，实害近零）；Remote/SSH 报错文案四语种引导 `hermes-agent.nousresearch.com/install.sh`（内网不可达，正确措辞需产品口径，暂记账）；pet 精灵素材仍为上游吉祥物（前轮已记）。
 

--- a/projects/black-pool-agent/deploy/rebrand.py
+++ b/projects/black-pool-agent/deploy/rebrand.py
@@ -153,6 +153,13 @@ BRAND_POST_RULES = [
         "⚕ Hermes",
         f"⚕ {BRAND}",
     ),
+    # 默认语言简体中文（守密人 2026-08-03 裁定）：desktop 全局缺省 locale 单一
+    # 真相源改 'zh'——无系统语言探测，配置未设时生效；用户已设语言不受影响。
+    # 归基座层：公私两版同得简中缺省（语言偏好属产品定制，非内网适配）。
+    (
+        "export const DEFAULT_LOCALE: Locale = 'en'\n",
+        "export const DEFAULT_LOCALE: Locale = 'zh'\n",
+    ),
 ]
 
 # ========================= 私有版（内网/便携适配层） =========================

--- a/projects/black-pool-agent/patches/black-pool-rebrand.patch
+++ b/projects/black-pool-agent/patches/black-pool-rebrand.patch
@@ -38013,6 +38013,19 @@ index fab8e07..367f79b 100644
      imageDownloadFailed: '画像のダウンロードに失敗しました',
      openImage: '画像を開く',
      downloadImage: '画像をダウンロード',
+diff --git a/apps/desktop/src/i18n/languages.ts b/apps/desktop/src/i18n/languages.ts
+index e4a1fb1..35660d6 100644
+--- a/apps/desktop/src/i18n/languages.ts
++++ b/apps/desktop/src/i18n/languages.ts
+@@ -2,7 +2,7 @@ import { normalize } from '@/lib/text'
+ 
+ import type { Locale } from './types'
+ 
+-export const DEFAULT_LOCALE: Locale = 'en'
++export const DEFAULT_LOCALE: Locale = 'zh'
+ 
+ export const LOCALE_OPTIONS = [
+   {
 diff --git a/apps/desktop/src/i18n/runtime.test.ts b/apps/desktop/src/i18n/runtime.test.ts
 index 499fc1d..736ce8a 100644
 --- a/apps/desktop/src/i18n/runtime.test.ts

--- a/tests/test_hermes_charter.py
+++ b/tests/test_hermes_charter.py
@@ -98,6 +98,7 @@ def test_brand_patch_sentinels():
         "AUMID 中性化": "com.biav.blackpool",
         "唤醒词帮助中性化": "toggle the wake word listener [on|off|status]",
         "CLI 面板残留品牌收尾": "⚕ Black Pool",
+        "默认语言简体中文": "DEFAULT_LOCALE: Locale = 'zh'",
     }
     missing = [k for k, v in sentinels.items() if v not in text]
     assert not missing, f"公版规则从补丁消失（锚点失配）: {missing}"


### PR DESCRIPTION
守密人裁定落地：desktop 默认语言简体中文。

- 单一真相源 `DEFAULT_LOCALE` `'en'` → `'zh'`（`apps/desktop/src/i18n/languages.ts`）。上游无系统语言探测，配置未设时即生效；用户已设语言不受影响。
- 归**基座层**规则：公私两版同得简中缺省（语言偏好属产品定制，非内网适配）。
- 哨兵入 `test_brand_patch_sentinels`；台账补行。

验证：全量 pytest 3,282 通过，charter 守卫 8 例绿。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_