### PR TITLE
fix(ci): 补回 collect-comments 的依赖安装步骤（线上静默失效 12 天）

### DIFF
--- a/.github/workflows/collect-comments.yml
+++ b/.github/workflows/collect-comments.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           python-version: '3.11'
 
+      # 本脚本自身只用 urllib，但为取 dump_json_atomic 而 import news_common，
+      # 后者顶层 import requests——缺此步即在 import 期 ModuleNotFoundError。
+      # 装声明档而非手挑单包：依赖清单单一真相源，防 news_common 日后再引新包时复发。
+      - name: Install dependencies
+        run: pip install -r projects/news/requirements.txt
+
       - name: Clone BIAV-SC-DATA（PAT，数据根：读 youtube 存档 + 写评论）
         env:
           DATA_TOKEN: ${{ secrets.BIAV_SC_DATA_TOKEN }}


### PR DESCRIPTION
## 概述

`collect-comments.yml` 从建档起就没有依赖安装步骤。脚本只碰标准库时这无害，但
`collect_video_comments.py` 现为取 `dump_json_atomic` 而 `import news_common`，后者第 27 行是顶层
`import requests`——自 2026-07-27T10:49:58Z 最后一次成功后，每日定时**全部死在 import 期**，
连续 12 天，`Record/Community/youtube_comments/` 自 07-28 起断档。

---

## 变更类型

- [x] Bug 修复

---

## 来源声明

不适用：本 PR 只改一个 CI 工作流的依赖安装步骤，不涉及任何数据补全、翻译或素材引用。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py` 通过（3350 passed / 51 skipped / 22 subtests）
- [x] `python3 scripts/premerge_gate.py --sparse` 稀疏检出形态下同样通过（3350 passed）
- [x] 正控：依赖齐备时 `archive_layout` + `news_common` import 链通、`dump_json_atomic` 在位
- [x] 负控已由线上取证：最新失败日志即 `ModuleNotFoundError: No module named 'requests'`
- [x] 不引入 emoji
- [x] 未动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 取证与判断

**线上取证**（run [31247198646](https://github.com/lightproud/BIAV-SC-CODE/actions/runs/31247198646)）：

```
File "projects/news/scripts/collect_video_comments.py", line 37, in <module>
    import news_common
File "projects/news/scripts/news_common.py", line 27, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

**为何 12 天没人发现**：死手开关每天都在报，但它那抹红一直被读成它自己已知的自指 NEVER
（它一有发现就 `exit 1`，而它把自己也列进看守名单），底下真正的发现因此没被读到。
08-08 的 `status.json` 读数为 `judged=21` / `unknown=0` / `findings=2`——`unknown=0`
排除了守卫失明，两条发现一条是它自己的自指，另一条就是本 PR 修的这个。

**为何装声明档而不手挑单包**：`requests` 是当下唯一缺的包，但手写单包会在
`news_common` 日后再引新包时原样复发。装 `projects/news/requirements.txt` 让依赖清单保持单一真相源，
与 `backfill-news.yml` 等同门工作流形态一致。**不装 playwright 浏览器**：本采集器经 urllib 直连
YouTube Data API，不需要浏览器。

**引入时点（部分钉死，照实标注）**：失效必落在 07-27 10:49Z（末次成功）与 07-28 07:05Z（次日定时）
之间，窗口内改到该链路的提交为 #861（04:58Z）与 #864（06:27Z）；#875（17:23Z）在首次失败之后可排除。
未逐档 diff 钉死是二者中哪一个。

---

## 关联 Issue

- Refs: 死手开关发现 `collect-comments.yml` state=stale，285.5h 未成功（阈值 50h）

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBbwerev4ybjV9WQde95hJ)_