### PR TITLE
部署套件：一键更新 update.cmd 六步流水线（守密人 2026-08-04 裁定）

### DIFF
--- a/projects/black-pool-agent/deploy/RUNBOOK.md
+++ b/projects/black-pool-agent/deploy/RUNBOOK.md
@@ -18,6 +18,7 @@ E:\BIAV-BP\bpa-dev\   （内部开发目录；部署目录 = E:\BIAV-BP\black-po
 │                  #   激活一次即可：launcher.cmd cli config set memory.provider blackpool）
 ├── skills\        # 内网技能 → 拷入 home\skills\
 ├── config\        # SOUL.md → home\；env.cmd → 包根；deploy-target.txt = 部署目录地址一行（凭据/端点的唯一的家）
+│                  #   git-root.txt = 银芯克隆根一行（可选，供 update.cmd 第①步；缺省自动探测）
 │                  #   assembly.txt = 选装表（可选，缺省全拼）：五节 patches/plugins/skills/config/overlay
 │                  #     逐条 name = on/off，"* = on/off" 定节内缺省；样例见 deploy\assembly.sample.txt
 │                  #   env.cmd 由 launcher 启动时 call——企业根证书/代理等在此注入，例：
@@ -42,6 +43,15 @@ E:\BIAV-BP\bpa-dev\   （内部开发目录；部署目录 = E:\BIAV-BP\black-po
 
 ## 三步操作
 
+0. **一键更新 `update.cmd`（守密人 2026-08-04 裁定，日常推荐入口）**：六步流水线
+   ① 银芯克隆 `git pull --ff-only`（克隆根自动探测；探不到时在 `config\git-root.txt`
+   写一行路径启用，没 git 就跳过）→ ② 车间根 `svn update`（顺带保鲜 deploy\ 外链；
+   没 svn 命令行就跳过）→ ③ 下载最新整包进 `releases\`（SHA-256 实测比对 Release
+   官方 digest，通过即登记 CHECKSUMS.txt；下载失败可选用现存最新包继续；
+   `update.cmd nodl` 显式跳过下载）→ ④⑤⑥ 依次调 assemble → deploy → 启动部署位。
+   底下三件照旧可单跑（诊断 / 只重部署 / 回滚排障）。脚本开跑先自拷 TEMP 再执行——
+   ①② 会改写 update.cmd 自身，cmd 边读边跑，不自拷会解析错乱；日志 `车间根\update.log`，
+   套件目录保持零写入。
 1. **组装** `assemble.cmd [zip名]`：验 SHA → 净台解压 → 注入阶段整体交
    `assemble_inject.py`（包内 Python）：按**选装表** `config\assembly.txt` 决定
    拼哪些补丁 / 插件 / 技能 / 配置 / 覆盖层（表不存在 = 全拼；样例

--- a/projects/black-pool-agent/deploy/update.cmd
+++ b/projects/black-pool-agent/deploy/update.cmd
@@ -1,0 +1,140 @@
+@echo off
+rem Black Pool one-click update pipeline (keeper ruling 2026-08-04):
+rem   [1] git pull silver-core clone  [2] svn update workshop
+rem   [3] download newest bundle     [4] assemble  [5] deploy  [6] launch
+rem Thin orchestrator: steps 4/5/6 call the existing kit scripts, which all
+rem stay independently runnable. Usage: update.cmd [nodl]
+rem   nodl = skip download, assemble newest zip already in releases\
+rem ASCII rem only + no zh echo after goto labels (65001 desync, RUNBOOK).
+if not defined BPA_KEEPWIN (
+  set "BPA_KEEPWIN=1"
+  cmd /d /k call "%~f0" %*
+  exit /b
+)
+rem Re-exec from a TEMP copy: steps 1/2 may rewrite this very file mid-run
+rem (cmd parses batch files incrementally - self-modification desyncs it).
+if not defined BPA_UPD_TMP (
+  set "BPA_UPD_TMP=1"
+  set "BPA_UPD_SD=%~dp0"
+  copy /y "%~f0" "%TEMP%\bpa-update-run.cmd" >nul
+  call "%TEMP%\bpa-update-run.cmd" %*
+  exit /b %errorlevel%
+)
+setlocal EnableExtensions EnableDelayedExpansion
+chcp 65001 >nul
+set "SD=%BPA_UPD_SD%"
+for %%I in ("%SD%..") do set "DEVROOT=%%~fI"
+set "LOG=%DEVROOT%\update.log"
+echo [%date% %time%] one-click update start > "%LOG%"
+echo ============ 黑池一键更新（六步流水线）============
+
+rem -- [1/6] git pull --ff-only on the silver-core clone --
+rem Clone root: config\git-root.txt if present, else auto-detect (works when
+rem deploy\ is junctioned/checked out inside the git working tree).
+set "GITROOT="
+if exist "%DEVROOT%\config\git-root.txt" set /p GITROOT=<"%DEVROOT%\config\git-root.txt"
+where git >nul 2>&1
+if errorlevel 1 (
+  echo [1/6] 跳过银芯仓更新：机器上没有 git 命令
+) else (
+  if not defined GITROOT for /f "delims=" %%G in ('git -C "%SD%." rev-parse --show-toplevel 2^>nul') do set "GITROOT=%%G"
+  if defined GITROOT (
+    set "GITROOT=!GITROOT:/=\!"
+    echo [1/6] 银芯仓 git pull --ff-only ...
+    git -C "!GITROOT!" pull --ff-only >> "%LOG%" 2>&1 && (
+      echo       完成：!GITROOT!
+    ) || (
+      echo       未成功（离线或本地有改动），跳过继续，详见 update.log
+    )
+  ) else (
+    echo [1/6] 跳过银芯仓更新：未定位克隆（可在 config\git-root.txt 写一行路径启用）
+  )
+)
+
+rem -- [2/6] svn update the workshop root (also refreshes deploy\ external) --
+where svn >nul 2>&1
+if errorlevel 1 (
+  echo [2/6] 跳过车间 svn update：没有 svn 命令行（TortoiseSVN 安装时勾 command line client tools）
+) else (
+  if exist "%DEVROOT%\.svn" (
+    echo [2/6] 车间 svn update ...
+    svn update "%DEVROOT%" >> "%LOG%" 2>&1 && (
+      echo       完成
+    ) || (
+      echo       未成功，跳过继续，详见 update.log
+    )
+  ) else (
+    echo [2/6] 跳过车间 svn update：%DEVROOT% 不是 SVN 工作副本
+  )
+)
+
+rem -- [3/6] download newest bundle into releases\ --
+set "REL=%DEVROOT%\releases"
+if not exist "%REL%" mkdir "%REL%"
+set "ZIPURL=https://github.com/lightproud/BIAV-SC-CODE/releases/download/black-pool-bundle/black-pool-win64.zip"
+set "APIURL=https://api.github.com/repos/lightproud/BIAV-SC-CODE/releases/tags/black-pool-bundle"
+if /i "%~1"=="nodl" (
+  echo [3/6] 跳过下载（nodl）：用 releases\ 现存最新包组装
+) else (
+  echo [3/6] 下载最新整包（数百 MB，视网速数分钟）...
+  set "DLOK="
+  curl.exe -L --fail -o "%REL%\black-pool-win64.zip.part" "%ZIPURL%" 2>> "%LOG%" && set "DLOK=1"
+  if defined DLOK (
+    move /y "%REL%\black-pool-win64.zip.part" "%REL%\black-pool-win64.zip" >nul
+    set "SHA="
+    for /f "skip=1 delims=" %%H in ('certutil -hashfile "%REL%\black-pool-win64.zip" SHA256 2^>nul') do if not defined SHA set "SHA=%%H"
+    set "SHA=!SHA: =!"
+    set "SHAOK="
+    curl.exe -s "%APIURL%" 2>nul | findstr /i /c:"!SHA!" >nul && set "SHAOK=1"
+    if defined SHAOK (
+      echo       验明正身：SHA-256 与 Release 官方 digest 一致
+    ) else (
+      echo       提示：未能对上官方 digest（离线或 API 不可达），按 TLS 下载信任
+    )
+    findstr /i /c:"!SHA!" "%REL%\CHECKSUMS.txt" >nul 2>&1 || >>"%REL%\CHECKSUMS.txt" echo !SHA!  black-pool-win64.zip  %date%
+    echo       下载完成，SHA-256 已登记 CHECKSUMS.txt
+  ) else (
+    del "%REL%\black-pool-win64.zip.part" >nul 2>&1
+    echo       下载失败（网络不通或 Release 不可达）。
+    choice /c YN /m "用 releases\ 里现存最新包继续吗"
+    if errorlevel 2 (
+      echo 已中止：本次一键更新未进行组装部署。
+      exit /b 1
+    )
+  )
+)
+
+rem -- [4/6] assemble (existing kit script, unchanged) --
+echo [4/6] 组装 ...
+call "%SD%assemble.cmd"
+if errorlevel 1 (
+  echo 流水线中止于组装步（原因见上方与 assemble.log）。
+  exit /b 1
+)
+
+rem -- [5/6] deploy (target from config\deploy-target.txt, same as manual) --
+echo [5/6] 部署 ...
+call "%SD%deploy.cmd"
+if errorlevel 1 (
+  echo 流水线中止于部署步（原因见上方与 deploy.log）。
+  exit /b 1
+)
+
+rem -- [6/6] launch the deployed bundle --
+set "BPA_DIR="
+if exist "%DEVROOT%\config\deploy-target.txt" set /p BPA_DIR=<"%DEVROOT%\config\deploy-target.txt"
+if defined BPA_DIR (
+  set "_ABS="
+  if "!BPA_DIR:~1,1!"==":" set "_ABS=1"
+  if "!BPA_DIR:~0,2!"=="\\" set "_ABS=1"
+  if not defined _ABS set "BPA_DIR=%DEVROOT%\!BPA_DIR!"
+  for %%I in ("!BPA_DIR!") do set "BPA_DIR=%%~fI"
+)
+if exist "!BPA_DIR!\launcher.cmd" (
+  echo [6/6] 启动黑池 ...
+  start "" "!BPA_DIR!\launcher.cmd"
+  echo ============ 一键更新完成，黑池启动中 ============
+) else (
+  echo [6/6] 未找到部署位 launcher.cmd，跳过启动（可手动双击部署位入口）。
+)
+exit /b 0


### PR DESCRIPTION
## 内容

守密人裁定的全链一键入口 `deploy/update.cmd`（约 150 行薄编排壳，底下 assemble / deploy / launcher 三件原样保留可单跑）：

1. 银芯克隆 `git pull --ff-only`（克隆根自动探测，`config\git-root.txt` 可显式指定；无 git 优雅跳过）
2. 车间根 `svn update`（顺带保鲜 deploy\ 外链；无 svn 命令行优雅跳过）
3. 下载最新整包进 `releases\`（SHA-256 实测比对 Release 官方 digest 后登记 CHECKSUMS.txt；`nodl` 参数跳过下载；下载失败可选现存包继续）
4. → 5. → 6. 依次调 assemble → deploy → 启动部署位

工程纪律：开跑自拷 TEMP 再执行（①②会改写脚本自身，cmd 边读边跑）；套件目录零写入（vendor 外链只读纪律）；全脚本零 goto 标签（65001 解析器错位家族雷区绕开）；`%date%` 重定向前置防句柄误吞。RUNBOOK「三步操作」加第 0 条 + config 键登记。

## 验证

`premerge_gate.py` 全绿；静态自检四项通过（rem 全 ASCII / 零 goto / 无重定向误吞 / 括号配平），`.gitattributes` 既有 `*.cmd eol=crlf` 规则接管行尾。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTnuUX4m5EsLpftW3ajy9U)_