### PR TITLE
部署目标支持相对路径（按车间根解析）

### DIFF
--- a/projects/black-pool-agent/deploy/RUNBOOK.md
+++ b/projects/black-pool-agent/deploy/RUNBOOK.md
@@ -35,7 +35,8 @@ E:\BIAV-BP\bpa-dev\   （内部开发目录；部署目录 = E:\BIAV-BP\black-po
    `apply_patch.py`，无需 git；任一张上下文不匹配即整体失败，绝不半打）→ 注配置
    插件 → 出 `staging\BlackPool\` + `MANIFEST.txt`（用了哪版 zip、哪些补丁，来历三行可查）。
 2. **部署** `deploy.cmd [部署目录]`：目标取参数 > 环境变量 BPA_DIR > `config\deploy-target.txt`
-   （文件里写一行地址如 `E:\BIAV-BP\black-pool-agent`，写好后**双击即部署**，rollback 同理）：旧 `home\` 用户数据增量并入
+   （文件里写一行地址，**支持相对路径、按车间根 bpa-dev\ 解析**——写 `..\black-pool-agent`
+   则整棵树搬盘符零改配置；绝对路径如 `E:\BIAV-BP\black-pool-agent` 亦可。写好后**双击即部署**，rollback 同理）：旧 `home\` 用户数据增量并入
    新包（不覆盖注入的配置）→ 旧版让位 `<目录>.old` 回滚位 → 成品上位。
 3. **回滚** `rollback.cmd <部署目录>`：一键回切 `.old`，问题版留 `.failed-*` 供取证。
 

--- a/projects/black-pool-agent/deploy/deploy.cmd
+++ b/projects/black-pool-agent/deploy/deploy.cmd
@@ -18,6 +18,12 @@ if not defined BPA_DIR (
   echo 部署失败：未指定部署目录（参数或环境变量 BPA_DIR）。
   pause & exit /b 1
 )
+rem 相对路径一律按车间根（bpa-dev\）解析——整棵树搬盘符零改配置；绝不按当前窗口目录（会静默指错）
+set "_ABS="
+if "%BPA_DIR:~1,1%"==":" set "_ABS=1"
+if "%BPA_DIR:~0,2%"=="\\" set "_ABS=1"
+if not defined _ABS set "BPA_DIR=%DEVROOT%\%BPA_DIR%"
+for %%I in ("%BPA_DIR%") do set "BPA_DIR=%%~fI"
 set "B=%DEVROOT%\staging\BlackPool"
 echo [%date% %time%] deploy to %BPA_DIR% > "%LOG%"
 if not exist "%B%\MANIFEST.txt" (

--- a/projects/black-pool-agent/deploy/rollback.cmd
+++ b/projects/black-pool-agent/deploy/rollback.cmd
@@ -17,6 +17,12 @@ if not defined BPA_DIR (
   echo 回滚失败：未指定部署目录（参数或环境变量 BPA_DIR）。
   pause & exit /b 1
 )
+rem 相对路径一律按车间根（bpa-dev\）解析——整棵树搬盘符零改配置；绝不按当前窗口目录（会静默指错）
+set "_ABS="
+if "%BPA_DIR:~1,1%"==":" set "_ABS=1"
+if "%BPA_DIR:~0,2%"=="\\" set "_ABS=1"
+if not defined _ABS set "BPA_DIR=%DEVROOT%\%BPA_DIR%"
+for %%I in ("%BPA_DIR%") do set "BPA_DIR=%%~fI"
 if not exist "%BPA_DIR%.old" (
   echo 回滚失败：没有回滚位 %BPA_DIR%.old（每次 deploy 只留最近一版）。
   pause & exit /b 1


### PR DESCRIPTION
守密人问「⑥ 不能写相对路径吗」的落地：可以。三级取址（参数 / `BPA_DIR` / `config\deploy-target.txt`）中的相对路径一律**按车间根 `bpa-dev\` 解析**（绝不按当前窗口目录——那会在从别处开 cmd 时静默指错）。`deploy-target.txt` 写 `..\black-pool-agent` 即可让整棵 `BIAV-BP` 树搬盘符零改配置。deploy / rollback 同规则；RUNBOOK 同步。套件测试 12 例绿。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_