### PR TITLE
fix(ci): gitleaks 豁免上游 vendored 树（修 main 红灯）

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -25,4 +25,26 @@ paths = [
   '''^deliverables/.*''',                              # 旧产物目录（已由 Public-Info-Pool 取代）
   '''^data/.*''',                                      # 远古根级数据布局（历史 blob）
   '''^news/.*''',                                      # 远古根级 news 布局（历史 blob）
+
+  # ---- 上游 vendored 树豁免（2026-08-16 守密人裁定）----
+  # black-pool-agent/upstream 是 hermes-agent 的原样搬运层，受「本体永远零修改，
+  # 改动只能走 patches/」约束（见 WEEKLY-UPDATE.md）——银芯自有凭据在设计上不可能
+  # 落在这里，与上面的数据层同属「非银芯凭据面」。
+  #
+  # 为什么必须走路径面而不是 .gitleaksignore 指纹面：指纹是
+  # `<commit>:<file>:<rule>:<line>`，含 commit SHA。周更例程每周把整棵 upstream 树
+  # 重新提交一次，SHA 一变全部指纹失效——指纹路线等于每周手工补一遍，永远补不完。
+  #
+  # 首次触发：2026-08-16 vendor 6f043a5b（v2026.8.3 → v2026.8.13）报 leaks found: 19，
+  # 逐条核实全为上游自带的合成夹具与公开配置，无一条银芯凭据：
+  #   - tests/agent/test_redact.py 等脱敏测试的假密钥（该测试断言的正是「密钥须被打码」，
+  #     夹具形如 sk-abc123def456 / xyzzyplugh1234567890abcd，另含 KEYBOARD=notsecret
+  #     这类专门验证「不该误伤」的反例）
+  #   - tests/test_redaction_registry.py 的 nvapi-AbCdEf...（字母表序，紧邻其待测正则）
+  #   - website/docusaurus.config.ts 的 Algolia DocSearch search-only key（设计上即公开，
+  #     随前端 JS 分发）
+  #
+  # 代价（已知并接受）：上游若某日自带真实凭据，本仓扫描不再拦截——那是上游的凭据面，
+  # 不是银芯的。patches/（银芯自有改动落点）与 build/ deploy/ plugins/ skills/ 照扫。
+  '''^projects/black-pool-agent/upstream/.*''',        # 上游 vendored 树（零修改策略，非银芯凭据面）
 ]


### PR DESCRIPTION
## 概述

2026-08-16 首次 vendor 同步（`6f043a5b`，hermes-agent v2026.8.3 → v2026.8.13）触发 secret-scan `leaks found: 19`，main 转红。19 条全部落在 `projects/black-pool-agent/upstream/`，逐条核实**无一是银芯凭据**。本 PR 在 `.gitleaks.toml` 加一条锚定路径豁免该 vendored 树。

单文件改动，只加一条 allowlist 路径 + 裁定注记。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [ ] 文档完善（CLAUDE.md / README.md / 子项目 CONTEXT.md / memory 档案）
- [x] Bug 修复（CI 门禁误报）
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [ ] 其他（请说明）：

---

## 19 条命中的核实结论

| 文件 | 内容 | 判定 |
|---|---|---|
| `tests/agent/test_redact.py`（多处） | `sk-abc123def456`、`xyzzyplugh1234567890abcd`，同文件另有 `KEYBOARD=notsecret` 这类「不该误伤」反例 | 合成夹具。该测试断言的正是「密钥必须被打码」 |
| `tests/test_redaction_registry.py:26` | `nvapi-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_-abcdEFGH` | 字母表序，紧邻其待测正则 `nvapi-[A-Za-z0-9_-]{20,}` |
| `website/docusaurus.config.ts:105` | Algolia DocSearch `apiKey` | search-only 公开 key，设计上随前端 JS 分发 |
| `tests/run_agent/*.py`、`tests/tools/test_process_registry.py`、`tests/plugins/test_langfuse_plugin.py`、`scripts/toolperf_abeval/ab_eval.py` | `api_key="..."` / `secret = "..."` / `monkeypatch.setenv(...)` 等 | 同类测试夹具 |

---

## 为什么走路径面而不是指纹面

`.gitleaksignore` 的指纹格式是 `<commit>:<file>:<rule>:<line>`，**含 commit SHA**。周更例程每周把整棵 upstream 树（8,939 个文件）重新提交一次，SHA 一变 19 条指纹全部失效——指纹路线等于每周手工补一遍，永远补不完。

路径面也更贴合本配置自己的哲学（「聚焦银芯自有凭据面（代码 / CI / 脚本 / 配置）」）：`upstream/` 是 hermes-agent 的原样搬运层，受「本体永远零修改，改动只能走 `patches/`」约束（见 `WEEKLY-UPDATE.md`），银芯自有凭据在设计上不可能落在这里，与既有的数据层豁免同属「非银芯凭据面」。

**代价（已知并接受）**：上游若某日自带真实凭据，本仓扫描不再拦截。那是上游的凭据面，不是银芯的。

---

## 来源声明

不适用：本 PR 仅改 CI 扫描配置，不含 Wiki 数据或翻译贡献。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

本地 gitleaks **8.24.3**（与 CI 同版本）实测：

- [x] 扫 vendor 提交 `6f043a5b`（`--log-opts="6f043a5b -1"`，与 CI 的单提交扫描口径一致）：
  - 改前：`leaks found: 19`
  - 改后：`no leaks found`
- [x] 豁免边界探针——三处各投一个假 `ghp_` token，全仓 `--no-git` 扫：

  | 探针位置 | 结果 | 说明 |
  |---|---|---|
  | `black-pool-agent/patches/_probe.patch` | **报出** | 银芯自有改动落点，仍拦 |
  | `black-pool-agent/upstream/_probe.py` | 豁免 | 目标豁免面 |
  | `projects/news/scripts/_probe.py` | **报出** | 工程面不受影响 |

  探针文件已全部清理，未进入提交。
- [x] 豁免路径锚定 `^`，不误伤同名目录；`build/` `deploy/` `plugins/` `skills/` 照扫
- [x] 不引入 emoji
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 附带影响

周更例程的守卫是「全绿即直推 main」。main 红着不修，下一轮 Hermes 同步会停手报障——本 PR 顺带解掉这个卡点。

与 #989（采集修复）无关，两者互不依赖，可各自合并。#989 自身两项检查已全绿。

---

## 关联 Issue

- Closes #
- Refs #

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtRggNGkbYMxyhBiG4CdB7)_