### PR TITLE
修复价格钩子锚点撞车（BPA 计费崩死野战案）+ 压缩提档 mx=7 + app 树深瘦身

### DIFF
--- a/.github/workflows/assemble-black-pool-bundle.yml
+++ b/.github/workflows/assemble-black-pool-bundle.yml
@@ -100,7 +100,8 @@ jobs:
             echo ""
             echo "- 版别：私有版（private edition）"
             echo "- 产品版本：${PRODVER}"
-            echo "- 上游 pin：$(grep -m1 'pin tag' projects/black-pool-agent/UPSTREAM.md || true)"
+            PIN_TAG=$(sed -n 's/.*pin tag.*`\(v[^`]*\)`.*/\1/p' projects/black-pool-agent/UPSTREAM.md | head -1)
+            echo "- 上游 pin：${PIN_TAG:-未探明}"
             echo "- 装配 commit：${GITHUB_SHA}"
             echo "- 装配运行：${GITHUB_RUN_ID} @ $(date -u +%Y-%m-%dT%H:%MZ)"
             echo ""
@@ -162,6 +163,13 @@ jobs:
           rm -rf BlackPool/app/apps/desktop/dist
           rm -rf BlackPool/app/apps/desktop/release
           rm -rf BlackPool/app/apps/shared/node_modules
+          # 三阶清场（守密人 2026-08-04「zip 没必要整个仓库」裁定）：desktop/shared
+          # TS 源码在成品并入 BlackPool\desktop 后运行期零用途；仓库元数据同判。
+          # ui-tui/web/docs/scripts 疑似运行时可达，按「宁胖勿断」保留。
+          rm -rf BlackPool/app/apps
+          rm -rf BlackPool/app/.github
+          rm -rf BlackPool/app/contributors
+          rm -f BlackPool/app/*.png BlackPool/app/*.jpg
           # 二阶清场（守密人 2026-08-03 继续压缩指示）：文档站源码与测试集运行期零用途。
           # docs/ 与 mcp-research-data/ 刻意保留——运行时是否消费未证伪，宁胖勿断。
           rm -rf BlackPool/app/website
@@ -189,7 +197,7 @@ jobs:
           rm -f BlackPool/launcher.log
 
       - name: Zip (transport container only)
-        run: 7z a -mx=5 "black-pool-win64.zip" BlackPool > /dev/null && ls -lh black-pool-win64.zip
+        run: 7z a -mx=7 "black-pool-win64.zip" BlackPool > /dev/null && ls -lh black-pool-win64.zip
 
       - name: Upload to Release
         env:

--- a/.github/workflows/assemble-black-pool-public.yml
+++ b/.github/workflows/assemble-black-pool-public.yml
@@ -100,7 +100,8 @@ jobs:
             echo ""
             echo "- 版别：公版（public edition，无内网适配层）"
             echo "- 产品版本：${PRODVER}"
-            echo "- 上游 pin：$(grep -m1 'pin tag' projects/black-pool-agent/UPSTREAM.md || true)"
+            PIN_TAG=$(sed -n 's/.*pin tag.*`\(v[^`]*\)`.*/\1/p' projects/black-pool-agent/UPSTREAM.md | head -1)
+            echo "- 上游 pin：${PIN_TAG:-未探明}"
             echo "- 装配 commit：${GITHUB_SHA}"
             echo "- 装配运行：${GITHUB_RUN_ID} @ $(date -u +%Y-%m-%dT%H:%MZ)"
             echo ""
@@ -160,6 +161,13 @@ jobs:
           rm -rf BlackPool/app/apps/desktop/dist
           rm -rf BlackPool/app/apps/desktop/release
           rm -rf BlackPool/app/apps/shared/node_modules
+          # 三阶清场（守密人 2026-08-04「zip 没必要整个仓库」裁定）：desktop/shared
+          # TS 源码在成品并入 BlackPool\desktop 后运行期零用途；仓库元数据同判。
+          # ui-tui/web/docs/scripts 疑似运行时可达，按「宁胖勿断」保留。
+          rm -rf BlackPool/app/apps
+          rm -rf BlackPool/app/.github
+          rm -rf BlackPool/app/contributors
+          rm -f BlackPool/app/*.png BlackPool/app/*.jpg
           # 二阶清场（守密人 2026-08-03 继续压缩指示）：文档站源码与测试集运行期零用途。
           # docs/ 与 mcp-research-data/ 刻意保留——运行时是否消费未证伪，宁胖勿断。
           rm -rf BlackPool/app/website
@@ -187,7 +195,7 @@ jobs:
           rm -f BlackPool/launcher.log
 
       - name: Zip (transport container only)
-        run: 7z a -mx=5 "black-pool-public-win64.zip" BlackPool > /dev/null && ls -lh black-pool-public-win64.zip
+        run: 7z a -mx=7 "black-pool-public-win64.zip" BlackPool > /dev/null && ls -lh black-pool-public-win64.zip
 
       - name: Upload to Release
         env:

--- a/memory/lessons-learned.md
+++ b/memory/lessons-learned.md
@@ -224,10 +224,16 @@
 - **准则**：文本换装规则的标识符免疫边界必须覆盖**所有连接符**（`_` 之外至少 `-`）；换装补丁上线前要对 diff 做一轮「功能标识符样本」审计（HTTP 头 / User-Agent / 文件名 / scheme），不能只靠正则自证。
 - **防护**：`deploy/rebrand.py` 连字符入免疫边界 + `tests/test_hermes_charter.py::test_rebrand_never_breaks_functional_identifiers` 哨兵（补丁含 `X-Silver Core` 即红）；代价面记 `BRANDING.md` 残留清单。
 
+## 58. 全文替换规则的锚点不唯一，就是在给别的函数注射
+
+- **坑**：私有版价格钩子锚定「函数体首两行」做全文 `replace()`——那两行在 `usage_pricing.py` 出现 3 次（三个函数体同开头），`return user_entry`（PricingEntry）被一并注进返回 CostResult 的 `estimate_usage_cost`，调用方取 `.amount_usd` 即 AttributeError。守密人填上 model-prices.json 当天引爆，BPA 每轮计费崩死（潜伏至数据到位才发作）。
+- **准则**：引擎是全文替换，则**每条锚点必须全档唯一**——首选把函数签名尾（返回类型行）纳入锚；写规则时先 `grep -c` 锚串验唯一，不能拿「看起来够特殊」当证据。
+- **防护**：锚点已带 `-> Optional[PricingEntry]:` 签名尾（rebrand.py 注释记案）；`test_intranet_patch_sentinels` 增「钩子注入点恰为 1 处」计数哨兵，撞车复发即红。
+
 ---
 
 > **维护说明**：
-> 1. 遇新坑立即追加，接续最高号（下一条 = #58）。**定额**：每条 3–5 行（坑 / 准则 / 防护指针），
+> 1. 遇新坑立即追加，接续最高号（下一条 = #59）。**定额**：每条 3–5 行（坑 / 准则 / 防护指针），
 >    长叙事直接写归档层案卷区，主档只留指针——主档是路口的交通牌，卷宗放档案室。
 > 2. **毕业纪律（守密人 2026-07-12 裁定）**：本档定位**中转站，不是终点**。每条记入时顺带回答
 >    「能否升格为测试 / 钩子 / CLAUDE.md 硬约束」——能则提案升格，升格落地即标毕业迁档。

--- a/projects/black-pool-agent/build/rebrand.py
+++ b/projects/black-pool-agent/build/rebrand.py
@@ -463,9 +463,15 @@ INTRANET_POST_RULES = [
         "def get_pricing_entry(",
         BLACK_POOL_PRICES_PY,
     ),
+    # ⚠ 锚点必须含签名尾「-> Optional[PricingEntry]」：函数体首两行在本档案出现 3 次
+    # （get_pricing_entry / estimate_usage_cost / has_pricing 类布尔查询），引擎是全文
+    # replace——裸体锚会把 return user_entry 注进返回 CostResult 的函数，调用方取
+    # .amount_usd 即 AttributeError（2026-08-04 野战实证：BPA 每轮计费崩死）。
     (
+        ") -> Optional[PricingEntry]:\n"
         "    route = resolve_billing_route(model_name, provider=provider, base_url=base_url)\n"
         '    if route.billing_mode == "subscription_included":\n',
+        ") -> Optional[PricingEntry]:\n"
         "    user_entry = _user_pricing_entry(model_name)\n"
         "    if user_entry:\n"
         "        return user_entry\n"

--- a/projects/black-pool-agent/patches/black-pool-intranet.patch
+++ b/projects/black-pool-agent/patches/black-pool-intranet.patch
@@ -1,5 +1,5 @@
 diff --git a/agent/usage_pricing.py b/agent/usage_pricing.py
-index 04d34d1..8a01575 100644
+index 04d34d1..73f7eb1 100644
 --- a/agent/usage_pricing.py
 +++ b/agent/usage_pricing.py
 @@ -1172,12 +1172,81 @@ def _pricing_entry_from_metadata(
@@ -84,26 +84,6 @@ index 04d34d1..8a01575 100644
      route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
      if route.billing_mode == "subscription_included":
          return PricingEntry(
-@@ -1305,6 +1374,9 @@ def estimate_usage_cost(
-     base_url: Optional[str] = None,
-     api_key: Optional[str] = None,
- ) -> CostResult:
-+    user_entry = _user_pricing_entry(model_name)
-+    if user_entry:
-+        return user_entry
-     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
-     if route.billing_mode == "subscription_included":
-         return CostResult(
-@@ -1387,6 +1459,9 @@ def has_known_pricing(
-     Uses direct lookup instead of routing through the full estimation
-     pipeline — avoids creating dummy usage objects just to check status.
-     """
-+    user_entry = _user_pricing_entry(model_name)
-+    if user_entry:
-+        return user_entry
-     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
-     if route.billing_mode == "subscription_included":
-         return True
 diff --git a/apps/desktop/electron/main.ts b/apps/desktop/electron/main.ts
 index 6e249aa..d3e9686 100644
 --- a/apps/desktop/electron/main.ts

--- a/tests/test_hermes_charter.py
+++ b/tests/test_hermes_charter.py
@@ -149,6 +149,12 @@ def test_intranet_patch_sentinels():
     }
     missing = [k for k, v in sentinels.items() if v not in text]
     assert not missing, f"私有版规则从补丁消失（锚点失配）: {missing}"
+    # 锚点唯一性回归（2026-08-04 野战：裸体锚匹配 3 处，把 return user_entry 注进
+    # 返回 CostResult 的 estimate_usage_cost，.amount_usd 崩死 BPA）：价格钩子
+    # 只许注入 get_pricing_entry 一处。
+    added = [l for l in text.splitlines() if l.startswith("+")]
+    hooks = [l for l in added if "user_entry = _user_pricing_entry" in l]
+    assert len(hooks) == 1, f"价格钩子注入点应恰为 1 处，实为 {len(hooks)}（锚点撞车复发）"
 
 
 def test_editions_are_cleanly_separated():


### PR DESCRIPTION
## 紧急修复：`'PricingEntry' object has no attribute 'amount_usd'`

私有版价格表钩子锚定的「函数体首两行」在 `usage_pricing.py` 出现 **3 次**，规则引擎全文替换把 `return user_entry`（PricingEntry）一并注进了返回 CostResult 的 `estimate_usage_cost` 与返回 bool 的定价探测函数——`model-prices.json` 一匹配上模型，调用方取 `.amount_usd` 即崩，BPA 每轮计费卡死（守密人填表当天引爆）。

- 锚点改带 `-> Optional[PricingEntry]:` 签名尾（全档唯一位点），补丁重生成（私有版 392→372 行，两处误注消失）
- 哨兵新增**注入点计数**（恰为 1 处，撞车复发即红）；实证：patch 后 `usage_pricing.py` AST 通过、钩子仅存于 `get_pricing_entry`
- lesson #58：全文替换规则的锚点必须全档唯一，写规则先 `grep -c` 验唯一

## 同轮裁定落地（守密人 2026-08-04「改吧，zip 没必要整个仓库」）

- 压缩提档 `7z -mx=5 → -mx=7`（runner 滚动镜像 deflate 劣化的对冲）
- 三阶清场：`app/apps`（桌面端 TS 源码 23M，成品已并入 `desktop\`）+ `.github` + `contributors` + 杂图出包；`ui-tui/web/docs/scripts` 按「宁胖勿断」保留
- BUILD.md「上游 pin」行净化为纯 tag

## 验证

`premerge_gate.py` 全绿（charter 8 例含真实序贯打补丁）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_