### PR TITLE
csc 路径全量 cygpath -w（CS1504 正斜杠源路径）

### DIFF
--- a/.github/workflows/assemble-black-pool-bundle.yml
+++ b/.github/workflows/assemble-black-pool-bundle.yml
@@ -105,10 +105,12 @@ jobs:
       - name: Native silent launcher (Black Pool.exe, embedded icon)
         run: |
           CSC="/c/Windows/Microsoft.NET/Framework64/v4.0.30319/csc.exe"
-          # dash-style flags: Git Bash MSYS path-mangling eats /nologo-style switches
-          "$CSC" -nologo -codepage:65001 -target:winexe "-win32icon:projects/black-pool-agent/build/brand-assets/icon.ico" \
-            -r:System.Windows.Forms.dll "-out:BlackPool/Black Pool.exe" \
-            projects/black-pool-agent/build/black-pool-launcher.cs
+          # dash flags (MSYS eats /switches); cygpath -w everything (csc chokes on fwd-slash paths, CS1504)
+          SRC=$(cygpath -w projects/black-pool-agent/build/black-pool-launcher.cs)
+          ICO=$(cygpath -w projects/black-pool-agent/build/brand-assets/icon.ico)
+          OUT=$(cygpath -w "BlackPool/Black Pool.exe")
+          "$CSC" -nologo -codepage:65001 -target:winexe "-win32icon:$ICO" \
+            -r:System.Windows.Forms.dll "-out:$OUT" "$SRC"
           ls -la "BlackPool/Black Pool.exe"
 
       - name: Relocatability + merge smoke test (moved path, launcher self-heal flow)

--- a/.github/workflows/assemble-black-pool-public.yml
+++ b/.github/workflows/assemble-black-pool-public.yml
@@ -106,10 +106,12 @@ jobs:
       - name: Native silent launcher (Black Pool.exe, embedded icon)
         run: |
           CSC="/c/Windows/Microsoft.NET/Framework64/v4.0.30319/csc.exe"
-          # dash-style flags: Git Bash MSYS path-mangling eats /nologo-style switches
-          "$CSC" -nologo -codepage:65001 -target:winexe "-win32icon:projects/black-pool-agent/build/brand-assets/icon.ico" \
-            -r:System.Windows.Forms.dll "-out:BlackPool/Black Pool.exe" \
-            projects/black-pool-agent/build/black-pool-launcher.cs
+          # dash flags (MSYS eats /switches); cygpath -w everything (csc chokes on fwd-slash paths, CS1504)
+          SRC=$(cygpath -w projects/black-pool-agent/build/black-pool-launcher.cs)
+          ICO=$(cygpath -w projects/black-pool-agent/build/brand-assets/icon.ico)
+          OUT=$(cygpath -w "BlackPool/Black Pool.exe")
+          "$CSC" -nologo -codepage:65001 -target:winexe "-win32icon:$ICO" \
+            -r:System.Windows.Forms.dll "-out:$OUT" "$SRC"
           ls -la "BlackPool/Black Pool.exe"
 
       - name: Relocatability + merge smoke test (moved path, launcher self-heal flow)


### PR DESCRIPTION
csc 第三案：原生 csc 拒收正斜杠相对源路径（`CS1504`，只取了文件名去仓根找）。源 / 图标 / 输出三路径全部过 `cygpath -w` 再喂，两线同修。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_