### PR TITLE
BPA deploy kit: interaction-lag triage tool (diagnose.cmd + diagnose_lag.py)

### DIFF
--- a/.github/workflows/assemble-black-pool-bundle.yml
+++ b/.github/workflows/assemble-black-pool-bundle.yml
@@ -90,6 +90,8 @@ jobs:
           cp projects/black-pool-agent/deploy/launcher.cmd BlackPool/
           cp projects/black-pool-agent/deploy/fix_venv_path.py BlackPool/
           cp projects/black-pool-agent/deploy/launch_desktop.py BlackPool/
+          cp projects/black-pool-agent/deploy/diagnose.cmd BlackPool/
+          cp projects/black-pool-agent/deploy/diagnose_lag.py BlackPool/
           # 组装根印章：editable 指针自愈的「旧根」依据（自愈后由脚本滚动更新）
           cygpath -w "$(pwd)/BlackPool" > BlackPool/bundle-root.txt
           # 出厂清单 BUILD.md（守密人 2026-08-04 裁定「补齐链条」）：第一级拼装

--- a/.github/workflows/assemble-black-pool-public.yml
+++ b/.github/workflows/assemble-black-pool-public.yml
@@ -91,6 +91,8 @@ jobs:
           cp projects/black-pool-agent/deploy/launcher.cmd BlackPool/
           cp projects/black-pool-agent/deploy/fix_venv_path.py BlackPool/
           cp projects/black-pool-agent/deploy/launch_desktop.py BlackPool/
+          cp projects/black-pool-agent/deploy/diagnose.cmd BlackPool/
+          cp projects/black-pool-agent/deploy/diagnose_lag.py BlackPool/
           # 组装根印章：editable 指针自愈的「旧根」依据（自愈后由脚本滚动更新）
           cygpath -w "$(pwd)/BlackPool" > BlackPool/bundle-root.txt
           # 出厂清单 BUILD.md（守密人 2026-08-04 裁定「补齐链条」）：公版只烧两张补丁。

--- a/projects/black-pool-agent/deploy/RUNBOOK.md
+++ b/projects/black-pool-agent/deploy/RUNBOOK.md
@@ -68,6 +68,17 @@ E:\BIAV-BP\bpa-dev\   （内部开发目录；部署目录 = E:\BIAV-BP\black-po
    或双击 `launcher.cmd`；或直接双击**车间里的** `deploy\launcher.cmd`——
    它检测到自己不在包内时，会按 `config\deploy-target.txt` 自动转发到部署位（kit 模式零写入）。
 
+## 卡顿分诊（2026-08-04「界面交互 5-10 秒」现场反馈后置备）
+
+界面整体迟缓时双击 `deploy\diagnose.cmd`（车间里跑会自动按 `config\deploy-target.txt`
+定位部署位，无需重新组装）：分诊器逐层实测**部署位盘型（网络盘/本地盘）→ 进程普查 →
+网关回环往返（含 localhost vs 127.0.0.1 的 IPv6 回退比对）→ 散文件读采样（杀软/SMB
+放大器）→ 子进程冷启采样（杀软 spawn 拦截）→ MOTW 普查 → 日志取证（网关早夭重启循环）**，
+末尾给判读提示，全文落部署位 `lag-report.txt`——把这份报告回传银芯即可远程续查。
+常见判读速记：网络盘 = 整拷回本地；散文件读 >20ms/件或 python 复启 >3s = 给部署目录加
+杀软排除项；MOTW 命中 = zip 解锁后重解压；日志见反复 attempt/respawn = 网关早夭，
+主进程被同步探针钉住（单针可达 10 秒级），把 `home\logs\` 一并回传。
+
 ## 纪律（写给将来的自己）
 
 - **补丁射程**：Python 面（agent / hermes_cli / gateway / tools）打完即生效；

--- a/projects/black-pool-agent/deploy/diagnose.cmd
+++ b/projects/black-pool-agent/deploy/diagnose.cmd
@@ -1,0 +1,36 @@
+@echo off
+rem Black Pool lag triage wrapper (kit-aware, plain cmd, no PowerShell).
+rem Runs deploy\diagnose_lag.py against the deployed bundle. Works from the
+rem workshop kit against existing deployments - no reassembly needed.
+rem NOTE: keep rem lines ASCII-short (chcp 65001 parser discipline).
+setlocal EnableExtensions
+chcp 65001 >nul
+set "ROOT=%~dp0"
+set "TARGET=%ROOT%."
+rem Kit mode: no bundle here - resolve config\deploy-target.txt like launcher.
+if exist "%ROOT%python\" goto have_target
+if not exist "%ROOT%..\config\deploy-target.txt" goto have_target
+set /p BPA_TARGET=<"%ROOT%..\config\deploy-target.txt"
+set "_ABS="
+if "%BPA_TARGET:~1,1%"==":" set "_ABS=1"
+if "%BPA_TARGET:~0,2%"=="\\" set "_ABS=1"
+if not defined _ABS set "BPA_TARGET=%ROOT%..\%BPA_TARGET%"
+for %%I in ("%BPA_TARGET%") do set "TARGET=%%~fI"
+:have_target
+if exist "%TARGET%\python\" goto run_diag
+echo [FAIL] no bundle found at %TARGET% - run assemble + deploy first.
+pause
+exit /b 1
+:run_diag
+set "PYHOME="
+for /d %%D in ("%TARGET%\python\cpython-*") do set "PYHOME=%%~fD"
+if not defined PYHOME goto no_python
+echo 正在分诊部署位 %TARGET% ...
+"%PYHOME%\python.exe" "%ROOT%diagnose_lag.py" "%TARGET%"
+echo.
+pause
+exit /b 0
+:no_python
+echo [FAIL] bundle python missing under %TARGET%\python\ - recopy the bundle.
+pause
+exit /b 1

--- a/projects/black-pool-agent/deploy/diagnose_lag.py
+++ b/projects/black-pool-agent/deploy/diagnose_lag.py
@@ -1,0 +1,357 @@
+"""Black Pool 交互卡顿分诊器（stdlib-only，diagnose.cmd 后端）。
+
+治「界面每个交互都要等 5-10 秒」类现场问题（守密人 2026-08-04 反馈）：卡顿的
+候选源分散在互不相干的几层——部署位磁盘形态（网络盘 / 同步盘）、杀软对散文件
+与子进程的实时扫描、MOTW（Mark-of-the-Web）触发的逐件核查、网关早夭重启循环
+把桌面主进程钉在同步探针里、localhost 的 IPv6 回退、代理环境变量误吞回环地址。
+远程无法复现，只能上实机分层测量。本器把每层各测一刀，输出判读提示，全文
+落 <root>/lag-report.txt 供回传银芯。
+
+用法：python diagnose_lag.py <整包根目录>
+只读部署位（写入仅 lag-report.txt 一件）；kit 模式由 diagnose.cmd 解析部署位后转入。
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+READ_SAMPLE_MAX_FILES = 300
+READ_SAMPLE_MAX_BYTES = 30 * 1024 * 1024
+MOTW_SAMPLE_MAX = 400
+HTTP_ROUNDS = 5
+HTTP_TIMEOUT = 6.0
+
+_LINES: list[str] = []
+
+
+def force_utf8_stdio() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+
+def say(msg: str = "") -> None:
+    print(msg, flush=True)
+    _LINES.append(msg)
+
+
+def section(title: str) -> None:
+    say("")
+    say(f"==== {title} ====")
+
+
+def run_capture(args: list[str], timeout: int = 30) -> str:
+    try:
+        return subprocess.run(args, capture_output=True, text=True,
+                              timeout=timeout).stdout or ""
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def drive_kind(root: pathlib.Path) -> str:
+    """部署位落在什么盘上：UNC / 网络映射盘 / 本地盘 / 可移动盘。"""
+    raw = str(root)
+    if raw.startswith("\\\\"):
+        return "UNC 网络路径"
+    if os.name != "nt":
+        return "非 Windows（本器按只读降级跑）"
+    try:
+        import ctypes
+        drive = os.path.splitdrive(raw)[0] + "\\"
+        kind = ctypes.windll.kernel32.GetDriveTypeW(ctypes.c_wchar_p(drive))
+        return {2: "可移动盘", 3: "本地固定盘", 4: "网络映射盘",
+                5: "光驱", 6: "RAM 盘"}.get(kind, f"未知类型 {kind}")
+    except Exception:  # noqa: BLE001 - 判型失败不挡分诊
+        return "判型失败"
+
+
+def check_env(root: pathlib.Path) -> list[str]:
+    hints: list[str] = []
+    section("1. 环境事实")
+    kind = drive_kind(root)
+    say(f"部署位: {root}")
+    say(f"盘类型: {kind}")
+    if "网络" in kind or "UNC" in kind:
+        hints.append("部署位在网络盘/共享目录——所有文件访问走 SMB，整体卡顿的首要嫌疑。"
+                     "处置：整目录拷到本地固定盘再跑（RUNBOOK 绿色版二次拷贝纪律）。")
+    for key in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+                "http_proxy", "https_proxy", "no_proxy"):
+        val = os.environ.get(key)
+        if val:
+            say(f"{key} = {val}")
+    proxy_on = any(os.environ.get(k) for k in
+                   ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"))
+    no_proxy = (os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or "").lower()
+    if proxy_on and not ("127.0.0.1" in no_proxy or "localhost" in no_proxy):
+        hints.append("设了代理但 NO_PROXY 未豁免 127.0.0.1/localhost——回环流量可能被"
+                     "错送代理。处置：config\\env.cmd 里补 set NO_PROXY=127.0.0.1,localhost。")
+    return hints
+
+
+def census(root: pathlib.Path) -> tuple[dict[str, str], list[str]]:
+    """进程普查：pid→映像名全表 + python/desktop 计数提示。"""
+    hints: list[str] = []
+    section("2. 进程普查")
+    pid_image: dict[str, str] = {}
+    out = run_capture(["tasklist", "/NH", "/FO", "CSV"])
+    for line in out.splitlines():
+        cells = [c.strip('"') for c in line.split('","')]
+        if len(cells) >= 2:
+            pid_image[cells[1]] = cells[0]
+    py_count = sum(1 for v in pid_image.values() if v.lower() == "python.exe")
+    exes = sorted((root / "desktop").glob("*.exe")) if (root / "desktop").is_dir() else []
+    desk_name = exes[0].name if exes else "(desktop exe 未找到)"
+    desk_count = sum(1 for v in pid_image.values() if v.lower() == desk_name.lower())
+    say(f"python.exe 进程数: {py_count}")
+    say(f"{desk_name} 进程数: {desk_count}")
+    if py_count >= 4:
+        hints.append(f"python.exe 多达 {py_count} 个——若日志同时显示反复 attempt/respawn，"
+                     "指向网关早夭重启循环（主进程被同步探针反复钉住 = 整个界面逐次卡秒级）。")
+    return pid_image, hints
+
+
+def gateway_ports(pid_image: dict[str, str]) -> list[tuple[int, str, str]]:
+    """netstat 找回环监听端口，标注属主映像。返回 (port, pid, image)。"""
+    found: list[tuple[int, str, str]] = []
+    out = run_capture(["netstat", "-ano", "-p", "TCP"])
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) >= 5 and parts[0].upper() == "TCP" and "LISTENING" in line.upper():
+            m = re.match(r"^127\.0\.0\.1:(\d+)$", parts[1])
+            if m:
+                pid = parts[-1]
+                found.append((int(m.group(1)), pid, pid_image.get(pid, "?")))
+    return found
+
+
+def time_connect(host: str, port: int) -> float | None:
+    t0 = time.perf_counter()
+    try:
+        with socket.create_connection((host, port), timeout=HTTP_TIMEOUT):
+            return time.perf_counter() - t0
+    except OSError:
+        return None
+
+
+def probe_gateway(pid_image: dict[str, str]) -> list[str]:
+    hints: list[str] = []
+    section("3. 网关往返（回环监听端口逐个测时）")
+    ports = gateway_ports(pid_image)
+    candidates = [(p, pid, img) for p, pid, img in ports if img.lower() == "python.exe"]
+    if not candidates:
+        say("未发现 python.exe 的回环监听端口（网关可能已死或以其他形态运行）。")
+        say(f"全部回环监听: {[(p, img) for p, _, img in ports][:20]}")
+        hints.append("找不到存活网关端口——若桌面端仍在跑，指向网关早夭；"
+                     "对照第 7 节日志取证的 attempt 计数。")
+        return hints
+    for port, pid, img in candidates[:6]:
+        say(f"-- 端口 {port}（pid {pid} / {img}）--")
+        v4 = time_connect("127.0.0.1", port)
+        vlocal = time_connect("localhost", port)
+        say(f"TCP 连接 127.0.0.1: {v4 * 1000:.0f} ms" if v4 is not None else
+            "TCP 连接 127.0.0.1: 失败")
+        say(f"TCP 连接 localhost: {vlocal * 1000:.0f} ms" if vlocal is not None else
+            "TCP 连接 localhost: 失败")
+        if v4 is not None and vlocal is not None and vlocal - v4 > 0.5:
+            hints.append(f"端口 {port}: localhost 比 127.0.0.1 慢 "
+                         f"{(vlocal - v4) * 1000:.0f} ms——IPv6 (::1) 回退迟滞，"
+                         "每个请求都要先撞一次空门再退回 IPv4。")
+        laps: list[float] = []
+        for _ in range(HTTP_ROUNDS):
+            t0 = time.perf_counter()
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}/",
+                                            timeout=HTTP_TIMEOUT):
+                    pass
+            except urllib.error.HTTPError:
+                pass  # 401/404 也算完成一次往返，测的就是耗时
+            except (urllib.error.URLError, OSError):
+                laps.append(-1.0)
+                continue
+            laps.append(time.perf_counter() - t0)
+        ok = sorted(x for x in laps if x >= 0)
+        if ok:
+            med = ok[len(ok) // 2]
+            say(f"HTTP 往返 x{len(ok)}: 最快 {ok[0] * 1000:.0f} ms / "
+                f"中位 {med * 1000:.0f} ms / 最慢 {ok[-1] * 1000:.0f} ms")
+            if med > 1.0:
+                hints.append(f"端口 {port}: HTTP 中位往返 {med * 1000:.0f} ms——"
+                             "网关本身响应慢，嫌疑在后端侧（磁盘/杀软拖 Python）。")
+            elif med < 0.2:
+                say("判读: 网关往返健康——若界面仍卡，嫌疑在桌面主进程/渲染层，不在后端。")
+        else:
+            say("HTTP 往返: 全部失败")
+    return hints
+
+
+def sample_read(root: pathlib.Path) -> list[str]:
+    hints: list[str] = []
+    section("4. 磁盘读采样（散文件区，杀软/网络盘放大器）")
+    base = root / "desktop" / "resources" / "app.asar.unpacked" / "dist"
+    if not base.is_dir():
+        say(f"跳过：{base} 不存在")
+        return hints
+    n_files = 0
+    n_bytes = 0
+    t0 = time.perf_counter()
+    for path in base.rglob("*"):
+        if n_files >= READ_SAMPLE_MAX_FILES or n_bytes >= READ_SAMPLE_MAX_BYTES:
+            break
+        if path.is_file():
+            try:
+                n_bytes += len(path.read_bytes())
+                n_files += 1
+            except OSError:
+                continue
+    elapsed = time.perf_counter() - t0
+    if n_files:
+        per_file = elapsed / n_files * 1000
+        say(f"读 {n_files} 件 / {n_bytes / 1048576:.1f} MiB，共 {elapsed:.2f} s"
+            f"（均 {per_file:.1f} ms/件）")
+        if per_file > 20:
+            hints.append(f"散文件读取均 {per_file:.0f} ms/件（健康值 <5ms）——"
+                         "杀软实时扫描或网络盘在放大所有文件访问；"
+                         "处置：给部署目录加杀软排除项 / 拷回本地盘。")
+    return hints
+
+
+def sample_spawn(root: pathlib.Path) -> list[str]:
+    hints: list[str] = []
+    section("5. 子进程冷启采样（杀软对 spawn 的拦截）")
+    py = root / "venv" / "Scripts" / "python.exe"
+    if not py.is_file():
+        say(f"跳过：{py} 不存在")
+        return hints
+    laps = []
+    for tag in ("首启", "复启"):
+        t0 = time.perf_counter()
+        try:
+            subprocess.run([str(py), "-c", "pass"], capture_output=True, timeout=60)
+        except (OSError, subprocess.SubprocessError):
+            say(f"{tag}: 失败")
+            return hints
+        laps.append(time.perf_counter() - t0)
+        say(f"{tag} python -c pass: {laps[-1]:.2f} s")
+    if laps and laps[-1] > 3.0:
+        hints.append(f"python 复启仍要 {laps[-1]:.1f} s（健康值 <0.5s）——杀软在逐次"
+                     "扫描子进程；界面上每个会 spawn 子进程的交互（终端/git/补全）都会吃这笔账。")
+    return hints
+
+
+def motw_scan(root: pathlib.Path) -> list[str]:
+    hints: list[str] = []
+    section("6. MOTW 普查（Zone.Identifier 下载标记）")
+    if os.name != "nt":
+        say("跳过：非 Windows")
+        return hints
+    hit = 0
+    seen = 0
+    for base in (root / "desktop", root / "venv" / "Scripts", root / "app"):
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*"):
+            if seen >= MOTW_SAMPLE_MAX:
+                break
+            if not path.is_file():
+                continue
+            seen += 1
+            try:
+                with open(f"{path}:Zone.Identifier", encoding="utf-8",
+                          errors="ignore"):
+                    hit += 1
+            except OSError:
+                pass
+    say(f"抽样 {seen} 件，带 MOTW 标记 {hit} 件")
+    if hit:
+        hints.append(f"{hit}/{seen} 抽样文件带 MOTW——SmartScreen/杀软对每件都要额外核查。"
+                     "处置：右键 zip → 属性 → 解除锁定后重新解压部署；"
+                     "或对已部署树 powershell 不可用时用 streams.exe / 重新整拷。")
+    return hints
+
+
+def log_forensics(root: pathlib.Path) -> list[str]:
+    hints: list[str] = []
+    section("7. 日志取证（重启循环 / 致命标记）")
+    stdout_log = root / "home" / "logs" / "desktop-stdout.log"
+    attempts = 0
+    fatal = 0
+    if stdout_log.is_file():
+        try:
+            text = stdout_log.read_text(encoding="utf-8", errors="replace")
+            attempts = text.count("===== attempt")
+            fatal = sum(text.count(m) for m in (
+                "A JavaScript error occurred in the main process",
+                "Uncaught Exception:"))
+        except OSError:
+            pass
+        say(f"desktop-stdout.log: attempt 段 {attempts} 个 / 致命标记 {fatal} 处")
+    else:
+        say("desktop-stdout.log 不存在")
+    interesting = re.compile(r"respawn|serve|probe|exited|spawn|backend", re.IGNORECASE)
+    for name in ("launcher.log", os.path.join("home", "logs", "desktop.log")):
+        path = root / name
+        if not path.is_file():
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        picked = [ln for ln in lines if interesting.search(ln)][-12:]
+        say(f"-- {name} 尾部相关行（{len(picked)} 条）--")
+        for ln in picked:
+            say(f"| {ln}")
+        respawnish = sum(1 for ln in lines if re.search(r"respawn|exited", ln, re.IGNORECASE))
+        if respawnish >= 5:
+            hints.append(f"{name} 含 {respawnish} 条 respawn/exited——网关子进程在反复死亡重启，"
+                         "桌面主进程每轮都被同步探针（单针可达 10 秒级）钉住 = 整界面逐次卡顿。")
+    return hints
+
+
+def main() -> int:
+    force_utf8_stdio()
+    if len(sys.argv) < 2:
+        say("用法: python diagnose_lag.py <整包根目录>")
+        return 2
+    root = pathlib.Path(sys.argv[1]).resolve()
+    say(f"Black Pool 交互卡顿分诊 @ {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    say(f"目标: {root}")
+
+    hints: list[str] = []
+    hints += check_env(root)
+    pid_image, h = census(root)
+    hints += h
+    hints += probe_gateway(pid_image)
+    hints += sample_read(root)
+    hints += sample_spawn(root)
+    hints += motw_scan(root)
+    hints += log_forensics(root)
+
+    section("8. 判读提示")
+    if hints:
+        for i, hint in enumerate(hints, 1):
+            say(f"[{i}] {hint}")
+    else:
+        say("各层实测均未见异常——卡顿源可能在渲染层本身或未覆盖的环节；"
+            "请把本报告连同 home\\logs\\ 一并回传银芯继续排查。")
+
+    report = root / "lag-report.txt"
+    try:
+        report.write_text("\n".join(_LINES) + "\n", encoding="utf-8")
+        say("")
+        say(f"报告已落盘: {report}")
+    except OSError as exc:
+        say(f"[warn] 报告写入失败: {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bpa_dev_kit.py
+++ b/tests/test_bpa_dev_kit.py
@@ -121,7 +121,7 @@ def test_kit_files_complete():
                  "apply_patch.py",
                  "RUNBOOK.md", "launcher.cmd", "launch_desktop.py", "fix_venv_path.py",
                  "make-shortcut.vbs", "kill_by_path.py", "assemble_inject.py",
-                 "assembly.sample.txt"]:
+                 "assembly.sample.txt", "diagnose.cmd", "diagnose_lag.py"]:
         assert (KIT / name).is_file(), f"bpa-dev 套件缺件: {name}"
 
 


### PR DESCRIPTION
## 背景

守密人 2026-08-04 现场反馈：部署位 Black Pool 桌面端整个界面交互迟缓，每个交互等 5-10 秒，怀疑与组装方式有关。卡顿候选源分散在远程不可见的几层（部署位盘型 / 杀软实时扫描 / MOTW / 网关早夭重启循环 / localhost IPv6 回退 / 代理误吞回环），只能上实机分层测量。

## 变更

- `deploy/diagnose_lag.py`：纯标准库分诊器，七层实测——环境事实（盘型 + 代理豁免）、进程普查、网关回环往返（localhost vs 127.0.0.1 比对）、散文件读采样、子进程冷启采样、MOTW 普查、日志取证（attempt/respawn 循环），末尾出中文判读提示，全文落部署位 `lag-report.txt`。
- `deploy/diagnose.cmd`：车间感知包装（按 `config\deploy-target.txt` 解析部署位），对**既有部署**直接可用、无需重新组装；kit 目录零写入。
- 两条 CI 装配线（私有版 / 公版）把分诊两件随包出货；套件完整性守卫登记；RUNBOOK 增「卡顿分诊」节。

## 验证

- `pytest tests/test_bpa_dev_kit.py tests/test_hermes_charter.py`：35 过。
- `premerge_gate.py` 常规 + `--sparse` 两形态：3333 过 / 51 跳过，全绿。
- 非 Windows 降级冒烟：各层优雅跳过、报告照常落盘。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMQbttJZ9MMKE2ok1PbPP7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMQbttJZ9MMKE2ok1PbPP7)_