### PR TITLE
fix(ci): 串行化 discord/global 的两个写方，并修好推送重试循环（#989 回归）

### DIFF
--- a/.github/workflows/discord-archive-jp.yml
+++ b/.github/workflows/discord-archive-jp.yml
@@ -92,8 +92,16 @@ jobs:
           git commit -m "data: archive JP Discord data (T62 P2-3c)"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件。不 abort 就重试，后续每一次
+            # pull 都只会回 "Pulling is not possible because you have unmerged
+            # files" —— 2026-08-17 run 31992498596 实测：4 次尝试里有 3 次是这条
+            # 空转，35 分钟采集成果原样丢弃。abort 让下一次重试回到干净基线，
+            # 也让真冲突（内容级、重试也解不开）尽快落到响亮失败而不是被噪声淹没。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
           echo "All push attempts failed"
+          # 未推上去 = origin 上的游标没有前移，下一轮从同一基线重抓，
+          # 只丢本轮工时、不丢数据、不会写坏归档。
           exit 1

--- a/.github/workflows/discord-archive-volunteer.yml
+++ b/.github/workflows/discord-archive-volunteer.yml
@@ -73,8 +73,16 @@ jobs:
           git commit -m "data: archive volunteer Discord data (T62 P2-3c)"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件。不 abort 就重试，后续每一次
+            # pull 都只会回 "Pulling is not possible because you have unmerged
+            # files" —— 2026-08-17 run 31992498596 实测：4 次尝试里有 3 次是这条
+            # 空转，35 分钟采集成果原样丢弃。abort 让下一次重试回到干净基线，
+            # 也让真冲突（内容级、重试也解不开）尽快落到响亮失败而不是被噪声淹没。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
           echo "All push attempts failed"
+          # 未推上去 = origin 上的游标没有前移，下一轮从同一基线重抓，
+          # 只丢本轮工时、不丢数据、不会写坏归档。
           exit 1

--- a/.github/workflows/discord-archive.yml
+++ b/.github/workflows/discord-archive.yml
@@ -27,7 +27,15 @@ on:
         default: ''
 
 concurrency:
-  group: discord-archive-${{ github.ref }}
+  # 与 discord-history-backfill 共用同一把锁：两者都 `git add Record/Community/discord/`，
+  # 都会改 global 的 state.json / activity_daily / channels——是同一份文件的两个写方。
+  # 频次提到每 3 小时、归档器又会吃满 35 分钟预算之后，本作业持有 data 仓 clone 的窗口
+  # 从 7~10 分钟涨到 35 分钟以上，正好罩住 backfill 的 `30 */3` 档，rebase 内容冲突
+  # 由「偶发」变成「必然」（2026-08-17 run 31992498596 即因此整轮丢弃）。
+  # 串行化是治本：跨 clone 并发改同一个 state.json，即便文本能合上，语义也是后写覆盖先写。
+  # jp / volunteer 各写自己的子目录（discord/jp、discord/volunteer），与本组无文件重叠，
+  # 保持各自独立的锁，不必陪跑。
+  group: discord-global-write-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -150,8 +158,16 @@ jobs:
           git commit -m "$MSG"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件。不 abort 就重试，后续每一次
+            # pull 都只会回 "Pulling is not possible because you have unmerged
+            # files" —— 2026-08-17 run 31992498596 实测：4 次尝试里有 3 次是这条
+            # 空转，35 分钟采集成果原样丢弃。abort 让下一次重试回到干净基线，
+            # 也让真冲突（内容级、重试也解不开）尽快落到响亮失败而不是被噪声淹没。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
           echo "All push attempts failed"
+          # 未推上去 = origin 上的游标没有前移，下一轮从同一基线重抓，
+          # 只丢本轮工时、不丢数据、不会写坏归档。
           exit 1

--- a/.github/workflows/discord-cold-compress.yml
+++ b/.github/workflows/discord-cold-compress.yml
@@ -89,6 +89,10 @@ jobs:
           git commit -m "data(discord): monthly cold compress (T62 P2-3c)"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+            # 都只回 "Pulling is not possible because you have unmerged files"，
+            # 重试全程空转（见 discord-archive.yml 同位注释与 run 31992498596）。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done

--- a/.github/workflows/discord-discover-guilds.yml
+++ b/.github/workflows/discord-discover-guilds.yml
@@ -69,6 +69,10 @@ jobs:
           git commit -m "data: snapshot Discord guild list (T62 P2-3c)"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+            # 都只回 "Pulling is not possible because you have unmerged files"，
+            # 重试全程空转（见 discord-archive.yml 同位注释与 run 31992498596）。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done

--- a/.github/workflows/discord-history-backfill.yml
+++ b/.github/workflows/discord-history-backfill.yml
@@ -8,7 +8,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: discord-history-backfill-${{ github.ref }}
+  # 与 discord-archive 共用同一把锁——见该工作流的同位注释。两者都 `git add
+  # Record/Community/discord/`、都改 global 的 state.json，是同一份文件的两个写方；
+  # discord-archive 提频到每 3 小时后窗口罩住本作业的 `30 */3` 档，必须串行。
+  group: discord-global-write-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -70,8 +73,16 @@ jobs:
           git commit -m "data: discord history backfill (T62 P2-3c)"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件。不 abort 就重试，后续每一次
+            # pull 都只会回 "Pulling is not possible because you have unmerged
+            # files" —— 2026-08-17 run 31992498596 实测：4 次尝试里有 3 次是这条
+            # 空转，35 分钟采集成果原样丢弃。abort 让下一次重试回到干净基线，
+            # 也让真冲突（内容级、重试也解不开）尽快落到响亮失败而不是被噪声淹没。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
           echo "All push attempts failed"
+          # 未推上去 = origin 上的游标没有前移，下一轮从同一基线重抓，
+          # 只丢本轮工时、不丢数据、不会写坏归档。
           exit 1


### PR DESCRIPTION
## 概述

**这是 #989 引入的回归，本 PR 修它。**

#989 把 discord-archive 提频到每 3 小时、并让归档器吃满 35 分钟预算之后，本作业持有 data 仓 clone 的窗口从 7~10 分钟涨到 35 分钟以上，正好罩住 `discord-history-backfill` 的 `30 */3` 档。2026-08-17 run [31992498596](https://github.com/lightproud/BIAV-SC-CODE/actions/runs/31992498596) 因此整轮丢弃：**归档器成功跑满 35 分 3 秒，commit/push 步却在 13 秒内四连败**。

现场日志：

```
error: could not apply 6655a5537... data: archive Discord data
Push attempt 1 failed, retrying in 1s...
error: Pulling is not possible because you have unmerged files.   <- 尝试 2/3/4 全是这条
All push attempts failed
```

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [ ] 文档完善（CLAUDE.md / README.md / 子项目 CONTEXT.md / memory 档案）
- [x] Bug 修复（CI 并发缺陷 + 重试逻辑缺陷）
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [ ] 其他（请说明）：

---

## 1. 病根：两个写方并发改同一份 state.json

`discord-archive` 与 `discord-history-backfill` 都执行 `git add Record/Community/discord/`，都会改 global 的 `state.json` / `activity_daily` / `channels`——是同一份文件的两个写方。跨 clone 并发改同一个 `state.json`，即便文本能合上，语义也是后写覆盖先写（前者写 `last_message_id`，后者写 `last_historical_message_id`）。

改为共用 concurrency 组 `discord-global-write-*` 串行化。

| 工作流 | cron | 写入路径 | concurrency 组 |
|---|---|---|---|
| discord-archive | `5 */3` | `discord/`（含 global） | **discord-global-write** |
| discord-history-backfill | `30 */3` | `discord/`（含 global） | **discord-global-write** |
| discord-archive-jp | `45 */3` | `discord/jp/` | 保持独立 |
| discord-archive-volunteer | `15 */3` | `discord/volunteer/` | 保持独立 |

jp / volunteer 各写自己的子目录，与本组无文件重叠，不必陪跑。

GitHub 同组至多排队一个 run，多余的排队 run 会被取消——**不会堆积**，而被跳过的采集轮本身无害（一切由游标驱动，下轮续抓）。窗口核算：global 至多 55 分 + backfill 至多 50 分 = 105 分 < 180 分的 3 小时档期。

## 2. 重试循环从第 2 次起就是空转

rebase 撞冲突后树里留着未合并文件，不 abort 就重试，后续每次 `git pull` 只会回 `Pulling is not possible because you have unmerged files`。四次尝试里三次是死噪声，真错误还被淹没。加 `git rebase --abort` 让每次重试回到干净基线。

**范围**：discord 家族 6 个工作流（archive / history-backfill / jp / volunteer / cold-compress / discover-guilds）。

> 同样的坏循环在仓内**另有 11 个工作流**复制粘贴存在（`backfill-gap`、`backfill-media`、`backfill-news`、`build-analysis-index`、`build-capability-registry`、`build-okf-bundle`、`collect-comments`、`community-cold-compress`、`refresh-claude-code-prompts`、`testbed-patrol`、`update-news`）。它们不在本次回归范围内，未擅自改动，留待单独裁定。

---

## 来源声明

不适用：本 PR 仅改 CI 工作流，不含 Wiki 数据或翻译贡献。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

本地起一个**真实的双 clone 冲突场景**（bare origin + 两个 clone 抢推同一个 `state.json`），而非只读代码推演：

- [x] **旧逻辑复现线上失败**：

  ```
  尝试 1 失败: could not apply
  尝试 2 失败: unmerged files
  尝试 3 失败: unmerged files
  尝试 4 失败: unmerged files
  最终 origin 上的值: {"cursor":"BACKFILL"}
  ```

  与 run 31992498596 的日志形态 1:1 吻合。

- [x] **新逻辑**：四次都报真错 `could not apply`，每次 abort 后树回干净基线；残留未合并文件 **0** 个，本地提交完好。

- [x] 六个工作流 YAML 均通过 `yaml.safe_load` 解析校验
- [x] 不引入 emoji
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md`

### 需要审阅者知道的一点

**abort 修复不会让内容级冲突通过**——重试解不开真冲突，治本的是第 1 条串行化。abort 保证的是三件事：失败诚实（真错误不被噪声淹没）、树不脏、**origin 数据不被写坏**。游标没前移，下一轮从同一基线重抓，只丢工时不丢数据。

这也意味着 run 31992498596 那 35 分钟的采集成果确实白费了，但归档没有损坏，游标仍停在 2026-08-07 基线——合并本 PR 后的下一轮会重做这段。

---

## 关联 Issue

- Refs #989

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtRggNGkbYMxyhBiG4CdB7)_