### PR TITLE
无感原生启动器：Black Pool.exe（内嵌图标，零黑框）

### DIFF
--- a/.github/workflows/assemble-black-pool-bundle.yml
+++ b/.github/workflows/assemble-black-pool-bundle.yml
@@ -94,6 +94,14 @@ jobs:
             echo "config: endpoints/credentials are injected on the intranet side (never bundled)"
           } > BlackPool/BUNDLE-INFO.txt
 
+      - name: Native silent launcher (Black Pool.exe, embedded icon)
+        run: |
+          CSC="/c/Windows/Microsoft.NET/Framework64/v4.0.30319/csc.exe"
+          "$CSC" /nologo /codepage:65001 /target:winexe /win32icon:projects/black-pool-agent/build/brand-assets/icon.ico \
+            /r:System.Windows.Forms.dll /out:"BlackPool/Black Pool.exe" \
+            projects/black-pool-agent/build/black-pool-launcher.cs
+          ls -la "BlackPool/Black Pool.exe"
+
       - name: Relocatability + merge smoke test (moved path, launcher self-heal flow)
         run: |
           mv BlackPool /c/black-pool-smoke

--- a/.github/workflows/assemble-black-pool-public.yml
+++ b/.github/workflows/assemble-black-pool-public.yml
@@ -95,6 +95,14 @@ jobs:
             echo "config: endpoints/credentials are injected on the intranet side (never bundled)"
           } > BlackPool/BUNDLE-INFO.txt
 
+      - name: Native silent launcher (Black Pool.exe, embedded icon)
+        run: |
+          CSC="/c/Windows/Microsoft.NET/Framework64/v4.0.30319/csc.exe"
+          "$CSC" /nologo /codepage:65001 /target:winexe /win32icon:projects/black-pool-agent/build/brand-assets/icon.ico \
+            /r:System.Windows.Forms.dll /out:"BlackPool/Black Pool.exe" \
+            projects/black-pool-agent/build/black-pool-launcher.cs
+          ls -la "BlackPool/Black Pool.exe"
+
       - name: Relocatability + merge smoke test (moved path, launcher self-heal flow)
         run: |
           mv BlackPool /c/black-pool-smoke

--- a/projects/black-pool-agent/build/black-pool-launcher.cs
+++ b/projects/black-pool-agent/build/black-pool-launcher.cs
@@ -1,0 +1,52 @@
+// Black Pool silent native launcher (build/ production piece, zero intranet values).
+// Compiled at assembly time by the stock .NET Framework csc (present on every
+// Windows runner/machine) into "Black Pool.exe" at the bundle root:
+//   /target:winexe  -> windowed subsystem, no console box ever flashes
+//   /win32icon      -> embedded brand icon
+// It runs launcher.cmd hidden (BPA_SILENT suppresses its pauses); on failure it
+// shows a message box and opens launcher.log. Success path is fully silent.
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
+
+static class BlackPoolLauncher
+{
+    [STAThread]
+    static int Main(string[] args)
+    {
+        string root = AppDomain.CurrentDomain.BaseDirectory;
+        string cmd = Path.Combine(root, "launcher.cmd");
+        if (!File.Exists(cmd))
+        {
+            MessageBox.Show("launcher.cmd 缺失，请完整复制整个 BlackPool 目录。",
+                            "Black Pool", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return 1;
+        }
+
+        string extra = args.Length > 0 ? " " + string.Join(" ", args) : "";
+        ProcessStartInfo psi = new ProcessStartInfo();
+        psi.FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe";
+        psi.Arguments = "/d /c call \"" + cmd + "\"" + extra;
+        psi.WorkingDirectory = root;
+        psi.UseShellExecute = false;
+        psi.CreateNoWindow = true;
+        psi.EnvironmentVariables["SC_LAUNCHER_KEEPWIN"] = "1"; // skip cmd /k re-wrap
+        psi.EnvironmentVariables["BPA_SILENT"] = "1";          // suppress pauses
+
+        Process p = Process.Start(psi);
+        p.WaitForExit();
+        if (p.ExitCode != 0)
+        {
+            string log = Path.Combine(root, "launcher.log");
+            MessageBox.Show("Black Pool 启动失败（退出码 " + p.ExitCode + "），即将打开诊断日志。",
+                            "Black Pool", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            if (File.Exists(log))
+            {
+                Process.Start("notepad.exe", "\"" + log + "\"");
+            }
+            return p.ExitCode;
+        }
+        return 0;
+    }
+}

--- a/projects/black-pool-agent/deploy/deploy.cmd
+++ b/projects/black-pool-agent/deploy/deploy.cmd
@@ -96,8 +96,10 @@ move "%B%" "%BPA_DIR%" >nul || (
 rem -- one-click icon entry: "Black Pool.lnk" next to launcher (icon from the exe) --
 set "BPA_EXE="
 for %%F in ("%BPA_DIR%\desktop\*.exe") do if not defined BPA_EXE set "BPA_EXE=%%~fF"
+set "LNK_TARGET=%BPA_DIR%\launcher.cmd"
+if exist "%BPA_DIR%\Black Pool.exe" set "LNK_TARGET=%BPA_DIR%\Black Pool.exe"
 if defined BPA_EXE (
-  cscript //nologo "%SD%make-shortcut.vbs" "%BPA_DIR%\Black Pool.lnk" "%BPA_DIR%\launcher.cmd" "%BPA_DIR%" "%BPA_EXE%,0" >nul 2>&1 && echo 已生成带图标入口：Black Pool.lnk（可拷到桌面）
+  cscript //nologo "%SD%make-shortcut.vbs" "%BPA_DIR%\Black Pool.lnk" "%LNK_TARGET%" "%BPA_DIR%" "%BPA_EXE%,0" >nul 2>&1 && echo 已生成带图标入口：Black Pool.lnk（可拷到桌面）
 )
 
 echo.

--- a/projects/black-pool-agent/deploy/launcher.cmd
+++ b/projects/black-pool-agent/deploy/launcher.cmd
@@ -33,6 +33,9 @@ call "%BPA_TARGET%\launcher.cmd" %*
 exit /b %errorlevel%
 :in_bundle
 set "LOG=%ROOT%launcher.log"
+rem Silent mode (set by the native exe wrapper): no pauses, exe shows the dialog.
+set "PAUSE_C=pause"
+if defined BPA_SILENT set "PAUSE_C=rem"
 echo [%date% %time%] launcher start ROOT=%ROOT% > "%LOG%"
 echo Black Pool 启动中，请稍候（本窗会显示进度，失败会停窗给出原因）...
 
@@ -51,7 +54,7 @@ if not defined PYHOME (
   echo [FAIL] bundle python not found under %ROOT%python\ >> "%LOG%"
   echo 启动失败：包内 python\cpython-* 目录缺失。请把整个 BlackPool 文件夹完整复制后重试。
   echo 详情见 %LOG%
-  pause
+  %PAUSE_C%
   exit /b 1
 )
 echo [ok] PYHOME=%PYHOME% >> "%LOG%"
@@ -61,7 +64,7 @@ rem -- step 2: venv self-heal (idempotent) --
 if errorlevel 1 (
   echo [FAIL] fix_venv_path failed >> "%LOG%"
   echo 启动失败：venv 自愈未通过。详情见 %LOG%
-  pause
+  %PAUSE_C%
   exit /b 1
 )
 
@@ -70,7 +73,7 @@ rem -- step 3: runtime import check --
 if errorlevel 1 (
   echo [FAIL] runtime import check failed >> "%LOG%"
   echo 启动失败：包内运行时导入自检未通过。详情见 %LOG%
-  pause
+  %PAUSE_C%
   exit /b 1
 )
 echo [ok] runtime import check passed >> "%LOG%"
@@ -92,7 +95,7 @@ if exist "%ROOT%desktop" (
     echo.
     echo 启动失败：桌面端进程未能存活。上方为取证日志尾部，
     echo 完整日志见 %LOG% 与 home\logs\ 目录。
-    pause
+    %PAUSE_C%
     exit /b 1
   )
   exit 0
@@ -109,7 +112,7 @@ if defined DESKTOP_EXE (
   echo   %DESKTOP_EXE%
   start "Black Pool" "%DESKTOP_EXE%"
   echo 若桌面端窗口没有出现，请把 home\logs\ 下日志发给艾瑞卡；本窗可手动关闭。
-  pause
+  %PAUSE_C%
   exit /b 0
 )
 
@@ -119,5 +122,5 @@ echo 未找到桌面端目录，回退命令行模式...
 "%ROOT%venv\Scripts\hermes.exe" %*
 echo.
 echo 命令行会话已结束。
-pause
+%PAUSE_C%
 endlocal

--- a/tests/test_bpa_dev_kit.py
+++ b/tests/test_bpa_dev_kit.py
@@ -164,6 +164,17 @@ def test_cmd_rem_lines_are_ascii_short(name):
             assert len(s) <= 100, f"{name} rem 行超长: {s[:60]}"
 
 
+def test_native_launcher_source_present_and_wired():
+    """无感原生外壳（守密人 2026-08-03 诉求）：C# 源在位且两条装配线都有编译步。"""
+    cs = KIT.parent / "build" / "black-pool-launcher.cs"
+    assert cs.is_file() and "winexe" in cs.read_text(encoding="utf-8")
+    for wf in ("assemble-black-pool-bundle.yml", "assemble-black-pool-public.yml"):
+        text = (REPO / ".github" / "workflows" / wf).read_text(encoding="utf-8")
+        assert "black-pool-launcher.cs" in text and "win32icon" in text, f"{wf} 缺编译步"
+    launcher = (KIT / "launcher.cmd").read_text(encoding="utf-8")
+    assert "BPA_SILENT" in launcher and "%PAUSE_C%" in launcher, "launcher 静默模式缺失"
+
+
 def test_kill_by_path_noop_on_non_windows(tmp_path):
     """路径杀进程器：非 Windows 空跑退出 0（管线可验）；Windows 行为靠野战。"""
     r = subprocess.run([sys.executable, str(KIT / "kill_by_path.py"), str(tmp_path)],


### PR DESCRIPTION
守密人诉求「launcher 做成无感 exe + 配图标」落地：

- **`build/black-pool-launcher.cs`**（约 50 行 C#，零内网值）：装配期由系统自带 csc 编译——`/target:winexe` 窗口子系统全程无黑框、`/win32icon` 内嵌黑池图标——产 **`Black Pool.exe`** 落包根。
- **行为**：静默后台跑 launcher.cmd 全套自检自愈（`BPA_SILENT` 令其 pause 让位）；成功 = 桌面端直接出现、全程无感；失败 = 弹窗提示并自动打开 `launcher.log`。
- deploy.cmd 的快捷方式改为优先指向原生 exe；两条装配线均加编译步；守卫测试断言源码 / 接线 / 静默模式三件在位。

全量 pytest 3,302 通过。exe 是 CI 产物——需换新包生效。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_