### PR TITLE
docs: upstream 0.20.0 full-suite rerun report (zero real defects)

### DIFF
--- a/Public-Info-Pool/Resource/repo-engineering/hermes-upstream-testrun-20260804.md
+++ b/Public-Info-Pool/Resource/repo-engineering/hermes-upstream-testrun-20260804.md
@@ -1,0 +1,48 @@
+# hermes-agent v2026.8.3（引擎 0.20.0）快照全量测试实证（移 pin 复跑）
+
+- 日期：2026-08-04（北京时间）· 执行：艾瑞卡会话（分支 `claude/hermes-0-20-update-powcs4`）
+- 对象：`projects/black-pool-agent/upstream/` 快照（pin `v2026.8.3` / commit `3c27eb62` / 引擎 0.20.0）
+- 环境：银芯云容器（Linux，root 用户，4 核，无 IPv6、无 openssh-client、无 systemd）
+- 前跑基线：`hermes-upstream-testrun-20260802.md`（v2026.7.30 / 0.19.1 首跑，40 例假红四簇分诊）
+
+## 一句话结论
+
+0.20.0 套件在银芯容器内**可完整复现运行**：**2,599 测试文件 / 25,176 断言通过 / 35 失败
++ 1 收集期错误**；36 个受影响档逐簇分诊**全部为环境 / 布局伪影，零上游代码真缺陷**。
+对首跑：假红池 40 → 36 净缩（上游修复自更新家族 5 例的 git 检出假设），两张新面孔均查实为
+已知簇的新成员（详见分诊表），无新增缺陷类别。
+
+## 复现口径（与首跑一致处从简，差异处加粗）
+
+| 项 | 值 |
+|----|----|
+| uv | 0.9.28（上游 tests.yml 钉版，0.20 核对未变）。**获取方式变更：astral.sh 官方安装脚本被银芯出网代理 403，改 GitHub Releases 直下二进制**（`uv-x86_64-unknown-linux-gnu.tar.gz`）|
+| 依赖 | `uv sync --locked --python 3.11 --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web`（九 extra 口径核对无增减）|
+| Python | 3.11.15 |
+| 运行器 | `scripts/run_tests.sh -j 4`。**0.20 需显式设 `HERMES_PYTHON=<venv>/bin/python`**——运行器只认树内 `.venv` 或该环境变量，venv 按纪律落会话 scratchpad 时必设（首跑报告未记此参数，本轮实测缺它直接拒跑）|
+| API key | `OPENROUTER_API_KEY="" OPENAI_API_KEY=""`（防真调用）|
+| venv / 缓存 | 全落会话 scratchpad（`UV_PROJECT_ENVIRONMENT` / `UV_CACHE_DIR`），仓树零污染 |
+
+## 36 档分诊（四簇不变，成员有进有出，均非代码缺陷）
+
+| 簇 | 本轮 | 首跑 | 变化与真因 |
+|----|-----|------|-----------|
+| 自更新家族（布局假红） | **17** | 22 | `test_cmd_update` 12 / `update_yes_flag` 2 / gateway `update_command` 2 / `update_streaming` 1。报错仍为快照 vendor 布局无自身 `.git`。**净缩 5 例**：`test_update_eol_churn` 0.20 已修其 git 检出假设，本轮 9 过全绿 |
+| root 用户伪影 | **8** | 9 | 成员同首跑（`approvals_suggest` / `gateway_service` / `migrate_xai` / `xai_provider_labels` / `approval` / `execution_flag_detection`×2 / `lazy_deps_durable_target`）；`gateway_service` 2→1 |
+| 环境缺件 | **10** | 8 | ssh×5 / IPv6 双栈×2（`browser_connect_dual_stack` + `webhook_adapter::TestDualStackBind`）/ sqlite 报错文案×1（`state_db_malformed_repair`）不变。**新成员：`test_teams.py` 整档收集期错误**——0.20 上游 #62935 将 Teams SDK 改为延迟导入，测试档收集期真调 `check_teams_requirements()` 触发 lazy install，容器内安装失败（耗时 14.7s 后返回 False）即整档 error；手动 `uv pip install microsoft-teams-apps==2.0.13.4 aiohttp==3.14.1` 后该档 **22/22 全绿，零代码缺陷**。注意 `teams` extra 不含于 `all`、也不在九 extra 口径内 |
+| 运行器环境敏感 | **2** | 1 | `test_vision_routing_31179`（首跑已知）；**新成员：`test_tui_gateway_server::test_write_json_serializes_concurrent_writes`**——并发写断言 8 行得 9 行，`-j 4` 负载下偶发时序敏感，同用例独立复跑 3/3 全绿 |
+
+## 附带事实
+
+- 通过断言 25,176 对首跑 22,766（**+2,410**）；测试文件 2,599 对 2,471（+128）——0.20 单版净增
+  逾百测试档，上游迭代速率与 M0 深读时观察一致。
+- 两张「新面孔」均系上游**测试写法变化**暴露既有环境限制（teams：mock 置位改真装依赖；tui：新增
+  并发时序断言），非环境退化亦非代码缺陷。
+- 树内跑测后清生成物纪律照例执行（`__pycache__` 清净后方入库，UPSTREAM.md 例程步 2）。
+
+## 对黑池侧输入
+
+1. 0.20.0 移 pin 后基线健康度与 0.19.1 持平（零真缺陷），黑池侧换包重测可引用本轮排除集。
+2. 若黑池部署启用 Teams 平台：装配时显式加 `teams` extra 或预装 `microsoft-teams-apps==2.0.13.4`
+   ——0.20 起该平台依赖不再被测试 mock 遮蔽，生产同样走 lazy install，内网无公网 PyPI 时必须预装。
+3. 复跑本套件的两个新增操作要点已固化在上方口径表（uv 经 GitHub Releases 取 / `HERMES_PYTHON` 必设）。

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -356,8 +356,8 @@
   （SOUL.md 模板 / CLI 别名）+ patches/ 白名单制（`build/rebrand.py` 规则引擎生成 388 文件补丁，含
   desktop/web 裸词换装——守密人补充「主要消费面是 desktop」后扩面；四不碰红线，upstream 零修改组装期应用）；台账 `BRANDING.md`。
 - **首件便携整包已实证落桶（2026-08-02，三轮迭代绿，run 30750724034）**：`silver-core-win64.zip`（1.04GB，sha256 在册）落 `silver-core-bundle` Release——合箱单目录搬移自愈冒烟全通；前两轮两坑（pyvenv.cfg 绝对路径 / 冒烟 cwd）均修入工作流。
-- **上游移 pin `v2026.8.3` / 0.20.0（2026-08-04，守密人派发）**：快照替换 + 哨兵同步 + 补丁重生成/
-  重放全绿（`UPSTREAM.md`）；同日浅色降饱和 12 表面令牌（诊断色值见 `BRANDING.md`）。
+- **上游移 pin `v2026.8.3` / 0.20.0（2026-08-04，守密人派发）**：快照替换 + 哨兵同步 + 补丁重生成/重放
+  全绿（`UPSTREAM.md`）；浅色降饱和 12 令牌（`BRANDING.md`）；套件复跑 25,176 过零真缺陷（testrun-20260804）。
 
 ## Silver Core SDK（`projects/silver-core-sdk/`，原名 BPT Agent SDK，2026-07-10 守密人裁定更名；npm 名 `silver-core-agent-sdk`，2026-07-18 定名，品牌名 Silver Core Agent SDK）
 

--- a/projects/black-pool-agent/CONTEXT.md
+++ b/projects/black-pool-agent/CONTEXT.md
@@ -52,13 +52,15 @@ UPSTREAM.md # pin 台账唯一权威
 
 ## 验证清单
 
-- **上游套件容器内可全量复现**（2026-08-02 首跑实证：2,471 文件 / 22,766 过 / 40 环境伪影零真缺陷，
-  报告 `Public-Info-Pool/Resource/repo-engineering/hermes-upstream-testrun-20260802.md`）。口径：
-  uv **0.9.28**（上游钉版，容器自带 0.8.17 读不懂其 lockfile）→ `uv sync --locked --python 3.11
+- **上游套件容器内可全量复现**（0.20.0 复跑实证 2026-08-04：2,599 文件 / 25,176 过 / 36 环境伪影
+  零真缺陷，报告 `Public-Info-Pool/Resource/repo-engineering/hermes-upstream-testrun-20260804.md`；
+  首跑基线 20260802 同目录）。口径：uv **0.9.28**（上游钉版；astral.sh 安装脚本被代理 403，
+  改 GitHub Releases 直下二进制）→ `uv sync --locked --python 3.11
   --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona
   --extra hindsight --extra parallel-web`（venv/缓存经 `UV_PROJECT_ENVIRONMENT`/`UV_CACHE_DIR`
-  落仓外）→ `OPENROUTER_API_KEY="" OPENAI_API_KEY="" scripts/run_tests.sh -j 4`。
-  已知假红排除集见报告（自更新家族 22 例为快照布局结构假红）；树内跑完测试须清生成物
-  （`UPSTREAM.md` 例程步 2）
-- 红线守卫：`pytest tests/test_hermes_charter.py -v`（patches 空 + 骨架完整）
+  落仓外）→ **`HERMES_PYTHON=<venv>/bin/python`**（0.20 运行器必设，缺则拒跑）→
+  `OPENROUTER_API_KEY="" OPENAI_API_KEY="" scripts/run_tests.sh -j 4`。
+  已知假红排除集见 20260804 报告四簇分诊（自更新家族布局假红 / root 伪影 / 环境缺件含 teams
+  lazy install / 运行器负载敏感）；树内跑完测试须清生成物（`UPSTREAM.md` 例程步 2）
+- 红线守卫：`pytest tests/test_hermes_charter.py -v`（patches 白名单 + 骨架完整）
 - 改档后跑 `pytest tests/test_claude_md*.py -v`（CLAUDE.md 对账三卫）确认指针一致


### PR DESCRIPTION
## 概述

守密人「套件重跑吧」派发：0.20.0 移 pin 后在银芯云容器内全量复跑上游 hermes-agent 测试套件，出对照实证报告——**2,599 文件 / 25,176 断言过 / 36 受影响档全部分诊为环境/布局伪影，零上游代码真缺陷**。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [x] 文档完善（CLAUDE.md / README.md / 子项目 CONTEXT.md / memory 档案）
- [ ] Bug 修复
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 其他（请说明）：上游套件复跑实证报告（Resource/repo-engineering 正式产物）

变更明细：
- 新增 `Public-Info-Pool/Resource/repo-engineering/hermes-upstream-testrun-20260804.md`：对照 20260802 首跑基线的四簇分诊（假红池 40→36 净缩：eol_churn 5 例上游修复；新面孔 teams 收集期 lazy install（#62935，SDK 装上 22/22 绿）与 tui 并发时序（solo 3/3 绿）均为已知簇新成员）
- `CONTEXT.md` 验证清单：口径指向新报告，补两个复现要点（uv 经 GitHub Releases 直下——astral.sh 被代理 403；`HERMES_PYTHON` 为 0.20 运行器必设）；顺手订正「patches 空」过时表述为「白名单」
- `memory/project-status.md` 状态条同步（含套件复跑结论）

---

## 来源声明

- [x] 本 PR 不涉及游戏数据；测试对象为公开 MIT 仓库 NousResearch/hermes-agent 的 vendor 快照。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `scripts/premerge_gate.py` 全绿 + `--sparse` 复跑同绿（指针守卫确认报告路径无空挂）
- [x] 树内跑测后生成物已清（`__pycache__` / `.pytest_cache` 零入库）
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案

---

## 关联 Issue

- 无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSHw4wMuuCo6BySGLrWoNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSHw4wMuuCo6BySGLrWoNA)_