### PR TITLE
fix(collect): 三项遗留推进 — 重试循环全仓补齐 / TapTap 残留缺陷 / 微博修在实际生效的路径上

### DIFF
--- a/.github/workflows/backfill-gap.yml
+++ b/.github/workflows/backfill-gap.yml
@@ -103,6 +103,11 @@ jobs:
           git commit -m "data(news): backfill data gap (T62 P2-3c)"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+            # 都只回 "Pulling is not possible because you have unmerged files"，
+            # 剩下几次尝试全是空转、真错误还被噪声淹没（2026-08-17 run 31992498596
+            # 实测：4 次尝试里 3 次是这条，35 分钟采集成果原样丢弃）。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done

--- a/.github/workflows/backfill-media.yml
+++ b/.github/workflows/backfill-media.yml
@@ -101,6 +101,10 @@ jobs:
             git commit -m "data: backfill media manifest"
             for i in 1 2 3 4; do
               git pull --rebase origin main && git push origin main && exit 0
+              # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+              # 都只回 "Pulling is not possible because you have unmerged files"，
+              # 剩下几次尝试全是空转（2026-08-17 run 31992498596 实测 4 次里 3 次是这条）。
+              git rebase --abort 2>/dev/null || true
               echo "Push attempt $i failed, retrying in ${i}s..."
               sleep $i
             done

--- a/.github/workflows/backfill-news.yml
+++ b/.github/workflows/backfill-news.yml
@@ -144,6 +144,10 @@ jobs:
           git commit -m "data: backfill ${{ matrix.platform }} historical data (T62 P2-3c)"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+            # 都只回 "Pulling is not possible because you have unmerged files"，
+            # 剩下几次尝试全是空转（2026-08-17 run 31992498596 实测 4 次里 3 次是这条）。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in $((i * 2))s..."
             sleep $((i * 2))
           done

--- a/.github/workflows/build-analysis-index.yml
+++ b/.github/workflows/build-analysis-index.yml
@@ -57,6 +57,10 @@ jobs:
             git commit -m "chore: rebuild analysis index [skip ci]"
             for i in 1 2 3 4; do
               git pull --rebase origin main && git push origin main && exit 0
+              # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+              # 都只回 "Pulling is not possible because you have unmerged files"，
+              # 剩下几次尝试全是空转（2026-08-17 run 31992498596 实测 4 次里 3 次是这条）。
+              git rebase --abort 2>/dev/null || true
               echo "Push attempt $i failed, retrying in ${i}s..."
               sleep $i
             done

--- a/.github/workflows/build-capability-registry.yml
+++ b/.github/workflows/build-capability-registry.yml
@@ -60,6 +60,10 @@ jobs:
             git commit -m "chore: rebuild capability registry [skip ci]"
             for i in 1 2 3 4; do
               git pull --rebase origin main && git push origin main && exit 0
+              # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+              # 都只回 "Pulling is not possible because you have unmerged files"，
+              # 剩下几次尝试全是空转（2026-08-17 run 31992498596 实测 4 次里 3 次是这条）。
+              git rebase --abort 2>/dev/null || true
               echo "Push attempt $i failed, retrying in ${i}s..."
               sleep $i
             done

--- a/.github/workflows/build-okf-bundle.yml
+++ b/.github/workflows/build-okf-bundle.yml
@@ -105,6 +105,10 @@ jobs:
             git commit -m "chore: rebuild OKF bundle [skip ci]"
             for i in 1 2 3 4; do
               git pull --rebase origin main && git push origin main && exit 0
+              # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+              # 都只回 "Pulling is not possible because you have unmerged files"，
+              # 剩下几次尝试全是空转（2026-08-17 run 31992498596 实测 4 次里 3 次是这条）。
+              git rebase --abort 2>/dev/null || true
               echo "Push attempt $i failed, retrying in ${i}s..."
               sleep $i
             done

--- a/.github/workflows/collect-comments.yml
+++ b/.github/workflows/collect-comments.yml
@@ -85,6 +85,11 @@ jobs:
           git commit -m "data: archive youtube video comments (T62 P2-3c)"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+            # 都只回 "Pulling is not possible because you have unmerged files"，
+            # 剩下几次尝试全是空转、真错误还被噪声淹没（2026-08-17 run 31992498596
+            # 实测：4 次尝试里 3 次是这条，35 分钟采集成果原样丢弃）。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done

--- a/.github/workflows/community-cold-compress.yml
+++ b/.github/workflows/community-cold-compress.yml
@@ -81,6 +81,11 @@ jobs:
           git commit -m "data(community): monthly cold compress (T62 P2-3c)"
           for i in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
+            # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+            # 都只回 "Pulling is not possible because you have unmerged files"，
+            # 剩下几次尝试全是空转、真错误还被噪声淹没（2026-08-17 run 31992498596
+            # 实测：4 次尝试里 3 次是这条，35 分钟采集成果原样丢弃）。
+            git rebase --abort 2>/dev/null || true
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done

--- a/.github/workflows/refresh-claude-code-prompts.yml
+++ b/.github/workflows/refresh-claude-code-prompts.yml
@@ -79,6 +79,10 @@ jobs:
             git commit -m "chore: refresh claude-code-system-prompts snapshot [skip ci]"
             for i in 1 2 3 4; do
               git pull --rebase origin main && git push origin main && exit 0
+              # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+              # 都只回 "Pulling is not possible because you have unmerged files"，
+              # 剩下几次尝试全是空转（2026-08-17 run 31992498596 实测 4 次里 3 次是这条）。
+              git rebase --abort 2>/dev/null || true
               sleep $i
             done
             exit 1

--- a/.github/workflows/testbed-patrol.yml
+++ b/.github/workflows/testbed-patrol.yml
@@ -77,6 +77,10 @@ jobs:
             git commit -m "chore: testbed patrol round [skip ci]"
             for i in 1 2 3 4; do
               git pull --rebase origin main && git push origin main && exit 0
+              # rebase 撞冲突会在树里留下未合并文件；不 abort 就重试，后续每次 pull
+              # 都只回 "Pulling is not possible because you have unmerged files"，
+              # 剩下几次尝试全是空转（2026-08-17 run 31992498596 实测 4 次里 3 次是这条）。
+              git rebase --abort 2>/dev/null || true
               echo "Push attempt $i failed, retrying in ${i}s..."
               sleep $i
             done

--- a/projects/news/scripts/playwright_collectors.py
+++ b/projects/news/scripts/playwright_collectors.py
@@ -13,11 +13,18 @@ Tested and working:
 import logging
 import re
 import sys
+from urllib.parse import quote
 from datetime import datetime, timedelta, timezone, UTC
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import news_common  # 时间归一单一真源（H4）
+
+# 微博 Playwright 路径的关键词与滚动深度。关键词与 global_collectors.KEYWORDS['zh']
+# 保持一致（简繁两个）——原实现只硬编码了简体那一个。滚动 6 轮：移动版每屏约 10 条，
+# 够把单关键词一轮的可见面从「首屏 20 条硬截」提到百条量级。
+WEIBO_KEYWORDS = ('忘却前夜', '忘卻前夜')
+WEIBO_MAX_SCROLLS = 6
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)
@@ -65,15 +72,34 @@ def _parse_weibo_article(article) -> dict:
         if href and not href.startswith('http'):
             href = f'https://m.weibo.cn{href}'
 
+    # author / engagement 原为硬编码 ''/0——归档里 weibo 全部条目作者空、互动量 0
+    # 就是这么来的（也因此这个源在社区报告里排不了序）。移动版 article 内有昵称与
+    # 转发/评论/点赞三个计数，能取就取，取不到再回落原默认值。
+    author = ''
+    author_el = article.query_selector('.m-text-cut, [class*="name"], header a')
+    if author_el:
+        author = (author_el.inner_text() or '').strip()[:40]
+
+    engagement = 0
+    try:
+        foot = article.query_selector('footer, [class*="toolbar"], [class*="card-act"]')
+        if foot:
+            nums = re.findall(r'\d[\d.]*\s*万?', foot.inner_text() or '')
+            for n in nums:
+                n = n.strip()
+                engagement += int(float(n[:-1]) * 10000) if n.endswith('万') else int(float(n))
+    except (ValueError, AttributeError):
+        engagement = 0
+
     item = {
         'title': text[:80],
         'summary': text[:500],
         'source': 'weibo',
         'time': parsed_time,
         'url': href,
-        'engagement': 0,
-        'is_hot': False,
-        'author': '',
+        'engagement': engagement,
+        'is_hot': engagement > 500,
+        'author': author,
         'tags': ['weibo'],
     }
     if time_approx:
@@ -236,27 +262,64 @@ def fetch_weibo_playwright() -> list[dict]:
             page = browser.new_page()
             page.set_default_timeout(TIMEOUT_MS)
 
-            # 移动版无需登录
-            url = 'https://m.weibo.cn/search?containerid=100103type%3D1%26q%3D%E5%BF%98%E5%8D%B4%E5%89%8D%E5%A4%9C'
-            logger.info('微博: 访问移动版')
-            page.goto(url, wait_until='networkidle')
-            page.wait_for_timeout(3000)
-
-            articles = page.query_selector_all('article')
-            logger.info(f'微博: 找到 {len(articles)} 条微博')
-
-            for article in articles[:20]:
+            # 移动版无需登录。两个关键词都要走：原实现只硬编码了简体「忘却前夜」，
+            # 而 HTTP 路径的 KEYWORDS['zh'] 是简繁两个，繁体那半在 Playwright 路径
+            # 一直没被采集过。
+            seen_urls: set[str] = set()
+            for keyword in WEIBO_KEYWORDS:
+                q = quote(keyword)
+                url = f'https://m.weibo.cn/search?containerid=100103type%3D1%26q%3D{q}'
+                logger.info(f'微博: 访问移动版 "{keyword}"')
                 try:
-                    item = _parse_weibo_article(article)
-                    if item is not None:
-                        items.append(item)
-                # 逐条解析是 best-effort（页面结构常变，单条失败不该毁掉整轮），但
-                # 原先的裸 `except Exception: continue` 连解析器**自己写崩**都一起
-                # 吞掉——结构改版导致的全军覆没与「今天就是没几条」长得一模一样。
-                # 照旧不中断，但出声：条数对不上时日志里有据可查。
+                    page.goto(url, wait_until='networkidle')
                 except Exception as exc:
-                    logger.debug(f'跳过一条解析失败的article: {type(exc).__name__}: {exc}')
+                    logger.warning(f'微博 "{keyword}" 打开失败: {type(exc).__name__}: {exc}')
                     continue
+                page.wait_for_timeout(3000)
+
+                # 滚动触发懒加载。原实现只取首屏并硬截 articles[:20]，
+                # 单轮上限 20 条——2026-08-15~18 每日归档稳定停在 10 条上下，
+                # 正是首屏那点量。连续两轮无新增即判到底。
+                stale = 0
+                for _ in range(WEIBO_MAX_SCROLLS):
+                    before = len(page.query_selector_all('article'))
+                    try:
+                        page.evaluate('window.scrollTo(0, document.body.scrollHeight)')
+                    except Exception:
+                        break
+                    page.wait_for_timeout(1500)
+                    if len(page.query_selector_all('article')) == before:
+                        stale += 1
+                        if stale >= 2:
+                            break
+                    else:
+                        stale = 0
+
+                articles = page.query_selector_all('article')
+                logger.info(f'微博 "{keyword}": DOM 上找到 {len(articles)} 条')
+
+                kept = 0
+                for article in articles:
+                    try:
+                        item = _parse_weibo_article(article)
+                        if item is None:
+                            continue
+                        # 跨关键词去重：简繁两轮会大量重合。url 为空时回退到正文，
+                        # 否则空 url 条目会每轮重复计入（与 taptap 同型的坑）。
+                        key = item.get('url') or item.get('summary', '')[:80]
+                        if key in seen_urls:
+                            continue
+                        seen_urls.add(key)
+                        items.append(item)
+                        kept += 1
+                    # 逐条解析是 best-effort（页面结构常变，单条失败不该毁掉整轮），但
+                    # 原先的裸 `except Exception: continue` 连解析器**自己写崩**都一起
+                    # 吞掉——结构改版导致的全军覆没与「今天就是没几条」长得一模一样。
+                    # 照旧不中断，但出声：条数对不上时日志里有据可查。
+                    except Exception as exc:
+                        logger.debug(f'跳过一条解析失败的article: {type(exc).__name__}: {exc}')
+                        continue
+                logger.info(f'微博 "{keyword}": 解析出 {kept} 条新条目')
 
             browser.close()
     except Exception as e:

--- a/projects/news/scripts/taptap_collector.py
+++ b/projects/news/scripts/taptap_collector.py
@@ -513,7 +513,32 @@ async def _extract_reviews_dom(page) -> list[dict]:
             const authorEl = el.querySelector(
                 '[class*="username"], [class*="user-name"], [class*="author"], [class*="nickname"]'
             );
+            // 星级：只取 innerText 在实测里始终为空（2026-08-17 归档 29 条评论
+            // 带星级 0 条，而其中一条正文明写「所以给三星」——分数在 DOM 里，
+            // 只是不在文本节点上）。改为多形态尝试，并把候选块的结构证据带出去，
+            // 让下一轮 CI 日志足以精确定位，而不是继续猜。
             const starEl = el.querySelector('[class*="star"], [class*="score"], [class*="rating"]');
+            let starProbe = '';
+            if (starEl) {
+                const inner = (starEl.innerText || starEl.textContent || '').trim();
+                const attr = starEl.getAttribute('aria-label') || starEl.getAttribute('title')
+                          || starEl.getAttribute('data-score') || starEl.getAttribute('data-rate') || '';
+                // 常见渲染：外层固定 5 颗灰星，内层按百分比宽度盖一层亮星
+                const widthEl = starEl.querySelector('[style*="width"]') ||
+                                (starEl.getAttribute('style') || '').includes('width') ? starEl : null;
+                const widthStyle = widthEl ? (widthEl.getAttribute('style') || '') : '';
+                // 或：N 个已点亮的子元素
+                const litCount = starEl.querySelectorAll(
+                    '[class*="active"], [class*="on"], [class*="filled"], [class*="light"]').length;
+                starProbe = JSON.stringify({
+                    cls: starEl.className && starEl.className.toString().slice(0, 80),
+                    inner: inner.slice(0, 24),
+                    attr: attr.slice(0, 24),
+                    width: (widthStyle.match(/width:[^;]+/) || [''])[0],
+                    lit: litCount,
+                    html: (starEl.innerHTML || '').slice(0, 160),
+                });
+            }
             const linkEl = el.querySelector('a[href*="/review/"]') || el.querySelector('a[href]');
 
             // 正文选择：原实现用 querySelector 取**文档序第一个**命中
@@ -540,6 +565,7 @@ async def _extract_reviews_dom(page) -> list[dict]:
                 likes: likeEl ? ((likeEl.innerText || likeEl.textContent || '').trim()) : '0',
                 author: authorEl ? ((authorEl.innerText || authorEl.textContent || '').trim()) : '',
                 score: starEl ? ((starEl.innerText || starEl.textContent || '').trim()) : '',
+                score_probe: starProbe,
                 url: linkEl ? linkEl.href : '',
             };
         });
@@ -561,10 +587,13 @@ async def _extract_reviews_dom(page) -> list[dict]:
             continue
         url = r.get("url", "")
         # 同一条评论在 DOM 里可能被多个卡片容器命中；按评论链接收敛。
-        if url:
-            if url in seen_urls:
-                continue
-            seen_urls.add(url)
+        # url 为空时不能跳过去重——2026-08-17 归档 29 条里有 7 条 linkEl 未命中、
+        # url 全为空串，它们绕过了本守卫，于是 29 条只落出 23 个唯一键。
+        # 回退键用「作者 + 正文前 80 字」：同一条评论这两项稳定，跨轮也判得出重复。
+        dedup_key = url or f"{author}|{content_text[:80]}"
+        if dedup_key in seen_urls:
+            continue
+        seen_urls.add(dedup_key)
         created_str = _parse_taptap_dom_time(r.get("time_str", ""))
         score = _parse_taptap_dom_score(r.get("score", ""))
         star_str = f"{'★' * score}{'☆' * (5 - score)} " if score else ""
@@ -589,6 +618,15 @@ async def _extract_reviews_dom(page) -> list[dict]:
             f"TapTap DOM: {dropped_author_echo} 条正文与用户名雷同已丢弃"
             f"（正文选择器疑似又抓到卡片头部块，请复查 debug_taptap_review.html）"
         )
+
+    # 星级取不到时，把星级块的结构证据打进日志。实测 2026-08-17 归档 29 条评论
+    # 带星级 0 条，而其中一条正文明写「所以给三星」——分数确实在 DOM 里，只是不在
+    # 文本节点上。与其继续猜选择器，不如让下一轮 CI 日志直接给出 class/属性/宽度/
+    # 点亮子元素数，据此一次改对。
+    if items and not any(i.get("score") for i in items):
+        probes = [r.get("score_probe") for r in (result or []) if r.get("score_probe")]
+        sample = probes[0] if probes else "（星级块选择器未命中任何元素）"
+        logger.warning(f"TapTap DOM: {len(items)} 条评论全部无评分，星级块结构样本: {sample}")
 
     if not items:
         logger.warning("TapTap: DOM extraction found no review elements")

--- a/tests/test_playwright_collectors.py
+++ b/tests/test_playwright_collectors.py
@@ -239,12 +239,18 @@ class FakePage:
     def __init__(self, selector_results=None):
         # selector_results: {selector: [FakeEl, ...]}
         self._selector_results = selector_results or {}
+        self.goto_urls = []      # 记录访问过的 URL（多关键词断言用）
+        self.evaluates = []      # 记录 evaluate 调用（滚动断言用）
 
     def set_default_timeout(self, ms):
         pass
 
     def goto(self, url, **kwargs):
-        pass
+        self.goto_urls.append(url)
+
+    def evaluate(self, script, *a, **kw):
+        self.evaluates.append(script)
+        return None
 
     def wait_for_timeout(self, ms):
         pass
@@ -333,6 +339,31 @@ class TestFetchWeiboPlaywright(unittest.TestCase, FetchPlaywrightTestMixin):
         # 不注入 playwright → import 失败 → 返回空
         with mock.patch.dict(sys.modules, {"playwright": None, "playwright.sync_api": None}):
             self.assertEqual(pc.fetch_weibo_playwright(), [])
+
+    def test_visits_both_keywords(self):
+        """简繁两个关键词都要走——原实现只硬编码了简体那一个。"""
+        art = FakeEl(children={
+            '.weibo-text, .content, p': FakeEl(text="足够长的微博正文内容用于采集测试"),
+            'time, [class*="time"], [class*="date"]': None,
+            'a[href*="status"]': None,
+        })
+        page = FakePage({'article': [art]})
+        with self._run_with_page(page):
+            pc.fetch_weibo_playwright()
+        self.assertEqual(len(page.goto_urls), len(pc.WEIBO_KEYWORDS))
+
+    def test_dedups_across_keywords(self):
+        """简繁两轮结果大量重合，同一条不能计两次。"""
+        art = FakeEl(children={
+            '.weibo-text, .content, p': FakeEl(text="足够长的微博正文内容用于采集测试"),
+            'time, [class*="time"], [class*="date"]': None,
+            'a[href*="status"]': None,
+        })
+        page = FakePage({'article': [art]})
+        with self._run_with_page(page):
+            items = pc.fetch_weibo_playwright()
+        # 两个关键词各看到同一条 → 去重后仍是 1 条
+        self.assertEqual(len(items), 1)
 
 
 class TestFetchTaptapPlaywright(unittest.TestCase, FetchPlaywrightTestMixin):

--- a/tests/test_taptap_collector_unit.py
+++ b/tests/test_taptap_collector_unit.py
@@ -270,6 +270,37 @@ class TestExtractReviewsDom(unittest.TestCase):
             out = _run(tt._extract_reviews_dom(page))
         self.assertEqual(len(out), 2)
 
+    def test_dedups_when_url_empty(self):
+        """url 为空的条目也必须去重。
+
+        回归实测：2026-08-17 归档 29 条评论里 7 条 linkEl 未命中、url 全为空串，
+        它们绕过了按 url 的去重守卫，29 条只落出 23 个唯一键。
+        """
+        dom = [
+            {"content": "很好玩很好玩很好玩", "author": "a", "time_str": "2026-08-17", "url": ""},
+            {"content": "很好玩很好玩很好玩", "author": "a", "time_str": "2026-08-17", "url": ""},
+            {"content": "另一条不同的评论", "author": "b", "time_str": "2026-08-17", "url": ""},
+        ]
+        page = FakePage(dom_result=dom)
+        with mock.patch.object(tt.news_common, "parse_relative_time",
+                               return_value=("2026-08-17T00:00:00+00:00", False)):
+            out = _run(tt._extract_reviews_dom(page))
+        self.assertEqual(len(out), 2)
+
+    def test_warns_with_probe_when_no_scores(self):
+        """整批无评分时要把星级块结构证据打进日志，供下一轮精确定位。"""
+        dom = [{"content": "所以给三星，观望", "author": "a", "time_str": "2026-08-17",
+                "url": "https://t/review/1", "score": "",
+                "score_probe": '{"cls":"rating-star","inner":"","width":"width: 60%","lit":3}'}]
+        page = FakePage(dom_result=dom)
+        with mock.patch.object(tt.news_common, "parse_relative_time",
+                               return_value=("2026-08-17T00:00:00+00:00", False)), \
+                mock.patch.object(tt.logger, "warning") as warn:
+            out = _run(tt._extract_reviews_dom(page))
+        self.assertEqual(len(out), 1)
+        self.assertTrue(warn.called)
+        self.assertIn("width: 60%", warn.call_args[0][0])
+
     def test_score_lands_in_title_and_field(self):
         dom = [{"content": "很好玩", "author": "a", "time_str": "2026-08-15",
                 "score": "4.5", "url": "https://t/review/1"}]


### PR DESCRIPTION
## 概述

推进 #989 / #991 收尾时挂起的三项遗留。三个提交彼此独立，可分别复核或回退。

**其中一项是对我自己上一轮改动的更正**：#989 给微博加的翻页改在了一条根本没在跑的代码路径上。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [ ] 文档完善（CLAUDE.md / README.md / 子项目 CONTEXT.md / memory 档案）
- [x] Bug 修复
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [ ] 其他（请说明）：

---

## 1. `8143a56` 剩余 11 个工作流补齐 `git rebase --abort`

#991 只修了 discord 家族 6 个。同一份复制粘贴的坏循环在仓内另有 11 处：`backfill-gap`、`backfill-media`、`backfill-news`、`build-analysis-index`、`build-capability-registry`、`build-okf-bundle`、`collect-comments`、`community-cold-compress`、`refresh-claude-code-prompts`、`testbed-patrol`、`update-news`。

加上 #991 的 6 个，**全仓 17 处推送循环现已全部带 abort**，`grep -L` 校验残留 0 个。

> abort 本身不解内容级冲突，它保证的是失败诚实、树不脏、下次重试从干净基线开始。防冲突靠各自的 concurrency 设计。

## 2. `b4437b2` TapTap 两个残留缺陷

**先说好消息：#989 的正文选择器修复已在线上验证生效。**

| 日期 | 条数 | 正文=用户名 | 样例 |
|---|---|---|---|
| 2026-08-15（修复前） | 52 | **19** | `'葱爆牛排'`（用户名） |
| 2026-08-17（修复后） | 29 | **0** | `'画风喜欢的不得了，玩法是杀戮尖塔这也很熟悉…'` |

同批数据暴露出两个残留问题：

**(a) url 为空的条目绕过了去重。** 守卫写成 `if url:` 才查表，而那 29 条里有 7 条 `linkEl` 未命中、url 全是空串，全部绕过守卫 —— 29 条只落出 23 个唯一键。回退键改用「作者 + 正文前 80 字」。

**(b) 星级始终取不到，但分数确实在 DOM 里。** 29 条带星级 0 条，而其中一条正文明写「所以给三星」。原实现只读 `innerText`，分数显然不在文本节点上。

这次**不猜选择器**：DOM 侧改为同时采集 class、`aria-label`/`title`/`data-score` 属性、`width` 百分比样式、点亮子元素计数与 `innerHTML` 片段；Python 侧在「整批无评分」时把这份结构样本打进 warning。下一轮 CI 日志到手即可一次改对。

> 另注：这批数据全部走 DOM 兜底（`item_id` 全空），API 拦截路径仍未拿到响应。该路径的 `_parse_review_api_body` 有结构化 `score`，API 若恢复则评分自然可用。

## 3. `c88c45c` 微博 —— 我上一轮修错了地方

#989 给 `fetch_weibo`（m.weibo.cn HTTP API 路径）加了翻页。合入后数据毫无变化：

```
08-10 106 / 08-11 102 / 08-12 109
08-13 整天缺失
08-14  33 / 08-15  10 / 08-16  10 / 08-17  10 / 08-18   7
       ↑ 翻页 08-17 01:50 合入，08-17 与 08-18 仍是 10 与 7
```

**定性证据**：归档里 08-12 与 08-17 的条目**全部** `author` 为空串、`engagement` 为 0。而 `fetch_weibo` 会从 `mblog` 填这两个字段，`_parse_weibo_article`（Playwright）则把它们硬编码成 `''`/`0`。即两天的数据都来自 Playwright 兜底 —— **HTTP API 路径没有产出，我上一轮的翻页改动从未被执行过**。

本次改实际在跑的那条路径，三处缺陷：

| # | 缺陷 | 修法 |
|---|---|---|
| 1 | 只查简体一个关键词（URL 里硬编码），繁体「忘卻前夜」从未采集 | 遍历 `WEIBO_KEYWORDS`（简繁两个），跨关键词去重 |
| 2 | `articles[:20]` 硬截 + 不滚动，单轮上限 20 条 | 加滚动懒加载（`WEIBO_MAX_SCROLLS=6`，连续两轮无新增判到底），去掉硬截 |
| 3 | `author`/`engagement` 硬编码 `''`/`0` | 从昵称元素与 footer 计数区提取，取不到回落默认值 |

单关键词打开失败不再中断整轮，并按关键词分别打日志（DOM 找到几条 / 解析出几条新条目）。

### 需要审阅者知道的

**这一项无法在此做 live 验证。** 本次改动提高的是覆盖面与可观测性。若真因是登录墙 / 限流导致首屏结果本身就少，滚动同样救不回来 —— 届时需要配 `WEIBO_COOKIE` 后看分关键词日志定夺。新加的日志正是为这一步准备的。

---

## 来源声明

不适用：本 PR 为采集器与 CI 修复，不含 Wiki 数据或翻译贡献。诊断依据全部来自本项目自己的公开归档产物（BIAV-SC-DATA 仓 `Record/Community/`）与仓内既有代码。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 全量测试 **3403 passed, 50 skipped, 22 subtests passed**
- [x] `projects/news/scripts/` ruff 全绿
- [x] 全部 workflow YAML 通过 `yaml.safe_load`
- [x] 全仓推送循环 abort 覆盖校验：`grep -L` 残留 **0** 个
- [x] 新增 4 个回归用例：空 url 去重、无评分时告警含结构样本、两个关键词都访问、跨关键词去重（`FakePage` 补 `goto`/`evaluate` 记录）
- [x] 三项诊断均以线上归档实测数据为依据，非代码推演
- [x] 不引入 emoji
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 关联 Issue

- Refs #989
- Refs #991

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtRggNGkbYMxyhBiG4CdB7)_