### PR TITLE
Add public-workshop: in-repo assembly capability for the public edition

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -96,7 +96,9 @@ desktop（`--win dir` 免装目录形态）+ `launcher.cmd` 双击即用。**zip
 零解压零安装零 PowerShell。**包内零凭据零内网参数**（§1.1-HC 切面化，配置内网侧注入）；
 升级 = 移 pin 重测后重跑 workflow 重发（文书 §2.4）。方案详见
 `projects/black-pool-agent/deploy/README.md`。定名前旧桶 `silver-core-bundle`
-已删除（守密人 2026-08-03 裁定，防误取旧包）。
+已删除（守密人 2026-08-03 裁定，防误取旧包）。**公版包的仓内落位车间**（银芯 checkout
+自持组装：验货 / 解压 / home 保全 / 回滚，守密人 2026-08-04 指示）=
+`projects/black-pool-agent/public-workshop/`，用法见其 `RUNBOOK.md`。
 
 ### 2.4 「克隆搬运包」`clone-bundle` —— 仓库离线搬运（2026-08-04 增设）
 

--- a/memory/project-status.md
+++ b/memory/project-status.md
@@ -88,7 +88,7 @@
 | agent SDK 源文件 / 测试档 | 141 / 213 | 磁盘实况 |
 | maestro SDK 源文件 / 测试档 | 20 / 40 | 磁盘实况 |
 | testbed 源文件 / 测试档 | 6 / 3 | 磁盘实况 |
-| Python 测试档 | 148 | 磁盘实况 |
+| Python 测试档 | 149 | 磁盘实况 |
 | CI 工作流 / 其中定时 | 49 / 21 | `.github/workflows/` |
 | 挂账台账 开 / 已清 | 22 / 64 | `memory/todo.md` |
 

--- a/projects/black-pool-agent/CONTEXT.md
+++ b/projects/black-pool-agent/CONTEXT.md
@@ -31,7 +31,7 @@
 plugins/    # 通用化域插件（零公司信息）        skills/   # 通用技能样例（团队技能实体在内网）
 deploy/     # 通用部署/overlay 脚本（参数化）    patches/  # 预留，当前必须为空（守卫钉死）
 gaps.md     # 漏缝清单（一等产出）              upstream/ # 官方源码快照（银芯开发镜像，见下）
-UPSTREAM.md # pin 台账唯一权威
+UPSTREAM.md # pin 台账唯一权威                  public-workshop/ # 公版仓内车间（checkout 自持组装，2026-08-04）
 ```
 
 - **upstream/ 定位（守密人 2026-08-02 交互澄清）**：保留在银芯仓，供**开发、测试、追官方新版**

--- a/projects/black-pool-agent/build/README.md
+++ b/projects/black-pool-agent/build/README.md
@@ -70,6 +70,15 @@ Windows venv 不可跨平台组装，故必须 Windows 台）单 job 产**唯一
 **合规联动（守密人 2026-08-02 交互裁定已闭）**：文书裁 7 报备口径不变（常规迭代不另行申报），
 其成立前提修订为「数据面与现状完全一致 + 免安装器便携分发（与 BPT 现状同形）」。
 
+## 公版仓内车间 `../public-workshop/`（守密人 2026-08-04 指示）
+
+「让银芯仓库本身也拥有组装能力，用于公版」的落地：任何克隆了银芯仓的 Windows 机器，
+凭 `public-workshop/` 即可把 Release 公版包（`black-pool-public-win64.zip`）验货 →
+解压 → 启动器套新 → home 保全 → 轮换落位为可用的 `BlackPool\`，并一键回滚。
+与内网 bpa-dev 车间同构但**自根于仓内、零内网件**（不含 assemble_inject 注入工序）。
+用法与目录约定见 `../public-workshop/RUNBOOK.md`；守卫 `tests/test_public_workshop.py`。
+一级出包（从源码构建 zip）仍归 CI 组装台，本车间只做二级落位。
+
 ## 品牌图标（2026-08-02 补漏 #2）
 
 - 源：`build/brand-assets/`（icon.png / icon.ico / apple-touch-icon.png / brand-tile.jpg），

--- a/projects/black-pool-agent/public-workshop/.gitignore
+++ b/projects/black-pool-agent/public-workshop/.gitignore
@@ -1,0 +1,8 @@
+# Workshop runtime dirs: input material, assembly bench, deployed product,
+# rollback/forensic slots and logs never enter git.
+releases/
+staging/
+BlackPool/
+BlackPool.old/
+BlackPool.failed-*/
+*.log

--- a/projects/black-pool-agent/public-workshop/RUNBOOK.md
+++ b/projects/black-pool-agent/public-workshop/RUNBOOK.md
@@ -1,0 +1,44 @@
+# public-workshop/ — 公版仓内车间（银芯 checkout 自持组装能力）
+
+> 守密人 2026-08-04 指示「让银芯仓库本身也拥有组装能力，用于公版」的落地：任何克隆了
+> 银芯仓的 Windows 机器，凭本目录即可把 Release 上的**公版** Black Pool 包组装落位、
+> 就地可用——与内网 `bpa-dev` 车间（`../deploy/` 拷走型三脚本）同构，但**自根于仓内**、
+> **零内网件**（公版 = 纯品牌换装，无 intranet 补丁 / 无配置注入，§1.1-HC 无涉）。
+
+## 目录约定（运行时目录均不入 git，见本目录 .gitignore）
+
+```
+public-workshop/
+├── RUNBOOK.md        # 本档
+├── assemble.cmd      # 组装 + 部署一步走（验货 → 解压 → 启动器套新 → home 保全 → 轮换落位）
+├── rollback.cmd      # 一键回切上一版
+├── releases/         # 进料位：把下载的 black-pool-public-win64.zip 放这里（可选 CHECKSUMS.txt 验货）
+├── staging/          # 组装台（脚本自管，勿手动动）
+├── BlackPool/        # 落位成品：双击其中 launcher.cmd 即用
+└── BlackPool.old/    # 回滚位（自动滚动，只留最近一版）
+```
+
+## 使用步骤
+
+1. **进料**：从银芯 Release 下载公版包放入 `releases/`：
+   - 直连：`https://github.com/lightproud/BIAV-SC-CODE/releases/download/black-pool-bundle/black-pool-public-win64.zip`
+   - 直连不稳时加镜像前缀（任选其一，前缀站存活率无常）：
+     `https://gh-proxy.com/<上面的直连地址>` 或 `https://ghfast.top/<直连地址>`
+   - 包不存在或要新鲜包时，先在 GitHub Actions 手动跑 `assemble-black-pool-public.yml` 出包。
+2. **组装**：双击 `assemble.cmd`（或命令行传 zip 文件名指定进料）。脚本依次：
+   SHA 验货（`releases/CHECKSUMS.txt` 存在时）→ 解压进 `staging/` → 启动器族按仓内
+   `../deploy/` 套件版覆盖（launcher / 监督器 / venv 自愈，保持与仓同新）→ 旧
+   `BlackPool/home` 用户数据增量保全 → 旧版轮换进 `BlackPool.old/` → 成品落位 `BlackPool/`。
+3. **启动**：双击 `BlackPool/launcher.cmd`（或落位时生成的 `Black Pool.lnk`）。
+4. **升级**：新 zip 入 `releases/` 重跑 `assemble.cmd`——home 自动保全，旧版自动进回滚位。
+5. **回滚**：双击 `rollback.cmd`，一键回切上一版（问题版让位到 `BlackPool.failed-*` 供取证）。
+
+## 边界与纪律
+
+- **只吃公版包**：本车间不含任何内网注入工序；私有版组装走内网 `bpa-dev` 车间
+  （部署件收纳与用法见 `../build/README.md`）。
+- **产物不入 git**：`releases/` / `staging/` / `BlackPool*` / 日志全部被 `.gitignore`
+  排除，车间怎么用都不会弄脏仓库。
+- **cmd 工程纪律沿用 `../deploy/` 车间实弹经验**：goto 守卫防括号路径、goto 标签后
+  ASCII-only 防 65001 解析错位、CRLF 由仓根 `.gitattributes` 钉死。
+- 守卫测试：`pytest tests/test_public_workshop.py -v`。

--- a/projects/black-pool-agent/public-workshop/assemble.cmd
+++ b/projects/black-pool-agent/public-workshop/assemble.cmd
@@ -1,0 +1,143 @@
+@echo off
+rem Public-edition in-repo workshop (keeper directive 2026-08-04): a silver-core
+rem checkout assembles and deploys the PUBLIC Black Pool bundle by itself.
+rem Self-rooted layout (everything under this dir); no intranet parts involved.
+rem Flow: pick zip from releases\ -> optional SHA check -> unpack to staging\
+rem -> refresh launcher family from ..\deploy -> preserve user home -> rotate
+rem old deployment into BlackPool.old -> land product at BlackPool\.
+rem goto-based guard: %~f0 / %* expanded inside a ( ) block breaks cmd
+rem parsing when the path or args contain a parenthesis (e.g. "xxx (1)").
+if defined BPW_KEEPWIN goto :bpw_keepwin
+set "BPW_KEEPWIN=1"
+cmd /d /k call "%~f0" %*
+exit /b
+:bpw_keepwin
+setlocal EnableExtensions EnableDelayedExpansion
+chcp 65001 >nul
+set "SD=%~dp0"
+set "KIT=%SD%..\deploy"
+set "LOG=%SD%assemble.log"
+echo [%date% %time%] public assemble start > "%LOG%"
+
+rem input zip: arg 1 (file name under releases\) or the newest zip there
+set "ZIP="
+if not "%~1"=="" (
+  set "ZIP=%SD%releases\%~1"
+) else (
+  for /f "delims=" %%F in ('dir /b /o:d "%SD%releases\*.zip" 2^>nul') do set "ZIP=%SD%releases\%%F"
+)
+if not defined ZIP (
+  echo 组装失败：releases\ 里没有 zip 包。先按 RUNBOOK.md 从银芯 Release 下载公版包放入。
+  echo 详情见 %LOG% & pause & exit /b 1
+)
+if not exist "%ZIP%" (
+  echo 组装失败：指定的包不存在 %ZIP%
+  pause & exit /b 1
+)
+echo 进料：%ZIP%
+echo [ok] zip=%ZIP% >> "%LOG%"
+
+rem optional goods check against releases\CHECKSUMS.txt (SHA-256)
+if exist "%SD%releases\CHECKSUMS.txt" (
+  set "SHA="
+  for /f "skip=1 delims=" %%H in ('certutil -hashfile "%ZIP%" SHA256 2^>nul') do if not defined SHA set "SHA=%%H"
+  set "SHA=!SHA: =!"
+  findstr /i /c:"!SHA!" "%SD%releases\CHECKSUMS.txt" >nul || (
+    echo 组装失败：SHA-256 与 CHECKSUMS.txt 不符（包损坏或未登记）。
+    echo   实测 !SHA! >> "%LOG%"
+    echo 详情见 %LOG% & pause & exit /b 1
+  )
+  echo 验货通过：SHA-256 已比对 CHECKSUMS.txt
+) else (
+  echo [warn] no CHECKSUMS.txt, skip goods check >> "%LOG%"
+  echo 提示：未做 SHA 验货（releases\CHECKSUMS.txt 不存在）。
+)
+
+rem unpack onto a clean bench
+if exist "%SD%staging" rd /s /q "%SD%staging"
+mkdir "%SD%staging"
+echo 解压中（约 1 分钟）...
+tar -xf "%ZIP%" -C "%SD%staging" || (
+  echo 组装失败：解压出错。& echo 详情见 %LOG% & pause & exit /b 1
+)
+set "B=%SD%staging\BlackPool"
+if not exist "%B%\launcher.cmd" (
+  echo 组装失败：包结构异常（未见 BlackPool\launcher.cmd）。
+  pause & exit /b 1
+)
+
+rem refresh launcher family from the repo deploy kit (repo fixes win over zip)
+for %%F in (launcher.cmd launch_desktop.py fix_venv_path.py) do (
+  if exist "%KIT%\%%F" copy /y "%KIT%\%%F" "%B%\%%F" >nul
+)
+echo 启动器族已按仓内套件版覆盖（launcher / 监督器 / venv 自愈）
+
+rem preserve user data from the previous deployment (incremental, no clobber)
+if exist "%SD%BlackPool\home" (
+  robocopy "%SD%BlackPool\home" "%B%\home" /e /xc /xn /xo /njh /njs /ndl /nfl >nul
+  if errorlevel 8 (echo 组装失败：home 保全拷贝出错。& echo 详情见 %LOG% & pause & exit /b 1)
+  echo 用户数据已保全（旧 home 增量并入，不覆盖新配置）
+)
+
+rem rotation deploy: kill lockers, current -> BlackPool.old (single slot)
+set "STPY="
+for /d %%D in ("%B%\python\cpython-*") do set "STPY=%%~fD\python.exe"
+set "OLD_EXE="
+for %%F in ("%SD%BlackPool\desktop\*.exe") do if not defined OLD_EXE set "OLD_EXE=%%~nxF"
+if defined OLD_EXE taskkill /f /im "%OLD_EXE%" >nul 2>&1
+if defined STPY "%STPY%" "%KIT%\kill_by_path.py" "%SD%BlackPool" >> "%LOG%" 2>&1
+ping -n 2 127.0.0.1 >nul
+
+set /a _TRIES=0
+:rot_old
+if exist "%SD%BlackPool.old" (
+  rd /s /q "%SD%BlackPool.old" >nul 2>&1
+  if exist "%SD%BlackPool.old" (
+    set /a _TRIES+=1
+    if !_TRIES! geq 3 goto rot_fail
+    echo 回滚位清理被占用，重试 !_TRIES!/3 ...
+    ping -n 3 127.0.0.1 >nul
+    goto rot_old
+  )
+)
+set /a _TRIES=0
+:rot_move
+if exist "%SD%BlackPool" (
+  move "%SD%BlackPool" "%SD%BlackPool.old" >nul 2>&1
+  if exist "%SD%BlackPool" (
+    set /a _TRIES+=1
+    if !_TRIES! geq 3 goto rot_fail
+    echo 目录占用，清障重试 !_TRIES!/3 ...
+    if defined OLD_EXE taskkill /f /im "%OLD_EXE%" >nul 2>&1
+    if defined STPY "%STPY%" "%KIT%\kill_by_path.py" "%SD%BlackPool" >> "%LOG%" 2>&1
+    ping -n 3 127.0.0.1 >nul
+    goto rot_move
+  )
+)
+move "%B%" "%SD%BlackPool" >nul || (
+  echo 部署失败：成品搬运出错；旧版仍在 BlackPool.old 可手工恢复。
+  echo 详情见 %LOG% & pause & exit /b 1
+)
+
+rem one-click icon entry beside the deployed product
+set "BPW_EXE="
+for %%F in ("%SD%BlackPool\desktop\*.exe") do if not defined BPW_EXE set "BPW_EXE=%%~fF"
+set "LNK_TARGET=%SD%BlackPool\launcher.cmd"
+if exist "%SD%BlackPool\Black Pool.exe" set "LNK_TARGET=%SD%BlackPool\Black Pool.exe"
+if defined BPW_EXE (
+  cscript //nologo "%KIT%\make-shortcut.vbs" "%SD%BlackPool\Black Pool.lnk" "%LNK_TARGET%" "%SD%BlackPool" "%BPW_EXE%,0" >nul 2>&1 && echo 已生成带图标入口：Black Pool.lnk（可拷到桌面）
+)
+
+echo.
+echo 组装部署完成（公版）：%SD%BlackPool
+echo 启动：双击 BlackPool\launcher.cmd 或 Black Pool.lnk   回滚：rollback.cmd
+echo 全程日志：%LOG%
+exit /b 0
+
+:rot_fail
+rem ASCII-only in this block: UTF-8 echo after goto labels desyncs the 65001
+rem parser (field case 3, see ..\deploy\deploy.cmd).
+echo [FAIL] BlackPool dir is locked - close Black Pool and any console window
+echo whose current directory sits inside it, then rerun assemble.cmd.
+echo Log: %LOG%
+pause & exit /b 1

--- a/projects/black-pool-agent/public-workshop/rollback.cmd
+++ b/projects/black-pool-agent/public-workshop/rollback.cmd
@@ -1,0 +1,33 @@
+@echo off
+rem Public workshop rollback: swap BlackPool.old back in (single slot).
+rem goto-based guard: %~f0 / %* expanded inside a ( ) block breaks cmd
+rem parsing when the path or args contain a parenthesis (e.g. "xxx (1)").
+if defined BPW_KEEPWIN goto :bpw_keepwin
+set "BPW_KEEPWIN=1"
+cmd /d /k call "%~f0" %*
+exit /b
+:bpw_keepwin
+setlocal EnableExtensions
+chcp 65001 >nul
+set "SD=%~dp0"
+if not exist "%SD%BlackPool.old" (
+  echo 回滚失败：没有回滚位 BlackPool.old（每次组装只留最近一版）。
+  pause & exit /b 1
+)
+set "RB_EXE="
+for %%F in ("%SD%BlackPool\desktop\*.exe") do if not defined RB_EXE set "RB_EXE=%%~nxF"
+if defined RB_EXE taskkill /f /im "%RB_EXE%" >nul 2>&1
+ping -n 2 127.0.0.1 >nul
+set "TS=%RANDOM%"
+if exist "%SD%BlackPool" (
+  move "%SD%BlackPool" "%SD%BlackPool.failed-%TS%" >nul || (
+    echo 回滚失败：当前目录占用中（先关掉正在运行的 Black Pool）。
+    pause & exit /b 1
+  )
+)
+move "%SD%BlackPool.old" "%SD%BlackPool" >nul || (
+  echo 回滚失败：回滚位搬运出错，当前版已让位到 BlackPool.failed-%TS%，请手工处置。
+  pause & exit /b 1
+)
+echo 回滚完成：BlackPool 已回到上一版；问题版留在 BlackPool.failed-%TS% 供取证。
+exit /b 0

--- a/tests/test_public_workshop.py
+++ b/tests/test_public_workshop.py
@@ -1,0 +1,67 @@
+"""Guards for the public-edition in-repo workshop (keeper directive 2026-08-04).
+
+The workshop lets any silver-core checkout assemble and deploy the PUBLIC
+Black Pool bundle by itself (projects/black-pool-agent/public-workshop/).
+These tests pin the three field-proven disciplines the cmd suite relies on:
+the kit files it references must exist, runtime dirs must never enter git,
+and goto-label blocks must stay ASCII (65001 parser desync, field case 3).
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+WS = ROOT / "projects" / "black-pool-agent" / "public-workshop"
+KIT = ROOT / "projects" / "black-pool-agent" / "deploy"
+
+
+class TestPublicWorkshop(unittest.TestCase):
+    def test_workshop_files_exist(self):
+        for name in ("RUNBOOK.md", "assemble.cmd", "rollback.cmd", ".gitignore"):
+            self.assertTrue((WS / name).is_file(), f"public-workshop/{name} missing")
+
+    def test_referenced_kit_helpers_exist(self):
+        """assemble.cmd borrows helpers from ../deploy — they must stay in place."""
+        for name in (
+            "launcher.cmd",
+            "launch_desktop.py",
+            "fix_venv_path.py",
+            "kill_by_path.py",
+            "make-shortcut.vbs",
+        ):
+            self.assertTrue((KIT / name).is_file(), f"deploy kit helper {name} missing")
+
+    def test_gitignore_covers_runtime_dirs(self):
+        ignore = (WS / ".gitignore").read_text(encoding="utf-8")
+        for entry in ("releases/", "staging/", "BlackPool/", "BlackPool.old/", "*.log"):
+            self.assertIn(entry, ignore, f".gitignore lost entry {entry}")
+
+    def test_failure_labels_stay_ascii(self):
+        """Blocks entered via goto must be ASCII-only (65001 desync, field case 3).
+
+        Heuristic: from a failure label (rot_fail) to the next exit, every echo
+        must be plain ASCII.
+        """
+        text = (WS / "assemble.cmd").read_text(encoding="utf-8")
+        block = re.search(r":rot_fail(.*?)exit /b", text, re.S)
+        self.assertIsNotNone(block, "rot_fail block missing")
+        for line in block.group(1).splitlines():
+            self.assertTrue(
+                line.isascii(), f"non-ASCII line inside goto-label block: {line!r}"
+            )
+
+    def test_no_intranet_ingredients(self):
+        """Public workshop must not invoke intranet injection machinery.
+
+        Checked by tool invocation, not by literal word — prose comments may
+        legitimately say 'no intranet parts involved'.
+        """
+        for name in ("assemble.cmd", "rollback.cmd"):
+            text = (WS / name).read_text(encoding="utf-8")
+            for tool in ("assemble_inject", "apply_patch", "assembly.txt"):
+                self.assertNotIn(tool, text, f"{name} pulls intranet step {tool}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

守密人 2026-08-04 指示「让银芯仓库本身也拥有组装能力，用于公版」。口径取二级落位：一级出包（源码构建 zip）仍归 CI 组装台（2026-08-02 既有裁定不动），本车间让任何银芯 checkout 把 Release 公版包就地组装成可用的 `BlackPool\`。

## 变更

- 新增 `projects/black-pool-agent/public-workshop/`（自根于仓内、零内网件）：
  - `assemble.cmd`：SHA 验货（可选 CHECKSUMS.txt）→ 解压 → 启动器族按仓内 `../deploy/` 套件覆盖 → 旧 `home` 增量保全 → `.old` 轮换落位 → 快捷方式；沿用内网车间实弹纪律（goto 守卫防括号路径、goto 块 ASCII-only 防 65001 错位）。
  - `rollback.cmd`：一键回切，问题版让位 `BlackPool.failed-*` 取证。
  - `RUNBOOK.md`（含镜像前缀下载指引）+ `.gitignore`（运行时目录全排除）。
- 守卫 `tests/test_public_workshop.py`：车间档案在位 / 借用的 deploy 套件件在位 / gitignore 覆盖 / goto 块 ASCII / 不得调用内网注入工序（按工序名判，不按字面词）。
- 登记：`build/README.md` 新节、`CONTEXT.md` 结构行、`RELEASES.md` §2.3 消费路径指针；`memory/project-status.md` 事实块重算（测试档 148 → 149）。

## 验证

- `premerge_gate.py` 双形态全绿（常规 + `--sparse`）：3,341 passed / 51 skipped。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A937biMf5YkmQ5vkz7sMqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01A937biMf5YkmQ5vkz7sMqY)_