### PR TITLE
Add make-clone-bundle workflow: offline repo transport via Release

### DIFF
--- a/.github/workflows/make-clone-bundle.yml
+++ b/.github/workflows/make-clone-bundle.yml
@@ -1,0 +1,58 @@
+name: Make Clone Bundle
+
+# 克隆搬运包（守密人 2026-08-04 要求）：直连 GitHub 克隆屡断的机器，改从 Release
+# 下载一个 git bundle 单文件——bundle 是 git 官方的离线仓库搬运格式，浏览器 / 下载
+# 工具天然支持断点续传，且下载链接可加镜像前缀加速。下载后本地展开即为完整克隆：
+#
+#   git clone biav-sc-main.bundle BIAV-SC-CODE
+#   cd BIAV-SC-CODE
+#   git remote set-url origin https://github.com/lightproud/BIAV-SC-CODE.git
+#
+# 手动触发、滚动覆盖同名资产（--clobber）；bundle 内容 = 触发时刻 main 全量历史。
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  BUNDLE_TAG: clone-bundle
+  BUNDLE_FILE: biav-sc-main.bundle
+
+jobs:
+  bundle:
+    name: Bundle main for offline transport
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create and verify bundle
+        run: |
+          git bundle create "${BUNDLE_FILE}" main
+          git bundle verify "${BUNDLE_FILE}"
+          ls -lh "${BUNDLE_FILE}"
+
+      - name: Upload to Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NOTES="仓库离线搬运包：main 全量历史的 git bundle（滚动覆盖，本份 @ ${GITHUB_SHA:0:12}, $(date -u +%Y-%m-%dT%H:%MZ) UTC）。
+
+用法：
+\`\`\`
+git clone ${BUNDLE_FILE} BIAV-SC-CODE
+cd BIAV-SC-CODE
+git remote set-url origin https://github.com/lightproud/BIAV-SC-CODE.git
+git pull --ff-only   # 补齐打包之后的新提交
+\`\`\`
+
+校验：clone 后 git rev-parse HEAD 应等于上面的打包 commit。详见 RELEASES.md。"
+          gh release view "${BUNDLE_TAG}" >/dev/null 2>&1 || \
+            gh release create "${BUNDLE_TAG}" --title "Clone bundle (offline transport)" --notes "${NOTES}"
+          gh release edit "${BUNDLE_TAG}" --notes "${NOTES}"
+          gh release upload "${BUNDLE_TAG}" "${BUNDLE_FILE}" --clobber

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -49,6 +49,7 @@
 | 同人图月归档 | `community-assets` | `fanart-archive-{YYYY-MM}.tar.gz` |
 | 回填的社区媒体 | `community-assets` | `media/backfill_manifest.json` 索引的媒体 |
 | Black Pool（黑池）便携整包（win64，Hermes 组装产物）| `black-pool-bundle` | `black-pool-win64.zip`（私有版，**合箱单目录**：运行时 + desktop + launcher，zip 仅传输载体）；`black-pool-public-win64.zip`（公版，独立工作流按需出包）|
+| 本仓离线搬运包（直连克隆屡断时整仓下载）| `clone-bundle` | `biav-sc-main.bundle`（main 全量历史 git bundle，可断点续传/镜像加速；用法见 §2.4）|
 
 ## 二、两个 Release 总览
 
@@ -96,6 +97,24 @@ desktop（`--win dir` 免装目录形态）+ `launcher.cmd` 双击即用。**zip
 升级 = 移 pin 重测后重跑 workflow 重发（文书 §2.4）。方案详见
 `projects/black-pool-agent/deploy/README.md`。定名前旧桶 `silver-core-bundle`
 已删除（守密人 2026-08-03 裁定，防误取旧包）。
+
+### 2.4 「克隆搬运包」`clone-bundle` —— 仓库离线搬运（2026-08-04 增设）
+
+守密人 2026-08-04 要求（B 机器直连 GitHub 克隆屡断 curl 56）：CI `make-clone-bundle.yml`
+（workflow_dispatch）把触发时刻的 main 全量历史打成 **git bundle 单文件**
+`biav-sc-main.bundle` 挂本桶滚动覆盖。bundle 是 git 官方离线搬运格式——浏览器 / 下载工具
+断点续传，下载 URL 可加镜像前缀加速，展开后即完整克隆（区别于 zip 快照：带 `.git` 全部对象，
+可正常 `pull`）。用法：
+
+```bash
+git clone biav-sc-main.bundle BIAV-SC-CODE
+cd BIAV-SC-CODE
+git remote set-url origin https://github.com/lightproud/BIAV-SC-CODE.git
+git pull --ff-only   # 补齐打包之后的新提交
+```
+
+校验：clone 后 `git rev-parse HEAD` 应等于 Release notes 标注的打包 commit。
+包为按需重打（非定时），取新鲜包前可先重跑 workflow。
 
 ## 三、整理历程
 

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -89,7 +89,7 @@
 | maestro SDK 源文件 / 测试档 | 20 / 40 | 磁盘实况 |
 | testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
 | Python 测试档 | 149 | 磁盘实况 |
-| CI 工作流 / 其中定时 | 48 / 21 | `.github/workflows/` |
+| CI 工作流 / 其中定时 | 49 / 21 | `.github/workflows/` |
 | 挂账台账 开 / 已清 | 22 / 64 | `memory/todo.md` |
 
 <!-- STATUS-FACTS:END -->


### PR DESCRIPTION
## 背景

守密人 B 机器直连 GitHub 克隆屡断（curl 56 Connection reset），要求把仓库打包挂 Release 供浏览器下载。zip 快照无 `.git` 不能当克隆用；改用 git bundle——git 官方离线搬运格式，单文件可断点续传 / 镜像前缀加速，展开后即完整克隆。

## 变更

- 新增 `.github/workflows/make-clone-bundle.yml`（workflow_dispatch）：main 全量历史打成 `biav-sc-main.bundle`，`git bundle verify` 后挂 `clone-bundle` Release 滚动覆盖（`--clobber`），notes 带打包 commit 供校验。
- `RELEASES.md` 藏宝图登记：快速定位表加一行 + 新增 §2.4 用法说明。
- `memory/project-status.md` 机器事实块重算（CI 工作流 48 → 49，`build_status_facts.py` 生成）。

## 验证

- `premerge_gate.py` 双形态全绿（常规 + `--sparse`）：3,325 passed / 51 skipped。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A937biMf5YkmQ5vkz7sMqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01A937biMf5YkmQ5vkz7sMqY)_