### PR TITLE
修 npm 缓存键：monorepo 根锁档（apps/desktop 无独立锁）

### DIFF
--- a/.github/workflows/assemble-black-pool-bundle.yml
+++ b/.github/workflows/assemble-black-pool-bundle.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: projects/black-pool-agent/upstream/apps/desktop/package-lock.json
+          cache-dependency-path: projects/black-pool-agent/upstream/package-lock.json
 
       - name: Build desktop (dir target, unsigned, merged into bundle)
         working-directory: BlackPool/app/apps/desktop

--- a/.github/workflows/assemble-black-pool-public.yml
+++ b/.github/workflows/assemble-black-pool-public.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: projects/black-pool-agent/upstream/apps/desktop/package-lock.json
+          cache-dependency-path: projects/black-pool-agent/upstream/package-lock.json
 
       - name: Build desktop (dir target, unsigned, merged into bundle)
         working-directory: BlackPool/app/apps/desktop


### PR DESCRIPTION
#951 轮失败于 setup-node：`apps/desktop/package-lock.json` 不存在——上游是 npm workspaces 单根锁结构。缓存键改指 `upstream/package-lock.json`，两线同修。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_