### PR TITLE
factory cleanup: stub the shipped test runner (bundle carries no test suite)

### DIFF
--- a/.github/workflows/assemble-black-pool-bundle.yml
+++ b/.github/workflows/assemble-black-pool-bundle.yml
@@ -177,6 +177,21 @@ jobs:
           rm -rf BlackPool/app/website
           rm -rf BlackPool/app/tests
           rm -rf BlackPool/app/tests-js
+          # 测试运行器存根（2026-08-04 野战案）：tests/ 已裁但 run_tests.sh 原件仍在，
+          # 现场跑它会先撞 venv 探针报「no virtualenv with pytest」——误导排障方向。
+          # 出厂即换成直说真相的存根：整包不载测试套件，套件在银芯 upstream/ 跑。
+          rm -f BlackPool/app/scripts/run_tests_parallel.py
+          cat > BlackPool/app/scripts/run_tests.sh <<'STUB'
+          #!/usr/bin/env bash
+          # Stubbed at bundle assembly time (factory cleanup).
+          echo "error: this is a Black Pool deployment bundle - the test suite is not shipped." >&2
+          echo "       app/tests was stripped at assembly time and the bundle venv carries no pytest," >&2
+          echo "       so there is nothing here for pytest to run. This is by design, not breakage." >&2
+          echo "       Run the suite from a silver-core checkout instead:" >&2
+          echo "         projects/black-pool-agent/upstream/  (recipe: projects/black-pool-agent/CONTEXT.md)" >&2
+          exit 2
+          STUB
+          chmod +x BlackPool/app/scripts/run_tests.sh
           du -sh BlackPool
 
       - name: Desktop launch smoke (supervised, captures Chromium stderr)

--- a/.github/workflows/assemble-black-pool-public.yml
+++ b/.github/workflows/assemble-black-pool-public.yml
@@ -175,6 +175,21 @@ jobs:
           rm -rf BlackPool/app/website
           rm -rf BlackPool/app/tests
           rm -rf BlackPool/app/tests-js
+          # 测试运行器存根（2026-08-04 野战案）：tests/ 已裁但 run_tests.sh 原件仍在，
+          # 现场跑它会先撞 venv 探针报「no virtualenv with pytest」——误导排障方向。
+          # 出厂即换成直说真相的存根：整包不载测试套件，套件在银芯 upstream/ 跑。
+          rm -f BlackPool/app/scripts/run_tests_parallel.py
+          cat > BlackPool/app/scripts/run_tests.sh <<'STUB'
+          #!/usr/bin/env bash
+          # Stubbed at bundle assembly time (factory cleanup).
+          echo "error: this is a Black Pool deployment bundle - the test suite is not shipped." >&2
+          echo "       app/tests was stripped at assembly time and the bundle venv carries no pytest," >&2
+          echo "       so there is nothing here for pytest to run. This is by design, not breakage." >&2
+          echo "       Run the suite from a silver-core checkout instead:" >&2
+          echo "         projects/black-pool-agent/upstream/  (recipe: projects/black-pool-agent/CONTEXT.md)" >&2
+          exit 2
+          STUB
+          chmod +x BlackPool/app/scripts/run_tests.sh
           du -sh BlackPool
 
       - name: Desktop launch smoke (supervised, captures Chromium stderr)

--- a/projects/black-pool-agent/deploy/RUNBOOK.md
+++ b/projects/black-pool-agent/deploy/RUNBOOK.md
@@ -85,6 +85,12 @@ E:\BIAV-BP\bpa-dev\   （内部开发目录；部署目录 = E:\BIAV-BP\black-po
   desktop / web UI 是已构建产物，**内网改不动**——UI 需求走银芯补丁入库、CI 装配线出包。
 - **补丁登记**：patches\ 里每张补丁在 README 记一行「用途 / 锚点 / 维护人」，学银芯白名单制。
 - **换包必经组装**：直接解压 zip 进部署位会丢掉全部内网补丁与配置——永远走 assemble → deploy。
+- **整包不载测试套件（2026-08-04 野战案）**：出厂清场已裁掉 `app\tests`，且整包 venv 刻意
+  不带 pytest——在部署位跑 `scripts\run_tests.sh` 结构上不可能成功，这不是环境坏了。
+  运行器已在出厂时换成直说真相的存根（跑它会明说原因并指路）。真要跑套件：场地是银芯
+  克隆的 `projects\black-pool-agent\upstream\`，配方见同目录 `CONTEXT.md` 验证清单
+  （uv sync 带 dev extras + 设 `HERMES_PYTHON`）；当前整包引擎版本已在银芯容器全量
+  复现过（零真缺陷报告在 `Public-Info-Pool\Resource\repo-engineering\`），本地重跑无增量。
 - **绿色版二次拷贝纪律（2026-08-04 实机断料案）**：包本身是绿色版，但把部署位拷去
   另一位置/另一台机时，**必须用不过滤目录的整拷方式**（`robocopy <源> <目标> /e` 或
   Explorer 整目录复制后核对件数）——部分同步/备份工具默认跳过 `node_modules` 目录，

--- a/tests/test_bpa_dev_kit.py
+++ b/tests/test_bpa_dev_kit.py
@@ -320,3 +320,19 @@ def test_kill_by_path_noop_on_non_windows(tmp_path):
     r = subprocess.run([sys.executable, str(KIT / "kill_by_path.py"), str(tmp_path)],
                        capture_output=True, text=True)
     assert r.returncode == 0 and "no-op" in r.stdout
+
+
+def test_factory_cleanup_stubs_test_runner():
+    """2026-08-04 野战回归（部署位跑 run_tests.sh 报 venv 缺 pytest）：整包既已
+    裁掉 app/tests，就不得再留会撞 venv 探针的运行器原件——两条装配线出厂清场
+    须 ① 裁 tests / tests-js ② 剔 run_tests_parallel.py ③ 把 run_tests.sh 换成
+    直说「套件不随包」的存根（exit 2 + 指路 upstream/）。"""
+    for wf in ("assemble-black-pool-bundle.yml", "assemble-black-pool-public.yml"):
+        text = (REPO / ".github" / "workflows" / wf).read_text(encoding="utf-8")
+        assert "rm -rf BlackPool/app/tests" in text, f"{wf} 未裁测试集"
+        assert "rm -f BlackPool/app/scripts/run_tests_parallel.py" in text, (
+            f"{wf} 未剔并行运行器"
+        )
+        assert "cat > BlackPool/app/scripts/run_tests.sh" in text, f"{wf} 缺运行器存根"
+        assert "the test suite is not shipped" in text, f"{wf} 存根未直说真相"
+        assert "projects/black-pool-agent/CONTEXT.md" in text, f"{wf} 存根未指路配方"


### PR DESCRIPTION
## 概述

野战案回归（守密人 2026-08-04 现场报错「no virtualenv with pytest found」）：整包出厂清场已裁 `app/tests` 且发行 venv 刻意不带 pytest，部署位结构上跑不了测试套件，但 `run_tests.sh` 原件仍随包、现场跑它报出误导性的 venv 缺失错。本 PR 让两条装配线出厂时把该运行器换成直说真相的存根（明说套件不随包 + 指路 upstream/ 配方），并同步 RUNBOOK 纪律与守卫测试。

---

## 变更类型

- [x] Bug 修复
- [x] 文档完善（CLAUDE.md / README.md / 子项目 CONTEXT.md / memory 档案）
- [ ] 其他（请说明）：

---

## 来源声明

- [x] 本 PR 不涉及游戏数据；变更对象为本仓库自有装配线（`.github/workflows/assemble-black-pool-*.yml`）、部署套件手册（`projects/black-pool-agent/deploy/RUNBOOK.md`）与守卫测试。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 所有引用素材均来自公开可查阅来源。
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**；不上传内部美术资产、客户端解包原始文件、未公开的剧情草稿等。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 存根经沙盒实证：从两条 workflow 的 YAML run 块解析出清场脚本实跑，heredoc 逐字落地、存根 exit 2、两线逐字节一致
- [x] `pytest tests/test_bpa_dev_kit.py`：36 过（含新守卫 `test_factory_cleanup_stubs_test_runner`）
- [x] `python3 scripts/premerge_gate.py --sparse` 全绿：3,336 过 / 51 跳（常规 + 稀疏检出双形态）
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案（这些归主控台）

---

## 关联 Issue

- 无

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbxrZq48vUbut9wbUid1Hz)_