### PR TITLE
CI 出包烘 BUILD.md 出厂清单：两级拼装链条包内自洽（守密人 2026-08-04 裁定）

### DIFF
--- a/.github/workflows/assemble-black-pool-bundle.yml
+++ b/.github/workflows/assemble-black-pool-bundle.yml
@@ -92,15 +92,33 @@ jobs:
           cp projects/black-pool-agent/deploy/launch_desktop.py BlackPool/
           # 组装根印章：editable 指针自愈的「旧根」依据（自愈后由脚本滚动更新）
           cygpath -w "$(pwd)/BlackPool" > BlackPool/bundle-root.txt
+          # 出厂清单 BUILD.md（守密人 2026-08-04 裁定「补齐链条」）：第一级拼装
+          # 的地面真相，与内网第二级 ASSEMBLY.md 在部署包内并列自洽。
+          PRODVER=$(sed -n 's/__version__ = "\(.*\)"/\1/p' BlackPool/app/hermes_cli/__init__.py | head -1)
           {
-            echo "Black Pool (黑池) portable bundle — private edition, brand v0.1.0 (win64, merged single dir)"
-            echo "edition: private (black-pool-rebrand.patch + black-pool-intranet.patch)"
-            echo "pin: $(grep -m1 'pin tag' projects/black-pool-agent/UPSTREAM.md || true)"
-            echo "assembled: run ${GITHUB_RUN_ID} @ $(date -u +%Y-%m-%dT%H:%MZ)"
-            echo "usage: copy the BlackPool folder anywhere, double-click launcher.cmd"
-            echo "       (desktop UI by default; CLI = venv\\Scripts\\hermes.exe)"
-            echo "config: endpoints/credentials are injected on the intranet side (never bundled)"
-          } > BlackPool/BUNDLE-INFO.txt
+            echo "# Black Pool 出厂清单（BUILD.md · 第一级拼装：银芯 CI）"
+            echo ""
+            echo "- 版别：私有版（private edition）"
+            echo "- 产品版本：${PRODVER}"
+            echo "- 上游 pin：$(grep -m1 'pin tag' projects/black-pool-agent/UPSTREAM.md || true)"
+            echo "- 装配 commit：${GITHUB_SHA}"
+            echo "- 装配运行：${GITHUB_RUN_ID} @ $(date -u +%Y-%m-%dT%H:%MZ)"
+            echo ""
+            echo "## 烧入补丁（构建期已应用）"
+            echo ""
+            for p in projects/black-pool-agent/patches/black-pool-rebrand.patch \
+                     projects/black-pool-agent/patches/black-pool-intranet.patch \
+                     projects/black-pool-agent/patches/conversation-cost-panel.patch; do
+              echo "- $(basename "$p")  (sha256:$(sha256sum "$p" | cut -c1-12))"
+            done
+            echo ""
+            echo "## 使用"
+            echo ""
+            echo "- 整个 BlackPool 目录任意拷贝，双击 launcher.cmd（桌面端）；CLI = venv\\Scripts\\hermes.exe"
+            echo "- 端点与凭据在内网侧注入（本包绝不携带）"
+            echo ""
+            echo "> 第二级拼装（内网 bpa-dev 注入补丁/插件/配置）见部署包内 ASSEMBLY.md。"
+          } > BlackPool/BUILD.md
 
       - name: Native silent launcher (Black Pool.exe, embedded icon)
         run: |

--- a/.github/workflows/assemble-black-pool-public.yml
+++ b/.github/workflows/assemble-black-pool-public.yml
@@ -93,15 +93,30 @@ jobs:
           cp projects/black-pool-agent/deploy/launch_desktop.py BlackPool/
           # 组装根印章：editable 指针自愈的「旧根」依据（自愈后由脚本滚动更新）
           cygpath -w "$(pwd)/BlackPool" > BlackPool/bundle-root.txt
+          # 出厂清单 BUILD.md（守密人 2026-08-04 裁定「补齐链条」）：公版只烧两张补丁。
+          PRODVER=$(sed -n 's/__version__ = "\(.*\)"/\1/p' BlackPool/app/hermes_cli/__init__.py | head -1)
           {
-            echo "Black Pool (黑池) portable bundle — public edition, brand v0.1.0 (win64, merged single dir)"
-            echo "edition: public (black-pool-rebrand.patch only, no intranet adaptations)"
-            echo "pin: $(grep -m1 'pin tag' projects/black-pool-agent/UPSTREAM.md || true)"
-            echo "assembled: run ${GITHUB_RUN_ID} @ $(date -u +%Y-%m-%dT%H:%MZ)"
-            echo "usage: copy the BlackPool folder anywhere, double-click launcher.cmd"
-            echo "       (desktop UI by default; CLI = venv\\Scripts\\hermes.exe)"
-            echo "config: endpoints/credentials are injected on the intranet side (never bundled)"
-          } > BlackPool/BUNDLE-INFO.txt
+            echo "# Black Pool 出厂清单（BUILD.md · 第一级拼装：银芯 CI）"
+            echo ""
+            echo "- 版别：公版（public edition，无内网适配层）"
+            echo "- 产品版本：${PRODVER}"
+            echo "- 上游 pin：$(grep -m1 'pin tag' projects/black-pool-agent/UPSTREAM.md || true)"
+            echo "- 装配 commit：${GITHUB_SHA}"
+            echo "- 装配运行：${GITHUB_RUN_ID} @ $(date -u +%Y-%m-%dT%H:%MZ)"
+            echo ""
+            echo "## 烧入补丁（构建期已应用）"
+            echo ""
+            for p in projects/black-pool-agent/patches/black-pool-rebrand.patch \
+                     projects/black-pool-agent/patches/conversation-cost-panel.patch; do
+              echo "- $(basename "$p")  (sha256:$(sha256sum "$p" | cut -c1-12))"
+            done
+            echo ""
+            echo "## 使用"
+            echo ""
+            echo "- 整个 BlackPool 目录任意拷贝，双击 launcher.cmd（桌面端）；CLI = venv\\Scripts\\hermes.exe"
+            echo ""
+            echo "> 第二级拼装（内网 bpa-dev 注入）见部署包内 ASSEMBLY.md。"
+          } > BlackPool/BUILD.md
 
       - name: Native silent launcher (Black Pool.exe, embedded icon)
         run: |

--- a/tests/test_bpa_dev_kit.py
+++ b/tests/test_bpa_dev_kit.py
@@ -273,6 +273,17 @@ def test_assemble_cmd_delegates_injection():
     assert "ASSEMBLY.md" in text
 
 
+def test_ci_bakes_build_manifest_into_bundle():
+    """两级拼装链条自洽（守密人 2026-08-04 裁定）：第一级（银芯 CI）须在包内
+    烘 BUILD.md（版别/产品版本/pin/commit/烧入补丁指纹），与内网第二级
+    ASSEMBLY.md 并列；旧三行体 BUNDLE-INFO.txt 退役不残留。"""
+    for wf in ("assemble-black-pool-bundle.yml", "assemble-black-pool-public.yml"):
+        text = (REPO / ".github" / "workflows" / wf).read_text(encoding="utf-8")
+        assert "BlackPool/BUILD.md" in text, f"{wf} 缺出厂清单烘制步"
+        assert "sha256sum" in text and "GITHUB_SHA" in text, f"{wf} 清单缺指纹/commit"
+        assert "BUNDLE-INFO" not in text, f"{wf} 旧 BUNDLE-INFO 残留"
+
+
 def test_kill_by_path_noop_on_non_windows(tmp_path):
     """路径杀进程器：非 Windows 空跑退出 0（管线可验）；Windows 行为靠野战。"""
     r = subprocess.run([sys.executable, str(KIT / "kill_by_path.py"), str(tmp_path)],


### PR DESCRIPTION
## 内容

补齐两级拼装链条的第一级：银芯 CI 两条装配线（私有版 / 公版）出包时在 `BlackPool\` 根烘 **`BUILD.md`** 出厂清单——版别、产品版本（从换装后 `__version__` 实测读出）、上游 pin、装配 commit 与运行号、**烧入补丁逐张 SHA-256 指纹**（私有版三张 / 公版两张）。部署后与内网第二级 `ASSEMBLY.md` 并列，整条供应链在包内自洽可查。旧三行体 `BUNDLE-INFO.txt` 退役。

守卫：`test_ci_bakes_build_manifest_into_bundle`（两工作流均须有烘制步 + 指纹 + commit，旧档不残留），kit 守卫 27 例。

## 验证

`premerge_gate.py` 全绿。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_