### PR TITLE
launcher 接通 env.cmd 内网注入钩（野战发现死钩）

### DIFF
--- a/projects/black-pool-agent/deploy/RUNBOOK.md
+++ b/projects/black-pool-agent/deploy/RUNBOOK.md
@@ -16,6 +16,10 @@ E:\BIAV-BP\bpa-dev\   （内部开发目录；部署目录 = E:\BIAV-BP\black-po
 ├── plugins\       # 黑池专属插件 → 拷入 app\plugins\
 ├── skills\        # 内网技能 → 拷入 home\skills\
 ├── config\        # SOUL.md → home\；env.cmd → 包根；deploy-target.txt = 部署目录地址一行（凭据/端点的唯一的家）
+│                  #   env.cmd 由 launcher 启动时 call——企业根证书/代理等在此注入，例：
+│                  #     set "SSL_CERT_FILE=%~dp0home\corp-ca.pem"
+│                  #     set "REQUESTS_CA_BUNDLE=%SSL_CERT_FILE%"
+│                  #     set "HTTPS_PROXY=..."（按内网实际；真值只写在内网这份文件里）
 ├── overlay\       # 万能覆盖层：内容原样覆盖到包根（以上四类盖不住的任意路径用它）
 ├── staging\       # 组装工作台（脚本自建自清，勿入 SVN）
 └── deploy\        # 本目录：部署件统一收纳（车间脚本 + 启动器家族 + 模板）

--- a/projects/black-pool-agent/deploy/launcher.cmd
+++ b/projects/black-pool-agent/deploy/launcher.cmd
@@ -37,6 +37,8 @@ echo [%date% %time%] launcher start ROOT=%ROOT% > "%LOG%"
 echo Black Pool 启动中，请稍候（本窗会显示进度，失败会停窗给出原因）...
 
 set "HERMES_HOME=%ROOT%home"
+rem Intranet env hook (proxy / corp CA / etc), injected at assemble time.
+if exist "%ROOT%env.cmd" call "%ROOT%env.cmd"
 rem Display-name pin (upstream official knob).
 set "HERMES_DESKTOP_APP_NAME=Black Pool"
 set "PATH=%ROOT%venv\Scripts;%PATH%"


### PR DESCRIPTION
排查 provider TLS 不可达时发现：`config\env.cmd` 是内网注入指定载体（企业根证书 / 代理 / 端点），assemble 会拷进包根——但 launcher 从未 `call` 它，钩子是死的。补上启动时调用；RUNBOOK 以占位示例记载用法（真值只存内网侧）。套件测试 15 例绿。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_