### PR TITLE
鎏金主题 + 字标字体修复 + 本地安装卡隐藏 + 图标入口（守密人四项）

### DIFF
--- a/projects/black-pool-agent/BRANDING.md
+++ b/projects/black-pool-agent/BRANDING.md
@@ -35,6 +35,9 @@
 | **审计轮二（2026-08-03 Sonnet 七断面动态编排 + 主循环终审）** | 后置规则八条：① `hermes update` 便携硬门禁（无 .git 的 win32 ZIP 兜底会拉未换装上游整树覆盖——字面撤销全部品牌补丁；文书 §2.4 从文档纪律升格代码门禁）② Billing 深路由封死（`?tab=billing` + 计费故障自动跳转两条暗道，从 `SETTINGS_VIEWS` 摘除）③ Help > Check for Updates 菜单整项摘除（三处自更新入口最后一处）④ Gateway Cloud 连接模式卡隐藏（portal.nousresearch.com OAuth 无对象）⑤ Telegram Quick setup 列隐藏（托管 Bot 固定代理 Nous 自营 SaaS，内网不可达却挂 recommended）⑥⑦ AUMID + appId 中性化 `com.biav.silvercore`（全小写躲过裸词规则，Windows 通知设置直接显示原始串）⑧ 唤醒词帮助文案中性化（裸词规则教出 "Hey Silver Core" 但声学模型只认 "hey hermes"）+ CLI `⚕ Hermes` 面板残留收尾；哨兵 `test_rebrand_audit_round2_rules_alive` | 8 条 |
 | **首启服务商引导跳过（守密人 2026-08-03 内网首部署实机裁定「首次部署推荐肯定不合适，跳过这个环节」）** | 私有版规则：引导头牌 Nous Portal 云订阅内网无对象，`readCachedSkipped` 恒真 = 视同已选「稍后再选」直接进应用；设置页手动配服务商（manual 通道）不受影响 | 1 处 |
 | **About 版本区重排（守密人 2026-08-03 两问对齐裁定）** | ①标题维持 Black Pool Desktop ②黑池版本为主：主版本行渲染 `0.1.0`（借 i18n version 模板各语种自适），出身行「B.I.A.V. Studio 出品 · 基于 Hermes Agent <上游版本> 定制」——上游版本仅出现一次、动态渲染移 pin 免改词 | 2 行 |
+| **品牌字体加载修复（守密人 2026-08-03 实机发现字标回退无衬线）** | 装配日志实锤 `didn't resolve at build time`：上游 CSS 按 monorepo 根 node_modules 写字体路径、我方装配只在 apps/desktop 里 npm ci——公版规则改指应用自身 node_modules，Collapse-Bold 构建期内嵌 | 1 处 |
+| **默认配色黑池金（守密人 2026-08-03 配色裁定，对标黑池终端参考图）** | 公版规则：新增内建主题 `black-pool`（浅 = 金×米白 / 深 = 金×暖黑，全 24 令牌双貌）并设 `DEFAULT_SKIN_NAME`；上游六款主题保留可选 | 1 主题 |
+| **本地安装卡隐藏（守密人 2026-08-03「安装默认地址还没品牌化」反馈）** | 私有版规则：真实安装路径属功能标识（小写 hermes 目录红线不碰、显示造假更不可）；便携包后端随包自带，「本地安装」整卡无对象且会拉未换装上游——整卡连路径行摘除，「连接现有网关」保留 | 2 处 |
 | **默认语言简体中文（守密人 2026-08-03 裁定）** | 基座层后置规则：desktop 缺省 locale 单一真相源 `DEFAULT_LOCALE` `'en'`→`'zh'`（无系统语言探测，配置未设时生效；已设用户不受影响）；公私两版同得（语言偏好属产品定制非内网适配）；哨兵入 `test_brand_patch_sentinels` | 1 处 |
 
 **审计轮二观察项（未处理，供守密人裁夺）**：`hermes uninstall` 的桌面产物探测硬编码 `Hermes` 目录名、换装后找不到 `Silver Core` 实际产物（便携形态卸载 = 删目录，实害近零）；Remote/SSH 报错文案四语种引导 `hermes-agent.nousresearch.com/install.sh`（内网不可达，正确措辞需产品口径，暂记账）；pet 精灵素材仍为上游吉祥物（前轮已记）。

--- a/projects/black-pool-agent/build/rebrand.py
+++ b/projects/black-pool-agent/build/rebrand.py
@@ -66,7 +66,7 @@ BARE_WORD_RE = re.compile(r"(?<![A-Za-z0-9_-])Hermes(?![A-Za-z0-9_-])")
 # .html 在列（2026-08-02 补漏）：desktop/web/bootstrap-installer 的 <title> 是
 # 任务栏 / Alt-Tab 显示名的实际来源（Electron 加载页面后 document.title 覆盖窗口题）。
 TEXT_SUFFIXES = {".py", ".ts", ".tsx", ".js", ".mjs", ".sh", ".yaml", ".yml", ".json",
-                 ".html"}
+                 ".html", ".css"}  # .css 2026-08-03 补入：字体路径修复规则的载体
 
 # ============================= 公版（品牌层） =============================
 
@@ -100,6 +100,72 @@ GENERIC_RULES = [
 
 # 公版后置全文规则（逐行规则之后对全文应用）：纯品牌一致性修复——
 # 插入体里允许保留 "Hermes" 字样（来源事实陈述），不会被后续规则二次换装。
+# Black Pool 内建主题 TS 体（注入 themes/presets.ts，见下方配色规则）
+BLACK_POOL_THEME_TS = """/** Black Pool（黑池）— 鎏金双貌：暖黑之金与米白之金（守密人 2026-08-03 配色裁定）。 */
+export const blackPoolTheme: DesktopTheme = {
+  name: 'black-pool',
+  label: 'Black Pool',
+  description: '黑池金 — 暖黑与米白双貌',
+  colors: {
+    background: '#F7F1E1',
+    foreground: '#332B18',
+    card: '#FCF8EC',
+    cardForeground: '#332B18',
+    muted: '#EFE7D2',
+    mutedForeground: '#8C8063',
+    popover: '#FBF6E9',
+    popoverForeground: '#332B18',
+    primary: '#C9A857',
+    primaryForeground: '#241C07',
+    secondary: '#F0E6CC',
+    secondaryForeground: '#4A3F24',
+    accent: '#EEE1BE',
+    accentForeground: '#4A3C1C',
+    border: '#DDD1AE',
+    input: '#D6C89F',
+    ring: '#B08E35',
+    midground: '#8F6F26',
+    composerRing: '#B08E35',
+    destructive: '#B4372E',
+    destructiveForeground: '#FEF2F2',
+    sidebarBackground: '#F2EBD6',
+    sidebarBorder: '#E0D5B2',
+    userBubble: '#F1E8CE',
+    userBubbleBorder: '#DECFA3'
+  },
+  darkColors: {
+    background: '#171310',
+    foreground: '#E9E0C9',
+    card: '#1E1913',
+    cardForeground: '#E9E0C9',
+    muted: '#262015',
+    mutedForeground: '#9C9074',
+    popover: '#211B14',
+    popoverForeground: '#E9E0C9',
+    primary: '#D6B877',
+    primaryForeground: '#241C07',
+    secondary: '#2A2314',
+    secondaryForeground: '#D9CDA8',
+    accent: '#2E2716',
+    accentForeground: '#E2D4A8',
+    border: '#332B1A',
+    input: '#2A2416',
+    ring: '#D6B877',
+    midground: '#D9B96A',
+    composerRing: '#D6B877',
+    destructive: '#C0473A',
+    destructiveForeground: '#FEF2F2',
+    sidebarBackground: '#120F0A',
+    sidebarBorder: '#292214',
+    userBubble: '#231D11',
+    userBubbleBorder: '#3B3220'
+  }
+}
+
+export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
+  'black-pool': blackPoolTheme,
+  nous: nousTheme,"""
+
 BRAND_POST_RULES = [
     # About 页出身声明 + 品牌版本号（守密人 2026-08-02 裁定「直接说明定制版本」；
     # 2026-08-03 裁定加发布版本号 0.1.0）：锚定 about-settings.tsx 版本行 JSX，
@@ -154,6 +220,25 @@ BRAND_POST_RULES = [
     (
         "⚕ Hermes",
         f"⚕ {BRAND}",
+    ),
+    # 品牌字体加载修复（守密人 2026-08-03 实机发现字标回退无衬线；装配日志实锤
+    # "didn't resolve at build time"）：上游 CSS 按 monorepo 根 node_modules 写
+    # 路径、官方从根装依赖故可解析；本装配只在 apps/desktop 里 npm ci——改指
+    # 应用自己的 node_modules，构建期即内嵌字体。
+    (
+        "url('../../../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2')",
+        "url('../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2')",
+    ),
+    # 默认配色方案（守密人 2026-08-03 裁定：对标黑池终端的鎏金双貌）：
+    # 新增内建主题 black-pool（浅 = 金×米白 / 深 = 金×暖黑）并设为默认皮肤；
+    # 上游六款主题保留可选。取色自守密人参考图。
+    (
+        "export const BUILTIN_THEMES: Record<string, DesktopTheme> = {\n  nous: nousTheme,",
+        BLACK_POOL_THEME_TS,
+    ),
+    (
+        "export const DEFAULT_SKIN_NAME = 'nous'",
+        "export const DEFAULT_SKIN_NAME = 'black-pool'",
     ),
     # 默认语言简体中文（守密人 2026-08-03 裁定）：desktop 全局缺省 locale 单一
     # 真相源改 'zh'——无系统语言探测，配置未设时生效；用户已设语言不受影响。
@@ -307,6 +392,43 @@ INTRANET_POST_RULES = [
     # 引导头牌是 Nous Portal 云订阅（内网无对象）。readCachedSkipped 只喂首启
     # 自动弹层（firstRunSkipped 初始态），恒真即「视同已点过稍后再选」；
     # 设置页手动配服务商走 manual 通道，不受影响。
+    # 本地安装卡隐藏（守密人 2026-08-03「安装默认地址还没品牌化」实机反馈）：
+    # 真实安装路径是功能标识（小写 hermes 目录，红线不碰、显示造假更不可）；
+    # 便携包后端随包自带，「本地安装」整卡无对象且会拉未换装上游——整卡摘除，
+    # 路径行随卡消失；「连接到现有网关」保留。
+    (
+        '            </button>\n'
+        '\n'
+        '            <button\n'
+        '              className="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-4 text-left transition hover:bg-(--chrome-action-hover) disabled:cursor-wait disabled:opacity-60"\n'
+        '              disabled={localStarting}\n',
+        '            </button>\n'
+        '\n'
+        '            {/* 便携包后端随包自带——本地安装卡隐藏（审计轮三） */}\n'
+        '            {false && (\n'
+        '            <button\n'
+        '              className="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-4 text-left transition hover:bg-(--chrome-action-hover) disabled:cursor-wait disabled:opacity-60"\n'
+        '              disabled={localStarting}\n',
+    ),
+    (
+        '              <p className="mt-2 text-sm leading-5 text-muted-foreground">{copy.installLocalDesc}</p>\n'
+        '            </button>\n'
+        '          </div>\n',
+        '              <p className="mt-2 text-sm leading-5 text-muted-foreground">{copy.installLocalDesc}</p>\n'
+        '            </button>\n'
+        '            )}\n'
+        '          </div>\n',
+    ),
+    (
+        '          <div className="mt-6 text-xs text-muted-foreground">\n'
+        "            {copy.installTo}{' '}\n"
+        '            <code className="font-mono text-(--ui-text-secondary)">{state.setupChoice.activeRoot}</code>\n'
+        '          </div>\n',
+        '          {false && <div className="mt-6 text-xs text-muted-foreground">\n'
+        "            {copy.installTo}{' '}\n"
+        '            <code className="font-mono text-(--ui-text-secondary)">{state.setupChoice.activeRoot}</code>\n'
+        '          </div>}\n',
+    ),
     (
         "function readCachedSkipped(): boolean {\n"
         "  if (typeof window === 'undefined') {\n"

--- a/projects/black-pool-agent/deploy/RUNBOOK.md
+++ b/projects/black-pool-agent/deploy/RUNBOOK.md
@@ -39,7 +39,8 @@ E:\BIAV-BP\bpa-dev\   （内部开发目录；部署目录 = E:\BIAV-BP\black-po
    则整棵树搬盘符零改配置；绝对路径如 `E:\BIAV-BP\black-pool-agent` 亦可。写好后**双击即部署**，rollback 同理）：旧 `home\` 用户数据增量并入
    新包（不覆盖注入的配置）→ 旧版让位 `<目录>.old` 回滚位 → 成品上位。
 3. **回滚** `rollback.cmd <部署目录>`：一键回切 `.old`，问题版留 `.failed-*` 供取证。
-4. **启动**：部署位双击 `launcher.cmd`；或直接双击**车间里的** `deploy\launcher.cmd`——
+4. **启动**：deploy 会在部署位生成带图标的 **`Black Pool.lnk`**（图标取自主程序，可拷到桌面/任务栏）；
+   或双击 `launcher.cmd`；或直接双击**车间里的** `deploy\launcher.cmd`——
    它检测到自己不在包内时，会按 `config\deploy-target.txt` 自动转发到部署位（kit 模式零写入）。
 
 ## 纪律（写给将来的自己）

--- a/projects/black-pool-agent/deploy/deploy.cmd
+++ b/projects/black-pool-agent/deploy/deploy.cmd
@@ -52,6 +52,13 @@ move "%B%" "%BPA_DIR%" >nul || (
   echo 部署失败：成品搬运出错；旧版仍在 %BPA_DIR%.old 可手工恢复。
   echo 详情见 %LOG% & pause & exit /b 1
 )
+rem -- one-click icon entry: "Black Pool.lnk" next to launcher (icon from the exe) --
+set "BPA_EXE="
+for %%F in ("%BPA_DIR%\desktop\*.exe") do if not defined BPA_EXE set "BPA_EXE=%%~fF"
+if defined BPA_EXE (
+  cscript //nologo "%SD%make-shortcut.vbs" "%BPA_DIR%\Black Pool.lnk" "%BPA_DIR%\launcher.cmd" "%BPA_DIR%" "%BPA_EXE%,0" >nul 2>&1 && echo 已生成带图标入口：Black Pool.lnk（可拷到桌面）
+)
+
 echo.
 echo 部署完成：%BPA_DIR%   （回滚位：%BPA_DIR%.old，rollback.cmd 一键回切）
 echo 启动：双击 %BPA_DIR%\launcher.cmd

--- a/projects/black-pool-agent/deploy/make-shortcut.vbs
+++ b/projects/black-pool-agent/deploy/make-shortcut.vbs
@@ -1,0 +1,9 @@
+' Black Pool shortcut maker (stock WSH, no PowerShell).
+' Usage: cscript //nologo make-shortcut.vbs <lnk-path> <target> <workdir> <icon>
+Set sh = CreateObject("WScript.Shell")
+Set lnk = sh.CreateShortcut(WScript.Arguments(0))
+lnk.TargetPath = WScript.Arguments(1)
+lnk.WorkingDirectory = WScript.Arguments(2)
+lnk.IconLocation = WScript.Arguments(3)
+lnk.Description = "Black Pool"
+lnk.Save

--- a/projects/black-pool-agent/patches/black-pool-intranet.patch
+++ b/projects/black-pool-agent/patches/black-pool-intranet.patch
@@ -99,6 +99,40 @@ index 8dccf3a..87d04b5 100644
        {
          active: activeView === 'providers',
          children: [
+diff --git a/apps/desktop/src/components/desktop-install-overlay.tsx b/apps/desktop/src/components/desktop-install-overlay.tsx
+index aedde11..71991ed 100644
+--- a/apps/desktop/src/components/desktop-install-overlay.tsx
++++ b/apps/desktop/src/components/desktop-install-overlay.tsx
+@@ -421,6 +421,8 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
+               <p className="mt-2 text-sm leading-5 text-muted-foreground">{copy.connectExistingDesc}</p>
+             </button>
+ 
++            {/* 便携包后端随包自带——本地安装卡隐藏（审计轮三） */}
++            {false && (
+             <button
+               className="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-4 text-left transition hover:bg-(--chrome-action-hover) disabled:cursor-wait disabled:opacity-60"
+               disabled={localStarting}
+@@ -451,6 +453,7 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
+               </div>
+               <p className="mt-2 text-sm leading-5 text-muted-foreground">{copy.installLocalDesc}</p>
+             </button>
++            )}
+           </div>
+ 
+           {localStartError ? (
+@@ -460,10 +463,10 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
+             </div>
+           ) : null}
+ 
+-          <div className="mt-6 text-xs text-muted-foreground">
++          {false && <div className="mt-6 text-xs text-muted-foreground">
+             {copy.installTo}{' '}
+             <code className="font-mono text-(--ui-text-secondary)">{state.setupChoice.activeRoot}</code>
+-          </div>
++          </div>}
+         </div>
+       </div>
+     )
 diff --git a/apps/desktop/src/store/onboarding.ts b/apps/desktop/src/store/onboarding.ts
 index 6fbf294..1ecaaf9 100644
 --- a/apps/desktop/src/store/onboarding.ts

--- a/projects/black-pool-agent/patches/black-pool-rebrand.patch
+++ b/projects/black-pool-agent/patches/black-pool-rebrand.patch
@@ -500,6 +500,25 @@ index e2a9522..05b9188 100644
    { name: 'dependencies', title: 'Python dependencies' },
    { name: 'node', title: 'Node runtime' },
    { name: 'desktop', title: 'Desktop app' }
+diff --git a/apps/bootstrap-installer/src/styles.css b/apps/bootstrap-installer/src/styles.css
+index c999a20..85dd347 100644
+--- a/apps/bootstrap-installer/src/styles.css
++++ b/apps/bootstrap-installer/src/styles.css
+@@ -1,11 +1,11 @@
+ /*
+- * Hermes Setup — defer entirely to the desktop's styles.css.
++ * Black Pool Setup — defer entirely to the desktop's styles.css.
+  *
+- * Rather than re-implement the Hermes design system (and inevitably drift
++ * Rather than re-implement the Black Pool design system (and inevitably drift
+  * from it), we import apps/desktop/src/styles.css wholesale. The desktop
+  * is the canonical source of truth for fonts, color tokens, button chrome,
+  * scrollbars, layout utilities, and animations. Any change to the
+- * Hermes look propagates here automatically with no copy-paste maintenance.
++ * Black Pool look propagates here automatically with no copy-paste maintenance.
+  *
+  * Path resolution caveats:
+  *   - Tailwind v4's `@import` resolves relative to this file. The desktop's
 diff --git a/apps/bootstrap-installer/vite.config.ts b/apps/bootstrap-installer/vite.config.ts
 index f0a0a31..03992a6 100644
 --- a/apps/bootstrap-installer/vite.config.ts
@@ -40105,6 +40124,19 @@ index 8f214f8..4d92f25 100644
    }
  
    return method === 'wake.start'
+diff --git a/apps/desktop/src/styles.css b/apps/desktop/src/styles.css
+index 95eeebe..7cd4000 100644
+--- a/apps/desktop/src/styles.css
++++ b/apps/desktop/src/styles.css
+@@ -30,7 +30,7 @@
+   font-style: normal;
+   font-weight: 700;
+   font-display: swap;
+-  src: url('../../../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2') format('woff2');
++  src: url('../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2') format('woff2');
+ }
+ 
+ /* JetBrains Mono — bundled terminal font (Apache-2.0) so bold/italic share the
 diff --git a/apps/desktop/src/themes/backend-sync.test.ts b/apps/desktop/src/themes/backend-sync.test.ts
 index 3733331..ba40887 100644
 --- a/apps/desktop/src/themes/backend-sync.test.ts
@@ -40183,7 +40215,7 @@ index e618534..3190292 100644
    // the choice sticks like any manual pick.
    const pendingSkin = useStore($pendingSkinApply)
 diff --git a/apps/desktop/src/themes/presets.ts b/apps/desktop/src/themes/presets.ts
-index 4643818..81e8eba 100644
+index 4643818..c9c9f18 100644
 --- a/apps/desktop/src/themes/presets.ts
 +++ b/apps/desktop/src/themes/presets.ts
 @@ -27,7 +27,7 @@ const nousTint = (pct: number) => `color-mix(in srgb, ${NOUS_BLUE} ${pct}%, #FFF
@@ -40195,6 +40227,82 @@ index 4643818..81e8eba 100644
   * glass geometry neutral, then lets the old bb/gui blue and psyche cream
   * return as accent seeds.
   */
+@@ -276,7 +276,69 @@ export const slateTheme: DesktopTheme = {
+   }
+ }
+ 
++/** Black Pool（黑池）— 鎏金双貌：暖黑之金与米白之金（守密人 2026-08-03 配色裁定）。 */
++export const blackPoolTheme: DesktopTheme = {
++  name: 'black-pool',
++  label: 'Black Pool',
++  description: '黑池金 — 暖黑与米白双貌',
++  colors: {
++    background: '#F7F1E1',
++    foreground: '#332B18',
++    card: '#FCF8EC',
++    cardForeground: '#332B18',
++    muted: '#EFE7D2',
++    mutedForeground: '#8C8063',
++    popover: '#FBF6E9',
++    popoverForeground: '#332B18',
++    primary: '#C9A857',
++    primaryForeground: '#241C07',
++    secondary: '#F0E6CC',
++    secondaryForeground: '#4A3F24',
++    accent: '#EEE1BE',
++    accentForeground: '#4A3C1C',
++    border: '#DDD1AE',
++    input: '#D6C89F',
++    ring: '#B08E35',
++    midground: '#8F6F26',
++    composerRing: '#B08E35',
++    destructive: '#B4372E',
++    destructiveForeground: '#FEF2F2',
++    sidebarBackground: '#F2EBD6',
++    sidebarBorder: '#E0D5B2',
++    userBubble: '#F1E8CE',
++    userBubbleBorder: '#DECFA3'
++  },
++  darkColors: {
++    background: '#171310',
++    foreground: '#E9E0C9',
++    card: '#1E1913',
++    cardForeground: '#E9E0C9',
++    muted: '#262015',
++    mutedForeground: '#9C9074',
++    popover: '#211B14',
++    popoverForeground: '#E9E0C9',
++    primary: '#D6B877',
++    primaryForeground: '#241C07',
++    secondary: '#2A2314',
++    secondaryForeground: '#D9CDA8',
++    accent: '#2E2716',
++    accentForeground: '#E2D4A8',
++    border: '#332B1A',
++    input: '#2A2416',
++    ring: '#D6B877',
++    midground: '#D9B96A',
++    composerRing: '#D6B877',
++    destructive: '#C0473A',
++    destructiveForeground: '#FEF2F2',
++    sidebarBackground: '#120F0A',
++    sidebarBorder: '#292214',
++    userBubble: '#231D11',
++    userBubbleBorder: '#3B3220'
++  }
++}
++
+ export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
++  'black-pool': blackPoolTheme,
+   nous: nousTheme,
+   midnight: midnightTheme,
+   ember: emberTheme,
+@@ -288,4 +350,4 @@ export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
+ export const BUILTIN_THEME_LIST = Object.values(BUILTIN_THEMES)
+ 
+ /** Skin used when nothing is persisted or the persisted name is retired. */
+-export const DEFAULT_SKIN_NAME = 'nous'
++export const DEFAULT_SKIN_NAME = 'black-pool'
 diff --git a/apps/desktop/src/themes/skin.ts b/apps/desktop/src/themes/skin.ts
 index 61fa711..350083b 100644
 --- a/apps/desktop/src/themes/skin.ts
@@ -44861,6 +44969,26 @@ index 38a5071..a6b4af7 100644
      },
    },
  
+diff --git a/web/src/index.css b/web/src/index.css
+index e4b5e27..808f04d 100644
+--- a/web/src/index.css
++++ b/web/src/index.css
+@@ -43,13 +43,13 @@
+ }
+ 
+ /* ------------------------------------------------------------------ */
+-/* Hermes Agent — Nous DS with the LENS_0 (Hermes teal) palette applied
++/* Black Pool Agent — Nous DS with the LENS_0 (Black Pool teal) palette applied
+    statically as the default dashboard theme. */
+ /* ------------------------------------------------------------------ */
+ 
+ :root {
+   /* LENS_0 — from design-language/src/ui/components/overlays/index.tsx.
+-     These are the defaults for the `default` (Hermes Teal) dashboard theme;
++     These are the defaults for the `default` (Black Pool Teal) dashboard theme;
+      ThemeProvider rewrites them as inline styles when a user switches themes. */
+   --foreground: color-mix(in srgb, #ffffff 0%, transparent);
+   --foreground-base: #ffffff;
 diff --git a/web/src/lib/gatewayClient.ts b/web/src/lib/gatewayClient.ts
 index d5ef547..42b6800 100644
 --- a/web/src/lib/gatewayClient.ts

--- a/tests/test_bpa_dev_kit.py
+++ b/tests/test_bpa_dev_kit.py
@@ -116,7 +116,8 @@ def test_kit_has_zero_intranet_values(name):
 
 def test_kit_files_complete():
     for name in ["assemble.cmd", "deploy.cmd", "rollback.cmd", "apply_patch.py",
-                 "RUNBOOK.md", "launcher.cmd", "launch_desktop.py", "fix_venv_path.py"]:
+                 "RUNBOOK.md", "launcher.cmd", "launch_desktop.py", "fix_venv_path.py",
+                 "make-shortcut.vbs"]:
         assert (KIT / name).is_file(), f"bpa-dev 套件缺件: {name}"
 
 

--- a/tests/test_hermes_charter.py
+++ b/tests/test_hermes_charter.py
@@ -100,6 +100,9 @@ def test_brand_patch_sentinels():
         "唤醒词帮助中性化": "toggle the wake word listener [on|off|status]",
         "CLI 面板残留品牌收尾": "⚕ Black Pool",
         "默认语言简体中文": "DEFAULT_LOCALE: Locale = 'zh'",
+        "品牌字体路径修复（Collapse 构建期内嵌）": "url('../node_modules/@nous-research/ui",
+        "黑池默认主题（鎏金双貌）": "DEFAULT_SKIN_NAME = 'black-pool'",
+        "黑池主题定义在位": "blackPoolTheme",
     }
     missing = [k for k, v in sentinels.items() if v not in text]
     assert not missing, f"公版规则从补丁消失（锚点失配）: {missing}"
@@ -119,6 +122,7 @@ def test_intranet_patch_sentinels():
         "Cloud 连接模式隐藏": "Cloud 连接模式隐藏",
         "Telegram Quick setup 列隐藏": "Quick setup 列隐藏",
         "首启服务商引导跳过": "首启引导跳过（服务商在设置页配）",
+        "本地安装卡隐藏": "本地安装卡隐藏",
     }
     missing = [k for k, v in sentinels.items() if v not in text]
     assert not missing, f"私有版规则从补丁消失（锚点失配）: {missing}"


### PR DESCRIPTION
守密人实机磨合四项一轮落地：

1. **字标字体修复（实锤野战 bug）**：装配日志证实 `Collapse-Bold.woff2 didn't resolve at build time`——上游 CSS 指 monorepo 根 node_modules，我方 per-app `npm ci` 不产该目录。公版规则改指应用自身 node_modules；**真根因**是 `.css` 从不在引擎扫描后缀里（本次补入），规则才有落点。
2. **默认配色黑池金**（对标守密人「黑池终端」参考图）：新增内建主题 `black-pool`——浅色 = 金×米白、深色 = 金×暖黑，全 24 令牌双貌——注册为首位并设 `DEFAULT_SKIN_NAME`；上游六款主题保留可选。
3. **设置屏「本地安装」卡隐藏**（私有版）：真实安装路径属功能标识（小写 hermes 目录红线不碰、显示造假更不可）；便携包后端随包自带，本地安装整卡无对象且会拉未换装上游——整卡连路径行摘除，「连接现有网关」保留。
4. **图标入口**：deploy.cmd 部署时用系统自带 WSH（`make-shortcut.vbs`，零 PowerShell）生成 `Black Pool.lnk`——图标取自主程序 exe，双击体验与 exe 等同、可钉任务栏。

哨兵：公版 12 / 私有版 11；套件测试 15 例。全量 pytest 3,297 通过。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_