### PR TITLE
Fix make-clone-bundle YAML: release notes broke the run block scalar

### DIFF
--- a/.github/workflows/make-clone-bundle.yml
+++ b/.github/workflows/make-clone-bundle.yml
@@ -41,17 +41,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NOTES="仓库离线搬运包：main 全量历史的 git bundle（滚动覆盖，本份 @ ${GITHUB_SHA:0:12}, $(date -u +%Y-%m-%dT%H:%MZ) UTC）。
-
-用法：
-\`\`\`
-git clone ${BUNDLE_FILE} BIAV-SC-CODE
-cd BIAV-SC-CODE
-git remote set-url origin https://github.com/lightproud/BIAV-SC-CODE.git
-git pull --ff-only   # 补齐打包之后的新提交
-\`\`\`
-
-校验：clone 后 git rev-parse HEAD 应等于上面的打包 commit。详见 RELEASES.md。"
+          # notes 用 printf 单行拼装——多行块标量顶格续行会撑破 YAML（2026-08-04 实弹教训）
+          STAMP="$(date -u +%Y-%m-%dT%H:%MZ)"
+          NOTES="$(printf '仓库离线搬运包：main 全量历史的 git bundle（滚动覆盖，本份 @ %s, %s UTC）。\n\n用法：\n```\ngit clone biav-sc-main.bundle BIAV-SC-CODE\ncd BIAV-SC-CODE\ngit remote set-url origin https://github.com/lightproud/BIAV-SC-CODE.git\ngit pull --ff-only\n```\n\n校验：clone 后 git rev-parse HEAD 应等于上面的打包 commit。详见 RELEASES.md。' "${GITHUB_SHA:0:12}" "$STAMP")"
           gh release view "${BUNDLE_TAG}" >/dev/null 2>&1 || \
             gh release create "${BUNDLE_TAG}" --title "Clone bundle (offline transport)" --notes "${NOTES}"
           gh release edit "${BUNDLE_TAG}" --notes "${NOTES}"


### PR DESCRIPTION
## 背景

#972 入库的 `make-clone-bundle.yml` 被 GitHub 注册但**解析失败**（指纹：API 元数据 `name` 回落为文件路径），workflow_dispatch 触发一律 422。真因：Release notes 多行字符串的续行顶格写，缩进比 `run: |` 块浅，YAML 块标量在此终止、后续行成非法顶层内容。

## 变更

- notes 改用 `printf` 单行拼装（含 `\n` 转义），全部内容保持在块标量缩进内。
- 本地 `yaml.safe_load` 验证通过（`name = Make Clone Bundle`、`workflow_dispatch` 在位）。

## 验证

- 仅工作流文件改动，不触及 pytest 判据；上一轮门禁双形态全绿基线未变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A937biMf5YkmQ5vkz7sMqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01A937biMf5YkmQ5vkz7sMqY)_