### PR TITLE
fix(ci): 凭据内联进 remote URL，修复所有 DATA 仓推送鉴权（归档已停摆 3 天）

### DIFF
--- a/.github/workflows/backfill-gap.yml
+++ b/.github/workflows/backfill-gap.yml
@@ -56,10 +56,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Install dependencies
         run: pip install -r projects/news/requirements.txt

--- a/.github/workflows/backfill-media.yml
+++ b/.github/workflows/backfill-media.yml
@@ -66,10 +66,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Install dependencies
         run: pip install -r projects/news/requirements.txt

--- a/.github/workflows/backfill-news.yml
+++ b/.github/workflows/backfill-news.yml
@@ -86,10 +86,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Install dependencies
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/build-analysis-index.yml
+++ b/.github/workflows/build-analysis-index.yml
@@ -38,10 +38,10 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone --depth 1 https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store（2026-08-21 裁定）。
+          # 详见 discord-archive.yml 同位注释：08-18 起 store helper 在 push 时不再
+          # 返回任何凭据，所有写 DATA 仓的作业整整停摆 3 天。
+          git clone --depth 1 "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
       - name: Rebuild story index
         run: python scripts/build_story_index.py
       - name: Rebuild community index (full archive · reads BIAV-SC-DATA)

--- a/.github/workflows/build-okf-bundle.yml
+++ b/.github/workflows/build-okf-bundle.yml
@@ -88,10 +88,10 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone --depth 1 https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store（2026-08-21 裁定）。
+          # 详见 discord-archive.yml 同位注释：08-18 起 store helper 在 push 时不再
+          # 返回任何凭据，所有写 DATA 仓的作业整整停摆 3 天。
+          git clone --depth 1 "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
       - name: Regenerate OKF bundle
         run: python scripts/build_okf_bundle.py
       - name: Commit if changed

--- a/.github/workflows/collect-comments.yml
+++ b/.github/workflows/collect-comments.yml
@@ -58,10 +58,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Collect video comments
         env:

--- a/.github/workflows/collect-fanart.yml
+++ b/.github/workflows/collect-fanart.yml
@@ -49,10 +49,10 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone --depth 1 https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store（2026-08-21 裁定）。
+          # 详见 discord-archive.yml 同位注释：08-18 起 store helper 在 push 时不再
+          # 返回任何凭据，所有写 DATA 仓的作业整整停摆 3 天。
+          git clone --depth 1 "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Collect fan art
         env:

--- a/.github/workflows/community-cold-compress.yml
+++ b/.github/workflows/community-cold-compress.yml
@@ -54,10 +54,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Run cold compress
         run: |

--- a/.github/workflows/community-platform-backup.yml
+++ b/.github/workflows/community-platform-backup.yml
@@ -55,11 +55,11 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
+          # 凭据内联进 remote URL，不再依赖 credential.helper store（2026-08-21 裁定）。
+          # 详见 discord-archive.yml 同位注释：08-18 起 store helper 在 push 时不再
+          # 返回任何凭据，所有写 DATA 仓的作业整整停摆 3 天。
           # 只读用途，--depth 1 足够（要的是当前全量内容，不是历史）
-          git clone --depth 1 https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          git clone --depth 1 "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Resolve the community root（单一真相源）
         id: root

--- a/.github/workflows/data-repo-sync.yml
+++ b/.github/workflows/data-repo-sync.yml
@@ -47,10 +47,15 @@ jobs:
           fi
           # 令牌走 credential store（不落 remote URL、不入 git config，防 git remote -v 泄漏）；
           # 先设凭据再 clone，故私有 data 仓 clone 与后续 push 均认证。
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: 快照镜像 Record/Community → data 仓
         run: |

--- a/.github/workflows/discord-archive-jp.yml
+++ b/.github/workflows/discord-archive-jp.yml
@@ -65,10 +65,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Run Discord archiver for JP guild
         if: steps.guard.outputs.skip == 'false'

--- a/.github/workflows/discord-archive-volunteer.yml
+++ b/.github/workflows/discord-archive-volunteer.yml
@@ -48,10 +48,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Run Discord archiver for volunteer guild
         env:

--- a/.github/workflows/discord-archive.yml
+++ b/.github/workflows/discord-archive.yml
@@ -75,10 +75,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Determine run mode
         id: mode

--- a/.github/workflows/discord-cold-compress.yml
+++ b/.github/workflows/discord-cold-compress.yml
@@ -62,10 +62,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Run cold compress
         run: |

--- a/.github/workflows/discord-discover-guilds.yml
+++ b/.github/workflows/discord-discover-guilds.yml
@@ -45,10 +45,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: List bot guilds
         env:

--- a/.github/workflows/discord-history-backfill.yml
+++ b/.github/workflows/discord-history-backfill.yml
@@ -49,10 +49,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Run history-only backfill
         env:

--- a/.github/workflows/recover-fanart.yml
+++ b/.github/workflows/recover-fanart.yml
@@ -56,11 +56,11 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
+          # 凭据内联进 remote URL，不再依赖 credential.helper store（2026-08-21 裁定）。
+          # 详见 discord-archive.yml 同位注释：08-18 起 store helper 在 push 时不再
+          # 返回任何凭据，所有写 DATA 仓的作业整整停摆 3 天。
           # 只读用途（产物直传 release，不回写数据仓），浅克隆即可
-          git clone --depth 1 https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          git clone --depth 1 "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Recover fan art across window (refresh Discord URLs)
         env:

--- a/.github/workflows/update-news.yml
+++ b/.github/workflows/update-news.yml
@@ -52,10 +52,15 @@ jobs:
           if [ -z "${DATA_TOKEN:-}" ]; then
             echo "::error::secret BIAV_SC_DATA_TOKEN 未配置"; exit 1
           fi
-          git config --global credential.helper store
-          printf 'https://x-access-token:%s@github.com\n' "$DATA_TOKEN" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          git clone https://github.com/lightproud/BIAV-SC-DATA.git data-repo
+          # 凭据内联进 remote URL，不再依赖 credential.helper store。
+          # 2026-08-18 09:48~13:07 之间起，store helper 在 push 时不再返回任何凭据
+          # （fatal: could not read Username for 'https://github.com'），而 pull 因
+          # DATA 仓公开、匿名可读照常成功——于是所有写 DATA 仓的作业从那一刻起全部
+          # 卡在 commit/push，社区归档整整停摆 3 天而无人察觉。同窗口内本仓零代码改动，
+          # 变的是 runner 环境（观测到 git 2.54.0 -> 2.55.0）。
+          # URL 内联与 git 版本、helper 实现无关；secret 值由 Actions 在日志中遮蔽，
+          # 且仅存在于本次运行的临时 .git/config 内。
+          git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
 
       - name: Install dependencies
         run: pip install -r projects/news/requirements.txt


### PR DESCRIPTION
## 概述

**社区归档自 2026-08-18 10:09 起完全停摆，至今已断 3 天 9 小时。** 不只是 discord —— 所有写 BIAV-SC-DATA 的作业每轮必败。

本 PR 修复根因。**与本仓此前任何改动无关**，故障来自 runner 环境。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [ ] 文档完善（CLAUDE.md / README.md / 子项目 CONTEXT.md / memory 档案）
- [x] Bug 修复（CI 鉴权链路失效）
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [ ] 其他（请说明）：

---

## 影响面

| 工作流 | 状态 |
|---|---|
| Discord Archive / JP / Volunteer / History Backfill | 每轮 failure |
| Update Community News | 每轮 failure |
| Backfill & Archive Media | 每轮 failure |
| Backfill Historical News、Deploy Site（不写 DATA 仓） | 仍 success |

## 精确切换点

`discord-archive-volunteer` 的连续轮次把窗口夹到了小时级：

```
run #481   2026-08-18 09:47:52   success   ← 最后一次成功
run #482   2026-08-18 13:07:01   failure   ← 第一次失败
```

**该窗口内本仓 main 只有 `[skip ci]` 数据提交，零代码改动**；凭据设置那段自 2026-08-16 起未被触碰。

## 根因

失败步骤统一是 `Commit and push`，报错：

```
fatal: could not read Username for 'https://github.com': No such device or address
```

两个关键细节：

1. **同一步里 `git pull --rebase` 是成功的**（日志 `Current branch main is up to date`）—— 因为 BIAV-SC-DATA 是公开仓，匿名可读。只有 push 需要凭据。
2. **报错是「读不到用户名」而非 401/403** —— 说明 credential helper 一个凭据都没返回，不是凭据被服务端拒绝。

### 已排除

- **secret 被删 / 为空**：18 个工作流都有 `[ -z "$DATA_TOKEN" ] && exit 1` 守卫，且 clone 步骤全部 success，守卫没有触发 → secret 存在且非空。
- **本仓改动**：见上，窗口内零代码提交。

### 观测到的相关性

runner 的 git 从 **2.54.0**（08-17 日志）变为 **2.55.0**（08-21 日志），`credential.helper store` + `~/.git-credentials` 这条链路在新环境下不再生效。

> **未能把版本切换精确钉进 09:48~13:07 窗口，故不断言因果，只记录相关性。** 好在修法对两种可能（helper 机制变化 / 环境其他变动）都成立。

## 修法

凭据内联进 remote URL：

```bash
git clone "https://x-access-token:${DATA_TOKEN}@github.com/lightproud/BIAV-SC-DATA.git" data-repo
```

与 git 版本、helper 实现完全无关，是跨仓推送的标准做法。secret 值由 Actions 在日志中遮蔽，且仅存在于本次运行的临时 `.git/config` 内。

覆盖**全部 18 个工作流**（13 个普通 clone + 5 个 `--depth 1`），一并移除 `credential.helper store`、`printf > ~/.git-credentials`、`chmod 600` 三行。

**空 token 守卫全部保留** —— 它仍是「secret 被删」这类故障的第一道防线。

---

## 来源声明

不适用：本 PR 仅改 CI 工作流，不含 Wiki 数据或翻译贡献。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 50 个工作流 YAML 全部通过 `yaml.safe_load`
- [x] 全量测试 **3399 passed, 50 skipped, 22 subtests passed**
- [x] 覆盖校验：可执行的 `credential.helper store` 残留 **0** 处、写 `~/.git-credentials` 残留 **0** 处、匿名 clone DATA 仓残留 **0** 处
- [x] 空 token 守卫 18 个工作流全部保留
- [x] 不引入 emoji
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md`

### 合并后

下一轮定时触发即可验证。数据未损坏 —— 推送失败意味着游标未前移，各采集器会从各自基线重抓这 3 天，不会有空洞。

### 暴露出的监控缺口

**归档整整停摆 3 天而无人察觉。** 沉默源审计看的是归档目录的产出日期，但它自己也跑在同一套 CI 上、同样推不上去。这类「监控与被监控对象共享故障域」的问题不在本 PR 范围内，建议单独裁定（例如把健康信号发到 CI 之外的渠道）。

---

## 关联 Issue

- Closes #
- Refs #

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtRggNGkbYMxyhBiG4CdB7)_