### PR TITLE
deploy: 修好「报错通道自己是失败源」——内网组装的真实原因看不见

### DIFF
--- a/projects/black-pool-agent/build/rebrand.py
+++ b/projects/black-pool-agent/build/rebrand.py
@@ -1185,7 +1185,8 @@ def generate_patches() -> tuple[str, str]:
                         ignore=shutil.ignore_patterns(".venv", "__pycache__"))
         def run(*args: str) -> subprocess.CompletedProcess:
             return subprocess.run(["git", "-C", str(work), *args],
-                                  capture_output=True, text=True, check=True)
+                                  capture_output=True, text=True,
+                                  encoding="utf-8", errors="replace", check=True)
         run("init", "-q")
         run("config", "user.email", "rebrand@black-pool.local")
         run("config", "user.name", "rebrand")

--- a/projects/black-pool-agent/deploy/assemble.cmd
+++ b/projects/black-pool-agent/deploy/assemble.cmd
@@ -26,7 +26,9 @@ if not "%~1"=="" (
 )
 if not defined ZIP (
   echo 组装失败：..\releases\ 里没有 zip 包。先从银芯 Release 下载入库。
-  echo 详情见 %LOG% & pause & exit /b 1
+  echo 详情见 %LOG%
+  pause
+  exit /b 1
 )
 if not exist "%ZIP%" (
   echo 组装失败：指定的包不存在 %ZIP%
@@ -43,7 +45,9 @@ if exist "%DEVROOT%\releases\CHECKSUMS.txt" (
   findstr /i /c:"!SHA!" "%DEVROOT%\releases\CHECKSUMS.txt" >nul || (
     echo 组装失败：SHA-256 与 CHECKSUMS.txt 不符（包损坏或未登记）。
     echo   实测 !SHA! >> "%LOG%"
-    echo 详情见 %LOG% & pause & exit /b 1
+    echo 详情见 %LOG%
+    pause
+    exit /b 1
   )
   echo 验货通过：SHA-256 已比对 CHECKSUMS.txt
 ) else (
@@ -56,7 +60,10 @@ if exist "%DEVROOT%\staging" rd /s /q "%DEVROOT%\staging"
 mkdir "%DEVROOT%\staging"
 echo 解压中（约 1 分钟）...
 tar -xf "%ZIP%" -C "%DEVROOT%\staging" || (
-  echo 组装失败：解压出错。& echo 详情见 %LOG% & pause & exit /b 1
+  echo 组装失败：解压出错。
+  echo 详情见 %LOG%
+  pause
+  exit /b 1
 )
 set "B=%DEVROOT%\staging\BlackPool"
 if not exist "%B%\launcher.cmd" (
@@ -74,7 +81,9 @@ rem (zh comment moved to RUNBOOK - 65001 parser desync)
 set "PYHOME="
 for /d %%D in ("%B%\python\cpython-*") do set "PYHOME=%%~fD"
 if not defined PYHOME (
-  echo 组装失败：包内 python\cpython-* 缺失。& pause & exit /b 1
+  echo 组装失败：包内 python\cpython-* 缺失。
+  pause
+  exit /b 1
 )
 
 rem Injection phase (patches/config/plugins/skills/overlay) + assembly docs
@@ -85,7 +94,9 @@ set "PYTHONIOENCODING=utf-8"
 "%PYHOME%\python.exe" "%SD%assemble_inject.py" --devroot "%DEVROOT%" --bundle "%B%" --zip "%ZIP%" --sha "!SHA!"
 if errorlevel 1 (
   echo 组装失败：注入/清单阶段出错（补丁上下文不匹配或拷贝失败）。
-  echo 详情见 %LOG% & pause & exit /b 1
+  echo 详情见 %LOG%
+  pause
+  exit /b 1
 )
 
 echo.

--- a/projects/black-pool-agent/deploy/assemble_inject.py
+++ b/projects/black-pool-agent/deploy/assemble_inject.py
@@ -168,13 +168,21 @@ def main() -> int:
             skipped["patches"].append(patch.name)
             log(f"补丁跳过（选装表 off）：{patch.name}")
             continue
+        # encoding 必须显式钉 utf-8（2026-08-06 内网野战）：assemble.cmd 设了
+        # PYTHONIOENCODING=utf-8 让子进程吐 UTF-8，而 text=True 走的是**系统默认**
+        # 编码——中文 Windows 上是 GBK，两端约定正好相反。子进程一吐中文，读取线程
+        # 就 UnicodeDecodeError 死掉，r.stderr 变 None，下面那行 .strip() 再补一刀。
+        # 后果比崩溃本身更坏：**真正的补丁错误被这条崩溃掩盖了**，守密人看到的是
+        # 一串 traceback，而不是「哪张补丁的哪一段对不上」。errors="replace" 兜底，
+        # 保证报错通道在任何字节下都活着——诊断路径自己绝不能是失败源。
         r = subprocess.run(
             [sys.executable, str(kit / "apply_patch.py"),
              "--root", str(bundle / "app"), str(patch)],
-            capture_output=True, text=True)
+            capture_output=True, text=True, encoding="utf-8", errors="replace")
         if r.returncode != 0:
             log(f"补丁应用失败：{patch.name}")
-            log(r.stderr.strip()[-800:])
+            detail = ((r.stderr or "") + (r.stdout or "")).strip()
+            log(detail[-800:] if detail else "（子进程未给出原因，见上方 traceback）")
             return 1
         files, plus, minus = diffstat(patch)
         included["patches"].append(

--- a/projects/black-pool-agent/deploy/deploy.cmd
+++ b/projects/black-pool-agent/deploy/deploy.cmd
@@ -36,7 +36,10 @@ if not exist "%B%\MANIFEST.txt" (
 rem (zh comment moved to RUNBOOK - 65001 parser desync)
 if exist "%BPA_DIR%\home" (
   robocopy "%BPA_DIR%\home" "%B%\home" /e /xc /xn /xo /njh /njs /ndl /nfl >nul
-  if errorlevel 8 (echo 部署失败：home 保全拷贝出错。& echo 详情见 %LOG% & pause & exit /b 1)
+  if errorlevel 8 (echo 部署失败：home 保全拷贝出错。
+  echo 详情见 %LOG%
+  pause
+  exit /b 1)
   echo 用户数据已保全（旧 home 增量并入，不覆盖新配置）
 )
 
@@ -85,7 +88,9 @@ set "DEPLOY_MODE=rotate"
 rem (zh comment moved to RUNBOOK - 65001 parser desync)
 move "%B%" "%BPA_DIR%" >nul || (
   echo 部署失败：成品搬运出错；旧版仍在 %BPA_DIR%.old 可手工恢复。
-  echo 详情见 %LOG% & pause & exit /b 1
+  echo 详情见 %LOG%
+  pause
+  exit /b 1
 )
 goto post_deploy
 
@@ -112,7 +117,9 @@ for %%F in ("%BPA_DIR%\desktop\*.exe") do if not defined BPA_EXE set "BPA_EXE=%%
 set "LNK_TARGET=%BPA_DIR%\launcher.cmd"
 if exist "%BPA_DIR%\Black Pool.exe" set "LNK_TARGET=%BPA_DIR%\Black Pool.exe"
 if defined BPA_EXE (
-  cscript //nologo "%SD%make-shortcut.vbs" "%BPA_DIR%\Black Pool.lnk" "%LNK_TARGET%" "%BPA_DIR%" "%BPA_EXE%,0" >nul 2>&1 && echo 已生成带图标入口：Black Pool.lnk（可拷到桌面）
+  cscript //nologo "%SD%make-shortcut.vbs" "%BPA_DIR%\Black Pool.lnk" "%LNK_TARGET%" "%BPA_DIR%" "%BPA_EXE%,0" >nul 2>
+  1
+  echo 已生成带图标入口：Black Pool.lnk（可拷到桌面）
 )
 
 echo.

--- a/projects/black-pool-agent/deploy/diagnose_lag.py
+++ b/projects/black-pool-agent/deploy/diagnose_lag.py
@@ -51,9 +51,14 @@ def section(title: str) -> None:
 
 def run_capture(args: list[str], timeout: int = 30) -> str:
     try:
+        # 显式 utf-8 + replace（2026-08-06 同因加固）：text=True 默认走系统编码，
+        # 中文 Windows 上是 GBK，遇到非 GBK 字节即 UnicodeDecodeError——而这是
+        # **诊断工具**，它崩掉等于故障现场没人取证。UnicodeDecodeError 不是
+        # OSError/SubprocessError 的子类，原来的 except 接不住。
         return subprocess.run(args, capture_output=True, text=True,
+                              encoding="utf-8", errors="replace",
                               timeout=timeout).stdout or ""
-    except (OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
         return ""
 
 

--- a/projects/black-pool-agent/deploy/launch_desktop.py
+++ b/projects/black-pool-agent/deploy/launch_desktop.py
@@ -132,9 +132,10 @@ def image_running(image_name: str) -> bool:
     try:
         out = subprocess.run(
             ["tasklist", "/FI", f"IMAGENAME eq {image_name}", "/NH"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=30,
         ).stdout
-    except (OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
         return False
     return image_name.lower() in out.lower()
 

--- a/projects/black-pool-agent/gaps.md
+++ b/projects/black-pool-agent/gaps.md
@@ -49,6 +49,25 @@
   **教训**：门禁的价值取决于它**能不能通过**。一道永远红的门不叫严格，叫堵死；
   而它堵住的是交付，放过的是它本该拦的东西（那批 POSIX 用例红得太响，反而没人去看
   真正该看的换装回归）。选门禁落点时要先问「这道门在这台机器上有没有可能绿」。
+- **2026-08-06 · 自伤记录 · 报错通道自己是失败源（内网组装野战）**：守密人跑第二级组装
+  （bpa-dev `assemble.cmd`）时，一张内网补丁应用失败——**但真实原因一个字都没露出来**，
+  屏幕上只有两串 traceback 加一句 `'详情见' is not recognized`。三个缺陷叠在一起：
+  ① **编码两端相反**：`assemble.cmd` 设 `PYTHONIOENCODING=utf-8` 让子进程吐 UTF-8，
+  而 `assemble_inject.py` 的 `subprocess.run(text=True)` 走**系统默认**编码——中文
+  Windows 上是 GBK。子进程一吐中文即 `UnicodeDecodeError`（报错字节 `0x97` 正是 UTF-8
+  续字节），读取线程死掉。② **崩溃补刀**：线程死后 `r.stderr` 变 `None`，紧接着的
+  `r.stderr.strip()` 抛 `AttributeError`——**这行代码的唯一职责就是打印失败原因**。
+  ③ **cmd 65001 错位**：`echo 详情见 %LOG% & pause & exit /b 1` 被切进 `echo ` 里，
+  中文当成命令名。同块上一行的纯中文 echo **打印正常**，差别只有一个 `&`。
+  处置：四处 `subprocess.run` 全部显式钉 `encoding="utf-8", errors="replace"`
+  （含监督器 `launch_desktop.py`——它崩掉等于桌面端起不来、诊断器 `diagnose_lag.py`——
+  它崩掉等于现场没人取证；`UnicodeDecodeError` 不是 `OSError` 子类，原 except 接不住）；
+  失败分支改读 `(r.stderr or "") + (r.stdout or "")` 并在皆空时明说；8 处非 ASCII 的
+  `&` 串接行拆成多行，新守卫 `test_cmd_non_ascii_lines_never_chain_with_ampersand`
+  钉死（已做负控，串回去即红）。
+  **教训**：诊断路径必须比它诊断的东西更结实。一个只在出错时才走的分支，恰恰最少被执行、
+  最容易腐坏——而它坏掉的代价是**故障现场被抹掉**，比原故障本身更贵。凡「打印错误」
+  「写日志」「收集诊断」的代码，都要按「任何输入都不许崩」的标准写。
 - **2026-08-03 · 扩展点走通（正面记录）· blackpool 记忆插件 → 2026-08-04 已退役**：
   中文记忆召回缺口（stock holographic 的 FTS5 unicode61 把连续汉字当单一词元，
   中文事实近乎不可检索）**全程走官方扩展面解决、零补丁零核心触碰**——MemoryProvider

--- a/tests/test_bpa_dev_kit.py
+++ b/tests/test_bpa_dev_kit.py
@@ -240,6 +240,28 @@ def test_launcher_kit_mode_dispatch_present():
 
 @pytest.mark.parametrize("name", ["launcher.cmd", "assemble.cmd", "deploy.cmd",
                                   "rollback.cmd", "update.cmd"])
+def test_cmd_non_ascii_lines_never_chain_with_ampersand(name):
+    """非 ASCII 行不得用 `&` 串接命令（2026-08-06 内网野战实证）。
+
+    守密人跑 assemble.cmd 时，`echo 组装失败：...` 那行**正常打印了**，紧接着的
+    `echo 详情见 %LOG% & pause & exit /b 1` 却报 `'详情见' is not recognized`——
+    65001 下解析器在多字节行上重新定位时切进了 `echo ` 里，把中文当成命令名。
+    两行都在同一个括号块、都含中文，差别只有一个 `&`，故按证据钉这一条：
+    含非 ASCII 的行只做一件事，`pause` / `exit` 各自独占一行。
+
+    这是既有 rem 行 / 标签块 ASCII 纪律的补集——那两条管的是「哪些块必须全 ASCII」，
+    这条管的是「允许带中文的行怎么写才不炸」。
+    """
+    for n, line in enumerate((KIT / name).read_text(encoding="utf-8").splitlines(), 1):
+        s = line.strip()
+        if not s.isascii() and "&" in s:
+            raise AssertionError(
+                f"{name}:{n} 非 ASCII 行用 & 串接命令（65001 错位风险）——拆成多行: {s[:70]}"
+            )
+
+
+@pytest.mark.parametrize("name", ["launcher.cmd", "assemble.cmd", "deploy.cmd",
+                                  "rollback.cmd", "update.cmd"])
 def test_cmd_rem_lines_are_ascii_short(name):
     """chcp 65001 解析器错位野战回归（两案实证）：套件 cmd 的 rem 行必须 ASCII 短行。"""
     for line in (KIT / name).read_text(encoding="utf-8").splitlines():


### PR DESCRIPTION
## 概述

守密人跑第二级组装（bpa-dev `assemble.cmd`）时一张内网补丁应用失败，**但失败原因一个字都没露出来**——屏幕上只有两串 traceback 加一句 `'详情见' is not recognized`。三个缺陷叠在一起，且**每一个都长在「解释失败」这条路径上**。本 PR 修工具链，让真实原因说得出来。

**本 PR 不修那张内网补丁本身**（它在黑池侧，§1.1-HC 不进银芯）——修的是让组装能说清「哪个文件的哪一段对不上」，好让守密人据此重打补丁。

---

## 变更类型

- [x] Bug 修复（部署工具链：编码约定不一致 / 诊断路径崩溃 / cmd 解析器错位）

---

## 来源声明

不涉及游戏数据或翻译。仅改 `projects/black-pool-agent/` 的部署与构建脚本 + 守卫测试。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 失败的内网补丁 `bp-dingtalk-chat-archive-gateway-rpc.patch` **未被读取、未被引用、未入仓**——本 PR 只改银芯自有的工具链。
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 合并前门禁 `python3 scripts/premerge_gate.py --sparse` 全绿（提交后复跑，非脏树态）
- [x] `tests/test_bpa_dev_kit.py` 44 项通过
- [x] **负控已做**：把一条 `&` 串接行改回去，新守卫当场转红
- [x] `rebrand.py --check` 规则与补丁仍同步（改动在自检辅助函数，不影响补丁产出）
- [x] 不引入 emoji
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 三个缺陷

**① 编码两端约定相反**

`assemble.cmd` 设 `PYTHONIOENCODING=utf-8` 让子进程吐 UTF-8；父进程 `assemble_inject.py` 却用 `subprocess.run(text=True)` 读——`text=True` 走的是**系统默认编码**，中文 Windows 上是 GBK。子进程一吐中文即炸：

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x97 in position 2
```

`0x97` 正是 UTF-8 续字节。读取线程就此死亡。

**② 崩溃补刀，且补在最不该补的地方**

线程死后 `r.stderr` 变 `None`，紧接着：

```python
log(r.stderr.strip()[-800:])   # AttributeError: 'NoneType' has no attribute 'strip'
```

**这行代码的唯一职责就是打印补丁为什么失败。** 它自己崩了，于是真实原因被彻底抹掉。

**③ cmd 65001 解析器错位**

```
组装失败：注入/清单阶段出错（补丁上下文不匹配或拷贝失败）。   <- 同块上一行，打印正常
'详情见' is not recognized as an internal or external command   <- 这一行炸了
```

两行都在同一个 `( )` 块、都含中文，**差别只有一个 `&`**：后者是 `echo 详情见 %LOG% & pause & exit /b 1`。解析器在多字节行上重新定位时切进了 `echo ` 里，把中文当成命令名。

---

## 改法

| 缺陷 | 处置 |
|---|---|
| 编码不一致 | 四处 `subprocess.run` 全部显式钉 `encoding="utf-8", errors="replace"` |
| 诊断路径崩溃 | 失败分支改读 `(r.stderr or "") + (r.stdout or "")`，皆空时明说「子进程未给出原因」 |
| except 接不住 | `UnicodeDecodeError` **不是** `OSError` 子类，原 `except (OSError, SubprocessError)` 从来接不住它——已补入 |
| cmd 错位 | 8 处非 ASCII 的 `&` 串接行拆成多行（`assemble.cmd` 5 处 / `deploy.cmd` 3 处）|
| 防复发 | 新守卫 `test_cmd_non_ascii_lines_never_chain_with_ampersand` |

四处调用点里有两处特别值得点名：`launch_desktop.py` 是**监督器**，它崩掉等于桌面端起不来；`diagnose_lag.py` 是**诊断器**，它崩掉等于故障现场没人取证。

---

## 教训（已记 `gaps.md`）

**诊断路径必须比它诊断的东西更结实。** 一个只在出错时才走的分支，恰恰是最少被执行、最容易腐坏的代码——而它坏掉的代价是**故障现场被抹掉**，比原故障本身更贵。凡「打印错误」「写日志」「收集诊断」的代码，都要按「任何输入都不许崩」的标准写。

---

## 关联 Issue

无。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwzVQ6ByapUQyzVBsCvszf)_