### PR TITLE
fix(bpa): 桌面端 Collapse 字标回退修复 —— 删掉误诊的字体路径改写规则

### DIFF
--- a/projects/black-pool-agent/build/rebrand.py
+++ b/projects/black-pool-agent/build/rebrand.py
@@ -317,14 +317,17 @@ BRAND_POST_RULES = [
         f'__version__ = "{UPSTREAM_VERSION}"',
         f'__version__ = "{BRAND_VERSION}"',
     ),
-    # 品牌字体加载修复（守密人 2026-08-03 实机发现字标回退无衬线；装配日志实锤
-    # "didn't resolve at build time"）：上游 CSS 按 monorepo 根 node_modules 写
-    # 路径、官方从根装依赖故可解析；本装配只在 apps/desktop 里 npm ci——改指
-    # 应用自己的 node_modules，构建期即内嵌字体。
-    (
-        "url('../../../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2')",
-        "url('../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2')",
-    ),
+    # 【勿再加「品牌字体路径修复」规则】2026-08-03 曾在此加一条把
+    # url('../../../node_modules/…/Collapse-Bold.woff2') 改写成 '../node_modules/…' 的规则，
+    # 判词是「本装配只在 apps/desktop 里 npm ci，故依赖在应用自己的 node_modules」——
+    # 判词错，该规则本身就是字标回退无衬线的成因（2026-08-08 容器内实证）：
+    # apps/desktop 无自己的 package-lock.json，`npm ci` 在此目录会被 npm 的 workspace
+    # 检测上溯到仓根，整个 workspace 装进**仓根** node_modules，apps/desktop/node_modules
+    # 只留一个 ignore 的去重例外。上游自己的 apps/desktop/scripts/assert-root-install.mjs
+    # （校验 <仓根>/node_modules/vite 在位）即此事实的书面确认。故上游的 '../../../'
+    # 本就正确，改成 '../' 反指向不存在的目录 → Vite 报
+    # "didn't resolve at build time, it will remain unchanged" → 字体不进 dist/assets。
+    # 不变量守卫：tests/test_hermes_charter.py::test_desktop_font_asset_path_matches_install_root
     # 默认配色方案（守密人 2026-08-03 裁定：对标黑池终端的鎏金双貌）：
     # 新增内建主题 black-pool（浅 = 金×米白 / 深 = 金×暖黑）并设为默认皮肤；
     # 上游六款主题保留可选。取色自守密人参考图。

--- a/projects/black-pool-agent/patches/black-pool-rebrand.patch
+++ b/projects/black-pool-agent/patches/black-pool-rebrand.patch
@@ -44511,19 +44511,6 @@ index 8f214f8..4d92f25 100644
    }
  
    return method === 'wake.start'
-diff --git a/apps/desktop/src/styles.css b/apps/desktop/src/styles.css
-index 2ee38e0..9a5d39e 100644
---- a/apps/desktop/src/styles.css
-+++ b/apps/desktop/src/styles.css
-@@ -30,7 +30,7 @@
-   font-style: normal;
-   font-weight: 700;
-   font-display: swap;
--  src: url('../../../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2') format('woff2');
-+  src: url('../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2') format('woff2');
- }
- 
- /* JetBrains Mono — bundled terminal font (Apache-2.0) so bold/italic share the
 diff --git a/apps/desktop/src/themes/backend-sync.test.ts b/apps/desktop/src/themes/backend-sync.test.ts
 index 3733331..ba40887 100644
 --- a/apps/desktop/src/themes/backend-sync.test.ts

--- a/tests/test_hermes_charter.py
+++ b/tests/test_hermes_charter.py
@@ -7,6 +7,8 @@ v0.1.0，补丁分**公版**（black-pool-rebrand.patch，纯品牌）与**私�
 （black-pool-intranet.patch，内网/便携适配叠加层）两张，装配按序应用。
 """
 import importlib.util
+import json
+import os
 import re
 import subprocess
 import sys
@@ -16,6 +18,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parent.parent
 SUB = REPO / "projects" / "black-pool-agent"
+UPSTREAM = SUB / "upstream"
 REBRAND = SUB / "build" / "rebrand.py"
 PATCH_BRAND = SUB / "patches" / "black-pool-rebrand.patch"
 PATCH_INTRANET = SUB / "patches" / "black-pool-intranet.patch"
@@ -172,7 +175,6 @@ def test_brand_patch_sentinels():
         "默认语言简体中文（后端真源头）": '"language": "zh",',
         "默认外观深色（缺省兜底）": "'system' ? value : 'dark'",
         "默认外观深色（契约用例同步翻面）": "fallback: 'dark', a: 'light'",
-        "品牌字体路径修复（Collapse 构建期内嵌）": "url('../node_modules/@nous-research/ui",
         "黑池默认主题（鎏金双貌）": "DEFAULT_SKIN_NAME = 'black-pool'",
         "默认皮肤后端真源头": '"skin": "black-pool"',
         "黑池主题定义在位": "blackPoolTheme",
@@ -186,6 +188,63 @@ def test_brand_patch_sentinels():
     added = [l for l in text.splitlines() if l.startswith("+")]
     assert not any("the recommended way to run" in l for l in added)
     assert not any("的推荐方式" in l for l in added)
+
+
+def _install_root() -> Path:
+    """上游自陈的依赖安装根。
+
+    apps/desktop 没有自己的 package-lock.json——`npm ci` 在该目录会被 npm 的
+    workspace 检测上溯到仓根，整个 workspace 装进**仓根** node_modules。上游把这条
+    事实写死在 apps/desktop/scripts/assert-root-install.mjs（校验
+    <仓根>/node_modules/vite 在位），故以那里的上溯层数为唯一真相源，而非本档硬编码。
+    """
+    scripts = UPSTREAM / "apps" / "desktop" / "scripts"
+    mjs = (scripts / "assert-root-install.mjs").read_text(encoding="utf-8")
+    m = re.search(r"const root = resolve\(import\.meta\.dirname,([^)]*)\)", mjs)
+    assert m, "assert-root-install.mjs 结构变了——移 pin 后请重新核对依赖安装根"
+    root = scripts.resolve()
+    for _ in re.findall(r'"\.\."', m.group(1)):
+        root = root.parent
+    return root
+
+
+def test_desktop_font_asset_path_matches_install_root():
+    """桌面端 CSS 里指向 node_modules 的资产路径必须落在依赖安装根上。
+
+    2026-08-03 曾有一条换装规则把品牌字体 Collapse-Bold 的 url 从 '../../../node_modules/…'
+    改写成 '../node_modules/…'，指向实际不存在的 apps/desktop/node_modules——Vite 报
+    "didn't resolve at build time" 后原样留字面 URL，字体不进 dist/assets，
+    发行包里字标回退系统默认字体（2026-08-08 容器内构建实证，两向对照）。
+    本守卫钉三件：源树路径对得上安装根 / 两张补丁都不许改写它 / 字体包仍是声明依赖。
+    """
+    root = _install_root()
+    assert root == UPSTREAM.resolve(), f"依赖安装根不再是 upstream 仓根: {root}"
+
+    src = UPSTREAM / "apps" / "desktop" / "src"
+    checked = []
+    for css in sorted(src.rglob("*.css")):
+        for url in re.findall(r"url\('([^']*node_modules[^']*)'\)", css.read_text(encoding="utf-8")):
+            target = (css.parent / url).resolve()
+            checked.append((css.relative_to(UPSTREAM), url))
+            assert str(target).startswith(str(root / "node_modules") + os.sep), (
+                f"{css.relative_to(UPSTREAM)} 的 {url} 落在 {target}，"
+                f"不在依赖安装根 {root / 'node_modules'} 下——构建期解析不到，字体/资产会静默丢失"
+            )
+    assert checked, "桌面 CSS 里的 node_modules 资产引用全没了——哨兵失配，请核对上游结构"
+
+    for patch in (PATCH_BRAND, PATCH_INTRANET):
+        added = [
+            l for l in patch.read_text(encoding="utf-8").splitlines()
+            if l.startswith("+") and not l.startswith("+++")
+        ]
+        assert not any("node_modules/@nous-research/ui/dist/fonts" in l for l in added), (
+            f"{patch.name} 又在改写品牌字体路径——见 build/rebrand.py 该处「勿再加」注释"
+        )
+
+    deps = json.loads((UPSTREAM / "apps" / "desktop" / "package.json").read_text(encoding="utf-8"))
+    assert "@nous-research/ui" in deps.get("dependencies", {}), (
+        "@nous-research/ui 不再是 apps/desktop 的声明依赖——品牌字体来源断了"
+    )
 
 
 def test_intranet_patch_sentinels():


### PR DESCRIPTION
## 概述

修复桌面端空对话首页 `BLACK POOL AGENT` 字标回退系统默认字体的问题。根因不是上游构建资源引用不完整，而是银芯自己 2026-08-03 加的那条「品牌字体路径修复」换装规则——它本身就是成因。删规则、重生成补丁、补不变量守卫。

---

## 变更类型

- [x] Bug 修复
- [x] 视觉/前端改进（BPA 桌面端字标渲染）

---

## 根因

2026-08-03 的规则把桌面 CSS 的字体 url 从 `../../../node_modules/@nous-research/ui/dist/fonts/Collapse-Bold.woff2` 改写成 `../node_modules/…`，判词是「本装配只在 `apps/desktop` 里 `npm ci`，故依赖在应用自己的 node_modules」。

**判词不成立**：`apps/desktop` 没有自己的 `package-lock.json`，`npm ci` 在该目录会被 npm 的 workspace 检测上溯到仓根，整个 workspace 装进**仓根** `node_modules`——实测 `apps/desktop/node_modules` 里只剩一个 `ignore` 的去重例外。上游把这条事实写死在自己的 `apps/desktop/scripts/assert-root-install.mjs`（校验 `<仓根>/node_modules/vite` 在位）。故上游的 `../../../` 本就正确，改成 `../` 指向了不存在的目录，Vite 报 `didn't resolve at build time, it will remain unchanged`，原样留下字面 URL，字体不进 `dist/assets`。

小学生比喻：字体一直在总仓库里，快递单原本写的也是总仓库地址；上次有人以为货放在分店，好心把地址改成了分店——分店其实是空的，快递员从此空手而归。

## 变更内容

- `build/rebrand.py`：删除该规则，原地留「勿再加」注释，把 workspace 提升这条事实写进档案防再次误诊
- `patches/black-pool-rebrand.patch`：经规则引擎重生成（不手改补丁），少 13 行、少一个 hunk——补丁面反而变小，与「核心零侵入」同向
- `tests/test_hermes_charter.py`：删旧规则哨兵，新增 `test_desktop_font_asset_path_matches_install_root`，钉三条不变量——桌面 CSS 的 node_modules 资产 url 必须落在从 `assert-root-install.mjs` **推导**（非硬编码）的安装根上、两张补丁都不得改写字体 url、`@nous-research/ui` 须仍是声明依赖

`upstream/` 逐字节零修改，铁律 1 未触碰。

未采纳「把字体复制进 `apps/desktop/src/fonts/`」的方案：要往 `upstream/` 塞二进制文件，与「upstream 本体零修改 + 补丁只走文本 diff」冲突，且同一字体在仓内变三份副本、移 pin 后需人工同步。实测只删一条错规则即可，取零新增文件那条路。

---

## 来源声明

- [x] 不涉及游戏数据/翻译；变更为工程侧构建配置与测试

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **不含内部美术资产 / 客户端解包原始文件 / 未公开草稿。** 未新增任何二进制文件。
- [x] **同意按 MIT License 提交贡献。** 上游 MIT 归因未触碰（LICENSE / 版权行 / 上游 URL 零改动）。

---

## 验证清单

- [x] 容器内两向对照构建实证：`../../../` → `dist/assets/Collapse-Bold-mgICk9-_.woff2` 落盘、CSS 引用 `./Collapse-Bold-*.woff2`、零 `node_modules` 残留；`../` → 复现原故障告警
- [x] 端到端复验：把重生成的公版补丁应用到干净 upstream 副本后实跑构建，产出字体与包内源文件 md5 一致（`6f35dc49…`）
- [x] `pytest tests/test_hermes_charter.py` 18 项全过；新守卫负向对照已跑（放回旧规则即报红）
- [x] 合并前门禁 `python3 scripts/premerge_gate.py`：3361 passed / 51 skipped
- [x] 稀疏检出复现 `--sparse`：同样 3361 passed（本 PR 判据读 `upstream/` 树，按 2026-07-27 教训必跑）
- [x] 不引入 emoji
- [x] 未动 `memory/decisions.md` / `memory/lessons-learned.md`

**未验环节（据实标注）**：`app.asar` 内列出字体、实机启动看字标——需 Windows + electron-builder，容器内跑不了。要闭合需重出包：手动跑 `assemble-black-pool-public.yml`（公版）或 `assemble-black-pool-bundle.yml`（私有版）。当前运行树 `app.asar` 未被触碰。

---

## 关联 Issue

- Refs: 守密人 2026-08-09 会话内派发（桌面端空对话标题缺少 Collapse 品牌字体）

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8YHp8A4vnxtNcpaTUjxV4)_