### PR TITLE
bpa-dev 套件适配 vendor 映射式取件（日志出脚本目录）

### DIFF
--- a/projects/black-pool-agent/deploy/bpa-dev/deploy/RUNBOOK.md
+++ b/projects/black-pool-agent/deploy/bpa-dev/deploy/RUNBOOK.md
@@ -21,6 +21,14 @@
 └── deploy\        # 本目录：部署件统一收纳（车间脚本 + 启动器家族 + 模板）
 ```
 
+## 取件两式（守密人 2026-08-03 问答定式）
+
+- **映射式（推荐）**：`黑池\bpa-dev\deploy` 经 `svn:externals` 挂到银芯 vendor 镜像内
+  `projects/black-pool-agent/deploy/bpa-dev/deploy`——脚本随 `svn update` 自动保鲜。
+  脚本全部按**挂载点**相对定位（`%~dp0..` = 车间根），日志与运行痕迹只写车间根，
+  vendor 映射目录保持零写入（只读纪律不破）。
+- **手拷式（兜底）**：镜像不便外链时，整目录拷入 `黑池\bpa-dev\deploy\`，银芯更新后手动重拷。
+
 ## 三步操作
 
 1. **组装** `assemble.cmd [zip名]`：验 SHA → 净台解压 → 打补丁（包内 Python 跑

--- a/projects/black-pool-agent/deploy/bpa-dev/deploy/assemble.cmd
+++ b/projects/black-pool-agent/deploy/bpa-dev/deploy/assemble.cmd
@@ -12,7 +12,7 @@ setlocal EnableExtensions EnableDelayedExpansion
 chcp 65001 >nul
 set "SD=%~dp0"
 set "DEVROOT=%SD%.."
-set "LOG=%SD%assemble.log"
+set "LOG=%DEVROOT%\assemble.log"
 echo [%date% %time%] assemble start > "%LOG%"
 
 rem -- 1. 选包 --

--- a/projects/black-pool-agent/deploy/bpa-dev/deploy/deploy.cmd
+++ b/projects/black-pool-agent/deploy/bpa-dev/deploy/deploy.cmd
@@ -10,7 +10,7 @@ setlocal EnableExtensions
 chcp 65001 >nul
 set "SD=%~dp0"
 set "DEVROOT=%SD%.."
-set "LOG=%SD%deploy.log"
+set "LOG=%DEVROOT%\deploy.log"
 if not "%~1"=="" set "BPA_DIR=%~1"
 if not defined BPA_DIR (
   echo 部署失败：未指定部署目录（参数或环境变量 BPA_DIR）。


### PR DESCRIPTION
守密人问答定式：`黑池\bpa-dev\deploy` 可经 `svn:externals` 直接映射银芯 vendor 镜像内的套件目录（脚本随 `svn update` 自动保鲜）。适配两处：

- 脚本日志改落车间根（`bpa-dev\`）而非脚本所在目录——vendor 映射目录必须保持零运行痕迹（只读纪律）。
- RUNBOOK 增「取件两式」：映射式（推荐）/ 手拷式（兜底）。

脚本本就按挂载点相对定位（`%~dp0..` = 车间根），映射后料目录解析天然正确。验证：全量 pytest 3,294 通过。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_