### PR TITLE
feat(news): YouTube 评论日档改按发布日分档

### DIFF
--- a/projects/news/scripts/collect_video_comments.py
+++ b/projects/news/scripts/collect_video_comments.py
@@ -8,7 +8,11 @@
 数据根——此前仍写迁移前旧路径 projects/news/data/platforms/，导致权威档案 6-20 后断更）：
   comments.jsonl   累积库，一行一条评论，按 comment id 去重、只增不删
   state.json       每视频分页状态 {video_id: {title, channel, exhausted, next_page}}
-  {date}.json      当次运行采到的评论快照（供当日报告引用「PV 视频评论」）
+  {date}.json      **该日发布**的评论日档（供当日报告引用「PV 视频评论」）。守密人
+                   2026-08-08 裁定改为按发布日分档，取代原「当轮快照」语义——原语义下
+                   本档记的是「哪一轮采到的」而非「评论发布于哪天」，断更后补采时整段
+                   积压会全挤进一个日期档、其余日期成空档。--date 自此降为**回落标签**，
+                   只用于 published 缺失 / 不可解析的评论。
 
 候选视频来源：YouTube 搜索（Morimens/忘却前夜…）+ 复用已归档的 youtube 视频 ID
 （Record/Community/youtube/ 全布局递归，含区服/类型子目录）。每视频按 order=time 分页：
@@ -113,9 +117,26 @@ def fetch_video_comments(key, vid, known_ids, max_pages):
     return new_rows, False       # 还有更多，下次续（回填未尽）
 
 
+def snapshot_date(row: dict, fallback: str) -> str:
+    """这条评论该落哪个日期档：按 published 折算北京日期；缺失/不可解析回落 fallback。
+
+    日期基准一律经 archive_layout.archive_date_str（归档布局 SSOT）——YouTube 的
+    publishedAt 已带 Z 偏移，手写 `+ timedelta(hours=8)` 会把偏移算两遍（该坑的原案
+    见 archive_layout 日期基准注释）。
+    """
+    raw = (row.get("published") or "").strip()
+    if raw:
+        try:
+            return archive_layout.archive_date_str(datetime.fromisoformat(raw))
+        except ValueError:      # 非 ISO8601（字段缺省 / 上游改格式）→ 回落标签，不丢条目
+            pass
+    return fallback
+
+
 def main():
     ap = argparse.ArgumentParser(description="YouTube 评论累积采集器")
-    ap.add_argument("--date", required=True, help="当次快照日期标签 YYYY-MM-DD")
+    ap.add_argument("--date", required=True,
+                    help="回落日期标签 YYYY-MM-DD（仅用于 published 缺失/不可解析的评论）")
     ap.add_argument("--max-pages", type=int, default=8, help="每视频每次最多翻页数（回填节流）")
     a = ap.parse_args()
     os.makedirs(DEST, exist_ok=True)   # 始终建目录，便于工作流容错
@@ -161,31 +182,38 @@ def main():
     # （YouTube API 有每日配额，重翻即烧配额）。
     news_common.dump_json_atomic(sp, state, indent=1)
 
-    # 当次快照（按 likes 排序，供报告引用）。
-    # 与同日既有快照并轨后再写：run_new 只含**本轮新采**的评论，而累积库 comments.jsonl
+    # 日档（按 likes 排序，供报告引用），按**评论发布日**分组落各自的档。
+    # 与同日既有日档并轨后再写：run_new 只含**本轮新采**的评论，而累积库 comments.jsonl
     # 是跨轮去重的——同一天第二次跑（CI 重跑失败作业 / workflow_dispatch 补同一日期）
-    # 时全部评论都已在库，run_new 恒为空，直写就把当日快照清成 `[]`，当日「PV 视频评论」
-    # 报告数据凭空蒸发（累积库还在，快照层已毁）。
-    snap_path = Path(f"{DEST}/{a.date}.json")
-    merged = []
-    seen_ids = set()
-    if snap_path.is_file():
-        try:
-            prev = json.loads(snap_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            prev = []
-        for r in prev if isinstance(prev, list) else []:
-            if isinstance(r, dict) and r.get("id") not in seen_ids:
+    # 时全部评论都已在库，run_new 恒为空，直写就把当日日档清成 `[]`，当日「PV 视频评论」
+    # 报告数据凭空蒸发（累积库还在，日档层已毁）。分组后**空组不落笔**，本轮没采到新
+    # 评论的日期一律不碰，上述清空路径遂在结构上不可达。
+    by_date: dict[str, list] = {}
+    for r in run_new:
+        by_date.setdefault(snapshot_date(r, a.date), []).append(r)
+    for day, rows in sorted(by_date.items()):
+        snap_path = Path(f"{DEST}/{day}.json")
+        merged = []
+        seen_ids = set()
+        if snap_path.is_file():
+            try:
+                prev = json.loads(snap_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                prev = []
+            for r in prev if isinstance(prev, list) else []:
+                if isinstance(r, dict) and r.get("id") not in seen_ids:
+                    seen_ids.add(r.get("id"))
+                    merged.append(r)
+        for r in rows:
+            if r.get("id") not in seen_ids:
                 seen_ids.add(r.get("id"))
                 merged.append(r)
-    for r in run_new:
-        if r.get("id") not in seen_ids:
-            seen_ids.add(r.get("id"))
-            merged.append(r)
-    merged.sort(key=lambda x: -x.get("likes", 0))
+        merged.sort(key=lambda x: -x.get("likes", 0))
+        news_common.dump_json_atomic(str(snap_path), merged, indent=1)
     run_new.sort(key=lambda x: -x.get("likes", 0))
-    news_common.dump_json_atomic(str(snap_path), merged, indent=1)
-    print(f"本次新增 {len(run_new)} 条；累积库共 {len(known)} 条 → {store}")
+    print(f"本次新增 {len(run_new)} 条，落 {len(by_date)} 个日档"
+          f"（{min(by_date) if by_date else '-'} … {max(by_date) if by_date else '-'}）；"
+          f"累积库共 {len(known)} 条 → {store}")
 
 
 if __name__ == "__main__":

--- a/tests/test_collect_video_comments_unit.py
+++ b/tests/test_collect_video_comments_unit.py
@@ -152,5 +152,67 @@ class TestMain(unittest.TestCase):
             self.assertIn("v0", state)
 
 
+class TestSnapshotDateByPublish(unittest.TestCase):
+    """日档按**发布日**分档（守密人 2026-08-08 裁定），--date 只作回落标签。"""
+
+    def test_offset_applied_exactly_once(self):
+        # 两侧夹逼，把「北京偏移」钉死为恰好一次：
+        #   16:30Z 北京已跨日 → 少算偏移会得 08-05；
+        #   10:00Z 北京仍当日 → 多算一遍偏移会得 08-06。
+        self.assertEqual(cvc.snapshot_date({"published": "2026-08-05T16:30:00Z"}, "x"),
+                         "2026-08-06")
+        self.assertEqual(cvc.snapshot_date({"published": "2026-08-05T10:00:00Z"}, "x"),
+                         "2026-08-05")
+
+    def test_unparsable_or_missing_falls_back_to_label(self):
+        for row in ({"published": "p"}, {"published": ""}, {}):
+            self.assertEqual(cvc.snapshot_date(row, "2026-06-01"), "2026-06-01")
+
+    def _run_main(self, dest, rows, date_label):
+        with mock.patch.object(cvc, "DEST", dest), \
+                mock.patch.object(sys, "argv", ["prog", "--date", date_label]), \
+                mock.patch.dict(cvc.os.environ, {"YOUTUBE_API_KEY": "k"}, clear=True), \
+                mock.patch.object(cvc, "discover_videos", return_value={"v1": ("T", "C")}), \
+                mock.patch.object(cvc, "fetch_video_comments", return_value=(rows, True)):
+            cvc.main()
+
+    def test_one_run_scatters_into_own_publish_day_files(self):
+        # 断更补采的核心诉求：一轮采回的跨日积压不再全挤进 --date 那一个档。
+        import tempfile
+        rows = [
+            {"id": "c1", "likes": 1, "published": "2026-07-28T03:00:00Z"},
+            {"id": "c2", "likes": 2, "published": "2026-08-01T03:00:00Z"},
+            {"id": "c3", "likes": 3, "published": "2026-08-01T04:00:00Z"},
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            dest = str(Path(d) / "yc")
+            self._run_main(dest, rows, "2026-08-07")
+            self.assertEqual(len(json.loads(Path(dest, "2026-07-28.json").read_text())), 1)
+            self.assertEqual(len(json.loads(Path(dest, "2026-08-01.json").read_text())), 2)
+            # 标签日自身不该凭空多出一个档
+            self.assertFalse(Path(dest, "2026-08-07.json").exists())
+
+    def test_empty_run_writes_no_file(self):
+        # 空组不落笔：本轮无新评论时不得造 `[]` 空档冒充「那天没评论」。
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            dest = str(Path(d) / "yc")
+            self._run_main(dest, [], "2026-08-07")
+            self.assertFalse(Path(dest, "2026-08-07.json").exists())
+
+    def test_merges_into_existing_day_without_clobbering(self):
+        # #875 幂等防线在新结构下仍在：并轨既有日档，不覆盖。
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            dest = Path(d) / "yc"
+            dest.mkdir()
+            (dest / "2026-08-01.json").write_text(
+                json.dumps([{"id": "old", "likes": 99}]), encoding="utf-8")
+            self._run_main(str(dest), [{"id": "c1", "likes": 1,
+                                        "published": "2026-08-01T03:00:00Z"}], "2026-08-07")
+            snap = json.loads((dest / "2026-08-01.json").read_text())
+            self.assertEqual([r["id"] for r in snap], ["old", "c1"])   # 按 likes 降序
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概述

`youtube_comments/{date}.json` 原先记的是「**哪一轮采到的**」而非「评论**发布于哪天**」。
它长得像按日档案、也被当按日档案消费，但二者只在「采集器天天跑且每轮都追平」时才碰巧重合——
而恰在最要紧的时候不重合：刚修好的 12 天断更，一轮补采会把整段积压扫进**一个**日期档，
其余 11 天要么没有档、要么是同日重跑写下的 `[]`。守密人 2026-08-08 裁定改为按发布日真分档。

---

## 变更类型

- [x] Bug 修复
- [x] 其他：数据分档语义变更（`{date}.json` 由「当轮快照」改为「该日发布」）

---

## 来源声明

不适用：本 PR 只改采集器的落档分组逻辑与其单测，不涉及数据补全、翻译或素材引用。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] `python3 scripts/premerge_gate.py` 通过（3360 passed / 51 skipped / 22 subtests）
- [x] `python3 scripts/premerge_gate.py --sparse` 通过（3355 passed）
- [x] 新增 4 条回归测试，**证伪验证已跑**（见下）
- [x] 不引入 emoji
- [x] 未动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 做法

`run_new` 按评论 `published` 分组，经 **`archive_layout.archive_date_str`**（归档布局 SSOT）
折算北京归档日，各组分别并轨写各自的日档。`--date` 降为**回落标签**，只服务
`published` 缺失 / 不可解析的评论——不会因时间戳畸形丢条目。

时区一律走 SSOT 而非手写 `+ timedelta(hours=8)`：YouTube 的 `publishedAt` 已带 Z 偏移，
手写换算会把偏移算两遍（该坑原案见 `archive_layout` 日期基准注释）。

**空组不落笔**。`#875` 修过的那条覆盖路径——同日重跑时 `run_new` 恒空、直写把日档清成 `[]`
——自此**在结构上不可达**（不再是靠并轨挡住）：本轮没采到新评论的日期根本不会被打开。
并轨既有日档时仍按 comment id 去重。

## 证伪验证

把分组退回旧的单标签行为，4 条新测试**红掉 3 条**（分档 / 时区 / 并轨）。第 4 条
「空组不落笔」测的是另一条路径，其旧行为对照是原代码无条件写 `snap_path`——原码即会产出 `[]`。

偏移**两侧夹逼**钉死为恰好一次：`16:30Z` 必须落次日北京日（少算偏移即红），
`10:00Z` 必须留在当日（多算一遍即红）。

## 一处需守密人另裁的遗留

本 PR 前已派发过一轮补采（run [31255733945](https://github.com/lightproud/BIAV-SC-CODE/actions/runs/31255733945)，成功），
12 天积压已进累积库 `comments.jsonl`，但按**旧**逻辑全贴在了 `2026-08-07.json` 上。
因累积库跨轮去重，此后再跑 `run_new` 恒空，这批评论**不会**被新逻辑自动重新分档。
要归位需一次性重建日档层（`comments.jsonl` 里每条都带 `published`，可完全推导），
但这会一并改写既有历史日档、blast radius 需守密人裁定，故不在本 PR 内动手。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBbwerev4ybjV9WQde95hJ)_