### PR TITLE
按路径杀进程器取代 wmic + cmd 注释全线 ASCII（占用顽症根治轮二）

### DIFF
--- a/projects/black-pool-agent/deploy/assemble.cmd
+++ b/projects/black-pool-agent/deploy/assemble.cmd
@@ -1,8 +1,8 @@
 @echo off
-rem bpa-dev 组装器（通用参数化，零内网值）。放置约定：本套件整目录拷入
-rem 黑池\bpa-dev\scripts\，兄弟目录 ..\releases ..\patches ..\config ..\plugins
-rem ..\skills ..\overlay ..\staging（缺哪个跳哪步，不硬性要求全建）。
-rem 用法：assemble.cmd [zip文件名]   缺省取 ..\releases\ 里最新的 *.zip
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if not defined BPA_KEEPWIN (
   set "BPA_KEEPWIN=1"
   cmd /d /k call "%~f0" %*
@@ -15,7 +15,7 @@ set "DEVROOT=%SD%.."
 set "LOG=%DEVROOT%\assemble.log"
 echo [%date% %time%] assemble start > "%LOG%"
 
-rem -- 1. 选包 --
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 set "ZIP="
 if not "%~1"=="" (
   set "ZIP=%DEVROOT%\releases\%~1"
@@ -33,7 +33,7 @@ if not exist "%ZIP%" (
 echo 进料：%ZIP%
 echo [ok] zip=%ZIP% >> "%LOG%"
 
-rem -- 2. 验货（CHECKSUMS.txt 存在则强制比对 SHA-256）--
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if exist "%DEVROOT%\releases\CHECKSUMS.txt" (
   set "SHA="
   for /f "skip=1 delims=" %%H in ('certutil -hashfile "%ZIP%" SHA256 2^>nul') do if not defined SHA set "SHA=%%H"
@@ -49,7 +49,7 @@ if exist "%DEVROOT%\releases\CHECKSUMS.txt" (
   echo 提示：未做 SHA 验货（..\releases\CHECKSUMS.txt 不存在）。
 )
 
-rem -- 3. 净台解压 --
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if exist "%DEVROOT%\staging" rd /s /q "%DEVROOT%\staging"
 mkdir "%DEVROOT%\staging"
 echo 解压中（约 1 分钟）...
@@ -62,20 +62,20 @@ if not exist "%B%\launcher.cmd" (
   pause & exit /b 1
 )
 
-rem -- 3b. 套件权威启动器族覆盖：部署件修复即刻生效，不必等新 zip --
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 for %%F in (launcher.cmd launch_desktop.py fix_venv_path.py) do (
   if exist "%SD%%%F" copy /y "%SD%%%F" "%B%\%%F" >nul
 )
 echo 启动器族已按套件版覆盖（launcher / 监督器 / venv 自愈）
 
-rem -- 4. 定位包内 Python（补丁应用器的运行时）--
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 set "PYHOME="
 for /d %%D in ("%B%\python\cpython-*") do set "PYHOME=%%~fD"
 if not defined PYHOME (
   echo 组装失败：包内 python\cpython-* 缺失。& pause & exit /b 1
 )
 
-rem -- 5. 打内网补丁（..\patches\*.patch 按名序；全 check 通过才落盘）--
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 set "PATCHED=0"
 if exist "%DEVROOT%\patches\*.patch" (
   for /f "delims=" %%P in ('dir /b /o:n "%DEVROOT%\patches\*.patch"') do (
@@ -88,7 +88,7 @@ if exist "%DEVROOT%\patches\*.patch" (
   )
 )
 
-rem -- 6. 注入配置与插件（存在才拷；凭据只活在内网这几个目录里）--
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if exist "%DEVROOT%\config\SOUL.md" (
   if not exist "%B%\home" mkdir "%B%\home"
   copy /y "%DEVROOT%\config\SOUL.md" "%B%\home\SOUL.md" >nul && echo 已注入 SOUL.md
@@ -106,7 +106,7 @@ if exist "%DEVROOT%\skills" (
 )
 if exist "%DEVROOT%\overlay" robocopy "%DEVROOT%\overlay" "%B%" /e /njh /njs /ndl /nfl >nul & if !errorlevel! geq 8 (echo 组装失败：overlay 拷贝出错 & pause & exit /b 1)
 
-rem -- 7. MANIFEST（来历三行可查）--
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 > "%B%\MANIFEST.txt" (
   echo assembled: %date% %time%
   echo source-zip: %ZIP%

--- a/projects/black-pool-agent/deploy/deploy.cmd
+++ b/projects/black-pool-agent/deploy/deploy.cmd
@@ -1,6 +1,6 @@
 @echo off
-rem bpa-dev 部署器：staging 成品 -> 运行部署位（整目录替换 + 用户数据保全 + 回滚位）。
-rem 用法：deploy.cmd <部署目录>    或预设环境变量 BPA_DIR 后直接双击。
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if not defined BPA_KEEPWIN (
   set "BPA_KEEPWIN=1"
   cmd /d /k call "%~f0" %*
@@ -12,13 +12,13 @@ set "SD=%~dp0"
 set "DEVROOT=%SD%.."
 set "LOG=%DEVROOT%\deploy.log"
 if not "%~1"=="" set "BPA_DIR=%~1"
-rem 目标地址属于「料」：一次写进 config\deploy-target.txt 后即可双击直跑（零参数）
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if not defined BPA_DIR if exist "%DEVROOT%\config\deploy-target.txt" set /p BPA_DIR=<"%DEVROOT%\config\deploy-target.txt"
 if not defined BPA_DIR (
   echo 部署失败：未指定部署目录（参数或环境变量 BPA_DIR）。
   pause & exit /b 1
 )
-rem 相对路径一律按车间根（bpa-dev\）解析——整棵树搬盘符零改配置；绝不按当前窗口目录（会静默指错）
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 set "_ABS="
 if "%BPA_DIR:~1,1%"==":" set "_ABS=1"
 if "%BPA_DIR:~0,2%"=="\\" set "_ABS=1"
@@ -31,19 +31,23 @@ if not exist "%B%\MANIFEST.txt" (
   pause & exit /b 1
 )
 
-rem -- 1. 用户数据保全：旧 home 中新包缺失的文件补进来（不覆盖注入的 SOUL 等）--
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if exist "%BPA_DIR%\home" (
   robocopy "%BPA_DIR%\home" "%B%\home" /e /xc /xn /xo /njh /njs /ndl /nfl >nul
   if errorlevel 8 (echo 部署失败：home 保全拷贝出错。& echo 详情见 %LOG% & pause & exit /b 1)
   echo 用户数据已保全（旧 home 增量并入，不覆盖新配置）
 )
 
-rem -- 2. 自清障轮换（field: every deploy hit dir locks; clear + retry） --
-rem 已知占用者三类：TSVN 图标缓存 / 桌面主程序 / 部署位内自家进程（含后端 python）
+rem -- 2. self-clearing rotation: kill known lockers, then retry --
+rem lockers: TSVN icon cache / desktop exe / any process running FROM the dir
+set "STPY="
+for /d %%D in ("%B%\python\cpython-*") do set "STPY=%%~fD\python.exe"
 taskkill /f /im TSVNCache.exe >nul 2>&1
 set "OLD_EXE="
 for %%F in ("%BPA_DIR%\desktop\*.exe") do if not defined OLD_EXE set "OLD_EXE=%%~nxF"
 if defined OLD_EXE taskkill /f /im "%OLD_EXE%" >nul 2>&1
+rem path-scoped kill via bundled python (wmic is gone on newer Windows)
+if defined STPY "%STPY%" "%SD%kill_by_path.py" "%BPA_DIR%" >> "%LOG%" 2>&1
 set "WQL=%BPA_DIR:\=\\%"
 wmic process where "ExecutablePath like '%WQL%\\%%'" call terminate >nul 2>&1
 ping -n 2 127.0.0.1 >nul
@@ -67,23 +71,24 @@ if exist "%BPA_DIR%" (
   if exist "%BPA_DIR%" (
     set /a _TRIES+=1
     if !_TRIES! geq 5 goto rot_fail
-    echo 旧目录占用中，自动清障后重试 !_TRIES!/5 ...
+    echo 目录占用，清障重试 !_TRIES!/5 ...
     taskkill /f /im TSVNCache.exe >nul 2>&1
     if defined OLD_EXE taskkill /f /im "%OLD_EXE%" >nul 2>&1
+    if defined STPY "%STPY%" "%SD%kill_by_path.py" "%BPA_DIR%" >> "%LOG%" 2>&1
     ping -n 3 127.0.0.1 >nul
     goto rot_move
   )
 )
 goto rot_done
 :rot_fail
-echo 部署失败：清障重试 5 轮后目录仍被占用。
-echo 请关闭浏览过该目录的资源管理器窗口/编辑器，或用 resmon 的
-echo 「CPU - 关联的句柄」搜索目录名找到占用进程后重试。
-echo 详情见 %LOG%
+echo 部署失败：重试 5 轮仍被占用。
+echo 排查：关掉浏览该目录的窗口；
+echo 或 resmon 句柄搜目录名找占用者。
+echo 日志：%LOG%
 pause & exit /b 1
 :rot_done
 
-rem -- 3. 上新 --
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 move "%B%" "%BPA_DIR%" >nul || (
   echo 部署失败：成品搬运出错；旧版仍在 %BPA_DIR%.old 可手工恢复。
   echo 详情见 %LOG% & pause & exit /b 1

--- a/projects/black-pool-agent/deploy/kill_by_path.py
+++ b/projects/black-pool-agent/deploy/kill_by_path.py
@@ -1,0 +1,67 @@
+"""按可执行路径杀进程（bpa-dev 部署件，纯标准库 ctypes 直调 Win32）。
+
+存在理由：deploy 轮换最常见的顽固占用者是部署目录内的自家后端进程
+（python.exe / hermes.exe），按镜像名杀会误伤机器上其他同名进程，
+按路径杀的 wmic 在新版 Windows 已被移除——本器用 EnumProcesses +
+QueryFullProcessImageNameW 精确匹配「可执行文件位于目标目录下」的
+进程并终止，绝不越界。
+
+用法：python kill_by_path.py <目录>   （终止所有 exe 路径在该目录下的进程）
+非 Windows 平台直接空跑退出 0（供测试面校验）。
+"""
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: kill_by_path.py <dir>", file=sys.stderr)
+        return 2
+    if sys.platform != "win32":
+        print("non-windows: no-op")
+        return 0
+
+    import ctypes
+    from ctypes import wintypes
+
+    root = sys.argv[1].replace("/", "\\").rstrip("\\").lower() + "\\"
+    psapi = ctypes.WinDLL("psapi")
+    kernel32 = ctypes.WinDLL("kernel32")
+
+    arr = (wintypes.DWORD * 4096)()
+    needed = wintypes.DWORD()
+    if not psapi.EnumProcesses(arr, ctypes.sizeof(arr), ctypes.byref(needed)):
+        print("EnumProcesses failed", file=sys.stderr)
+        return 1
+    count = needed.value // ctypes.sizeof(wintypes.DWORD)
+    me = kernel32.GetCurrentProcessId()
+
+    PROCESS_TERMINATE = 0x0001
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    killed = 0
+    for pid in arr[:count]:
+        if not pid or pid == me:
+            continue
+        h = kernel32.OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE, False, pid
+        )
+        if not h:
+            continue
+        try:
+            buf = ctypes.create_unicode_buffer(1024)
+            size = wintypes.DWORD(len(buf))
+            if kernel32.QueryFullProcessImageNameW(h, 0, buf, ctypes.byref(size)):
+                path = buf.value.lower()
+                if path.startswith(root):
+                    if kernel32.TerminateProcess(h, 1):
+                        killed += 1
+                        print(f"killed pid={pid} {buf.value}")
+        finally:
+            kernel32.CloseHandle(h)
+    print(f"done: {killed} process(es) under {sys.argv[1]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/black-pool-agent/deploy/rollback.cmd
+++ b/projects/black-pool-agent/deploy/rollback.cmd
@@ -1,6 +1,6 @@
 @echo off
-rem bpa-dev 回滚器：部署位一键回切上一版（.old 回滚位）。
-rem 用法：rollback.cmd <部署目录>    或预设环境变量 BPA_DIR。
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if not defined BPA_KEEPWIN (
   set "BPA_KEEPWIN=1"
   cmd /d /k call "%~f0" %*
@@ -11,13 +11,13 @@ chcp 65001 >nul
 set "SD=%~dp0"
 set "DEVROOT=%SD%.."
 if not "%~1"=="" set "BPA_DIR=%~1"
-rem 目标地址属于「料」：一次写进 config\deploy-target.txt 后即可双击直跑（零参数）
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if not defined BPA_DIR if exist "%DEVROOT%\config\deploy-target.txt" set /p BPA_DIR=<"%DEVROOT%\config\deploy-target.txt"
 if not defined BPA_DIR (
   echo 回滚失败：未指定部署目录（参数或环境变量 BPA_DIR）。
   pause & exit /b 1
 )
-rem 相对路径一律按车间根（bpa-dev\）解析——整棵树搬盘符零改配置；绝不按当前窗口目录（会静默指错）
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 set "_ABS="
 if "%BPA_DIR:~1,1%"==":" set "_ABS=1"
 if "%BPA_DIR:~0,2%"=="\\" set "_ABS=1"
@@ -27,7 +27,7 @@ if not exist "%BPA_DIR%.old" (
   echo 回滚失败：没有回滚位 %BPA_DIR%.old（每次 deploy 只留最近一版）。
   pause & exit /b 1
 )
-rem 轻量清障（与 deploy 同款）：TSVN 缓存与桌面主程序常锁目录
+rem (zh comment moved to RUNBOOK - 65001 parser desync)
 taskkill /f /im TSVNCache.exe >nul 2>&1
 set "RB_EXE="
 for %%F in ("%BPA_DIR%\desktop\*.exe") do if not defined RB_EXE set "RB_EXE=%%~nxF"

--- a/tests/test_bpa_dev_kit.py
+++ b/tests/test_bpa_dev_kit.py
@@ -117,7 +117,7 @@ def test_kit_has_zero_intranet_values(name):
 def test_kit_files_complete():
     for name in ["assemble.cmd", "deploy.cmd", "rollback.cmd", "apply_patch.py",
                  "RUNBOOK.md", "launcher.cmd", "launch_desktop.py", "fix_venv_path.py",
-                 "make-shortcut.vbs"]:
+                 "make-shortcut.vbs", "kill_by_path.py"]:
         assert (KIT / name).is_file(), f"bpa-dev 套件缺件: {name}"
 
 
@@ -154,10 +154,18 @@ def test_launcher_kit_mode_dispatch_present():
     )
 
 
-def test_launcher_rem_lines_are_ascii_short():
-    """chcp 65001 解析器错位野战回归：launcher.cmd 的 rem 行必须 ASCII 且不超长。"""
-    for line in (KIT / "launcher.cmd").read_text(encoding="utf-8").splitlines():
+@pytest.mark.parametrize("name", ["launcher.cmd", "assemble.cmd", "deploy.cmd", "rollback.cmd"])
+def test_cmd_rem_lines_are_ascii_short(name):
+    """chcp 65001 解析器错位野战回归（两案实证）：套件 cmd 的 rem 行必须 ASCII 短行。"""
+    for line in (KIT / name).read_text(encoding="utf-8").splitlines():
         s = line.strip()
         if s.lower().startswith("rem"):
-            assert s.isascii(), f"launcher.cmd rem 行含非 ASCII（65001 错位风险）: {s[:60]}"
-            assert len(s) <= 100, f"launcher.cmd rem 行超长: {s[:60]}"
+            assert s.isascii(), f"{name} rem 行含非 ASCII（65001 错位风险）: {s[:60]}"
+            assert len(s) <= 100, f"{name} rem 行超长: {s[:60]}"
+
+
+def test_kill_by_path_noop_on_non_windows(tmp_path):
+    """路径杀进程器：非 Windows 空跑退出 0（管线可验）；Windows 行为靠野战。"""
+    r = subprocess.run([sys.executable, str(KIT / "kill_by_path.py"), str(tmp_path)],
+                       capture_output=True, text=True)
+    assert r.returncode == 0 and "no-op" in r.stdout


### PR DESCRIPTION
野战轮二：重试机制已在岗但五轮仍锁——真占用者（包内后端 python）没被清掉，因为按路径杀进程的 `wmic` 在新版 Windows 已移除。

- **新套件件 `kill_by_path.py`**：纯标准库 ctypes 直调 Win32（EnumProcesses + QueryFullProcessImageNameW），精确终止「可执行文件位于部署目录下」的进程，绝不误伤同名进程；由 staging 包内 CPython 运行，清障步与每轮重试都调用；wmic 降为备胎。
- **65001 错位第二案**：失败提示块中文长行改短行；三张 cmd 的 rem 注释全线 ASCII 化，守卫测试扩展到整套件。

套件测试 19 例绿。纯套件件，同步镜像 + SVN Update 即用。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_