### PR TITLE
fix(monitor): 断开死手开关的自锁——警报此前从建成起就卡在常亮

### DIFF
--- a/scripts/dead_man_switch.py
+++ b/scripts/dead_man_switch.py
@@ -42,6 +42,16 @@ STATUS_PATH = REPO / "Public-Info-Pool" / "Record" / "heartbeat" / "status.json"
 
 THRESHOLD_FACTOR = 2.0
 GRACE_HOURS = 2.0
+
+# 本工作流自身：判据必须换一维，否则警报会卡在常亮。
+# 本作业的设计是「有发现就 exit 1 变红」（红=可见）。可它同时把自己也列入看守名单、
+# 判据用「最近一次 workflow success」——于是：有发现 → 红 → 自己永无 success 记录 →
+# 自己被判 never → findings 恒 ≥ 1 → 永远红。自 2026-07-26 建成起 27 次运行 27 次红，
+# 从第一天就锁死；2026-08-18 采集全线停摆 70 小时时它确实抓到并写进了 status.json，
+# 但那抹红与前 24 天的自噬性红色毫无分别，等于没有警报。
+# 改判「上一轮有没有扫完」——status.json 的 generated_at 每轮无条件落盘（findings
+# 与否都写），正是设计档里点名的那一维。循环就此断开：无真发现时可转绿，红重新有信息量。
+SELF_WORKFLOW = "dead-man-switch.yml"
 #  cron 采样窗口：要能覆盖到月度 cron 的两次触发（每月 3 日 → 需 > 31 天）
 SAMPLE_DAYS = 400
 
@@ -179,6 +189,18 @@ def github_fetcher(repo: str, token: str | None) -> Callable[[str], dict]:
     return fetch
 
 
+def self_last_beat(status_path: Path = STATUS_PATH) -> str | None:
+    """本工作流上一轮扫完的时间，取自它上一次写下的 status.json。
+
+    读的是**上一轮**留下的文件（本轮的还没写），所以这就是「昨天有没有扫」的直接答案。
+    读不到（首次运行 / 文件损坏）返回 None，交回 classify 的 created_at 宽限逻辑。
+    """
+    try:
+        return json.loads(status_path.read_text(encoding="utf-8")).get("generated_at")
+    except (OSError, json.JSONDecodeError, AttributeError, TypeError):
+        return None
+
+
 def _parse_ts(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -211,6 +233,7 @@ def build_status(
     fetch: Callable[[str], dict],
     now: datetime,
     workflow_dir: Path = WORKFLOW_DIR,
+    status_path: Path = STATUS_PATH,
 ) -> dict:
     entries = []
     for name, crons in scheduled_workflows(workflow_dir).items():
@@ -227,6 +250,10 @@ def build_status(
             record.update(state="unknown", note=f"API 查询失败: {exc}")
             entries.append(record)
             continue
+        if name == SELF_WORKFLOW:
+            # 见 SELF_WORKFLOW 注释：自己的 workflow success 恒为空，改用心跳。
+            record["last_success"] = self_last_beat(status_path) or record.get("last_success")
+            record["self_judged_by"] = "status.json/generated_at"
         state, note = classify(record, now)
         record["state"] = state
         record["note"] = note

--- a/tests/test_dead_man_switch.py
+++ b/tests/test_dead_man_switch.py
@@ -7,6 +7,7 @@
 """
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, UTC
 from pathlib import Path
 
@@ -129,6 +130,67 @@ class TestBuildStatus:
         assert status["entries"][0]["workflow"] == "daily.yml"
         assert status["entries"][0]["state"] == "stale"
         assert status["generated_at"] == NOW.isoformat()
+
+    def _self_only_dir(self, tmp_path):
+        wf = tmp_path / "workflows"
+        wf.mkdir()
+        (wf / dms.SELF_WORKFLOW).write_text(
+            "on:\n  schedule:\n    - cron: '50 7 * * *'\n", encoding="utf-8")
+        return wf
+
+    @staticmethod
+    def _no_success(name):
+        """真实情况：本作业有发现即 exit 1，故自己永远没有 workflow success 记录。"""
+        return {
+            "created_at": (NOW - timedelta(days=26)).isoformat(),
+            "state": "active",
+            "last_success": None,
+        }
+
+    def test_self_judged_by_heartbeat_not_workflow_success(self, tmp_path):
+        """自锁回归：自己判自己不能用 workflow success，否则警报永远卡在常亮。
+
+        本作业「有发现就变红」，于是自己永无 success → 自判 never → findings 恒 ≥1
+        → 永远红。实测 2026-07-26 建成起 27 次运行 27 次红，2026-08-18 采集停摆
+        70 小时时那抹红与前 24 天的自噬性红毫无分别。改判上一轮心跳后循环断开。
+        """
+        wf = self._self_only_dir(tmp_path)
+        status_path = tmp_path / "status.json"
+        status_path.write_text(
+            json.dumps({"generated_at": (NOW - timedelta(hours=24)).isoformat()}),
+            encoding="utf-8")
+
+        status = dms.build_status(self._no_success, NOW, workflow_dir=wf,
+                                  status_path=status_path)
+        assert status["findings"] == 0          # 关键：能转绿了
+        assert status["entries"][0]["state"] == "ok"
+        assert status["entries"][0]["self_judged_by"] == "status.json/generated_at"
+
+    def test_self_still_alarms_when_sweeper_itself_goes_quiet(self, tmp_path):
+        """断开自锁不等于放过自己：扫描器真哑掉时仍须报。"""
+        wf = self._self_only_dir(tmp_path)
+        status_path = tmp_path / "status.json"
+        status_path.write_text(
+            json.dumps({"generated_at": (NOW - timedelta(hours=80)).isoformat()}),
+            encoding="utf-8")
+
+        status = dms.build_status(self._no_success, NOW, workflow_dir=wf,
+                                  status_path=status_path)
+        assert status["findings"] == 1
+        assert status["entries"][0]["state"] == "stale"
+
+    def test_self_heartbeat_unreadable_falls_back_to_created_at(self, tmp_path):
+        """心跳文件缺失/损坏时回落原逻辑，不能因读不到就静悄悄判 ok。"""
+        wf = self._self_only_dir(tmp_path)
+        for content in (None, "{bad json"):
+            status_path = tmp_path / "status.json"
+            if content is None:
+                status_path.unlink(missing_ok=True)
+            else:
+                status_path.write_text(content, encoding="utf-8")
+            status = dms.build_status(self._no_success, NOW, workflow_dir=wf,
+                                      status_path=status_path)
+            assert status["entries"][0]["state"] == "never"
 
     def test_api_failure_degrades_to_unknown_not_to_silence(self, tmp_path):
         """查不到 ≠ 没事：降级为 unknown 并留痕，绝不悄悄算作 ok。"""


### PR DESCRIPTION
## 概述

死手开关自 2026-07-26 建成起，**27 次运行 27 次全部 failure，从无一次成功**。

它不是没检测到这次的 3 天停摆 —— 它**准确抓到了**，只是那抹红与前 24 天的自噬性红色毫无分别。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [ ] 文档完善（CLAUDE.md / README.md / 子项目 CONTEXT.md / memory 档案）
- [x] Bug 修复（监控自锁）
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [ ] 其他（请说明）：

---

## 自锁循环

本作业的设计是「有发现就 exit 1 变红」（红=可见），但它同时把自己也列入看守名单、判据用「最近一次 workflow success」：

```
有发现 → exit 1 变红 → 自己永无 success 记录 → 自判 never
      → findings 恒 ≥ 1 → 永远红 → 回到第一步
```

**从第一天就锁死。**

## 它其实抓到了

2026-08-18 采集全线停摆 70 小时，`status.json` 里白纸黑字：

```
[stale] discord-archive.yml            最近一次成功在 70.2h 前，超阈值 8.0h
[stale] discord-archive-jp.yml         70.3h / 8.0h
[stale] discord-archive-volunteer.yml  70.5h / 8.0h
[stale] discord-history-backfill.yml   70.2h / 8.0h
[stale] update-news.yml                70.8h / 8.0h
[stale] backfill-media.yml             70.4h / 50.0h
[stale] collect-comments.yml           72.5h / 50.0h
[never] dead-man-switch.yml            至今从无一次成功        ← 自锁那一条
```

**警报常亮等于没有警报。** 代价是实打实的：3 天停摆无人察觉，其中平台源（快照式采集，抓的是「此刻页面上有什么」）08-19 / 08-20 两天的数据**已永久丢失**，没有任何接口能翻回来。Discord 因为是游标驱动，已于本次全部补回。

## 修法

自身判据换一维：改用 `status.json` 的 `generated_at`（每轮**无条件**落盘，findings 与否都写），即「上一轮有没有扫完」—— 正是设计档里点名的那条兜底线（「最后一道是人：status.json 自带 generated_at」）。

循环就此断开：无真发现时可转绿，红重新具备信息量。

**断开自锁不等于放过自己：**

| 情形 | 行为 |
|---|---|
| 上一轮 24h 前扫过 | `ok`，findings=0 → **可转绿** |
| 扫描器自己哑了 80h | `stale` → 照报 |
| 心跳文件缺失 / 损坏 | 回落 `created_at` 宽限逻辑 → `never`，绝不因读不到就静悄悄判 ok |

`build_status` 新增 `status_path` 参数（默认 `STATUS_PATH`），便于测试注入。

---

## 来源声明

不适用：本 PR 仅改监控脚本与其测试，不含 Wiki 数据或翻译贡献。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。**
- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材。**
- [x] **同意按 MIT License 提交贡献。**

---

## 验证清单

- [x] 新增 3 个回归用例：心跳新鲜 → findings=0 可转绿、扫描器自身哑掉 → 仍报 stale、心跳不可读 → 回落 never
- [x] 另以**真实 status.json** 的三种情形手工跑过判定，确认循环断开
- [x] `tests/test_dead_man_switch.py` 26 passed
- [x] 全量测试 **3351 passed, 50 skipped, 22 subtests passed**
- [x] ruff 全绿
- [x] 不引入 emoji
- [x] 未改动 `memory/decisions.md` / `memory/lessons-learned.md`

---

## 遗留（不在本 PR 范围）

**红色仍只存在于 GitHub Actions 内，本身不构成通知。** 本 PR 恢复的是「红有信息量」，但没人主动去看 Actions 页面这件事没变。信号出域的那一半另行处理。

---

## 关联 Issue

- Refs #995

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtRggNGkbYMxyhBiG4CdB7)_