### PR TITLE
内网首部署两处野战修复：无印章 venv 自愈 + launcher 65001 错位

### DIFF
--- a/projects/black-pool-agent/deploy/assemble.cmd
+++ b/projects/black-pool-agent/deploy/assemble.cmd
@@ -62,6 +62,12 @@ if not exist "%B%\launcher.cmd" (
   pause & exit /b 1
 )
 
+rem -- 3b. 套件权威启动器族覆盖：部署件修复即刻生效，不必等新 zip --
+for %%F in (launcher.cmd launch_desktop.py fix_venv_path.py) do (
+  if exist "%SD%%%F" copy /y "%SD%%%F" "%B%\%%F" >nul
+)
+echo 启动器族已按套件版覆盖（launcher / 监督器 / venv 自愈）
+
 rem -- 4. 定位包内 Python（补丁应用器的运行时）--
 set "PYHOME="
 for /d %%D in ("%B%\python\cpython-*") do set "PYHOME=%%~fD"

--- a/projects/black-pool-agent/deploy/fix_venv_path.py
+++ b/projects/black-pool-agent/deploy/fix_venv_path.py
@@ -8,10 +8,14 @@
    上游构建后端刻意禁 wheel（「use an editable install instead」），故指针自愈是
    便携化的正解而非绕道。
 
-「旧根」来自 `bundle-root.txt`（组装期落章，本脚本自愈后滚动更新为当前根），
-新根 = argv[1]。两根相同即幂等直通。用法：python fix_venv_path.py <整包根目录>
+「旧根」解析两级（2026-08-03 内网首部署实证加固：印章丢失曾致自愈整段跳过、
+导入自检必挂）：优先 `bundle-root.txt` 印章；印章缺失则**直接从指针文件里反推**
+（指针里写的就是旧 app 源树绝对路径，取其去掉尾段 `\\app` 的众数）——印章从
+必需品降级为加速缓存，丢了照样自愈。新根 = argv[1]。两根相同即幂等直通。
+用法：python fix_venv_path.py <整包根目录>
 """
 import pathlib
+import re
 import sys
 
 
@@ -19,6 +23,25 @@ def _variants(root: str) -> list[str]:
     """同一路径的三种书写形态（原样 / 双反斜杠转义 / 正斜杠）。"""
     back = root.replace("/", "\\")
     return [back, back.replace("\\", "\\\\"), back.replace("\\", "/")]
+
+
+_APP_PATH_RE = re.compile(r"[A-Za-z]:[\\/][^'\";\r\n]*?app(?=['\";\r\n\\/]|$)")
+
+
+def _derive_old_root(site: pathlib.Path) -> str | None:
+    """从 editable 指针文件反推旧整包根（指针路径去掉尾段 \\app 的众数）。"""
+    counts: dict[str, int] = {}
+    for pattern in ("*.pth", "__editable__*.py"):
+        for f in site.glob(pattern):
+            try:
+                text = f.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            for m in _APP_PATH_RE.finditer(text):
+                p = m.group(0).replace("\\\\", "\\").replace("/", "\\")
+                if p.lower().endswith("\\app"):
+                    counts[p[: -len("\\app")]] = counts.get(p[: -len("\\app")], 0) + 1
+    return max(counts, key=lambda k: counts[k]) if counts else None
 
 
 def main() -> int:
@@ -39,14 +62,18 @@ def main() -> int:
     print(f"venv home -> {py_home}")
 
     # -- 2) editable 指针改写（旧根 -> 当前根） --
+    site = root / "venv" / "Lib" / "site-packages"
     stamp = root / "bundle-root.txt"
-    if not stamp.is_file():
-        print("no bundle-root.txt stamp; skip editable heal", file=sys.stderr)
-        return 0
-    old_root = stamp.read_text(encoding="utf-8").strip()
+    old_root = ""
+    if stamp.is_file():
+        old_root = stamp.read_text(encoding="utf-8").strip()
+    if not old_root:
+        derived = _derive_old_root(site)
+        if derived:
+            old_root = derived
+            print(f"stamp missing; old root derived from editable pointers: {old_root}")
     new_root = str(root)
     if old_root and old_root.rstrip("\\/") != new_root.rstrip("\\/"):
-        site = root / "venv" / "Lib" / "site-packages"
         pairs = list(zip(_variants(old_root.rstrip("\\/")), _variants(new_root), strict=True))
         touched = 0
         for pattern in ("*.pth", "__editable__*.py"):

--- a/projects/black-pool-agent/deploy/launcher.cmd
+++ b/projects/black-pool-agent/deploy/launcher.cmd
@@ -1,16 +1,14 @@
 @echo off
-rem 双击防闪退外壳：把真正的执行放进 cmd /k 子窗——后面任何一步出事（含批处理
-rem 语法错这种 pause 都来不及跑的死法），窗口都停住可读；成功路径用 exit 0 关窗。
+rem Keep-window shell: rerun inside cmd /k so ANY failure stays readable.
 if not defined SC_LAUNCHER_KEEPWIN (
   set "SC_LAUNCHER_KEEPWIN=1"
   cmd /d /k call "%~f0" %*
   exit /b
 )
-rem Black Pool（黑池）便携整包启动器（cmd 批处理，零 PowerShell）。
-rem 合箱布局：python\（uv 托管 CPython）、venv\、app\（组装源树）、desktop\（win-unpacked）、
-rem home\（HERMES_HOME）与本文件同级。默认拉起 desktop；CLI 用法 launcher.cmd cli <args>。
-rem 自诊断：全程写 launcher.log；任何一步失败都停窗展示原因（不再闪退吞错）；
-rem desktop 由 launch_desktop.py 监督式拉起（捕获输出 + 探活 + 软渲染重试，治黑屏一闪即终）。
+rem Black Pool portable launcher (plain cmd, no PowerShell).
+rem Layout: python\ venv\ app\ desktop\ home\ next to this file.
+rem NOTE: keep rem lines ASCII-short - long UTF-8 comments desync the
+rem cmd parser under chcp 65001 (field-proven 2026-08-03).
 setlocal EnableExtensions
 chcp 65001 >nul
 set "ROOT=%~dp0"
@@ -19,14 +17,12 @@ echo [%date% %time%] launcher start ROOT=%ROOT% > "%LOG%"
 echo Black Pool 启动中，请稍候（本窗会显示进度，失败会停窗给出原因）...
 
 set "HERMES_HOME=%ROOT%home"
-rem 应用显示名（上游官方旋钮）：main.ts 的 APP_NAME 行因含 HERMES_ 被换装规则
-rem 跳线保留，兜底值仍是 'Hermes'——app.setName / About 面板 / 菜单标签全跟它走，
-rem 任务管理器与 Alt-Tab 因此漏显 Hermes。经环境针覆盖为 Black Pool（零侵入）。
+rem Display-name pin (upstream official knob).
 set "HERMES_DESKTOP_APP_NAME=Black Pool"
 set "PATH=%ROOT%venv\Scripts;%PATH%"
 if not exist "%HERMES_HOME%" mkdir "%HERMES_HOME%"
 
-rem -- 步骤 1：定位包内便携 CPython --
+rem -- step 1: locate bundled CPython --
 set "PYHOME="
 for /d %%D in ("%ROOT%python\cpython-*") do set "PYHOME=%%~fD"
 if not defined PYHOME (
@@ -38,7 +34,7 @@ if not defined PYHOME (
 )
 echo [ok] PYHOME=%PYHOME% >> "%LOG%"
 
-rem -- 步骤 2：venv 自愈（pyvenv.cfg home 指回当前位置；幂等） --
+rem -- step 2: venv self-heal (idempotent) --
 "%PYHOME%\python.exe" "%ROOT%fix_venv_path.py" "%ROOT%." >> "%LOG%" 2>&1
 if errorlevel 1 (
   echo [FAIL] fix_venv_path failed >> "%LOG%"
@@ -47,7 +43,7 @@ if errorlevel 1 (
   exit /b 1
 )
 
-rem -- 步骤 3：运行时健康自检（真启动 CLI 入口） --
+rem -- step 3: runtime import check --
 "%ROOT%venv\Scripts\python.exe" -c "import hermes_cli" >> "%LOG%" 2>&1
 if errorlevel 1 (
   echo [FAIL] runtime import check failed >> "%LOG%"
@@ -58,14 +54,14 @@ if errorlevel 1 (
 echo [ok] runtime import check passed >> "%LOG%"
 echo 运行时自检通过。
 
-rem -- CLI 模式：launcher.cmd cli <args> --
+rem -- CLI mode: launcher.cmd cli <args> --
 if /i "%~1"=="cli" (
   shift
   "%ROOT%venv\Scripts\hermes.exe" %2 %3 %4 %5 %6 %7 %8 %9
   exit /b %errorlevel%
 )
 
-rem -- 步骤 4：监督式拉起 desktop（捕获输出 + 探活 + 软渲染重试；未找到则回退 CLI） --
+rem -- step 4: supervised desktop start (fallback: CLI) --
 if not exist "%ROOT%launch_desktop.py" goto legacy_start
 if exist "%ROOT%desktop" (
   echo 正在启动桌面端，自检守窗约 25 秒，窗口正常出现后本窗自动关闭...
@@ -82,8 +78,7 @@ if exist "%ROOT%desktop" (
 goto cli_fallback
 
 :legacy_start
-rem 旧包没有监督器时的兜底（本文件可单独拷进旧 SilverCore 直接用）：
-rem 直接拉起 desktop，窗口停住等守密人确认桌面端是否出现。
+rem Fallback for bundles without the supervisor script.
 set "DESKTOP_EXE="
 for %%F in ("%ROOT%desktop\*.exe") do if not defined DESKTOP_EXE set "DESKTOP_EXE=%%~fF"
 if defined DESKTOP_EXE (

--- a/tests/test_bpa_dev_kit.py
+++ b/tests/test_bpa_dev_kit.py
@@ -115,5 +115,39 @@ def test_kit_has_zero_intranet_values(name):
 
 
 def test_kit_files_complete():
-    for name in ["assemble.cmd", "deploy.cmd", "rollback.cmd", "apply_patch.py", "RUNBOOK.md"]:
+    for name in ["assemble.cmd", "deploy.cmd", "rollback.cmd", "apply_patch.py",
+                 "RUNBOOK.md", "launcher.cmd", "launch_desktop.py", "fix_venv_path.py"]:
         assert (KIT / name).is_file(), f"bpa-dev 套件缺件: {name}"
+
+
+def test_fix_venv_path_derives_old_root_without_stamp(tmp_path):
+    """2026-08-03 内网首部署野战回归：bundle-root.txt 印章缺失时，旧根必须能从
+    editable 指针文件反推——否则自愈整段跳过、导入自检必挂。"""
+    (tmp_path / "python" / "cpython-3.11.14-test").mkdir(parents=True)
+    site = tmp_path / "venv" / "Lib" / "site-packages"
+    site.mkdir(parents=True)
+    (tmp_path / "venv" / "pyvenv.cfg").write_text(
+        "home = C:\\old\\python\nversion = 3.11\n", encoding="utf-8")
+    (site / "x.pth").write_text("D:\\a\\ws\\BlackPool\\app\n", encoding="utf-8")
+    (site / "__editable__.hermes.py").write_text(
+        "M = {'hermes_cli': 'D:\\\\a\\\\ws\\\\BlackPool\\\\app\\\\hermes_cli'}\n",
+        encoding="utf-8")
+    r = subprocess.run([sys.executable, str(KIT / "fix_venv_path.py"), str(tmp_path)],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    assert "derived from editable pointers" in r.stdout
+    assert "BlackPool" not in (site / "x.pth").read_text(encoding="utf-8")
+    assert "BlackPool" not in (site / "__editable__.hermes.py").read_text(encoding="utf-8")
+    assert (tmp_path / "bundle-root.txt").read_text(encoding="utf-8").strip() == str(tmp_path)
+    r2 = subprocess.run([sys.executable, str(KIT / "fix_venv_path.py"), str(tmp_path)],
+                        capture_output=True, text=True)
+    assert r2.returncode == 0, "二跑必须幂等直通"
+
+
+def test_launcher_rem_lines_are_ascii_short():
+    """chcp 65001 解析器错位野战回归：launcher.cmd 的 rem 行必须 ASCII 且不超长。"""
+    for line in (KIT / "launcher.cmd").read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if s.lower().startswith("rem"):
+            assert s.isascii(), f"launcher.cmd rem 行含非 ASCII（65001 错位风险）: {s[:60]}"
+            assert len(s) <= 100, f"launcher.cmd rem 行超长: {s[:60]}"


### PR DESCRIPTION
守密人内网首次实机部署暴露两处真实故障（launcher.log 取证）：

1. **导入自检失败（真死因）**：部署树里 `bundle-root.txt` 印章缺失 → editable 指针自愈整段跳过 → venv 指针仍指 GitHub 装配机路径 → `import hermes_cli` 必挂。`fix_venv_path.py` 升级**无印章自愈**：旧根直接从 editable 指针文件反推（路径去尾段 `\app` 取众数），印章从必需品降级为加速缓存。
2. **注释碎片被当命令执行**：chcp 65001 下 cmd 解析器在长 UTF-8 注释内错位断行（`'es。经环境针覆盖为' is not recognized…`）。launcher.cmd 的 rem 行全部改短 ASCII，用户面中文 echo 保留。
3. **套件权威启动器族**：assemble.cmd 组装时用套件版 launcher / 监督器 / venv 自愈覆盖包内版——部署件修复即刻抵达用户，不必等新 zip 重发（386MB 重下载省了）。

守卫扩至 14 例，含两处野战回归（无印章反推 + rem 行 ASCII 短行断言）。全量 pytest 3,296 通过。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_