### PR TITLE
fix(collect): 修复 Discord 积压不收敛、微信重复归档、TapTap 评论抓成用户名

### DIFF
--- a/.github/workflows/discord-archive.yml
+++ b/.github/workflows/discord-archive.yml
@@ -8,7 +8,12 @@ name: Discord Archive
 
 on:
   schedule:
-    - cron: '0 7 * * *'
+    # 每 3 小时（对齐 jp=45 / volunteer=15 / history-backfill=30，本工作流占 05 分位）。
+    # 原为 '0 7 * * *' 一天一轮：global 是三个公会里最大的一个（日均 ~1 万条），
+    # 一天一轮 × 每频道 5k 配额 = 日排干上限 5k/频道，而 general-chat 日产 ~7.2k、
+    # morimens-game-chat ~7k —— 每天净欠 2k+，游标只会越掉越远。频次 ×8 与归档器
+    # 侧的积压追赶轮（Track 1b）是同一个赤字的两半，必须一起上。
+    - cron: '5 */3 * * *'
     - cron: '0 6 1 * *'
   workflow_dispatch:
     inputs:
@@ -32,7 +37,10 @@ jobs:
   archive:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 55 > 归档器 35 + forum starter 15 + checkout/commit/push 余量。
+    # 原为 45，正好等于归档器自己的默认预算：归档器一旦吃满，作业会在 commit 之前
+    # 被砍，整轮采集白跑。加了积压追赶轮后归档器确实会吃满，所以这里必须留出空档。
+    timeout-minutes: 55
     env:
       BIAV_SC_DATA_ROOT: ${{ github.workspace }}/data-repo
     steps:
@@ -82,13 +90,16 @@ jobs:
         if: steps.mode.outputs.mode == 'incremental'
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_RUNTIME_BUDGET: '2100'   # 35 min，给同作业后续步骤留出预算
         run: python projects/news/scripts/discord_archiver.py
 
       - name: Backfill forum thread starters (catches up legacy gap)
         if: steps.mode.outputs.mode == 'incremental'
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          RUNTIME_BUDGET: '3600'
+          # 原为 3600（60 min）——比作业 timeout 本身还长，从来没有兑现过，
+          # 实际预算一直是「45 分钟减去归档器用掉的部分」。改成 15 min 说实话。
+          RUNTIME_BUDGET: '900'
           RATE_LIMIT_SLEEP: '0.2'
         run: python projects/news/scripts/backfill_forum_starters.py
 

--- a/projects/news/scripts/archive_platforms.py
+++ b/projects/news/scripts/archive_platforms.py
@@ -60,12 +60,25 @@ INPUT_NEWS = OUTPUT_DIR / 'news.json'
 PLATFORMS = ARCHIVE_PLATFORMS
 
 
+# URL 不可作去重键的源：拿到的不是文章直链，而是**每次请求都重新签发**的跳转链接，
+# 同一篇文章每轮采集都得到一个全新 URL —— 用 URL 做键 = 永远判不出重复。
+# weixin 走搜狗中转（/link?url=…&token=…）：实测同一篇公告在单日档里攒了 114 份、
+# 另一篇 144 份，114 个 URL 无一相同（连 url 参数本身都轮换，只有 type 固定）。
+# 这类源改用 `标题|时间|作者`——实测 time 字段稳定，正是能把它们收敛成 1 条的那一维。
+_UNSTABLE_URL_SOURCES = {'weixin'}
+
+
 def item_key(item: dict) -> str:
     """Generate a dedup key for an item."""
+    source = normalize_source(item.get('source', '') or '')
     url = item.get('url', '').strip()
-    if url:
+    if url and source not in _UNSTABLE_URL_SOURCES:
         return url
-    return f"{item.get('title', '')}|{item.get('time', '')}|{item.get('author', '')}"
+    # time_is_approximate = 采集器没能解析出真实发布时间、填的是 now()。那种时间
+    # 每轮都不一样，放进键里等于给同一条内容每轮发一个新身份——与上面 URL 轮换
+    # 是同一个坑。近似时间一律不入键。
+    time_part = '' if item.get('time_is_approximate') else item.get('time', '')
+    return f"{item.get('title', '')}|{time_part}|{item.get('author', '')}"
 
 
 def load_news() -> list[dict]:

--- a/projects/news/scripts/backfill_platforms.py
+++ b/projects/news/scripts/backfill_platforms.py
@@ -709,7 +709,8 @@ BACKFILL_REGISTRY = {
     'bilibili': backfill_bilibili,
     'appstore': backfill_appstore,
     'steam_review': backfill_steam_reviews,
-    'arca_live': backfill_arca_live,
+    # arca_live 已摘除（守密人 2026-08-16 裁定）：backfill_arca_live 实现保留在本模块
+    # 待复用，但不再登记——CF 封死 Actions 出口，登记着只会让手动回填每次空手而归。
     'pixiv': backfill_pixiv,
     'ruliweb': backfill_ruliweb,
     'weixin': backfill_weixin,

--- a/projects/news/scripts/collect_global.py
+++ b/projects/news/scripts/collect_global.py
@@ -49,7 +49,6 @@ SOURCE_MAP = {
     'steam': 'steam_review',
     'weibo': 'weibo',
     'bahamut': 'bahamut',
-    'arca_live': 'arca_live',
     'appstore': 'appstore',
     'google_play': 'google_play',
     'pixiv': 'pixiv',
@@ -127,7 +126,6 @@ def run_zero_cost_collectors() -> list[dict]:
     # Playwright fallback: platforms where HTTP fails but browser works
     PW_FALLBACK: dict[str, str] = {
         # name → playwright_collectors function name
-        'Arca.live':   'fetch_arca_live_playwright',
         'Ruliweb':     'fetch_ruliweb_playwright',
         'Bahamut':     'fetch_bahamut_playwright',
         'Weibo':       'fetch_weibo_playwright',
@@ -161,7 +159,8 @@ def run_zero_cost_collectors() -> list[dict]:
     api_fetchers = [
         ('YouTube', c.fetch_youtube),
         ('Bahamut', c.fetch_bahamut),
-        ('Arca.live', c.fetch_arca_live),
+        # Arca.live 已退出编排（守密人 2026-08-16 裁定摘除注册表；CF 封死 Actions
+        # 机房 IP，采集器与 collect_arca_daily.py 单脚本均保留在树上待复用）
         ('Google Play', c.fetch_google_play),
     ]
 
@@ -174,7 +173,7 @@ def run_zero_cost_collectors() -> list[dict]:
         'StopGame': 'stopgame', '搜狗微信': 'weixin',
         'YouTube': 'youtube',
         'Bahamut': 'bahamut',
-        'Arca.live': 'arca_live', 'Google Play': 'google_play',
+        'Google Play': 'google_play',
     }
 
     # 各采集器互相独立、采集前无共享状态 → 用线程并行（阻塞 requests 用线程即可）。

--- a/projects/news/scripts/discord_archiver.py
+++ b/projects/news/scripts/discord_archiver.py
@@ -1188,6 +1188,7 @@ class DiscordArchiver:
         if catchup_rounds:
             state = '积压已抽干' if not lagging else f'{len(lagging)} 个频道仍有积压（预算耗尽）'
             logger.info(f'Catch-up: {catchup_rounds} 轮追赶，{state}')
+        self._warn_unresolved_backlog(lagging)
 
         # Forum channels: active + archived threads, incremental (no historical backfill)
         for ch in forum_channels:
@@ -1261,6 +1262,28 @@ class DiscordArchiver:
         logger.info(
             f'Archival complete: {total_incremental} incremental msgs, '
             f'{len(workable)} channels, {elapsed}s elapsed'
+        )
+
+    def _warn_unresolved_backlog(self, lagging: list) -> None:
+        """追赶轮跑完仍有积压的频道要出声——这类停摆此前对所有监控都是隐形的。
+
+        沉默源审计只看 source 级（discord 整体有没有产出），并明确把频道级健康
+        「交给 archiver 的 state.json 自理」，而 archiver 从来没做过这个检查。
+        于是 general-chat 停摆 9 天、morimens-game-chat 停摆近 2 个月，全程零告警
+        ——公会整体每天照常几千条进账，聚合层面完全看不出来。
+
+        判据用「本轮反复撞配额、到预算耗尽仍没抽干」而不是「游标很旧」：後者会把
+        已停用频道全部误报（实测 global 121 个文字频道里有 31 个游标超 3 天，其中
+        绝大多数是「已停止使用」类频道，最久的 990 天没人发言——那是频道死了，不是
+        采集坏了）。撞配额是活跃度与滞后的合取，死频道永远不会命中。
+        """
+        if not lagging:
+            return
+        names = ', '.join(str(ch.get('name', ch.get('id'))) for ch in lagging[:10])
+        logger.warning(
+            f'积压未抽干频道 {len(lagging)} 个（预算耗尽仍在撞单轮配额）：{names}'
+            ' —— 单轮排干速度已跟不上这些频道的产出，若连续多轮出现同一批频道，'
+            '说明采集频次或预算需要再上调，否则游标会像 general-chat 那样越掉越远'
         )
 
 

--- a/projects/news/scripts/discord_archiver.py
+++ b/projects/news/scripts/discord_archiver.py
@@ -54,8 +54,12 @@ def resolve_data_dir(guild_id: str | None = None) -> Path:
                                              guild_id or GLOBAL_GUILD_ID)
 
 REQUEST_DELAY = 0.25          # seconds between API calls (Discord allows 50 req/s per bot)
-MAX_RUNTIME_SECONDS = 45 * 60         # 45-minute limit (GitHub Actions safe margin)
-MAX_MESSAGES_PER_CHANNEL = 5000     # incremental cap per channel per run
+# 单轮预算。默认 45 分钟不变；允许 env 覆盖，是因为加了积压追赶轮（Track 1b）之后
+# 归档器**真的会**吃满预算，而它只是作业里的第一步——后面还有 forum starter 回填与
+# commit/push。作业 timeout 必须 > 归档器预算 + 回填预算，否则积压重的那几轮会在
+# 提交前被 CI 砍掉，等于白跑。谁排在同一个作业里，谁就在工作流里显式分配预算。
+MAX_RUNTIME_SECONDS = int(os.environ.get('DISCORD_RUNTIME_BUDGET') or 45 * 60)
+MAX_MESSAGES_PER_CHANNEL = 5000     # 单轮**每频道公平配额**（非本轮抓取总量上限，见 Track 1b）
 # 429 `retry_after` 由**服务端**给值，本地无上限地照睡是把整轮跑的进度权交了出去:
 # 一个 retry_after=86400 的响应（全局限流 / Cloudflare 拦截 / 被篡改的中间层）就让
 # 进程干睡到 CI 作业超时被杀 —— 45 分钟预算 `_is_time_up()` 检查不到睡眠里,
@@ -1142,13 +1146,48 @@ class DiscordArchiver:
 
         # ── Track 1: Incremental ──
         total_incremental = 0
+        lagging: list[dict] = []
         for ch in text_channels:
             if self._is_time_up():
                 logger.warning('Runtime limit: stopping incremental track')
                 break
             count = self.fetch_channel_incremental(ch['id'], ch.get('name', ''))
             total_incremental += count
+            # 撞到单轮配额 = 该频道还有没抽干的积压，登记进追赶轮
+            if count >= MAX_MESSAGES_PER_CHANNEL:
+                lagging.append(ch)
             self._save_state()  # per-channel save for 断点续传
+
+        # ── Track 1b: 积压追赶轮 ──────────────────────────────────────────────
+        # MAX_MESSAGES_PER_CHANNEL 是**单轮公平配额**（防一个大频道把预算吃光、
+        # 饿死排在后面的频道），不是「本轮最多只要这么多」。少了这一轮，日产出
+        # 高于配额的频道每轮净欠一截、游标越掉越远且**永不收敛**：global 的
+        # general-chat 日均 ~7.2k 条、morimens-game-chat ~7k 条，对 5k 配额每天
+        # 净欠 2k+，于是 general-chat 卡死在 2026-08-07、morimens-game-chat 卡死
+        # 在 2026-06-18；而同一轮里排在更后面的 game-question 反倒始终是新的
+        # （日产出低于配额，一轮就抽干）——「靠后的活、靠前的死」正是配额缺追赶
+        # 的指纹，不是频道顺序或权限问题。
+        #
+        # 所以第一轮走完后，只要预算还有剩，就对撞了配额的频道反复补抽，直到抽干
+        # 或时间到。抽 5k 条 ≈ 50 次请求 × REQUEST_DELAY(0.25s) ≈ 13 秒，相对 45
+        # 分钟预算极宽裕；真正的护栏自始至终是 _is_time_up()，不是配额本身。
+        catchup_rounds = 0
+        while lagging and not self._is_time_up():
+            catchup_rounds += 1
+            still_lagging = []
+            for ch in lagging:
+                if self._is_time_up():
+                    still_lagging.append(ch)
+                    continue
+                count = self.fetch_channel_incremental(ch['id'], ch.get('name', ''))
+                total_incremental += count
+                if count >= MAX_MESSAGES_PER_CHANNEL:
+                    still_lagging.append(ch)
+                self._save_state()
+            lagging = still_lagging
+        if catchup_rounds:
+            state = '积压已抽干' if not lagging else f'{len(lagging)} 个频道仍有积压（预算耗尽）'
+            logger.info(f'Catch-up: {catchup_rounds} 轮追赶，{state}')
 
         # Forum channels: active + archived threads, incremental (no historical backfill)
         for ch in forum_channels:

--- a/projects/news/scripts/global_collectors.py
+++ b/projects/news/scripts/global_collectors.py
@@ -18,6 +18,7 @@
 
 import asyncio
 import hashlib
+import html as _html
 import json
 import os
 import re
@@ -1165,6 +1166,10 @@ def fetch_weixin():
                 if not time_str:
                     time_str = datetime.now(UTC).isoformat()
                     time_approx = True
+
+                # href 取自 HTML 属性，实体未解码时链接会带字面量 &amp;（归档里
+                # 的微信链接因此全是 `?url=…&amp;token=…` 这种点不开的坏链）。
+                url = _html.unescape(url)
 
                 item = _make_item(
                     title=f"[微信] {title}",

--- a/projects/news/scripts/global_collectors.py
+++ b/projects/news/scripts/global_collectors.py
@@ -59,6 +59,10 @@ def _refresh_cutoff():
     global CUTOFF
     CUTOFF = datetime.now(UTC) - timedelta(hours=HOURS_LOOKBACK)
 
+# 微博搜索每个关键词最多向后翻几页。取 5：单页约十余条，5 页 ≈ 每关键词每轮 50~70
+# 条，足以覆盖高峰日的刷新速度；再深就开始大量撞到时窗外的旧贴，纯烧请求。
+WEIBO_MAX_PAGES = int(os.environ.get("WEIBO_MAX_PAGES") or 5)
+
 # 多语言搜索关键词
 KEYWORDS = {
     "zh": ["忘却前夜", "忘卻前夜"],
@@ -589,50 +593,75 @@ def _parse_weibo_time(created_str):
 
 
 def fetch_weibo():
-    """从微博搜索忘却前夜相关热帖。支持 WEIBO_COOKIE 环境变量提升成功率。"""
+    """从微博搜索忘却前夜相关热帖。支持 WEIBO_COOKIE 环境变量提升成功率。
+
+    翻页（2026-08-16）：原实现每个关键词只取搜索结果第一页（约十余条），一轮采集
+    的可见面就是首屏那点内容——高峰日刷得快就整段刷过去了，实测 2026-08-13 单日
+    归档为 0，其后三天只有 33/10/9 条。现按 page 参数向后翻至多 WEIBO_MAX_PAGES 页，
+    空页或重复页即停。
+    """
     cookie = os.environ.get("WEIBO_COOKIE", "")
     items = []
     for keyword in KEYWORDS["zh"]:
-        try:
-            headers = {"Referer": "https://m.weibo.cn"}
-            if cookie:
-                headers["Cookie"] = cookie
-            data = _get(
-                "https://m.weibo.cn/api/container/getIndex",
-                params={"containerid": f"100103type=1&q={keyword}", "page_type": "searchall"},
-                headers=headers,
-            ).json()
+        seen_ids: set[str] = set()
+        for page in range(1, WEIBO_MAX_PAGES + 1):
+            try:
+                headers = {"Referer": "https://m.weibo.cn"}
+                if cookie:
+                    headers["Cookie"] = cookie
+                data = _get(
+                    "https://m.weibo.cn/api/container/getIndex",
+                    params={"containerid": f"100103type=1&q={keyword}",
+                            "page_type": "searchall", "page": page},
+                    headers=headers,
+                ).json()
 
-            for card in data.get("data", {}).get("cards", []):
-                if card.get("card_type") != 9:
-                    continue
-                mblog = card.get("mblog", {})
-                created_str = mblog.get("created_at", "")
-                parsed_time, time_approx = _parse_weibo_time(created_str)
-                text = mblog.get("text", "")
-                text_clean = re.sub(r"<[^>]+>", "", text)
+                cards = [c for c in data.get("data", {}).get("cards", [])
+                         if c.get("card_type") == 9]
+                if not cards:
+                    break  # 到底了
 
-                item = _make_item(
-                    title=text_clean[:100],
-                    summary=text_clean,
-                    source="weibo",
-                    platform_region="cn",
-                    time_str=parsed_time,
-                    url=f"https://m.weibo.cn/detail/{mblog.get('id', '')}",
-                    engagement=mblog.get("reposts_count", 0) + mblog.get("comments_count", 0) + mblog.get("attitudes_count", 0),
-                    is_hot=mblog.get("attitudes_count", 0) > 500,
-                    author=mblog.get("user", {}).get("screen_name", ""),
-                    lang="zh",
-                )
-                if time_approx:
-                    item["time_is_approximate"] = True
-                items.append(item)
+                # 微博在越界翻页时会重复回吐上一页——整页无新 id 即停，
+                # 否则会把同一批内容反复计入（且白烧请求）。
+                page_ids = {str((c.get("mblog") or {}).get("id", "")) for c in cards}
+                if page_ids and page_ids <= seen_ids:
+                    break
+                seen_ids |= page_ids
 
-            logger.info(f'Weibo "{keyword}": {len(items)} posts')
-        except Exception as e:
-            logger.warning(f'Weibo "{keyword}" failed: {e}')
+                _collect_weibo_cards(cards, items)
+                logger.info(f'Weibo "{keyword}" p{page}: {len(cards)} cards')
+            except Exception as e:
+                logger.warning(f'Weibo "{keyword}" p{page} failed: {e}')
+                break
 
     return items
+
+
+def _collect_weibo_cards(cards, items):
+    """把一页搜索卡片解析成标准 item 追加进 items。"""
+    for card in cards:
+        mblog = card.get("mblog", {})
+        parsed_time, time_approx = _parse_weibo_time(mblog.get("created_at", ""))
+        text_clean = re.sub(r"<[^>]+>", "", mblog.get("text", ""))
+
+        item = _make_item(
+            title=text_clean[:100],
+            summary=text_clean,
+            source="weibo",
+            platform_region="cn",
+            time_str=parsed_time,
+            url=f"https://m.weibo.cn/detail/{mblog.get('id', '')}",
+            engagement=(mblog.get("reposts_count", 0) + mblog.get("comments_count", 0)
+                        + mblog.get("attitudes_count", 0)),
+            is_hot=mblog.get("attitudes_count", 0) > 500,
+            author=mblog.get("user", {}).get("screen_name", ""),
+            lang="zh",
+        )
+        if time_approx:
+            item["time_is_approximate"] = True
+        items.append(item)
+
+
 def fetch_arca_live():
     """从 Arca.live 抓取韩国忘却前夜频道 (forgettingeve)。
 

--- a/projects/news/scripts/sources.py
+++ b/projects/news/scripts/sources.py
@@ -29,7 +29,6 @@ KNOWN_SOURCES = [
     # 全球扩展平台
     'weibo',
     'bahamut',
-    'arca_live',
     'appstore',
     'google_play',
     'pixiv',
@@ -47,6 +46,14 @@ KNOWN_SOURCES = [
 # twitter 已摘除（守密人 2026-07-30 裁定，归档完整性审计待裁项④）：挂名 1,126 天审计窗口
 # 零产出、归档目录从未存在（syndication 接口 API 墙）。采集器 fetch_twitter 保留在
 # global_collectors 但不再入 collect_global 编排；未来要采集须重新登记并接回编排。
+#
+# arca_live 已摘除（守密人 2026-08-16 裁定，明文放弃）：Cloudflare 三路封死 Actions
+# 机房 IP（HTTP 403 / PW 挑战页超时 / App API 403）。2026-07-10 方案 2 本要改由每日
+# 云端例程绕行，但那条 Routine 从未建立——数据停在 2026-07-11，归档共 10 个文件。
+# 韩区实际声量主要在 YouTube 创作者侧而非 arca，为它单挂一条云端例程投入产出不成立。
+# 采集器 fetch_arca_live / fetch_arca_live_playwright 与 collect_arca_daily.py 单脚本
+# 均保留（CF 某日放行 Actions 即可原样复用），但都不再入编排；未来要恢复须重新登记
+# 回 KNOWN_SOURCES 并接回 collect_global。
 
 # 原始源名 → 规范源名
 SOURCE_ALIASES = {
@@ -68,7 +75,7 @@ SPARSE_SOURCES = {
     'weixin',
     'pixiv',
     'stopgame',
-    'note_com', 'ruliweb', 'arca_live', 'bahamut',
+    'note_com', 'ruliweb', 'bahamut',   # arca_live 已摘除（2026-08-16）
     'taptap', 'taptap_review',
     'discord',
 }
@@ -96,8 +103,10 @@ AUTH_GATED = {
 ARCHIVE_PLATFORMS = [s for s in KNOWN_SOURCES if s != 'discord']
 
 # backfill_platforms.py 的 PLATFORM_BACKFILLERS 实际支持的源（务必与之同步）
+# arca_live 已摘除（2026-08-16）：回填器实现保留在 backfill_platforms，但不再登记，
+# 否则 backfill-news 的手动回填仍会去撞 Cloudflare、每次必然空手而归。
 BACKFILL_PLATFORMS = [
-    'bilibili', 'appstore', 'steam_review', 'arca_live',
+    'bilibili', 'appstore', 'steam_review',
     'pixiv', 'ruliweb', 'weixin', 'taptap',
 ]
 

--- a/projects/news/scripts/taptap_collector.py
+++ b/projects/news/scripts/taptap_collector.py
@@ -13,6 +13,7 @@ TapTap 已废弃 webapiv2 全部端点（均返回404），页面使用 Nuxt 客
 import asyncio
 import json
 import logging
+import math
 import re
 import sys
 from datetime import datetime, timedelta, timezone, UTC
@@ -81,6 +82,33 @@ def _parse_taptap_dom_time(time_str):
     Falls back to now if unparseable.
     """
     return news_common.parse_relative_time(time_str)[0]
+
+
+def _parse_taptap_dom_score(raw: Any) -> int:
+    """从 DOM 星级块的文本里取 1–5 分，取不到返回 0（不入标题、不写 score 字段）。
+
+    评分块可能渲染成 "4.5"、"4 分"、"★★★★☆" 几种形态；API 路径有结构化 score，
+    DOM 兜底只能从文本猜，所以拿不准就返回 0，让下游知道「这条没有评分」，而不是
+    编一个出来。
+    """
+    if raw is None:
+        return 0
+    text = str(raw).strip()
+    if not text:
+        return 0
+    filled = text.count('★')
+    if filled:
+        return min(filled, 5)
+    m = re.search(r'\d+(?:\.\d+)?', text)
+    if not m:
+        return 0
+    try:
+        # 四舍五入而非 round()：内建 round 是银行家舍入，round(4.5)==4，
+        # 对"4.5 星"这种半档评分会系统性地往下压一档。
+        value = math.floor(float(m.group()) + 0.5)
+    except ValueError:
+        return 0
+    return value if 1 <= value <= 5 else 0
 
 
 # ─── 滚动深采（懒加载分页）─────────────────────────────────────
@@ -480,9 +508,6 @@ async def _extract_reviews_dom(page) -> list[dict]:
         }
 
         return els.map(el => {
-            const contentEl = el.querySelector(
-                '[class*="content"], [class*="text"], [class*="body"], p'
-            );
             const timeEl = el.querySelector('time, [class*="time"], [class*="date"]');
             const likeEl = el.querySelector('[class*="like"], [class*="thumb"]');
             const authorEl = el.querySelector(
@@ -490,6 +515,22 @@ async def _extract_reviews_dom(page) -> list[dict]:
             );
             const starEl = el.querySelector('[class*="star"], [class*="score"], [class*="rating"]');
             const linkEl = el.querySelector('a[href*="/review/"]') || el.querySelector('a[href]');
+
+            // 正文选择：原实现用 querySelector 取**文档序第一个**命中
+            // '[class*="content"], [class*="text"], …' 的元素。TapTap 的卡片把用户名
+            // 也包在带 content/text 类名的头部块里，且它排在正文之前 —— 于是抓回来的
+            // 「正文」就是用户名，落档成 title=summary=author=用户名、评分全空
+            // （实测两周 1,185 条评论无一条有正文）。
+            // 改成：候选里挑**文本最长**的那个，并排除作者块本身及其祖先容器。
+            const contentCandidates = Array.from(el.querySelectorAll(
+                '[class*="content"], [class*="text"], [class*="body"], p'
+            )).filter(c => !authorEl || !(c === authorEl || c.contains(authorEl)));
+            let contentEl = null;
+            let bestLen = 0;
+            for (const c of contentCandidates) {
+                const t = (c.innerText || c.textContent || '').trim();
+                if (t.length > bestLen) { bestLen = t.length; contentEl = c; }
+            }
 
             return {
                 content: contentEl ? ((contentEl.innerText || contentEl.textContent || '').trim()) : '',
@@ -505,24 +546,49 @@ async def _extract_reviews_dom(page) -> list[dict]:
     }""")
 
     items = []
+    seen_urls = set()
+    dropped_author_echo = 0
     for r in result or []:
         content_text = r.get("content", "").strip()
         if not content_text:
             continue
+        author = r.get("author", "").strip()
+        # 正文与用户名雷同 = 选择器又抓到了头部块，不是评论正文。宁可这轮空手
+        # 触发响亮失败，也不要把一堆用户名当评论灌进归档（那批数据无法回溯识别，
+        # 只能靠人肉发现「1,185 条评论全是用户名」）。
+        if author and content_text == author:
+            dropped_author_echo += 1
+            continue
+        url = r.get("url", "")
+        # 同一条评论在 DOM 里可能被多个卡片容器命中；按评论链接收敛。
+        if url:
+            if url in seen_urls:
+                continue
+            seen_urls.add(url)
         created_str = _parse_taptap_dom_time(r.get("time_str", ""))
+        score = _parse_taptap_dom_score(r.get("score", ""))
+        star_str = f"{'★' * score}{'☆' * (5 - score)} " if score else ""
         item = {
-            "title": content_text[:60],
+            "title": f"{star_str}{content_text[:60]}".strip(),
             "summary": content_text,
             "like_count": _parse_num(r.get("likes")),
             "comment_count": 0,
             "created": created_str,
-            "url": r.get("url", ""),
-            "author": r.get("author", ""),
+            "url": url,
+            "author": author,
             "item_id": "",
         }
+        if score:
+            item["score"] = score
         if not r.get("time_str"):
             item["time_is_approximate"] = True
         items.append(item)
+
+    if dropped_author_echo:
+        logger.warning(
+            f"TapTap DOM: {dropped_author_echo} 条正文与用户名雷同已丢弃"
+            f"（正文选择器疑似又抓到卡片头部块，请复查 debug_taptap_review.html）"
+        )
 
     if not items:
         logger.warning("TapTap: DOM extraction found no review elements")

--- a/tests/test_archive_platforms_unit.py
+++ b/tests/test_archive_platforms_unit.py
@@ -27,6 +27,31 @@ class TestItemKey(unittest.TestCase):
         k = ap.item_key({"url": "   ", "title": "T"})
         self.assertEqual(k, "T||")
 
+    def test_weixin_ignores_rotating_sogou_url(self):
+        """搜狗中转链每次请求重签，同一篇公告必须仍判为同一条。
+
+        回归实测：2026-08-07 单日档里「运营主体变更通知」攒了 114 份、
+        「第4届N厨杯」144 份，114 个 URL 无一相同（连 url 参数本身都轮换）。
+        """
+        base = {"source": "weixin", "title": "[微信] 关于《忘却前夜》运营主体变更的通知",
+                "time": "2026-08-07T03:11:00+00:00", "author": ""}
+        a = ap.item_key({**base, "url": "/link?url=dn9a_AAA&type=2&token=0ED020BE"})
+        b = ap.item_key({**base, "url": "/link?url=dn9a_BBB&type=2&token=9FC431AA"})
+        self.assertEqual(a, b)
+
+    def test_stable_url_source_still_keys_on_url(self):
+        """只有中转链源改键；URL 稳定的源不受影响（同标题不同贴仍是两条）。"""
+        a = ap.item_key({"source": "reddit", "title": "T", "url": "https://x/1"})
+        b = ap.item_key({"source": "reddit", "title": "T", "url": "https://x/2"})
+        self.assertNotEqual(a, b)
+
+    def test_approximate_time_excluded_from_key(self):
+        """时间是 now() 兜底出来的就不能进键，否则每轮又是一个新身份。"""
+        base = {"source": "weixin", "title": "T", "author": "a", "time_is_approximate": True}
+        a = ap.item_key({**base, "time": "2026-08-07T01:00:00+00:00"})
+        b = ap.item_key({**base, "time": "2026-08-07T04:00:00+00:00"})
+        self.assertEqual(a, b)
+
 
 class TestItemDateUtc8(unittest.TestCase):
     def test_no_time_uses_fallback(self):

--- a/tests/test_collect_global_unit.py
+++ b/tests/test_collect_global_unit.py
@@ -159,14 +159,15 @@ class TestRunZeroCostBranches(unittest.TestCase):
         self.assertEqual(core_failures, [])
 
     def test_playwright_fallback_on_empty(self):
-        # Arca.live returns [] via HTTP → playwright fallback yields items.
+        # Ruliweb returns [] via HTTP → playwright fallback yields items.
+        # （原以 Arca.live 举例；该源 2026-08-16 摘除后已不在编排里）
         pw_mod = mock.MagicMock()
-        pw_mod.fetch_arca_live_playwright = lambda: [_item("pw", "https://pw/1")]
+        pw_mod.fetch_ruliweb_playwright = lambda: [_item("pw", "https://pw/1")]
         with mock.patch.object(global_collectors, "_refresh_cutoff", return_value=None), \
                 mock.patch.dict(sys.modules, {"data_quality": mock.MagicMock(
                     SilentPlatformTracker=mock.MagicMock(side_effect=Exception("off"))),
                     "playwright_collectors": pw_mod}):
-            self._patch_all_empty({"Arca.live": list})
+            self._patch_all_empty({"Ruliweb": list})
             items, _ = cg.run_zero_cost_collectors()
         self.assertTrue(any(i["title"] == "pw" for i in items))
 

--- a/tests/test_discord_archiver_unit.py
+++ b/tests/test_discord_archiver_unit.py
@@ -564,6 +564,27 @@ class TestPipelines(unittest.TestCase):
             self.assertLess(fci.call_count, 10)
             self.assertTrue((arch.data_dir / "state.json").exists())
 
+    def test_unresolved_backlog_warns(self):
+        """预算耗尽仍在撞配额的频道必须出声——此前这类停摆对所有监控都是隐形的。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            arch = _make_archiver(tmp)
+            with mock.patch.object(da.logger, "warning") as warn:
+                arch._warn_unresolved_backlog([{"id": "111", "name": "morimens-game-chat"}])
+            self.assertTrue(warn.called)
+            self.assertIn("morimens-game-chat", warn.call_args[0][0])
+
+    def test_drained_backlog_stays_quiet(self):
+        """抽干了就不该报警——判据是「撞配额」，不是「游标旧」。
+
+        用游标年龄做判据会把已停用频道全部误报：实测 global 121 个文字频道里 31 个
+        游标超 3 天，绝大多数是「已停止使用」类频道（最久 990 天没人发言）。
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            arch = _make_archiver(tmp)
+            with mock.patch.object(da.logger, "warning") as warn:
+                arch._warn_unresolved_backlog([])
+            self.assertFalse(warn.called)
+
     def test_runtime_budget_env_override(self):
         """作业要能把归档器预算压到 job timeout 之下，给 commit/push 留出空档。"""
         import importlib

--- a/tests/test_discord_archiver_unit.py
+++ b/tests/test_discord_archiver_unit.py
@@ -515,6 +515,64 @@ class TestPipelines(unittest.TestCase):
             fci.assert_called()
             self.assertTrue((arch.data_dir / "state.json").exists())
 
+    def test_catchup_drains_channel_over_quota(self):
+        """撞了单轮配额的频道会被反复补抽，直到抽干。
+
+        回归 general-chat（日产 ~7.2k）在 5k 配额下卡死在 2026-08-07 的那个缺陷：
+        只有配额、没有追赶轮时一轮只排 5k，日增大于日排 → 游标永不收敛。
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            arch = _make_archiver(tmp)
+            arch.state["history_backfill_complete"] = True
+            # 频道 111 积压 12k：首轮 5k（撞配额）→ 追赶 5k、2k（抽干）
+            drains = iter([da.MAX_MESSAGES_PER_CHANNEL,
+                           da.MAX_MESSAGES_PER_CHANNEL,
+                           2000])
+
+            def fake_incremental(_cid, _name=""):
+                return next(drains, 0)
+
+            with mock.patch.object(arch, "fetch_guild_meta", return_value=self._channels()), \
+                    mock.patch.object(arch, "fetch_channel_incremental",
+                                      side_effect=fake_incremental) as fci, \
+                    mock.patch.object(arch, "fetch_forum_threads", return_value=0), \
+                    mock.patch.object(da.time, "sleep"):
+                arch.run()
+            # 首轮 1 次 + 追赶 2 次；最后一次低于配额即判定抽干、停止追赶
+            self.assertEqual(fci.call_count, 3)
+
+    def test_catchup_yields_when_budget_exhausted(self):
+        """预算耗尽时追赶轮必须让位——不能为了抽干把作业拖到被 CI 砍掉。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            arch = _make_archiver(tmp)
+            arch.state["history_backfill_complete"] = True
+            # 永远抽不干（每轮都撞配额）：没有时间护栏就是死循环
+            calls = {"n": 0}
+
+            def time_up():
+                calls["n"] += 1
+                return calls["n"] > 3
+
+            with mock.patch.object(arch, "fetch_guild_meta", return_value=self._channels()), \
+                    mock.patch.object(arch, "fetch_channel_incremental",
+                                      return_value=da.MAX_MESSAGES_PER_CHANNEL) as fci, \
+                    mock.patch.object(arch, "fetch_forum_threads", return_value=0), \
+                    mock.patch.object(arch, "_is_time_up", side_effect=time_up), \
+                    mock.patch.object(da.time, "sleep"):
+                arch.run()
+            # 有限次返回后收尾，且状态照常落盘（下一轮从游标接着抓）
+            self.assertLess(fci.call_count, 10)
+            self.assertTrue((arch.data_dir / "state.json").exists())
+
+    def test_runtime_budget_env_override(self):
+        """作业要能把归档器预算压到 job timeout 之下，给 commit/push 留出空档。"""
+        import importlib
+        with mock.patch.dict(os.environ, {"DISCORD_RUNTIME_BUDGET": "2100"}, clear=False):
+            reloaded = importlib.reload(da)
+            self.assertEqual(reloaded.MAX_RUNTIME_SECONDS, 2100)
+        importlib.reload(da)  # 还原默认值，避免污染同批其余用例
+        self.assertEqual(da.MAX_RUNTIME_SECONDS, 45 * 60)
+
     def test_run_history_only_pipeline(self):
         with tempfile.TemporaryDirectory() as tmp:
             arch = _make_archiver(tmp)

--- a/tests/test_global_collectors_more.py
+++ b/tests/test_global_collectors_more.py
@@ -271,6 +271,42 @@ class TestFetchWeiboExtra(unittest.TestCase):
                 mock.patch.object(gc, "_get", side_effect=RuntimeError("down")):
             self.assertEqual(gc.fetch_weibo(), [])
 
+    @staticmethod
+    def _card(mid):
+        return {"card_type": 9, "mblog": {
+            "created_at": "", "text": f"忘却前夜 {mid}", "id": str(mid),
+            "reposts_count": 0, "comments_count": 0, "attitudes_count": 0,
+            "user": {"screen_name": "u"},
+        }}
+
+    def test_pagination_walks_pages(self):
+        """翻页：只取首页时一轮就那十来条，高峰日会整段刷过去（实测 8-13 归档为 0）。"""
+        pages = {1: [self._card(1)], 2: [self._card(2)], 3: []}
+
+        def fake_get(_url, params=None, **_kw):
+            return FakeResp(json_data={"data": {"cards": pages.get(params["page"], [])}})
+
+        with mock.patch.dict(gc.os.environ, {}, clear=True), \
+                mock.patch.object(gc, "_get", side_effect=fake_get):
+            items = gc.fetch_weibo()
+        # 2 个中文关键词 × 2 页各 1 条
+        self.assertEqual(len(items), 4)
+
+    def test_pagination_stops_on_repeated_page(self):
+        """微博越界翻页会重复回吐上一页——整页无新 id 必须停，否则同批内容反复计入。"""
+        calls = {"n": 0}
+
+        def fake_get(_url, params=None, **_kw):
+            calls["n"] += 1
+            return FakeResp(json_data={"data": {"cards": [self._card(1)]}})
+
+        with mock.patch.dict(gc.os.environ, {}, clear=True), \
+                mock.patch.object(gc, "_get", side_effect=fake_get):
+            items = gc.fetch_weibo()
+        # 每个关键词翻到第 2 页即判定重复停下：2 关键词 × 1 条，共 2×2 次请求
+        self.assertEqual(len(items), 2)
+        self.assertEqual(calls["n"], 4)
+
 
 # ─── arca extra branches ───────────────────────────────────
 

--- a/tests/test_taptap_collector_unit.py
+++ b/tests/test_taptap_collector_unit.py
@@ -246,6 +246,54 @@ class TestExtractReviewsDom(unittest.TestCase):
         self.assertEqual(out[0]["like_count"], 9)
         self.assertNotIn("time_is_approximate", out[0])
 
+    def test_drops_rows_where_content_echoes_author(self):
+        """正文==用户名 = 选择器抓到了卡片头部块，必须丢弃而不是落档。
+
+        回归实测：两周 1,185 条 TapTap「评论」全部 title=summary=author=用户名、
+        无正文无评分——这批数据事后无法自动识别，只能靠人肉发现。
+        """
+        dom = [{"content": "葱爆牛排", "author": "葱爆牛排", "time_str": "2026-08-15",
+                "url": "https://www.taptap.cn/review/50027316"}]
+        page = FakePage(dom_result=dom)
+        out = _run(tt._extract_reviews_dom(page))
+        self.assertEqual(out, [])
+
+    def test_dedups_same_review_url(self):
+        dom = [
+            {"content": "很好玩", "author": "a", "time_str": "2026-08-15", "url": "https://t/review/1"},
+            {"content": "很好玩", "author": "a", "time_str": "2026-08-15", "url": "https://t/review/1"},
+            {"content": "还行", "author": "b", "time_str": "2026-08-15", "url": "https://t/review/2"},
+        ]
+        page = FakePage(dom_result=dom)
+        with mock.patch.object(tt.news_common, "parse_relative_time",
+                               return_value=("2026-08-15T00:00:00+00:00", False)):
+            out = _run(tt._extract_reviews_dom(page))
+        self.assertEqual(len(out), 2)
+
+    def test_score_lands_in_title_and_field(self):
+        dom = [{"content": "很好玩", "author": "a", "time_str": "2026-08-15",
+                "score": "4.5", "url": "https://t/review/1"}]
+        page = FakePage(dom_result=dom)
+        with mock.patch.object(tt.news_common, "parse_relative_time",
+                               return_value=("2026-08-15T00:00:00+00:00", False)):
+            out = _run(tt._extract_reviews_dom(page))
+        self.assertEqual(out[0]["score"], 5)
+        self.assertTrue(out[0]["title"].startswith("★★★★★"))
+
+
+class TestParseTaptapDomScore(unittest.TestCase):
+    def test_star_glyphs(self):
+        self.assertEqual(tt._parse_taptap_dom_score("★★★★☆"), 4)
+
+    def test_numeric_forms(self):
+        self.assertEqual(tt._parse_taptap_dom_score("4.5"), 5)
+        self.assertEqual(tt._parse_taptap_dom_score("3 分"), 3)
+
+    def test_unparseable_returns_zero(self):
+        """拿不准就返回 0（下游据此知道「没有评分」），不编一个出来。"""
+        for bad in (None, "", "评分", "99"):
+            self.assertEqual(tt._parse_taptap_dom_score(bad), 0)
+
 
 # ── collect() orchestration (fully mocked playwright) ────────────────────────
 


### PR DESCRIPTION
## 概述

修复四个采集缺陷，均由 2026-08-03~16 的归档数据反查定位。其中 Discord 那个最严重：`general-chat` 自 08-07、`morimens-game-chat` 自 06-18 起游标停摆，且**永不会自行恢复**——global 日均消息量从 1.4 万「掉」到 7~9k 是采集假象，不是社区萎缩。另按守密人 2026-08-16 裁定摘除 arca_live。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [ ] 文档完善（CLAUDE.md / README.md / 子项目 CONTEXT.md / memory 档案）
- [x] Bug 修复
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 其他（请说明）：源注册表变更（arca_live 摘除，照 twitter 2026-07-30 先例）

---

## 变更内容

### 1. Discord 频道游标永不收敛（影响最大）

`MAX_MESSAGES_PER_CHANNEL = 5000` 被当成了「本轮抓取上限」，而它本该是「单轮**每频道**公平配额」。日产出高于配额的频道每轮净欠一截：

| 频道 | 日产出 | 单轮排干上限 | 结果 |
|---|---|---|---|
| general-chat | ~7,200 | 5,000 x 1 轮/天 | 每天净欠 ~2,200，卡死 08-07 |
| morimens-game-chat | ~7,000 | 同上 | 卡死 06-18，积压近两个月 |
| game-question | 低于配额 | 一轮抽干 | 始终是新的 |

`game-question` 在频道列表里排在 `general-chat` **后面**（103/121 vs 99/121）却完全正常——「靠后的活、靠前的死」正是配额缺追赶的指纹，与频道顺序、权限均无关。commit `e4da0732` 里 `08125010/2026-08-07.jsonl` 正好 `+5000` 行即撞配额现场。

修法是赤字的两半一起补：

- **Track 1b 积压追赶轮**：首轮走完后，只要预算有剩就对撞了配额的频道反复补抽，直到抽干或时间到。抽 5k 条约 50 次请求 x 0.25s ≈ 13 秒，45 分钟预算相对配额极宽裕，真正的护栏始终是 `_is_time_up()`。
- **采集频次 1 天 1 轮 → 每 3 小时一轮**，对齐 jp / volunteer / history-backfill。global 是最大的公会，却是唯一一天只跑一轮的。

顺带修一个被本次改动激活的隐患：作业 `timeout-minutes: 45` 恰好等于归档器自身预算。以前归档器撞配额就早早收工所以没暴露，加了追赶轮后它真的会吃满——那样作业会在 commit 之前被砍、整轮白跑。现拆为 归档器 35 + forum starter 15 + 作业 55，并让归档器预算可经 `DISCORD_RUNTIME_BUDGET` 覆盖。forum starter 的 `RUNTIME_BUDGET` 从 3600 改 900：它比作业 timeout 本身还长，从来没有兑现过。

### 2. 补上频道级监控盲区

沉默源审计只看 source 级产出，并明确把频道级健康「交给 archiver 的 state.json 自理」（`silent_sources_audit.build_leaf_report` 对 discord 直接 `continue`），而 archiver 从来没做过这个检查——这就是上述停摆全程零告警的原因：公会整体每天照常几千条进账，聚合层面完全看不出来。

判据用「追赶轮跑完仍在撞单轮配额」而非「游标很旧」：后者实测会把 global 121 个文字频道里的 31 个全报出来，绝大多数是「已停止使用」类频道（最久的 990 天没人发言）——那是频道死了，不是采集坏了。撞配额是活跃度与滞后的合取，死频道永远不会命中。

### 3. 微信同一篇公告归档上百份

搜狗中转链每次请求重新签发，而去重键就是 URL。实测 2026-08-07 单日档：「运营主体变更通知」114 份、「第4届N厨杯」144 份，逐个比对这 114 个 URL **无一相同**（连 `url` 参数本身都轮换，只有 `type` 固定）。

- `item_key` 对中转链源改用 `标题|时间|作者`（实测 `time` 稳定，正是收敛维）
- 近似时间（采集器解析失败、填 `now()` 兜底）一律不入键，否则每轮又是新身份
- 顺带解码 `href` 的 HTML 实体：归档里的微信链接目前全是带字面量 `&amp;` 的坏链

### 4. TapTap 评论正文抓成用户名

DOM 兜底用 `querySelector` 取文档序**第一个** `[class*="content"]` 命中，而 TapTap 把用户名也包在带 content 类名的头部块里且排在正文之前。结果两周 1,185 条「评论」全部 `title=summary=author=用户名`，无正文、无评分，数据完全不可用。

- 正文改取候选中文本最长者，并排除作者块及其祖先容器
- 补 DOM 星级解析（星形计数 / 数值形态，拿不准返回 0 而不是编一个；用 `floor(x+0.5)` 而非 `round()`，后者是银行家舍入会把 4.5 星系统性压低一档）
- 按评论链接去重（同一条评论可能被多个卡片容器命中）
- 守卫：正文与用户名雷同即丢弃并告警——宁可空手触发响亮失败，也不要再把一批用户名灌进归档（这种数据事后只能靠人肉发现）

### 5. arca_live 摘除 + 微博补翻页

**arca_live**（守密人 2026-08-16 裁定，明文放弃）：Cloudflare 三路封死 Actions 机房 IP，2026-07-10 方案 2 本要改由每日云端例程绕行，但那条 Routine 从未建立——数据停在 2026-07-11，归档共 10 个文件。照 twitter（2026-07-30）先例从 `KNOWN_SOURCES` / `SPARSE_SOURCES` / `BACKFILL_PLATFORMS` / `BACKFILL_REGISTRY` / `collect_global` 编排与 PW 兜底表摘除；采集器 `fetch_arca_live`、`fetch_arca_live_playwright`、`backfill_arca_live` 与 `collect_arca_daily.py` 全部保留在树上待复用。跨模块漂移守卫 `test_sync_with_backfill_registry` 在改动中如期报警，已同步两侧。

**微博翻页**：原实现每关键词只取搜索结果第一页（约十余条），高峰日刷得快就整段刷过去——实测 2026-08-13 单日归档为 0，其后三天仅 33/10/9 条。现按 `page` 翻至多 `WEIBO_MAX_PAGES`(=5) 页，空页即停；并对「整页无新 id」单独判停（微博越界翻页会重复回吐上一页，不判停会把同一批内容反复计入且白烧请求）。

> 待定性：08-13 那个洞是否**仅**由无翻页导致尚未确认。`fetch_weibo` 需要 `WEIBO_COOKIE`，本次无法 live 验证；若真因是 cookie 过期，翻页解决不了，需在有 cookie 的环境复跑确认。

---

## 来源声明

不适用：本 PR 为采集器代码修复，不含 Wiki 数据或翻译贡献。诊断依据全部来自本项目自己的公开归档产物（BIAV-SC-DATA 仓 `Record/Community/`）与仓内既有代码。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 诊断引用的均为已公开归档的社区数据与仓内代码。
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**；未上传内部美术资产、客户端解包原始文件、未公开剧情草稿等。
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 全量测试通过：**3390 passed, 51 skipped, 22 subtests passed**
- [x] 改动文件 ruff 全绿（`tests/` 目录基线上本就有 27 个报错，不在门禁范围，与本次改动无关——已用 `git stash` 对照确认）
- [x] 工作流 YAML 解析校验：schedules `5 */3 * * *` + `0 6 1 * *`，timeout 55，两个预算 env 就位
- [x] 新增 15 个回归用例：追赶轮收敛 / 预算耗尽让位 / 预算 env 覆盖 / 积压告警与不误报、搜狗轮换链去重 / 近似时间不入键 / 稳定 URL 源不受影响、正文回声丢弃 / 评论去重 / 星级解析、微博走页 / 重复页判停
- [x] 停摆检测判据已用真实 `state.json`（global / jp / volunteer）验证过误报率，据此换掉了初版的游标年龄判据
- [ ] 不涉及 site / wiki / news 视觉，无需本地预览
- [x] 不引入 emoji
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md`

### 合并后的生效前提

工作流带 `if: github.ref == 'refs/heads/main'`，且 cron 表只从默认分支读取——**合入 main 前新频次与追赶轮都不生效**。合并后首批追赶轮会很重（general-chat 约 6.5 万条积压，morimens-game-chat 两个月、量级数十万条），预计连跑数轮才抽得干，因此头几轮出现「积压未抽干频道」告警属**预期内**；真正需要警惕的是连续多轮同一批频道且推进量上不去，那说明频次或预算仍需上调。

游标核验（在 BIAV-SC-DATA 仓）：

```bash
python3 -c "
import json,datetime
s=json.load(open('Record/Community/discord/global/state.json'))['channels']
for cid,n in [('1400750050208125010','general-chat'),('1170692781216378960','morimens-game-chat')]:
    i=int(s[cid]['last_message_id'])
    print(n, datetime.datetime.utcfromtimestamp(((i>>22)+1420070400000)/1000))
"
```

基线：general-chat `1535421150459461652` = 2026-08-07 22:55；morimens-game-chat `1517163528849461339` = 2026-06-18。

---

## 关联 Issue

- Closes #
- Refs #

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtRggNGkbYMxyhBiG4CdB7)_