### PR TITLE
修 csc 编译步：开关改 dash 风格（MSYS 路径改写吞 /nologo）

### DIFF
--- a/.github/workflows/assemble-black-pool-bundle.yml
+++ b/.github/workflows/assemble-black-pool-bundle.yml
@@ -105,8 +105,9 @@ jobs:
       - name: Native silent launcher (Black Pool.exe, embedded icon)
         run: |
           CSC="/c/Windows/Microsoft.NET/Framework64/v4.0.30319/csc.exe"
-          "$CSC" /nologo /codepage:65001 /target:winexe /win32icon:projects/black-pool-agent/build/brand-assets/icon.ico \
-            /r:System.Windows.Forms.dll /out:"BlackPool/Black Pool.exe" \
+          # dash-style flags: Git Bash MSYS path-mangling eats /nologo-style switches
+          "$CSC" -nologo -codepage:65001 -target:winexe "-win32icon:projects/black-pool-agent/build/brand-assets/icon.ico" \
+            -r:System.Windows.Forms.dll "-out:BlackPool/Black Pool.exe" \
             projects/black-pool-agent/build/black-pool-launcher.cs
           ls -la "BlackPool/Black Pool.exe"
 

--- a/.github/workflows/assemble-black-pool-public.yml
+++ b/.github/workflows/assemble-black-pool-public.yml
@@ -106,8 +106,9 @@ jobs:
       - name: Native silent launcher (Black Pool.exe, embedded icon)
         run: |
           CSC="/c/Windows/Microsoft.NET/Framework64/v4.0.30319/csc.exe"
-          "$CSC" /nologo /codepage:65001 /target:winexe /win32icon:projects/black-pool-agent/build/brand-assets/icon.ico \
-            /r:System.Windows.Forms.dll /out:"BlackPool/Black Pool.exe" \
+          # dash-style flags: Git Bash MSYS path-mangling eats /nologo-style switches
+          "$CSC" -nologo -codepage:65001 -target:winexe "-win32icon:projects/black-pool-agent/build/brand-assets/icon.ico" \
+            -r:System.Windows.Forms.dll "-out:BlackPool/Black Pool.exe" \
             projects/black-pool-agent/build/black-pool-launcher.cs
           ls -la "BlackPool/Black Pool.exe"
 


### PR DESCRIPTION
#948 首跑失败诊断：Git Bash 的 MSYS 路径改写把 Windows 风格开关 `/nologo`、`/r:` 当成路径转换（`CS2001: Source file 'C:/Program Files/Git/nologo'`）。csc 同样接受 `-` 前缀开关且 MSYS 不碰——两条装配线同改。失败轮未上传资产，现行 Release 包完好无损。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_