### PR TITLE
launcher 双模：车间里双击自动转发部署位

### DIFF
--- a/projects/black-pool-agent/deploy/RUNBOOK.md
+++ b/projects/black-pool-agent/deploy/RUNBOOK.md
@@ -39,6 +39,8 @@ E:\BIAV-BP\bpa-dev\   （内部开发目录；部署目录 = E:\BIAV-BP\black-po
    则整棵树搬盘符零改配置；绝对路径如 `E:\BIAV-BP\black-pool-agent` 亦可。写好后**双击即部署**，rollback 同理）：旧 `home\` 用户数据增量并入
    新包（不覆盖注入的配置）→ 旧版让位 `<目录>.old` 回滚位 → 成品上位。
 3. **回滚** `rollback.cmd <部署目录>`：一键回切 `.old`，问题版留 `.failed-*` 供取证。
+4. **启动**：部署位双击 `launcher.cmd`；或直接双击**车间里的** `deploy\launcher.cmd`——
+   它检测到自己不在包内时，会按 `config\deploy-target.txt` 自动转发到部署位（kit 模式零写入）。
 
 ## 纪律（写给将来的自己）
 

--- a/projects/black-pool-agent/deploy/launcher.cmd
+++ b/projects/black-pool-agent/deploy/launcher.cmd
@@ -12,6 +12,26 @@ rem cmd parser under chcp 65001 (field-proven 2026-08-03).
 setlocal EnableExtensions
 chcp 65001 >nul
 set "ROOT=%~dp0"
+rem Kit mode: launched from the workshop (no bundle here) - dispatch to
+rem the deployed bundle named by config\deploy-target.txt. No writes in
+rem kit mode (this dir may be a read-only vendor external).
+if exist "%ROOT%python\" goto in_bundle
+if not exist "%ROOT%..\config\deploy-target.txt" goto in_bundle
+set /p BPA_TARGET=<"%ROOT%..\config\deploy-target.txt"
+set "_ABS="
+if "%BPA_TARGET:~1,1%"==":" set "_ABS=1"
+if "%BPA_TARGET:~0,2%"=="\\" set "_ABS=1"
+if not defined _ABS set "BPA_TARGET=%ROOT%..\%BPA_TARGET%"
+for %%I in ("%BPA_TARGET%") do set "BPA_TARGET=%%~fI"
+if not exist "%BPA_TARGET%\launcher.cmd" (
+  echo 启动失败：部署位 %BPA_TARGET% 里没有 launcher.cmd（先跑 assemble + deploy）。
+  pause
+  exit /b 1
+)
+echo 车间入口：转至部署位 %BPA_TARGET% ...
+call "%BPA_TARGET%\launcher.cmd" %*
+exit /b %errorlevel%
+:in_bundle
 set "LOG=%ROOT%launcher.log"
 echo [%date% %time%] launcher start ROOT=%ROOT% > "%LOG%"
 echo Black Pool 启动中，请稍候（本窗会显示进度，失败会停窗给出原因）...

--- a/tests/test_bpa_dev_kit.py
+++ b/tests/test_bpa_dev_kit.py
@@ -144,6 +144,15 @@ def test_fix_venv_path_derives_old_root_without_stamp(tmp_path):
     assert r2.returncode == 0, "二跑必须幂等直通"
 
 
+def test_launcher_kit_mode_dispatch_present():
+    """车间双模入口（守密人 2026-08-03 诉求）：kit 里双击 launcher 须能经
+    deploy-target.txt 转发到部署位，且 kit 模式零写入（vendor 外链只读）。"""
+    text = (KIT / "launcher.cmd").read_text(encoding="utf-8")
+    assert "deploy-target.txt" in text and ":in_bundle" in text, (
+        "launcher.cmd 车间转发模式缺失"
+    )
+
+
 def test_launcher_rem_lines_are_ascii_short():
     """chcp 65001 解析器错位野战回归：launcher.cmd 的 rem 行必须 ASCII 且不超长。"""
     for line in (KIT / "launcher.cmd").read_text(encoding="utf-8").splitlines():


### PR DESCRIPTION
守密人诉求：`bpa-dev\deploy\launcher.cmd` 应能直接用。落地双模：

- **包内模式**（身边有 `python\`）：行为原样不变。
- **车间模式**（身边无包）：读 `config\deploy-target.txt`（相对路径按车间根解析）自动 `call` 部署位的 launcher——车间里双击即启动部署好的 Black Pool；kit 模式**零写入**（vendor 外链只读纪律）；部署位没货时停窗提示先跑 assemble + deploy。

守卫 +1（转发模式在位断言），套件测试 15 例绿。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_