### PR TITLE
brand: 裸词换装铺开六目录 + 整行跳线改掩码法（残留 659 → 9）

### DIFF
--- a/projects/black-pool-agent/BRANDING.md
+++ b/projects/black-pool-agent/BRANDING.md
@@ -59,9 +59,21 @@
 
 | **安装位解引用改可选链（守密人 2026-08-05 裁定「现在修」）** | `desktop-install-overlay.tsx` 的安装路径行被本层死代码化，但上游对 `state.setupChoice` 的**非空收窄来自外层 `{state.setupChoice && (`，而那个外层也被本层死代码化了**——收窄没了、解引用还在。运行时 `false &&` 短路不炸，tsc 却照查死代码（TS18047），私有版 typecheck 因此长红、也就没法把 typecheck 接进装配线门禁。上游原树实测零报错，确认是换装自带缺陷而非上游问题 | 1 处 |
 
-**审计轮四观察项（2026-08-05 新增，未处理）**：提示词 `HERMES_AGENT_HELP_GUIDANCE` 仍把 `https://hermes-agent.nousresearch.com/docs` 作为「产品自身问题去查这里」的指引——该域内网不可达，且被 `https://` 跳线标记保护故换装扫不到；模型会据此引导用户去查一个打不开的文档站。正确措辞需产品口径（自建文档？删除该指引？），记账待裁。
+**审计轮四观察项（2026-08-05 新增，未处理）**：提示词 `HERMES_AGENT_HELP_GUIDANCE` 仍把 `https://hermes-agent.nousresearch.com/docs` 作为「产品自身问题去查这里」的指引——该域内网不可达；模型会据此引导用户去查一个打不开的文档站。正确措辞需产品口径（自建文档？删除该指引？），记账待裁。**2026-08-25 订正**：原写「被 `https://` 跳线标记保护故换装扫不到」——掩码法上线后该行的品牌词已正常换装（`You run on Black Pool Agent … help with Black Pool itself`），URL 本身仍原样保留。故本观察项**只剩「域名不可达」一半**，品牌词那一半已消。
 
-**后端裸词下一层挂账（守密人 2026-08-05 分层裁定）**：`hermes_cli` / `gateway` / `tools` / `plugins` / `skills` 尚未铺开，已量到字符串字面量 **575 处**（667 减去 agent 的 92）+ skills **269 处 / 134 文件**。这几处含真功能标识——皮肤名 `Hermes Teal`（`load_skin` 按名查找）、MCP server 名、`Hermes.app`/`.exe`/`.desktop` 桌面产物探测路径、`user.name=Hermes`、qqbot UA 片段 `; Hermes/`——**须先定豁免名单再入列**，`test_bare_word_scope_safety` 已就位等着接住误伤。
+**后端裸词下一层已铺开（2026-08-25 销案，守密人「品牌补丁不够完整，很多状态提示还是 hermes」现场反馈后四项交互裁定）**：`hermes_cli` / `gateway` / `tools` / `plugins` / `acp_adapter` / `skills` 六目录入列，`BARE_WORD_DIRS` 与 `RUNTIME_DIRS` 同步扩容（**两表是两道闸，须同进同退**——本轮先只改前者，实测 acp_adapter 11 处 / skills 5 处纹丝不动，即「配了钥匙没开门」，守卫 `test_bare_word_rollout_reaches_six_new_dirs` 已锁死这条一致性）。
+
+挂账两年的「须先定豁免名单」在换装后的私有版树上实测出了名单，且比预想小得多：六目录 Python **代码 token 里裸词 Hermes 为 0 处**（659 处生产残留全部落在字符串字面量），故铺开**不改动任何类名 / 变量名 / 模块名**。当年点名的五处「真功能标识」逐条复核结论：
+
+| 当年判词 | 复核结论 |
+|---|---|
+| 皮肤名 `Hermes Teal`（`load_skin` 按名查找） | **判词有误但结论对**：`load_skin` 查的是 `name` 键（`"default"`，全小写不受裸词影响），`Hermes Teal` 只是 `label` 显示名。仍**豁免**——它与 `Nous Blue` / `Ember` 并列，是上游自有主题名，且其描述「the canonical Hermes look」指的正是上游青调皮肤（黑池自己的是鎏金 `black-pool`），换了即说假话 |
+| `Hermes.app` / `.exe` / `.desktop` 桌面产物探测路径 | **判词方向搞反，照换不豁免**：`productName` / `executableName` 换装后均为 `Black Pool`，electron-builder 产出的就是 `Black Pool.exe`——这些是**黑池自己产物**的门牌号，豁免才会去找不存在的文件。旁证：`apps/` 早在射程内，`desktop-uninstall.ts` 同类路径旧引擎下已是 `Black Pool.app`。`StartupWMClass` 同理（WM_CLASS 派生自 executableName，不换反而任务栏图标归不了组） |
+| `user.name=Hermes` | **照换**：git 提交署名是用户在 log 里直接看到的显示名，且列参数传递、含空格合法 |
+| qqbot UA 片段 `; Hermes/` | **豁免**（走既有政策非新裁定）：UA 是发给腾讯接口的线上标识符、非用户感知显示名，与已受保护的 `X-Client-Name` 遥测头同类；塞含空格品牌名会把产品令牌劈成两截（lesson #57 同病灶） |
+| MCP server 名 | 复核为零命中（`Hermes` 裸词未出现在 server 名位置） |
+
+铺开后残留由 **659 → 8**，8 处全部为有意保留：7 处豁免（Teal 3 / Index 1 / Tools 3）+ 1 处自家规则故意注入（relay 旧持久化名并收）。
 
 **审计轮二观察项（未处理，供守密人裁夺）**：`hermes uninstall` 的桌面产物探测硬编码 `Hermes` 目录名、换装后找不到 `Silver Core` 实际产物（便携形态卸载 = 删目录，实害近零）；Remote/SSH 报错文案四语种引导 `hermes-agent.nousresearch.com/install.sh`（内网不可达，正确措辞需产品口径，暂记账）；pet 精灵素材仍为上游吉祥物（前轮已记）。
 
@@ -72,13 +84,24 @@
 - **`HERMES_*` 环境变量名 / 配置键 / `~/.hermes` 路径 / 模块与包名**：功能标识符，
   改之即 fork 级侵入且破坏上游测试基线。
 - **`X-Client-Name: hermes-agent` 遥测头**：对上游服务如实自报，不冒充。
+- **qqbot UA 片段 `; Hermes/<ver>`**（2026-08-25 入列）：同上，线上标识符非显示名；
+  含空格品牌名会把产品令牌劈成两截（lesson #57）。
+- **上游 / 外部自有名**（2026-08-25 守密人裁定）：`Hermes Teal` 主题名、`Hermes Index`
+  技能源标签、`Hermes Tools` 子系统名——入 2026-08-03 Nous Portal 图标先例，
+  对方自有之物不戴黑池面具（改 `Hermes Index` 更会让用户搜不到那个外部注册表）。
 - **上游测试与文档**（tests/ · *.md）：测试基线须与官方逐字节同判；文档非部署运行面。
 
 ## 已知残留（照实记录，随移 pin 复测）
 
 - 非白名单目录（website / docs 等纯站点面）的品牌串未扫——不进部署产物。
   ~~apps / web 原列此处~~：守密人 2026-08-02 补充「内部主要消费面是 desktop」后已扩入扫描面（误判订正照实记录）。
-- 含 URL / `HERMES_*` 的行内伴生显示词因跳线谓词整行保留（保护优先于净度）。
+- ~~含 URL / `HERMES_*` 的行内伴生显示词因跳线谓词整行保留（保护优先于净度）~~
+  **2026-08-25 已消（守密人「掩码法」裁定）**：跳线谓词由一档拆两档——版权 / SPDX 仍整行跳过，
+  URL / `HERMES_*` / `X-Client-Name` 改**片段掩码**（先换占位符、规则跑完再还原）。原代价面
+  12 处生产残留随之消失：i18n 四语种「远程主机上未安装 Hermes……或设置 Hermes 路径」（行内含安装 URL）、
+  electron 托盘标签 `Hermes at ${ACTIVE_HERMES_ROOT}` 与「Hermes install at … is missing or incomplete」
+  （变量名含 `HERMES_`）现已正常换装，URL 与变量名一字未动。另修同族假阴性一处：`"\nHermes relaunch failed"`
+  里 `\n` 的那个 `n` 被词边界当成字母、静默漏换，掩码转义序列后恢复。
 - 安装器 `install.sh` / `hermes update` 路径的品牌串未处理——生产禁用该路径（文书 §2.4）。
 - **连字复合显示词**（德/荷/匈 i18n 的 `Hermes-Plugins` 类、UA 值 `Hermes-Desktop`、
   artifactName `Hermes-<版本>`）随连字符免疫边界一并保留（2026-08-02 头名事故的代价面：

--- a/projects/black-pool-agent/build/rebrand.py
+++ b/projects/black-pool-agent/build/rebrand.py
@@ -77,7 +77,13 @@ _RULES_FIRED: set[tuple[str, int]] = set()
 # apps/（desktop 为内部主要消费面，守密人 2026-08-02 补充情报）与 web/（desktop
 # 所包 UI）在列；website/docs 等纯站点面不扫（残留清单见 BRANDING.md）。
 RUNTIME_DIRS = ["agent", "hermes_cli", "gateway", "tools", "plugins",
-                "ui-tui/src", "apps", "web"]
+                "ui-tui/src", "apps", "web",
+                # acp_adapter / skills 于 2026-08-25 随裸词六目录铺开一并入列。
+                # 教训（同日自查逮到）：BARE_WORD_DIRS 与 RUNTIME_DIRS 是**两道闸**——
+                # 前者管「这个目录换不换裸词」，后者管「这个目录扫不扫」。只加前者、
+                # 不加后者，等于给一扇没开的门配了钥匙：实测 acp_adapter 11 处、
+                # skills 5 处残留纹丝不动。两表须同进同退，守卫见 test_hermes_charter.py。
+                "acp_adapter", "skills"]
 
 # 裸词换装目录：display 密集面（UI / i18n / 桌面壳）。裸词 "Hermes" 以词边界
 # 正则替换——`updateHermes`（i18n 键）/ `HermesClient`（类名）等标识符因前后
@@ -99,10 +105,56 @@ RUNTIME_DIRS = ["agent", "hermes_cli", "gateway", "tools", "plugins",
 # 功能面因此为零风险：无 HTTP 头名、无 `HERMES_` 环境变量（大写不匹配裸词）、
 # 无 `.app`/`.exe` 产物路径（那些在 hermes_cli/，尚未入列）。
 # 守卫见 tests/test_hermes_charter.py::test_bare_word_scope_safety。
-# 下一层（hermes_cli / gateway / tools / plugins / skills）挂账未铺——那几处含
-# 皮肤名 `Hermes Teal`、MCP server 名、桌面产物路径等真功能标识，需先定豁免名单。
-BARE_WORD_DIRS = ("apps", "web", "ui-tui/src", "agent")
+# 下一层于 2026-08-25 入列（守密人「品牌补丁不够完整，很多状态提示还是 hermes」
+# 现场反馈后三项交互裁定：全铺六目录 / 掩码法 / 外部自有名九处全豁免）。挂账两年多的
+# 「需先定豁免名单」在换装后的私有版树上实测出了名单：这六个目录的 Python **代码
+# token 里裸词 Hermes 为 0 处**（659 处全部落在字符串字面量、其余在注释与 docstring），
+# 故铺开不改动任何类名 / 变量名 / 模块名；字符串里的功能标识符共 35 处，
+# 已逐条枚举进 BARE_WORD_EXEMPT。铺开前生产字符串残留：hermes_cli 420 / plugins 115
+# / tools 70 / gateway 38 / acp_adapter 11 / skills 5——`tips.py` 的提示语、
+# `console_engine.py` 的「Hermes Console」「Show Hermes component status.」、
+# `gateway/run.py` 的「Starting Hermes Gateway...」皆在其中，正是守密人看见的那些状态提示。
+BARE_WORD_DIRS = ("apps", "web", "ui-tui/src", "agent",
+                  "hermes_cli", "gateway", "tools", "plugins", "acp_adapter", "skills")
 BARE_WORD_RE = re.compile(r"(?<![A-Za-z0-9_-])Hermes(?![A-Za-z0-9_-])")
+
+# 裸词豁免名单（守密人 2026-08-25 两项裁定，分两类）：
+#
+# 【甲类已撤销 · 2026-08-25 守密人第四裁，勿再加回】原拟豁免 `Hermes.exe` /
+#   `Hermes.app` / `Hermes.desktop` / `StartupWMClass=Hermes` 共 27 处，判词是
+#   「真功能标识符，改了就找不到文件」。**该判词方向搞反了**：实测 apps/desktop/
+#   package.json 的 `productName` 与 `executableName` 换装后均为 `Black Pool`，
+#   故 electron-builder 产出的就是 `Black Pool.exe` / `Black Pool.app/Contents/
+#   MacOS/Black Pool`——这些路径指的是**黑池自己的产物**，不是上游的门牌号；
+#   豁免它们才会去找一个不存在的文件名。旁证：apps/ 早在裸词射程内，
+#   `desktop-uninstall.ts` 的同类路径旧引擎下已是 `Black Pool.app`，
+#   豁免 hermes_cli 侧只会造成两边分裂。StartupWMClass 同理——WM_CLASS 派生自
+#   executableName，不跟着换任务栏图标反而归不了组。故甲类一律照换，不入豁免。
+#
+# 乙 · **外部 / 上游自有名**（守密人「九处全豁免」裁定，入 2026-08-03 Nous Portal
+#   图标先例：对方自有之物不戴黑池面具，红线「不抹来源事实」同样适用）：
+#   `Hermes Teal` / `Hermes Teal (Large)`（5 处，仪表盘主题名，与 `Nous Blue` /
+#   `Midnight` / `Ember` 并列；其描述「the canonical Hermes look」说的正是上游青调皮肤，
+#   而黑池自己的皮肤是鎏金 `black-pool`——换成「the canonical Black Pool look」即说假话）
+#   `Hermes Index`（1 处，技能中心源标签，与 `Official (Nous)` / `skills.sh` /
+#   `ClawHub` 并列；那是个外部注册表，改名会让用户搜不到它）
+#   `Hermes Tools`（3 处，上游子系统名）
+#
+# 实现走**掩码**而非整行跳过：命中片段先换占位符、规则跑完再还原——精度到片段，
+# 同一行其余文案照常换装（同 MASK_PATTERNS，见下）。
+#
+# 丙 · **线上标识符**（非用户感知的显示名，走既有政策不走新裁定）：qqbot 适配器发给
+#   腾讯接口的 User-Agent 片段 `; Hermes/<ver>`（`gateway/platforms/qqbot/utils.py`
+#   3 行，全树仅此一处形态）。与 MASK_PATTERNS 里的 `X-Client-Name` 遥测头同类——
+#   红线只换「用户感知的显示名」，UA 是对外报的客户端身份，且塞进含空格的品牌名会把
+#   一个产品令牌劈成两截（lesson #57 `X-Hermes-Session-Token` 同一病灶）。
+#   BRANDING.md 2026-08-05 挂账时即点名此处须先定豁免，本轮据既有政策收口。
+BARE_WORD_EXEMPT = [
+    re.compile(r"Hermes Teal(?: \(Large\))?"),
+    re.compile(r"Hermes Index"),
+    re.compile(r"Hermes Tools"),
+    re.compile(r"; Hermes/"),
+]
 # .html 在列（2026-08-02 补漏）：desktop/web/bootstrap-installer 的 <title> 是
 # 任务栏 / Alt-Tab 显示名的实际来源（Electron 加载页面后 document.title 覆盖窗口题）。
 TEXT_SUFFIXES = {".py", ".ts", ".tsx", ".js", ".mjs", ".sh", ".yaml", ".yml", ".json",
@@ -121,10 +173,30 @@ SPECIAL_RULES = [
     ),
 ]
 
-# 跳线谓词：含以下片段的行不做任何替换（保 URL / 环境变量 / 遥测 / 版权）。
-LINE_SKIP_MARKERS = [
-    "http://", "https://", "HERMES_", "X-Client-Name",
+# 跳线谓词（守密人 2026-08-25「掩码法」裁定后由一档拆成两档）。
+#
+# 甲 · **整行跳过**：整行都是来源事实，行内不存在该换的显示文案。
+WHOLE_LINE_SKIP_MARKERS = [
     "Copyright", "copyright", "SPDX-License-Identifier",
+]
+#
+# 乙 · **片段掩码**：只有那一小段是功能标识符，同一行其余部分照常换装。
+#   原先这三样也走整行跳过，代价是同行的用户文案被一并豁免——实测 12 处生产残留
+#   正出自此：i18n 四语种「远程主机上未安装 Hermes……或设置 Hermes 路径」因行内含
+#   安装 URL 而整行免疫，electron 托盘标签 `Hermes at ${ACTIVE_HERMES_ROOT}` 与
+#   「Hermes install at … is missing or incomplete」因变量名含 `HERMES_` 而整行免疫。
+#   掩码后功能标识符风险不变（片段原样还原），显示文案不再搭便车。
+#   注：`X-Hermes-Session-Token` 一类 HTTP 头名另由 BARE_WORD_RE 的连字符免疫边界
+#   独立防住（2026-08-02 生产事故的真防线），掩码层是第二道网而非唯一那道。
+MASK_PATTERNS = [
+    re.compile(r"https?://\S*"),                       # URL（含 hermes-agent.nousresearch.com 等小写域名）
+    re.compile(r"[A-Za-z0-9_]*HERMES_[A-Za-z0-9_]*"),  # HERMES_HOME / ACTIVE_HERMES_ROOT 等环境变量与常量名
+    re.compile(r"X-Client-Name"),                       # 遥测头名
+    # 转义序列（2026-08-25 铺开时实测逮到 1 处）：源码字面 `"\\nHermes relaunch failed"`
+    # 里，紧挨 Hermes 前面的字符是 `\n` 的那个 `n`——字母，于是 BARE_WORD_RE 的
+    # 左边界当场判它「不是词首」而放行，换装静默漏掉。把 `\n` / `\t` / `\r` 整体
+    # 掩成占位符，词边界即恢复；还原后转义序列一字不变。
+    re.compile(r"\\[ntr]"),
 ]
 
 # 归属行豁免（守密人 2026-08-04 裁定「回退」）：plugins/**/plugin.yaml 的
@@ -244,13 +316,13 @@ BRAND_POST_RULES = [
         f"            {{'B.I.A.V. Studio 出品 · 基于 Hermes Agent {UPSTREAM_VERSION} 定制'}}\n"
         "          </p>\n",
     ),
-    # APP_NAME 兜底统一：该行含 HERMES_ 被跳线保留，兜底值 'Hermes' 与已换装的
-    # productName 分裂——electron userData 路径在 app.setName 前后按不同名字解析，
-    # 绕过 launcher 直启 exe 时配置会写进两个目录（脑裂）。环境变量名原样保留。
-    (
-        "const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME || 'Hermes'\n",
-        f"const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME || '{BRAND}'\n",
-    ),
+    # 【已退役 2026-08-25 · 被掩码法接管，勿重新加回】APP_NAME 兜底统一。
+    # 原因：该行含 `HERMES_DESKTOP_APP_NAME`，整行跳线年代被整行豁免，兜底值
+    # 'Hermes' 与已换装的 productName 分裂（electron userData 路径在 app.setName
+    # 前后按不同名字解析，绕过 launcher 直启 exe 时配置写进两个目录 = 脑裂），
+    # 故当年补一条 POST 规则收尾。改掩码后环境变量名被单独掩住、行内 'Hermes'
+    # 由裸词规则正常换装，产出逐字相同（实测 `|| 'Black Pool'`），本规则遂成死锚，
+    # 留着会被点火台账判为哑火。环境变量名仍原样保留（掩码还原）。
     # 钉钉 relay 默认名抑制加固：旧持久化配置里存的可能仍是换装前的
     # "Hermes Agent"，只比对新名会漏抑制、回复前缀泄漏旧品牌名。两名并收。
     (
@@ -276,12 +348,10 @@ BRAND_POST_RULES = [
         f"toggle the 'Hey {BRAND}' wake word listener [on|off|status]",
         "toggle the wake word listener [on|off|status]",
     ),
-    # CLI 响应面板残留品牌：'⚕ Hermes'（裸词 + hermes_cli 不在裸词目录）
-    # 在 Rich Panel 标题直接可见。通用规则跑完后剩下的都是裸词形态，统一收尾。
-    (
-        "⚕ Hermes",
-        f"⚕ {BRAND}",
-    ),
+    # 【已退役 2026-08-25 · 被裸词目录扩容接管，勿重新加回】CLI 面板标题 '⚕ Hermes'。
+    # 原因：当年 hermes_cli 不在 BARE_WORD_DIRS，这条是对该目录的单点补丁式收尾。
+    # 六目录铺开后 hermes_cli 已在裸词射程内，同一处由裸词规则自然换成 '⚕ Black Pool'
+    # （实测 agent_import.py / claw.py 等 Rich Panel 标题均已换），本规则遂成死锚。
     # Nous Portal 账号卡图标保持官方原版（守密人 2026-08-03 裁定）：
     # 品牌覆盖吃掉了 apple-touch-icon，而该卡表示的是对方服务——改用
     # 组装期预存的官方原版专名（见 overlay_assets）。
@@ -1106,20 +1176,58 @@ def _skip_file(rel: Path) -> bool:
     return rel.suffix not in TEXT_SUFFIXES
 
 
+# 掩码占位符：`\x00` 是控制字符，上游文本源零出现（守卫 test_mask_placeholder_absent
+# 全树核过）。占位体不含任何规则会匹配的字面，故规则跑过它必然原样穿过。
+_MASK_OPEN = "\x00"
+
+
+def _mask(line: str, patterns: list[re.Pattern],
+          fire: tuple[str, int] | None = None) -> tuple[str, list[str]]:
+    """把敏感片段换成占位符，返回（掩码后的行, 原片段表）。
+
+    `fire` 给出（台账名, 该表在 patterns 中的起始下标）时，逐条记录点火——
+    豁免名单沿用 2026-08-16 事故立的规矩：**全树一次没命中即在生成期响亮失败**，
+    因为豁免哑火不像替换哑火那样看得见（它的症状是「某个功能标识符被顺手改掉了」，
+    要等组装线回归网甚至出厂后才炸）。
+    """
+    stash: list[str] = []
+
+    def take(m: "re.Match[str]") -> str:
+        stash.append(m.group(0))
+        return f"{_MASK_OPEN}{len(stash) - 1}{_MASK_OPEN}"
+
+    for idx, rx in enumerate(patterns):
+        before = len(stash)
+        line = rx.sub(take, line)
+        if fire is not None and len(stash) > before and idx >= fire[1]:
+            _RULES_FIRED.add((fire[0], idx - fire[1]))
+    return line, stash
+
+
+def _unmask(line: str, stash: list[str]) -> str:
+    """还原掩码。序号两侧都有 \x00 定界，故 #1 不会误配进 #10 内部。"""
+    for i, original in enumerate(stash):
+        line = line.replace(f"{_MASK_OPEN}{i}{_MASK_OPEN}", original)
+    return line
+
+
 def transform_brand(text: str, bare_word: bool = False) -> str:
     """公版变换：品牌显示名换装 + 品牌一致性修复。"""
     for old, new in SPECIAL_RULES:
         text = text.replace(old, new)
+    mask_patterns = MASK_PATTERNS + (BARE_WORD_EXEMPT if bare_word else [])
     out_lines = []
     for line in text.splitlines(keepends=True):
-        if any(m in line for m in LINE_SKIP_MARKERS) or ATTRIBUTION_LINE_RE.match(line):
+        if any(m in line for m in WHOLE_LINE_SKIP_MARKERS) or ATTRIBUTION_LINE_RE.match(line):
             out_lines.append(line)
             continue
+        line, stash = _mask(line, mask_patterns,
+                            fire=("exempt", len(MASK_PATTERNS)) if bare_word else None)
         for old, new in GENERIC_RULES:
             line = line.replace(old, new)
         if bare_word:
             line = BARE_WORD_RE.sub(BRAND, line)
-        out_lines.append(line)
+        out_lines.append(_unmask(line, stash))
     text = "".join(out_lines)
     for i, (old, new) in enumerate(BRAND_POST_RULES):
         if old in text:
@@ -1280,6 +1388,12 @@ def _assert_every_rule_fired() -> None:
             if (kind, i) not in _RULES_FIRED:
                 probe = next((l.strip() for l in old.splitlines() if l.strip()), old[:60])
                 dead.append(f"{kind}#{i}: {probe[:100]}")
+    # 裸词豁免名单同守此规（2026-08-25 铺开六目录时立）：某条豁免全树没命中，
+    # 意味着它保护的那个功能标识符在上游已改名/消失——处置是按新形态重锚，
+    # 不是删豁免（删了下次就把真路径 / 外部服务名一起换掉了）。
+    for i, rx in enumerate(BARE_WORD_EXEMPT):
+        if ("exempt", i) not in _RULES_FIRED:
+            dead.append(f"exempt#{i}: {rx.pattern}")
     if dead:
         raise RebrandError(
             "以下规则的锚点在当前 upstream 快照上一次也没命中（上游改了那块代码，"

--- a/projects/black-pool-agent/patches/black-pool-intranet.patch
+++ b/projects/black-pool-agent/patches/black-pool-intranet.patch
@@ -85,7 +85,7 @@ index c955bdc..f77a32d 100644
      if route.billing_mode == "subscription_included":
          return PricingEntry(
 diff --git a/apps/desktop/electron/main.ts b/apps/desktop/electron/main.ts
-index d8ceea5..4eb1848 100644
+index 7efb8ab..131116f 100644
 --- a/apps/desktop/electron/main.ts
 +++ b/apps/desktop/electron/main.ts
 @@ -6385,11 +6385,7 @@ function buildApplicationMenu() {
@@ -621,7 +621,7 @@ index 476354e..88148e2 100644
      return
    }
 diff --git a/hermes_cli/update_cmd.py b/hermes_cli/update_cmd.py
-index 212e8e6..6d75f4e 100644
+index cd765b5..60e3041 100644
 --- a/hermes_cli/update_cmd.py
 +++ b/hermes_cli/update_cmd.py
 @@ -5328,6 +5328,11 @@ def _cmd_update_impl(args, gateway_mode: bool):

--- a/projects/black-pool-agent/patches/black-pool-rebrand.patch
+++ b/projects/black-pool-agent/patches/black-pool-rebrand.patch
@@ -1,3 +1,514 @@
+diff --git a/acp_adapter/auth.py b/acp_adapter/auth.py
+index b04a7b7..e68bf5e 100644
+--- a/acp_adapter/auth.py
++++ b/acp_adapter/auth.py
+@@ -1,4 +1,4 @@
+-"""ACP auth helpers — detect and advertise Hermes authentication methods."""
++"""ACP auth helpers — detect and advertise Black Pool authentication methods."""
+ 
+ from __future__ import annotations
+ 
+@@ -9,7 +9,7 @@ TERMINAL_SETUP_AUTH_METHOD_ID = "hermes-setup"
+ 
+ 
+ def detect_provider() -> Optional[str]:
+-    """Resolve the active Hermes runtime provider, or None if unavailable.
++    """Resolve the active Black Pool runtime provider, or None if unavailable.
+ 
+     Treats a ``Callable`` ``api_key`` (Azure Foundry Entra ID bearer
+     token provider — see :mod:`agent.azure_identity_adapter`) as a valid
+@@ -34,16 +34,16 @@ def detect_provider() -> Optional[str]:
+ 
+ 
+ def has_provider() -> bool:
+-    """Return True if Hermes can resolve any runtime provider credentials."""
++    """Return True if Black Pool can resolve any runtime provider credentials."""
+     return detect_provider() is not None
+ 
+ 
+ def build_auth_methods() -> list[Any]:
+-    """Return registry-compatible ACP auth methods for Hermes.
++    """Return registry-compatible ACP auth methods for Black Pool.
+ 
+     The official ACP registry validates that agents advertise at least one
+     usable auth method during the initial handshake. A fresh Zed install may
+-    not have Hermes provider credentials configured yet, so Hermes always
++    not have Black Pool provider credentials configured yet, so Black Pool always
+     advertises a terminal setup method. When credentials are already present,
+     it also advertises the resolved provider as the default agent-managed
+     runtime credential method.
+@@ -58,7 +58,7 @@ def build_auth_methods() -> list[Any]:
+                 id=provider,
+                 name=f"{provider} runtime credentials",
+                 description=(
+-                    "Authenticate Hermes using the currently configured "
++                    "Authenticate Black Pool using the currently configured "
+                     f"{provider} runtime credentials."
+                 ),
+             )
+@@ -67,10 +67,10 @@ def build_auth_methods() -> list[Any]:
+     methods.append(
+         TerminalAuthMethod(
+             id=TERMINAL_SETUP_AUTH_METHOD_ID,
+-            name="Configure Hermes provider",
++            name="Configure Black Pool provider",
+             description=(
+-                "Open Hermes' interactive model/provider setup in a terminal. "
+-                "Use this when Hermes has not been configured on this machine yet."
++                "Open Black Pool' interactive model/provider setup in a terminal. "
++                "Use this when Black Pool has not been configured on this machine yet."
+             ),
+             type="terminal",
+             args=["--setup"],
+diff --git a/acp_adapter/entry.py b/acp_adapter/entry.py
+index 40ad336..bdd34ea 100644
+--- a/acp_adapter/entry.py
++++ b/acp_adapter/entry.py
+@@ -25,7 +25,7 @@ except ModuleNotFoundError:
+     pass
+ else:
+     # Stop a ``utils/``/``proxy/``/``ui/`` package in the launch directory from
+-    # shadowing Hermes's own modules — ``hermes acp`` can be started from any
++    # shadowing Black Pool's own modules — ``hermes acp`` can be started from any
+     # cwd, including a project that has same-named packages on its path.
+     hermes_bootstrap.harden_import_path()
+ 
+@@ -119,9 +119,9 @@ def _load_env() -> None:
+ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+     parser = argparse.ArgumentParser(
+         prog="hermes-acp",
+-        description="Run Hermes Agent as an ACP stdio server.",
++        description="Run Black Pool Agent as an ACP stdio server.",
+     )
+-    parser.add_argument("--version", action="store_true", help="Print Hermes version and exit")
++    parser.add_argument("--version", action="store_true", help="Print Black Pool version and exit")
+     parser.add_argument(
+         "--check",
+         action="store_true",
+@@ -130,7 +130,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+     parser.add_argument(
+         "--setup",
+         action="store_true",
+-        help="Run interactive Hermes provider/model setup for ACP terminal auth",
++        help="Run interactive Black Pool provider/model setup for ACP terminal auth",
+     )
+     parser.add_argument(
+         "--setup-browser",
+@@ -159,7 +159,7 @@ def _run_check() -> None:
+     import acp  # noqa: F401
+     from acp_adapter.server import HermesACPAgent  # noqa: F401
+ 
+-    print("Hermes ACP check OK")
++    print("Black Pool ACP check OK")
+ 
+ 
+ def _run_setup() -> None:
+diff --git a/acp_adapter/events.py b/acp_adapter/events.py
+index ab82c0e..cd22ff4 100644
+--- a/acp_adapter/events.py
++++ b/acp_adapter/events.py
+@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
+ 
+ 
+ def _json_loads_maybe_prefix(value: str) -> Any:
+-    """Parse a JSON object even when Hermes appended a human hint after it."""
++    """Parse a JSON object even when Black Pool appended a human hint after it."""
+     text = value.strip()
+     try:
+         return json.loads(text)
+@@ -37,10 +37,10 @@ def _json_loads_maybe_prefix(value: str) -> Any:
+ 
+ 
+ def _build_plan_update_from_todo_result(result: Any) -> AgentPlanUpdate | None:
+-    """Translate Hermes' todo tool result into ACP's native plan update.
++    """Translate Black Pool' todo tool result into ACP's native plan update.
+ 
+     Zed renders ``sessionUpdate: plan`` as its first-class task/todo panel. The
+-    Hermes agent already maintains task state through the ``todo`` tool, so the
++    Black Pool agent already maintains task state through the ``todo`` tool, so the
+     ACP adapter should expose that state natively instead of only as a generic
+     tool-call transcript block.
+     """
+diff --git a/acp_adapter/permissions.py b/acp_adapter/permissions.py
+index b10b2a1..d7ac838 100644
+--- a/acp_adapter/permissions.py
++++ b/acp_adapter/permissions.py
+@@ -1,4 +1,4 @@
+-"""ACP permission bridging for Hermes dangerous-command approvals."""
++"""ACP permission bridging for Black Pool dangerous-command approvals."""
+ 
+ from __future__ import annotations
+ 
+@@ -15,7 +15,7 @@ from acp.schema import (
+ 
+ logger = logging.getLogger(__name__)
+ 
+-# Maps ACP permission option ids to Hermes approval result strings.
++# Maps ACP permission option ids to Black Pool approval result strings.
+ # Option ids are stable across both the ``allow_permanent=True`` and
+ # ``allow_permanent=False`` paths even though the option list differs.
+ _OPTION_ID_TO_HERMES = {
+@@ -41,7 +41,7 @@ def _permission_option_supports_kind(kind: str) -> bool:
+ def _build_permission_options(
+     *, allow_permanent: bool, smart_denied: bool = False,
+ ) -> list[PermissionOption]:
+-    """Return ACP options that match Hermes approval semantics."""
++    """Return ACP options that match Black Pool approval semantics."""
+     options = [PermissionOption(
+         option_id="allow_once", kind="allow_once", name="Allow once",
+     )]
+@@ -49,7 +49,7 @@ def _build_permission_options(
+         options.append(PermissionOption(
+             option_id="allow_session",
+             # ACP has no session-scoped kind, so use the closest persistent
+-            # hint while keeping Hermes semantics in the option id.
++            # hint while keeping Black Pool semantics in the option id.
+             kind="allow_always",
+             name="Allow for session",
+         ))
+@@ -96,7 +96,7 @@ def _build_permission_tool_call(command: str, description: str):
+ 
+ 
+ def _map_outcome_to_hermes(outcome: object, *, allowed_option_ids: set[str]) -> str:
+-    """Map an ACP permission outcome into Hermes approval strings."""
++    """Map an ACP permission outcome into Black Pool approval strings."""
+     if not isinstance(outcome, AllowedOutcome):
+         return "deny"
+ 
+diff --git a/acp_adapter/provenance.py b/acp_adapter/provenance.py
+index 58b05da..0aa224e 100644
+--- a/acp_adapter/provenance.py
++++ b/acp_adapter/provenance.py
+@@ -1,12 +1,12 @@
+ """Derive ACP session-provenance metadata from the existing compression chain.
+ 
+-This is an additive Hermes extension surfaced under ACP ``_meta.hermes`` so
++This is an additive Black Pool extension surfaced under ACP ``_meta.hermes`` so
+ existing ACP clients ignore it. It carries no new persisted state: everything
+ is derived on demand from the ``sessions`` table (``parent_session_id`` /
+ ``end_reason``), which already models compression-continuation chains.
+ 
+ The ACP/editor ``session_id`` stays the stable public handle. When context
+-compression rotates the internal Hermes head, ``build_session_provenance`` lets
++compression rotates the internal Black Pool head, ``build_session_provenance`` lets
+ a client see the previous/current internal ids and the lineage root without
+ parsing status text, guessing from token drops, or reading ``state.db``.
+ """
+@@ -31,7 +31,7 @@ def build_session_provenance(
+     Args:
+         db: A ``SessionDB`` (must expose ``get_session``).
+         acp_session_id: The stable ACP/editor-facing session handle.
+-        current_hermes_session_id: The live internal Hermes DB session id
++        current_hermes_session_id: The live internal Black Pool DB session id
+             (``state.agent.session_id``).
+         previous_hermes_session_id: The internal id from before the most recent
+             turn, when known. Supplied by ``prompt()`` to flag a rotation.
+diff --git a/acp_adapter/server.py b/acp_adapter/server.py
+index 792e44b..0bcd940 100644
+--- a/acp_adapter/server.py
++++ b/acp_adapter/server.py
+@@ -1,4 +1,4 @@
+-"""ACP agent server — exposes Hermes Agent via the Agent Client Protocol."""
++"""ACP agent server — exposes Black Pool Agent via the Agent Client Protocol."""
+ 
+ from __future__ import annotations
+ 
+@@ -304,7 +304,7 @@ def _path_from_file_uri(uri: str) -> Path | None:
+ 
+     Zed may send POSIX file URIs from Linux/WSL workspaces or Windows-ish paths
+     when launched through wsl.exe. Translate the common Windows drive form to
+-    /mnt/<drive>/... so Hermes running in WSL can read it.
++    /mnt/<drive>/... so Black Pool running in WSL can read it.
+     """
+     raw = (uri or "").strip()
+     if not raw:
+@@ -385,7 +385,7 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
+                 uri=uri,
+                 name=name,
+                 title=title,
+-                body="[Resource link only; Hermes cannot read non-file ACP resource URIs directly.]",
++                body="[Resource link only; Black Pool cannot read non-file ACP resource URIs directly.]",
+             ),
+         }]
+ 
+@@ -553,7 +553,7 @@ def _content_blocks_to_openai_user_content(
+         | EmbeddedResourceContentBlock
+     ],
+ ) -> str | list[dict[str, Any]]:
+-    """Convert ACP prompt blocks into a Hermes/OpenAI-compatible user content payload."""
++    """Convert ACP prompt blocks into a Black Pool/OpenAI-compatible user content payload."""
+     parts: list[dict[str, Any]] = []
+     text_parts: list[str] = []
+ 
+@@ -596,7 +596,7 @@ def _content_blocks_to_openai_user_content(
+ 
+ 
+ class HermesACPAgent(acp.Agent):
+-    """ACP Agent implementation wrapping Hermes AIAgent."""
++    """ACP Agent implementation wrapping Black Pool AIAgent."""
+ 
+     _SLASH_COMMANDS = {
+         "help": "Show available commands",
+@@ -607,7 +607,7 @@ class HermesACPAgent(acp.Agent):
+         "compress": "Compress conversation context",
+         "steer": "Inject guidance into the currently running agent turn",
+         "queue": "Queue a prompt to run after the current turn finishes",
+-        "version": "Show Hermes version",
++        "version": "Show Black Pool version",
+     }
+ 
+     _ADVERTISED_COMMANDS = (
+@@ -648,7 +648,7 @@ class HermesACPAgent(acp.Agent):
+         },
+         {
+             "name": "version",
+-            "description": "Show Hermes version",
++            "description": "Show Black Pool version",
+         },
+     )
+ 
+@@ -684,7 +684,7 @@ class HermesACPAgent(acp.Agent):
+ 
+         Zed renders ``config_options`` in the prominent selector slot where the
+         model picker was visible. Claude/Codex expose policy-like controls as ACP
+-        modes, which coexist with the model picker, so Hermes maps edit approval
++        modes, which coexist with the model picker, so Black Pool maps edit approval
+         policy onto modes instead of advertising config options.
+         """
+ 
+@@ -731,7 +731,7 @@ class HermesACPAgent(acp.Agent):
+     def _build_model_state(self, state: SessionState) -> SessionModelState | None:
+         """Return authenticated providers and their models for ACP clients.
+ 
+-        The shared Hermes inventory is also used by ``hermes model``, the TUI,
++        The shared Black Pool inventory is also used by ``hermes model``, the TUI,
+         and the dashboard. Keeping ACP on that substrate prevents its selector
+         from silently collapsing to the current provider's curated list.
+         """
+@@ -1001,7 +1001,7 @@ class HermesACPAgent(acp.Agent):
+ 
+         Zed's circular context indicator is driven by ACP ``usage_update``
+         session updates: ``size`` is the model context window and ``used`` is
+-        the current request pressure.  Hermes estimates ``used`` from the same
++        the current request pressure.  Black Pool estimates ``used`` from the same
+         buckets it sends to providers: system prompt, conversation history, and
+         tool schemas.
+         """
+@@ -1075,9 +1075,9 @@ class HermesACPAgent(acp.Agent):
+         current_hermes_session_id: Optional[str] = None,
+         previous_hermes_session_id: Optional[str] = None,
+     ) -> None:
+-        """Send ACP native session metadata after Hermes changes it.
++        """Send ACP native session metadata after Black Pool changes it.
+ 
+-        When the internal Hermes head rotated (e.g. compression-driven session
++        When the internal Black Pool head rotated (e.g. compression-driven session
+         split during a turn), pass ``previous_hermes_session_id`` so the
+         attached ``_meta.hermes.sessionProvenance`` flags the rotation reason.
+         """
+@@ -1331,7 +1331,7 @@ class HermesACPAgent(acp.Agent):
+         # provider we advertised in initialize(). Without this check,
+         # authenticate() would acknowledge any method_id as long as the
+         # server has provider credentials configured — harmless under
+-        # Hermes' threat model (ACP is stdio-only, local-trust), but poor
++        # Black Pool' threat model (ACP is stdio-only, local-trust), but poor
+         # API hygiene and confusing if ACP ever grows multi-method auth.
+         if not isinstance(method_id, str):
+             return None
+@@ -1339,7 +1339,7 @@ class HermesACPAgent(acp.Agent):
+         provider = detect_provider()
+ 
+         if normalized_method == TERMINAL_SETUP_AUTH_METHOD_ID:
+-            # Terminal auth launches Hermes setup/model selection out-of-band.
++            # Terminal auth launches Black Pool setup/model selection out-of-band.
+             # Only report success once that flow has produced usable runtime
+             # credentials for the normal ACP session.
+             return AuthenticateResponse() if provider else None
+@@ -1500,7 +1500,7 @@ class HermesACPAgent(acp.Agent):
+ 
+         Replays the conversation as user/assistant chunks, thinking-mode
+         thought chunks, plus reconstructed tool-call start/completion
+-        notifications. Merely restoring server-side state makes Hermes
++        notifications. Merely restoring server-side state makes Black Pool
+         remember context, but leaves the editor looking like a clean thread.
+         """
+         if not self._conn or not state.history:
+@@ -1793,7 +1793,7 @@ class HermesACPAgent(acp.Agent):
+         session_id: str,
+         **kwargs: Any,
+     ) -> PromptResponse:
+-        """Run Hermes on the user's prompt and stream events back to the editor."""
++        """Run Black Pool on the user's prompt and stream events back to the editor."""
+         state = self.session_manager.get_session(session_id)
+         if state is None:
+             logger.error("prompt: session %s not found", session_id)
+@@ -1978,7 +1978,7 @@ class HermesACPAgent(acp.Agent):
+ 
+         agent = state.agent
+         agent.tool_progress_callback = tool_progress_cb
+-        # ACP thought panes should not receive Hermes' local kawaii waiting/status
++        # ACP thought panes should not receive Black Pool' local kawaii waiting/status
+         # updates. Route provider/model reasoning deltas instead; if the provider
+         # emits no reasoning, Zed should not get a fake "thinking" accordion.
+         agent.thinking_callback = None
+@@ -2020,7 +2020,7 @@ class HermesACPAgent(acp.Agent):
+                 # ``cwd`` pins the logical working directory for this context,
+                 # which is what the system prompt's "Current working directory"
+                 # line reports (agent/prompt_builder.py -> resolve_agent_cwd).
+-                # Without it the prompt advertises the global Hermes workspace
++                # Without it the prompt advertises the global Black Pool workspace
+                 # while the tools are rooted at the client's project, so the
+                 # model emits absolute paths under ~/.hermes/workspace and the
+                 # edit silently lands outside the editor's workspace.
+@@ -2111,7 +2111,7 @@ class HermesACPAgent(acp.Agent):
+                         logger.debug("Could not clear ACP session context", exc_info=True)
+ 
+         try:
+-            # Snapshot the internal Hermes DB session id before the turn so we
++            # Snapshot the internal Black Pool DB session id before the turn so we
+             # can detect a compression-driven session rotation afterwards. The
+             # ACP `session_id` stays the stable client handle; agent.session_id
+             # is the live internal head that compression may rotate.
+@@ -2161,7 +2161,7 @@ class HermesACPAgent(acp.Agent):
+         final_response = result.get("final_response", "")
+         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
+         interrupted = bool(result.get("interrupted")) or cancelled
+-        # Hermes' local "waiting for model response" interrupt status is metadata,
++        # Black Pool' local "waiting for model response" interrupt status is metadata,
+         # not assistant prose — clients get cancellation from stop_reason instead.
+         from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+ 
+@@ -2294,7 +2294,7 @@ class HermesACPAgent(acp.Agent):
+         # contextvars.copy_context() that pins the session cwd for the agent
+         # call. ``/compress`` and ``/model`` reach code that REBUILDS the
+         # system prompt (agent._build_system_prompt -> resolve_agent_cwd), so
+-        # an unpinned handler bakes the Hermes install tree into the session's
++        # an unpinned handler bakes the Black Pool install tree into the session's
+         # cached prompt — persisted, and therefore poisoning every later turn
+         # even though the turn itself is pinned. Pin inside a fresh context so
+         # the write can't leak into other concurrent ACP sessions and needs no
+@@ -2563,7 +2563,7 @@ class HermesACPAgent(acp.Agent):
+         return f"Queued for the next turn. ({depth} queued)"
+ 
+     def _cmd_version(self, args: str, state: SessionState) -> str:
+-        return f"Hermes Agent v{HERMES_VERSION}"
++        return f"Black Pool Agent v{HERMES_VERSION}"
+ 
+     # ---- Model switching (ACP protocol method) -------------------------------
+ 
+@@ -2620,7 +2620,7 @@ class HermesACPAgent(acp.Agent):
+     async def set_config_option(
+         self, config_id: str, session_id: str, value: str, **kwargs: Any
+     ) -> SetSessionConfigOptionResponse | None:
+-        """Accept ACP config option updates even when Hermes has no typed ACP config surface yet."""
++        """Accept ACP config option updates even when Black Pool has no typed ACP config surface yet."""
+         state = self.session_manager.get_session(session_id)
+         if state is None:
+             logger.warning("Session %s: config update requested for missing session", session_id)
+diff --git a/acp_adapter/session.py b/acp_adapter/session.py
+index 870ec95..b2968e8 100644
+--- a/acp_adapter/session.py
++++ b/acp_adapter/session.py
+@@ -1,4 +1,4 @@
+-"""ACP session manager — maps ACP sessions to Hermes AIAgent instances.
++"""ACP session manager — maps ACP sessions to Black Pool AIAgent instances.
+ 
+ Sessions are persisted to the shared SessionDB (``~/.hermes/state.db``) so they
+ survive process restarts and appear in ``session_search``.  When the editor
+@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
+ 
+ 
+ def _translate_acp_cwd(cwd: str) -> str:
+-    """Translate Windows ACP cwd values when Hermes itself is running in WSL.
++    """Translate Windows ACP cwd values when Black Pool itself is running in WSL.
+ 
+     Windows ACP clients can launch ``hermes acp`` inside WSL while still sending
+     editor workspaces as Windows drive paths (``E:\\Projects``) or
+@@ -123,7 +123,7 @@ def _acp_stderr_print(*args, **kwargs) -> None:
+ def _register_task_cwd(task_id: str, cwd: str) -> None:
+     """Bind a task/session id to the editor's working directory for tools.
+ 
+-    Zed can launch Hermes from a Windows workspace while the ACP process runs
++    Zed can launch Black Pool from a Windows workspace while the ACP process runs
+     inside WSL. In that case ACP sends cwd as e.g. ``E:\\Projects\\POTI``;
+     local tools need the WSL mount equivalent or subprocess creation fails
+     before the command can run.
+@@ -168,7 +168,7 @@ def _clear_task_cwd(task_id: str) -> None:
+ 
+ @dataclass
+ class SessionState:
+-    """Tracks per-session state for an ACP-managed Hermes agent."""
++    """Tracks per-session state for an ACP-managed Black Pool agent."""
+ 
+     session_id: str
+     agent: Any  # AIAgent instance
+@@ -184,7 +184,7 @@ class SessionState:
+ 
+ 
+ class SessionManager:
+-    """Thread-safe manager for ACP sessions backed by Hermes AIAgent instances.
++    """Thread-safe manager for ACP sessions backed by Black Pool AIAgent instances.
+ 
+     Sessions are held in-memory for fast access **and** persisted to the
+     shared SessionDB so they survive process restarts and are searchable
+@@ -196,7 +196,7 @@ class SessionManager:
+         Args:
+             agent_factory: Optional callable that creates an AIAgent-like object.
+                            Used by tests. When omitted, a real AIAgent is created
+-                           using the current Hermes runtime provider configuration.
++                           using the current Black Pool runtime provider configuration.
+             db:            Optional SessionDB instance. When omitted, the default
+                            SessionDB (``~/.hermes/state.db``) is lazily created.
+         """
+@@ -687,7 +687,7 @@ class SessionManager:
+         agent = AIAgent(**kwargs)
+         # Codex app-server sessions are spawned lazily on the first turn. Stamp
+         # the ACP workspace onto the agent so the Codex runtime starts from the
+-        # editor/session cwd instead of the Hermes daemon's process cwd.
++        # editor/session cwd instead of the Black Pool daemon's process cwd.
+         agent.session_cwd = cwd
+         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.
+         # Route any incidental human-readable agent output to stderr instead.
+diff --git a/acp_adapter/tools.py b/acp_adapter/tools.py
+index bb997dc..78ebdba 100644
+--- a/acp_adapter/tools.py
++++ b/acp_adapter/tools.py
+@@ -201,7 +201,7 @@ def _json_loads_maybe(value: Optional[str]) -> Any:
+     except Exception:
+         pass
+ 
+-    # Some Hermes tools append a human hint after a JSON payload, e.g.
++    # Some Black Pool tools append a human hint after a JSON payload, e.g.
+     # ``{...}\n\n[Hint: Results truncated...]``. Keep the structured rendering path
+     # by decoding the first JSON value instead of falling back to raw text.
+     try:
+@@ -212,7 +212,7 @@ def _json_loads_maybe(value: Optional[str]) -> Any:
+ 
+ 
+ def _tool_result_failed(result: Optional[str], tool_name: str | None = None) -> bool:
+-    """Return True when a structured Hermes tool result clearly failed.
++    """Return True when a structured Black Pool tool result clearly failed.
+ 
+     Keep this deliberately conservative. Plain text can contain words like
+     "error" because tests failed or a command printed diagnostics; Zed should
+@@ -239,7 +239,7 @@ def _tool_result_failed(result: Optional[str], tool_name: str | None = None) ->
+     if isinstance(exit_code, int) and exit_code != 0:
+         return True
+ 
+-    # Hermes core/polished tools commonly report tool-level failures as a
++    # Black Pool core/polished tools commonly report tool-level failures as a
+     # structured {"error": "..."} payload without an explicit success flag.
+     # Keep generic plugin/unknown tool payloads conservative to avoid marking
+     # optional diagnostic messages as failed.
+@@ -315,7 +315,7 @@ def _format_read_file_result(result: Optional[str], args: Optional[Dict[str, Any
+     header = f"Read {path}{suffix}"
+     if data.get("total_lines") is not None:
+         header += f" — {data.get('total_lines')} total lines"
+-    # Hermes read_file output is line-numbered with `|`. If we send it as raw
++    # Black Pool read_file output is line-numbered with `|`. If we send it as raw
+     # Markdown, Zed can interpret pipes as tables and collapse the layout.
+     # Fence the payload so file lines stay readable and literal.
+     return _truncate_text(f"{header}\n\n{_fenced_text(content)}")
 diff --git a/agent/account_usage.py b/agent/account_usage.py
 index b7abb18..60a5de1 100644
 --- a/agent/account_usage.py
@@ -1317,7 +1828,7 @@ index 92cd7c3..2873a6d 100644
      )
  
 diff --git a/agent/file_safety.py b/agent/file_safety.py
-index 7547000..87aff16 100644
+index 7547000..dc8763f 100644
 --- a/agent/file_safety.py
 +++ b/agent/file_safety.py
 @@ -17,7 +17,7 @@ def _hermes_home_path() -> Path:
@@ -1329,7 +1840,7 @@ index 7547000..87aff16 100644
      try:
          from hermes_constants import get_default_hermes_root  # local import to avoid cycles
          return get_default_hermes_root()
-@@ -245,7 +245,7 @@ _BLOCKED_PROJECT_ENV_BASENAMES: set[str] = {
+@@ -245,14 +245,14 @@ _BLOCKED_PROJECT_ENV_BASENAMES: set[str] = {
  
  
  def get_read_block_error(path: str) -> Optional[str]:
@@ -1338,6 +1849,15 @@ index 7547000..87aff16 100644
  
      Three categories are blocked:
  
+-      * Internal Hermes cache files under ``HERMES_HOME/skills/.hub`` —
++      * Internal Black Pool cache files under ``HERMES_HOME/skills/.hub`` —
+         readable metadata that an attacker could use as a prompt-injection
+         carrier.
+-      * Credential / secret stores under HERMES_HOME and the global Hermes
++      * Credential / secret stores under HERMES_HOME and the global Black Pool
+         root: ``auth.json``, ``auth.lock``, ``.anthropic_oauth.json``,
+         ``.env``, ``webhook_subscriptions.json``, ``auth/google_oauth.json``,
+         and anything under ``mcp-tokens/``. These hold plaintext provider keys,
 @@ -292,7 +292,7 @@ def get_read_block_error(path: str) -> Optional[str]:
      resolved = Path(path).expanduser().resolve()
  
@@ -1392,6 +1912,15 @@ index 7547000..87aff16 100644
      :func:`get_read_block_error`), else return.
  
      Shared chokepoint for provider input-loading sites that read a local
+@@ -417,7 +417,7 @@ def raise_if_read_blocked(path: str) -> None:
+ # ---------------------------------------------------------------------------
+ # Cross-profile write guard (#TBD)
+ #
+-# Hermes profiles are separate HERMES_HOME dirs under
++# Black Pool profiles are separate HERMES_HOME dirs under
+ # ``<root>/profiles/<name>/``. Each profile has its own skills/, plugins/,
+ # cron/, memories/. When an agent runs under one profile, writing into
+ # ANOTHER profile's directories is almost always wrong — those skills /
 @@ -471,7 +471,7 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
      """Classify a write target as cross-profile if it lands in another
      profile's scoped area (skills/plugins/cron/memories).
@@ -4455,6 +4984,19 @@ index c385f9b..693f94e 100644
    "type": "module",
    "scripts": {
      "dev": "vite --host 127.0.0.1 --port 5175",
+diff --git a/apps/bootstrap-installer/src-tauri/capabilities/default.json b/apps/bootstrap-installer/src-tauri/capabilities/default.json
+index 9500e4b..e917ca3 100644
+--- a/apps/bootstrap-installer/src-tauri/capabilities/default.json
++++ b/apps/bootstrap-installer/src-tauri/capabilities/default.json
+@@ -1,7 +1,7 @@
+ {
+   "$schema": "https://schema.tauri.app/config/2/capability",
+   "identifier": "default",
+-  "description": "Capabilities required by Hermes Setup. Narrowly scoped: we don't write user files outside HERMES_HOME, we don't read arbitrary paths, and the only external network call goes through reqwest (Rust side, not exposed to the webview).",
++  "description": "Capabilities required by Black Pool Setup. Narrowly scoped: we don't write user files outside HERMES_HOME, we don't read arbitrary paths, and the only external network call goes through reqwest (Rust side, not exposed to the webview).",
+   "windows": ["main"],
+   "permissions": [
+     "core:default",
 diff --git a/apps/bootstrap-installer/src-tauri/tauri.conf.json b/apps/bootstrap-installer/src-tauri/tauri.conf.json
 index 35ad53b..14e4386 100644
 --- a/apps/bootstrap-installer/src-tauri/tauri.conf.json
@@ -23830,7 +24372,7 @@ index 19f2d81..19fcab5 100644
  
    test('renderer mounts and shows DOM content', async () => {
 diff --git a/apps/desktop/e2e/fixtures.ts b/apps/desktop/e2e/fixtures.ts
-index 787be42..9fbecc5 100644
+index 787be42..b07e205 100644
 --- a/apps/desktop/e2e/fixtures.ts
 +++ b/apps/desktop/e2e/fixtures.ts
 @@ -1,5 +1,5 @@
@@ -23840,6 +24382,15 @@ index 787be42..9fbecc5 100644
   *
   * Two fixture modes:
   *
+@@ -487,7 +487,7 @@ providers:
+   )
+   writeEnvFile(sandbox.hermesHome)
+ 
+-  const env = buildAppEnv(sandbox, options.fakeError ? { HERMES_DESKTOP_BOOT_FAKE_ERROR: 'Failed to connect to Hermes backend: connection refused' } : {})
++  const env = buildAppEnv(sandbox, options.fakeError ? { HERMES_DESKTOP_BOOT_FAKE_ERROR: 'Failed to connect to Black Pool backend: connection refused' } : {})
+   const { app, page } = await launchDesktop(env)
+ 
+   return {
 @@ -509,13 +509,13 @@ providers:
   */
  function resolvePackagedBinaryPath(): string {
@@ -24696,7 +25247,7 @@ index f8c77f3..2dc16d2 100644
          'confirm the plain-text storage option when prompted in Settings → Gateway, ' +
          'or set HERMES_DESKTOP_REMOTE_URL and HERMES_DESKTOP_REMOTE_TOKEN in your environment.'
 diff --git a/apps/desktop/electron/main.ts b/apps/desktop/electron/main.ts
-index adf7338..d8ceea5 100644
+index adf7338..7efb8ab 100644
 --- a/apps/desktop/electron/main.ts
 +++ b/apps/desktop/electron/main.ts
 @@ -486,7 +486,7 @@ if (IS_WINDOWS) {
@@ -24717,6 +25268,15 @@ index adf7338..d8ceea5 100644
  // around the clock. Throttling is now a runtime dial scoped to streaming:
  // see createStreamThrottle() — chat windows are unthrottled while any turn is
  // in flight (so a live answer keeps painting while blurred, occluded, or
+@@ -716,7 +716,7 @@ function pathWithHermesManagedNode(...entries) {
+   return [...managed, ...entries, process.env.PATH].filter(Boolean).join(path.delimiter)
+ }
+ 
+-// ACTIVE_HERMES_ROOT — the canonical mutable Hermes install. Same path
++// ACTIVE_HERMES_ROOT — the canonical mutable Black Pool install. Same path
+ // install.ps1 / install.sh use, so a desktop-only user and a CLI-only user end
+ // up with identical layouts and can share one install.
+ const ACTIVE_HERMES_ROOT = path.join(HERMES_HOME, 'hermes-agent')
 @@ -746,7 +746,7 @@ const DESKTOP_INSTALLATION_PATH = path.join(app.getPath('userData'), 'desktop-in
  const DESKTOP_UPDATE_CONFIG_PATH = path.join(app.getPath('userData'), 'updates.json')
  const DESKTOP_WINDOW_STATE_PATH = path.join(app.getPath('userData'), 'window-state.json')
@@ -24885,6 +25445,15 @@ index adf7338..d8ceea5 100644
    // on macOS). Sessions spawned there leave files inside the app bundle
    // and bewilder users when "where did my files go?" is the install dir.
    // The user-configurable default project directory wins over everything,
+@@ -4428,7 +4428,7 @@ function createActiveBackend(backendArgs) {
+ 
+   return {
+     kind: 'python',
+-    label: `Hermes at ${ACTIVE_HERMES_ROOT}`,
++    label: `Black Pool at ${ACTIVE_HERMES_ROOT}`,
+     command,
+     args: ['-m', 'hermes_cli.main', ...backendArgs],
+     env: buildDesktopBackendEnv({
 @@ -4448,7 +4448,7 @@ function resolveHermesBackend(backendArgs) {
    const overrideRoot = process.env.HERMES_DESKTOP_HERMES_ROOT && path.resolve(process.env.HERMES_DESKTOP_HERMES_ROOT)
  
@@ -24903,6 +25472,15 @@ index adf7338..d8ceea5 100644
  
      if (backend) {
        return backend
+@@ -4480,7 +4480,7 @@ function resolveHermesBackend(backendArgs) {
+   if (activeRuntime.shouldUseActiveRuntime && !bootstrapRepairRequested) {
+     if (!activeRuntime.hasValidMarker) {
+       rememberLog(
+-        `[bootstrap] Active Hermes runtime at ${ACTIVE_HERMES_ROOT} is usable but the bootstrap marker is missing or stale; skipping first-run bootstrap.`
++        `[bootstrap] Active Black Pool runtime at ${ACTIVE_HERMES_ROOT} is usable but the bootstrap marker is missing or stale; skipping first-run bootstrap.`
+       )
+     }
+ 
 @@ -4508,7 +4508,7 @@ function resolveHermesBackend(backendArgs) {
        } else if (!isWindowsBinaryPathInWsl(hermesOverride, { isWsl: IS_WSL })) {
          hermesCommand = hermesOverride
@@ -24980,7 +25558,13 @@ index adf7338..d8ceea5 100644
            `${bootstrapResult.error || 'unknown error'}. ` +
            `Check ${path.join(HERMES_HOME, 'logs', 'desktop.log')} for the full transcript.`
        ) as any
-@@ -4745,7 +4745,7 @@ async function ensureRuntime(backend) {
+@@ -4740,12 +4740,12 @@ async function ensureRuntime(backend) {
+   // attests they ran successfully).
+   if (!isHermesSourceRoot(ACTIVE_HERMES_ROOT)) {
+     throw new Error(
+-      `Hermes install at ${ACTIVE_HERMES_ROOT} is missing or incomplete. ` +
++      `Black Pool install at ${ACTIVE_HERMES_ROOT} is missing or incomplete. ` +
+         'Reinstall via the desktop installer or scripts/install.ps1.'
      )
    }
  
@@ -25002,7 +25586,7 @@ index adf7338..d8ceea5 100644
      )
    }
  
-@@ -4771,7 +4771,7 @@ async function ensureRuntime(backend) {
+@@ -4771,15 +4771,15 @@ async function ensureRuntime(backend) {
      // If we hit this, the user (or a deleted venv) broke the invariant; tell
      // them to re-run the install.
      throw new Error(
@@ -25011,8 +25595,9 @@ index adf7338..d8ceea5 100644
      )
    }
  
-@@ -4779,7 +4779,7 @@ async function ensureRuntime(backend) {
-   backend.label = `Hermes at ${ACTIVE_HERMES_ROOT} (venv: ${VENV_ROOT})`
+   backend.command = getVenvPython(VENV_ROOT)
+-  backend.label = `Hermes at ${ACTIVE_HERMES_ROOT} (venv: ${VENV_ROOT})`
++  backend.label = `Black Pool at ${ACTIVE_HERMES_ROOT} (venv: ${VENV_ROOT})`
    updateBootProgress({
      phase: 'runtime.ready',
 -    message: 'Hermes runtime is ready',
@@ -26488,9 +27073,31 @@ index 1b24aaa..7a9b0d2 100644
      execFileSync() {
        throw new Error('access denied')
 diff --git a/apps/desktop/electron/windows-user-env.test.ts b/apps/desktop/electron/windows-user-env.test.ts
-index 6b92650..ccf73aa 100644
+index 6b92650..1c4ca3d 100644
 --- a/apps/desktop/electron/windows-user-env.test.ts
 +++ b/apps/desktop/electron/windows-user-env.test.ts
+@@ -7,8 +7,8 @@ import { expandWindowsEnvRefs, parseRegQueryValue, readWindowsUserEnvVar } from
+ // ── parseRegQueryValue ─────────────────────────────────────────────────────
+ 
+ test('parseRegQueryValue extracts a REG_SZ value', () => {
+-  const out = ['', 'HKEY_CURRENT_USER\\Environment', '    HERMES_HOME    REG_SZ    F:\\Hermes\\data', ''].join('\r\n')
+-  assert.equal(parseRegQueryValue(out, 'HERMES_HOME'), 'F:\\Hermes\\data')
++  const out = ['', 'HKEY_CURRENT_USER\\Environment', '    HERMES_HOME    REG_SZ    F:\\Black Pool\\data', ''].join('\r\n')
++  assert.equal(parseRegQueryValue(out, 'HERMES_HOME'), 'F:\\Black Pool\\data')
+ })
+ 
+ test('parseRegQueryValue matches the name case-insensitively', () => {
+@@ -17,8 +17,8 @@ test('parseRegQueryValue matches the name case-insensitively', () => {
+ })
+ 
+ test('parseRegQueryValue preserves spaces inside the value', () => {
+-  const out = '    HERMES_HOME    REG_SZ    C:\\Program Files\\Hermes\r\n'
+-  assert.equal(parseRegQueryValue(out, 'HERMES_HOME'), 'C:\\Program Files\\Hermes')
++  const out = '    HERMES_HOME    REG_SZ    C:\\Program Files\\Black Pool\r\n'
++  assert.equal(parseRegQueryValue(out, 'HERMES_HOME'), 'C:\\Program Files\\Black Pool')
+ })
+ 
+ test('parseRegQueryValue returns null when the value line is absent', () => {
 @@ -35,7 +35,7 @@ test('expandWindowsEnvRefs expands %VAR% case-insensitively', () => {
  })
  
@@ -26500,8 +27107,17 @@ index 6b92650..ccf73aa 100644
    assert.equal(expandWindowsEnvRefs('%NOPE%\\x', {}), '%NOPE%\\x')
  })
  
+@@ -60,7 +60,7 @@ test('readWindowsUserEnvVar queries HKCU\\Environment and expands the value', ()
+   const exec = (cmd, args) => {
+     calls.push([cmd, args])
+ 
+-    return 'HKEY_CURRENT_USER\\Environment\r\n    HERMES_HOME    REG_EXPAND_SZ    %DRIVE%\\Hermes\r\n'
++    return 'HKEY_CURRENT_USER\\Environment\r\n    HERMES_HOME    REG_EXPAND_SZ    %DRIVE%\\Black Pool\r\n'
+   }
+ 
+   const value = readWindowsUserEnvVar('HERMES_HOME', {
 diff --git a/apps/desktop/electron/windows-user-env.ts b/apps/desktop/electron/windows-user-env.ts
-index 890cd6f..5c81dc7 100644
+index 890cd6f..f87eef7 100644
 --- a/apps/desktop/electron/windows-user-env.ts
 +++ b/apps/desktop/electron/windows-user-env.ts
 @@ -5,7 +5,7 @@
@@ -26513,6 +27129,15 @@ index 890cd6f..5c81dc7 100644
  // desktop's HERMES_HOME resolution relies on process.env, so that stale-snapshot
  // gap silently sends the backend to the default %LOCALAPPDATA%\hermes. Reading
  // the live registry value closes the gap. See #45471.
+@@ -15,7 +15,7 @@ import { execFileSync } from 'node:child_process'
+ // Parse the output of `reg query HKCU\Environment /v <name>`, which looks like:
+ //
+ //   HKEY_CURRENT_USER\Environment
+-//       HERMES_HOME    REG_SZ    F:\Hermes\data
++//       HERMES_HOME    REG_SZ    F:\Black Pool\data
+ //
+ // Returns the raw value string (spaces inside the value preserved), or null when
+ // the requested value line isn't present.
 diff --git a/apps/desktop/electron/workspace-cwd.test.ts b/apps/desktop/electron/workspace-cwd.test.ts
 index 1377b9f..0d81e50 100644
 --- a/apps/desktop/electron/workspace-cwd.test.ts
@@ -41336,16 +41961,17 @@ index de9bb5c..cf53182 100644
      // Producer-gated, not wall-clock-gated: the old test slept 80ms and
      // assumed a 500ms timer could not fire before the assertion. On a loaded
 diff --git a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
-index 3ad0e17..f40cb1d 100644
+index 3ad0e17..0e14543 100644
 --- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
 +++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
-@@ -96,14 +96,14 @@ describe('buildToolView web-search query', () => {
+@@ -96,16 +96,16 @@ describe('buildToolView web-search query', () => {
    it('keeps the query separate from structured search results', () => {
      const view = buildToolView(
        part({
 -        args: { query: 'Hermes Agent Desktop tool calls' },
+-        result: { web: [{ snippet: 'Desktop docs', title: 'Hermes docs', url: 'https://example.com/docs' }] },
 +        args: { query: 'Black Pool Agent Desktop tool calls' },
-         result: { web: [{ snippet: 'Desktop docs', title: 'Hermes docs', url: 'https://example.com/docs' }] },
++        result: { web: [{ snippet: 'Desktop docs', title: 'Black Pool docs', url: 'https://example.com/docs' }] },
          toolName: 'web_search'
        }),
        ''
@@ -41354,8 +41980,11 @@ index 3ad0e17..f40cb1d 100644
 -    expect(view.searchQuery).toBe('Hermes Agent Desktop tool calls')
 +    expect(view.searchQuery).toBe('Black Pool Agent Desktop tool calls')
      expect(view.searchHits).toEqual([
-       { snippet: 'Desktop docs', title: 'Hermes docs', url: 'https://example.com/docs' }
+-      { snippet: 'Desktop docs', title: 'Hermes docs', url: 'https://example.com/docs' }
++      { snippet: 'Desktop docs', title: 'Black Pool docs', url: 'https://example.com/docs' }
      ])
+   })
+ })
 diff --git a/apps/desktop/src/components/boot-failure-overlay.test.tsx b/apps/desktop/src/components/boot-failure-overlay.test.tsx
 index e86f987..4a7e60f 100644
 --- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -42400,7 +43029,7 @@ index 024cecf..a5f70f2 100644
        fileChanged: url => `تغيّر الملف، جار إعادة تحميل المعاينة: ${url}`,
        filesChanged: (count, url) => `${count} تغييرات ملفات، جار إعادة تحميل المعاينة: ${url}`,
 diff --git a/apps/desktop/src/i18n/en.ts b/apps/desktop/src/i18n/en.ts
-index 66fcc36..01d1250 100644
+index 66fcc36..48f85ea 100644
 --- a/apps/desktop/src/i18n/en.ts
 +++ b/apps/desktop/src/i18n/en.ts
 @@ -65,19 +65,19 @@ export const en: Translations = {
@@ -42754,7 +43383,8 @@ index 66fcc36..01d1250 100644
        sshErrHostKey:
          'The host key has CHANGED since you last connected. Verify this is expected, then run ssh-keygen -R <host> and reconnect.',
        sshErrNotInstalled:
-         'Hermes is not installed on the remote host. Install it there (curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh) or set the Hermes path.',
+-        'Hermes is not installed on the remote host. Install it there (curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh) or set the Hermes path.',
++        'Black Pool is not installed on the remote host. Install it there (curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh) or set the Black Pool path.',
        sshErrPlatform:
 -        'Unsupported remote platform. Hermes Desktop SSH mode supports Linux, macOS, and Windows remote hosts.',
 +        'Unsupported remote platform. Black Pool Desktop SSH mode supports Linux, macOS, and Windows remote hosts.',
@@ -43027,7 +43657,8 @@ index 66fcc36..01d1250 100644
 +    remoteSetupTitle: 'Connect to existing Black Pool',
 +    remoteSetupDesc: 'Enter your gateway URL. Black Pool Desktop will detect whether it needs a token or browser sign-in.',
      remoteUrlTitle: 'Gateway URL',
-     remoteUrlDesc: 'Use the base URL of the Hermes gateway, including https:// when remote.',
+-    remoteUrlDesc: 'Use the base URL of the Hermes gateway, including https:// when remote.',
++    remoteUrlDesc: 'Use the base URL of the Black Pool gateway, including https:// when remote.',
      remoteUrlPlaceholder: 'https://gateway.example.com/hermes',
      probing: 'Detecting gateway authentication...',
 -    probeError: 'Could not reach that Hermes gateway.',
@@ -43241,7 +43872,7 @@ index 66fcc36..01d1250 100644
      openImage: 'Open image',
      downloadImage: 'Download image',
 diff --git a/apps/desktop/src/i18n/ja.ts b/apps/desktop/src/i18n/ja.ts
-index 64ea8ed..ffee068 100644
+index 64ea8ed..b549b11 100644
 --- a/apps/desktop/src/i18n/ja.ts
 +++ b/apps/desktop/src/i18n/ja.ts
 @@ -65,19 +65,19 @@ export const ja = defineLocale({
@@ -43530,7 +44161,8 @@ index 64ea8ed..ffee068 100644
        sshErrHostKey:
          '前回の接続以降、ホスト鍵が変更されています。想定どおりか確認し、ssh-keygen -R <host> を実行してから再接続してください。',
        sshErrNotInstalled:
-         'リモートホストに Hermes がインストールされていません。リモートでインストールする（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）か、Hermes パスを設定してください。',
+-        'リモートホストに Hermes がインストールされていません。リモートでインストールする（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）か、Hermes パスを設定してください。',
++        'リモートホストに Black Pool がインストールされていません。リモートでインストールする（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）か、Black Pool パスを設定してください。',
        sshErrPlatform:
 -        'サポートされていないリモートプラットフォームです。Hermes Desktop の SSH モードは Linux、macOS、Windows のリモートホストに対応しています。',
 +        'サポートされていないリモートプラットフォームです。Black Pool Desktop の SSH モードは Linux、macOS、Windows のリモートホストに対応しています。',
@@ -43798,7 +44430,8 @@ index 64ea8ed..ffee068 100644
 -      'ゲートウェイ URL を入力してください。Hermes Desktop がトークンとブラウザーサインインのどちらが必要かを検出します。',
 +      'ゲートウェイ URL を入力してください。Black Pool Desktop がトークンとブラウザーサインインのどちらが必要かを検出します。',
      remoteUrlTitle: 'ゲートウェイ URL',
-     remoteUrlDesc: 'Hermes ゲートウェイのベース URL を使用します。リモートの場合は https:// を含めてください。',
+-    remoteUrlDesc: 'Hermes ゲートウェイのベース URL を使用します。リモートの場合は https:// を含めてください。',
++    remoteUrlDesc: 'Black Pool ゲートウェイのベース URL を使用します。リモートの場合は https:// を含めてください。',
      remoteUrlPlaceholder: 'https://gateway.example.com/hermes',
      probing: 'ゲートウェイ認証方式を検出中...',
 -    probeError: 'その Hermes ゲートウェイに到達できませんでした。',
@@ -44040,7 +44673,7 @@ index dcf743d..b5a4cdc 100644
        boot.ready = originalReady
      }
 diff --git a/apps/desktop/src/i18n/zh-hant.ts b/apps/desktop/src/i18n/zh-hant.ts
-index a393008..eecd8ec 100644
+index a393008..363566a 100644
 --- a/apps/desktop/src/i18n/zh-hant.ts
 +++ b/apps/desktop/src/i18n/zh-hant.ts
 @@ -65,19 +65,19 @@ export const zhHant = defineLocale({
@@ -44325,8 +44958,9 @@ index a393008..eecd8ec 100644
 +        'SSH 驗證失敗。請將金鑰載入 ssh-agent（ssh-add），或在 ~/.ssh/config 中設定 IdentityFile——Black Pool 以非互動方式執行 ssh。',
        sshErrHostKey: '自上次連線以來主機金鑰已變更。請確認這是預期的，然後執行 ssh-keygen -R <host> 並重新連線。',
        sshErrNotInstalled:
-         '遠端主機上未安裝 Hermes。請在遠端安裝（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）或設定 Hermes 路徑。',
+-        '遠端主機上未安裝 Hermes。請在遠端安裝（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）或設定 Hermes 路徑。',
 -      sshErrPlatform: '不支援的遠端平台。Hermes Desktop 的 SSH 模式支援 Linux、macOS 和 Windows 遠端主機。',
++        '遠端主機上未安裝 Black Pool。請在遠端安裝（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）或設定 Black Pool 路徑。',
 +      sshErrPlatform: '不支援的遠端平台。Black Pool Desktop 的 SSH 模式支援 Linux、macOS 和 Windows 遠端主機。',
        sshErrTimeout: 'SSH 連線逾時。主機可能無法存取或處於睡眠狀態。',
 -      sshErrUpdateRequired: '使用 Desktop SSH 連線前，請更新遠端主機上的 Hermes。',
@@ -44593,7 +45227,8 @@ index a393008..eecd8ec 100644
 +    remoteSetupTitle: '連線到現有 Black Pool',
 +    remoteSetupDesc: '輸入閘道 URL。Black Pool Desktop 會偵測需要權杖還是瀏覽器登入。',
      remoteUrlTitle: '閘道 URL',
-     remoteUrlDesc: '使用 Hermes 閘道的基礎 URL；遠端位址請包含 https://。',
+-    remoteUrlDesc: '使用 Hermes 閘道的基礎 URL；遠端位址請包含 https://。',
++    remoteUrlDesc: '使用 Black Pool 閘道的基礎 URL；遠端位址請包含 https://。',
      remoteUrlPlaceholder: 'https://gateway.example.com/hermes',
      probing: '正在偵測閘道驗證方式...',
 -    probeError: '無法連線到該 Hermes 閘道。',
@@ -44795,7 +45430,7 @@ index a393008..eecd8ec 100644
      openImage: '開啟圖片',
      downloadImage: '下載圖片',
 diff --git a/apps/desktop/src/i18n/zh.ts b/apps/desktop/src/i18n/zh.ts
-index 0fa9e21..4f033eb 100644
+index 0fa9e21..12fa150 100644
 --- a/apps/desktop/src/i18n/zh.ts
 +++ b/apps/desktop/src/i18n/zh.ts
 @@ -65,19 +65,19 @@ export const zh: Translations = {
@@ -45185,8 +45820,9 @@ index 0fa9e21..4f033eb 100644
 +        'SSH 认证失败。请将密钥加载到 ssh-agent（ssh-add），或在 ~/.ssh/config 中设置 IdentityFile——Black Pool 以非交互方式运行 ssh。',
        sshErrHostKey: '自上次连接以来主机密钥已更改。请确认这是预期的，然后运行 ssh-keygen -R <host> 并重新连接。',
        sshErrNotInstalled:
-         '远程主机上未安装 Hermes。请在远程安装（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）或设置 Hermes 路径。',
+-        '远程主机上未安装 Hermes。请在远程安装（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）或设置 Hermes 路径。',
 -      sshErrPlatform: '不支持的远程平台。Hermes Desktop 的 SSH 模式支持 Linux、macOS 和 Windows 远程主机。',
++        '远程主机上未安装 Black Pool。请在远程安装（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）或设置 Black Pool 路径。',
 +      sshErrPlatform: '不支持的远程平台。Black Pool Desktop 的 SSH 模式支持 Linux、macOS 和 Windows 远程主机。',
        sshErrTimeout: 'SSH 连接超时。主机可能无法访问或处于休眠状态。',
 -      sshErrUpdateRequired: '使用 Desktop SSH 连接前，请更新远程主机上的 Hermes。',
@@ -45479,7 +46115,8 @@ index 0fa9e21..4f033eb 100644
 +    remoteSetupTitle: '连接到现有 Black Pool',
 +    remoteSetupDesc: '输入网关 URL。Black Pool Desktop 会检测需要令牌还是浏览器登录。',
      remoteUrlTitle: '网关 URL',
-     remoteUrlDesc: '使用 Hermes 网关的基础 URL；远程地址请包含 https://。',
+-    remoteUrlDesc: '使用 Hermes 网关的基础 URL；远程地址请包含 https://。',
++    remoteUrlDesc: '使用 Black Pool 网关的基础 URL；远程地址请包含 https://。',
      remoteUrlPlaceholder: 'https://gateway.example.com/hermes',
      probing: '正在检测网关认证方式...',
 -    probeError: '无法连接到该 Hermes 网关。',
@@ -46729,9 +47366,18 @@ index d1aa8f2..a8f43e7 100644
  /** Pick a save location and export `profile` (default: the active one).
   *  Returns the archive path, or null when the user cancelled. */
 diff --git a/apps/desktop/src/store/projects.test.ts b/apps/desktop/src/store/projects.test.ts
-index e80b645..969c987 100644
+index e80b645..bcdf343 100644
 --- a/apps/desktop/src/store/projects.test.ts
 +++ b/apps/desktop/src/store/projects.test.ts
+@@ -341,7 +341,7 @@ describe('startWorkInRepo remote capability gate (#81724)', () => {
+     desktopGit.mockReturnValue({
+       worktreeAdd: vi.fn(async () => {
+         throw new Error(
+-          'Expected JSON from https://vps/api/git/worktree/add but got HTML (status 404). The endpoint is likely missing on the Hermes backend.'
++          'Expected JSON from https://vps/api/git/worktree/add but got HTML (status 404). The endpoint is likely missing on the Black Pool backend.'
+         )
+       })
+     } as never)
 @@ -597,7 +597,7 @@ describe('repository discovery policy', () => {
      expect(getHermesConfig).not.toHaveBeenCalled()
      // The desktop can't crawl the remote host's filesystem, so it asks the
@@ -47221,6 +47867,94 @@ index 24592c4..eb869db 100644
      }
  
      try {
+diff --git a/gateway/__init__.py b/gateway/__init__.py
+index 140cc32..8150262 100644
+--- a/gateway/__init__.py
++++ b/gateway/__init__.py
+@@ -1,7 +1,7 @@
+ """
+-Hermes Gateway - Multi-platform messaging integration.
++Black Pool Gateway - Multi-platform messaging integration.
+ 
+-This module provides a unified gateway for connecting the Hermes agent
++This module provides a unified gateway for connecting the Black Pool agent
+ to various messaging platforms (Telegram, Discord, WhatsApp, Weixin, and more) with:
+ - Session management (persistent conversations with reset policies)
+ - Dynamic context injection (agent knows where messages come from)
+diff --git a/gateway/authz_mixin.py b/gateway/authz_mixin.py
+index fae4b74..4e8957c 100644
+--- a/gateway/authz_mixin.py
++++ b/gateway/authz_mixin.py
+@@ -326,7 +326,7 @@ class GatewayAuthorizationMixin:
+ 
+         WeCom supports ``groups.<group_id>.allow_from`` on top of the top-level
+         ``group_policy``. A group may be open at the chat level while still
+-        restricting which senders inside that group can invoke Hermes. If such a
++        restricting which senders inside that group can invoke Black Pool. If such a
+         message reached the gateway, the adapter already checked that sender
+         allowlist, so it is a trustworthy intake decision rather than the
+         fail-open ``group_policy: open`` case.
+diff --git a/gateway/config.py b/gateway/config.py
+index fece329..3b3896d 100644
+--- a/gateway/config.py
++++ b/gateway/config.py
+@@ -670,7 +670,7 @@ class PlatformConfig:
+     # assistant.threads.setStatus line (shown next to the bot name; needs the
+     # assistant:write scope to render) and Google Chat's visible marker
+     # message. None keeps each platform's built-in default ("is thinking..." /
+-    # "Hermes is thinking…"). Platforms with textless indicators (Discord,
++    # "Black Pool is thinking…"). Platforms with textless indicators (Discord,
+     # Telegram, Matrix, …) ignore it.
+     typing_status_text: Optional[str] = None
+ 
+diff --git a/gateway/display_config.py b/gateway/display_config.py
+index e58e6e8..ddeba9f 100644
+--- a/gateway/display_config.py
++++ b/gateway/display_config.py
+@@ -154,7 +154,7 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
+     "signal":          _TIER_LOW,
+     "whatsapp":        _TIER_MEDIUM,  # Baileys bridge supports /edit
+     # WhatsApp Cloud API: Meta added message editing in 2023 but the
+-    # Hermes Cloud adapter doesn't implement edit_message yet, so we
++    # Black Pool Cloud adapter doesn't implement edit_message yet, so we
+     # stay on TIER_LOW (tool_progress off) to avoid spamming each
+     # status update as a separate message. Promote to TIER_MEDIUM once
+     # Cloud's edit_message lands.
+diff --git a/gateway/drain_control.py b/gateway/drain_control.py
+index ba7d9f6..d598ccc 100644
+--- a/gateway/drain_control.py
++++ b/gateway/drain_control.py
+@@ -25,7 +25,7 @@ Contract (presence-based, mirroring ``.restart_notify.json``):
+     marker from a *prior* instantiation) means "not draining" (revert to
+     ``running`` if we had flipped it).
+ 
+-Why the epoch (NS-570). ``HERMES_HOME`` is a **durable** store — on Hermes
++Why the epoch (NS-570). ``HERMES_HOME`` is a **durable** store — on Black Pool
+ Cloud it is a persistent Fly volume (``/opt/data``). A begin-drain marker
+ written there *survives a machine restart*. But the disruptive lifecycle
+ actions a drain protects (auto-update / image migrate / env edit / profile
+@@ -303,7 +303,7 @@ def drain_requested(*, home: Optional[Path] = None) -> bool:
+ 
+     A marker whose ``epoch`` does not match the current instantiation epoch is
+     treated as absent: it survived a container/VM restart (HERMES_HOME is a
+-    durable Fly volume on Hermes Cloud) and the lifecycle action that triggered
++    durable Fly volume on Black Pool Cloud) and the lifecycle action that triggered
+     the drain has already completed — honouring it would wedge the
+     freshly-restarted gateway in ``draining`` (NS-570). A marker whose
+     ``requested_at`` is older than :data:`DRAIN_REQUEST_MAX_AGE_SECONDS` is
+diff --git a/gateway/hooks.py b/gateway/hooks.py
+index 6ecba2a..17c61a4 100644
+--- a/gateway/hooks.py
++++ b/gateway/hooks.py
+@@ -25,7 +25,7 @@ Context dict passed to ``agent:start`` / ``agent:end`` handlers:
+   thread_id    -- Telegram forum-topic id / thread root id (string; empty
+                   when not in a thread / topic)
+   chat_type    -- "dm" | "group" | "forum" (empty if unknown)
+-  session_id   -- Hermes session id
++  session_id   -- Black Pool session id
+   message      -- inbound message text (truncated to 500 chars)
+ 
+ ``agent:end`` adds:
 diff --git a/gateway/kanban_watchers.py b/gateway/kanban_watchers.py
 index eb267c1..9a897f2 100644
 --- a/gateway/kanban_watchers.py
@@ -47243,10 +47977,34 @@ index eb267c1..9a897f2 100644
              """
              # Only probe the review column when autonomous review dispatch is
              # actually on. With ``review_dispatch`` off (the default — no
+diff --git a/gateway/platform_registry.py b/gateway/platform_registry.py
+index e639bc8..9d8c4e3 100644
+--- a/gateway/platform_registry.py
++++ b/gateway/platform_registry.py
+@@ -192,7 +192,7 @@ class PlatformEntry:
+     # explicit target.  Invoked by ``tools/send_message_tool._parse_target_ref``
+     # before channel-directory fallback so plugin platforms can declare their
+     # own native target syntax (e.g. ``fmsg:@alice@example.com``) without
+-    # hard-casing in Hermes core.
++    # hard-casing in Black Pool core.
+     #
+     # Signature:
+     #     (target_ref: str) -> Optional[tuple[str, Optional[str]]]
 diff --git a/gateway/platforms/api_server.py b/gateway/platforms/api_server.py
-index 30ed5a8..4f25105 100644
+index 30ed5a8..915dbe4 100644
 --- a/gateway/platforms/api_server.py
 +++ b/gateway/platforms/api_server.py
+@@ -8,8 +8,8 @@ Exposes an HTTP server with endpoints:
+ - DELETE /v1/responses/{response_id} — Delete a stored response
+ - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
+ - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
+-- GET  /api/sessions               — list client-visible Hermes sessions
+-- POST /api/sessions               — create an empty Hermes session
++- GET  /api/sessions               — list client-visible Black Pool sessions
++- POST /api/sessions               — create an empty Black Pool session
+ - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
+ - GET  /api/sessions/{session_id}/messages — read session message history
+ - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
 @@ -124,7 +124,7 @@ logger = logging.getLogger(__name__)
  
  
@@ -47256,21 +48014,266 @@ index 30ed5a8..4f25105 100644
  
      ``hermes_cli.__version__`` is the runtime source of truth used by the CLI,
      dashboard, portal tags, and release script. Prefer it over installed
+@@ -1280,7 +1280,7 @@ def _derive_chat_session_id(
+     conversation history with every request.  The system prompt and first user
+     message are constant across all turns of the same conversation, so hashing
+     them produces a deterministic session ID that lets the API server reuse
+-    the same Hermes session (and therefore the same Docker container sandbox
++    the same Black Pool session (and therefore the same Docker container sandbox
+     directory) across turns.
+     """
+     seed = f"{system_prompt or ''}\n{first_user_message}"
+@@ -3109,11 +3109,11 @@ class APIServerAdapter(BasePlatformAdapter):
+         return web.json_response({"object": "list", "data": models})
+ 
+     async def _handle_model_options(self, request: "web.Request") -> "web.Response":
+-        """GET /api/model/options — return Hermes provider/model inventory.
++        """GET /api/model/options — return Black Pool provider/model inventory.
+ 
+         This mirrors the dashboard/TUI model picker inventory endpoint so
+         external clients using the API server can sync to the user's configured
+-        Hermes provider catalog instead of scraping the single OpenAI-compatible
++        Black Pool provider catalog instead of scraping the single OpenAI-compatible
+         `/v1/models` alias.
+         """
+         auth_err = self._check_auth(request)
+@@ -3150,7 +3150,7 @@ class APIServerAdapter(BasePlatformAdapter):
+ 
+         External UIs and orchestrators use this endpoint to discover the API
+         server's plugin-safe contract without scraping docs or assuming that
+-        every Hermes version exposes the same endpoints.
++        every Black Pool version exposes the same endpoints.
+         """
+         auth_err = self._check_auth(request)
+         if auth_err:
+@@ -3169,7 +3169,7 @@ class APIServerAdapter(BasePlatformAdapter):
+                 "tool_execution": "server",
+                 "split_runtime": False,
+                 "description": (
+-                    "The API server creates a server-side Hermes AIAgent; "
++                    "The API server creates a server-side Black Pool AIAgent; "
+                     "tools execute on the API-server host unless a future "
+                     "explicit split-runtime mode is enabled."
+                 ),
+@@ -3398,7 +3398,7 @@ class APIServerAdapter(BasePlatformAdapter):
+             return []
+ 
+     async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
+-        """GET /api/sessions — list persisted Hermes sessions."""
++        """GET /api/sessions — list persisted Black Pool sessions."""
+         auth_err = self._check_auth(request)
+         if auth_err:
+             return auth_err
+@@ -3433,7 +3433,7 @@ class APIServerAdapter(BasePlatformAdapter):
+         })
+ 
+     async def _handle_create_session(self, request: "web.Request") -> "web.Response":
+-        """POST /api/sessions -- create an empty Hermes session row.
++        """POST /api/sessions -- create an empty Black Pool session row.
+ 
+         The existence check, insert, title handling, and invalid-title
+         rollback run as a single off-loop operation to avoid a TOCTOU
+@@ -4285,7 +4285,7 @@ class APIServerAdapter(BasePlatformAdapter):
+         else:
+             # Derive a stable session ID from the conversation fingerprint so
+             # that consecutive messages from the same Open WebUI (or similar)
+-            # conversation map to the same Hermes session.  The first user
++            # conversation map to the same Black Pool session.  The first user
+             # message + system prompt are constant across all turns.
+             first_user = ""
+             for cm in conversation_messages:
+@@ -6213,7 +6213,7 @@ class APIServerAdapter(BasePlatformAdapter):
+                         "id": f"fc_{uuid.uuid4().hex[:24]}",
+                         "type": "function_call",
+                         # These calls were already executed server-side by the
+-                        # Hermes agent; they are replayed for structured tool
++                        # Black Pool agent; they are replayed for structured tool
+                         # UI only.  Mark them completed (matching the SSE
+                         # streaming path) so OpenAI clients don't interpret
+                         # them as pending calls the client must execute.
 diff --git a/gateway/platforms/base.py b/gateway/platforms/base.py
-index 6bae26a..6e645f3 100644
+index 6bae26a..f14ac25 100644
 --- a/gateway/platforms/base.py
 +++ b/gateway/platforms/base.py
+@@ -44,9 +44,9 @@ def _consume_detached_handler_exception(task: "asyncio.Task") -> None:
+         )
+ 
+ 
+-# Audio file extensions Hermes recognizes for native audio delivery.
++# Audio file extensions Black Pool recognizes for native audio delivery.
+ # Keep Telegram's narrower attachment/voice sets below separate: formats such
+-# as MPEG-2 Layer II are audio to Hermes but unsupported by sendAudio/sendVoice.
++# as MPEG-2 Layer II are audio to Black Pool but unsupported by sendAudio/sendVoice.
+ _AUDIO_MIME_TYPES = {
+     ".ogg": "audio/ogg",
+     ".opus": "audio/opus",
+@@ -96,7 +96,7 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None)
+     """Build platform-aware thread metadata for adapter sends.
+ 
+     Most platforms route threaded sends with a generic ``thread_id`` metadata
+-    value. Telegram private-chat topics created through Hermes' DM-topic helper
++    value. Telegram private-chat topics created through Black Pool' DM-topic helper
+     are exposed in updates as ``message_thread_id`` plus a reply anchor. Live
+     user-message replies route with ``message_thread_id`` + ``reply_to_message_id``;
+     synthetic/resumed sends that have no reply anchor fall back to Telegram's
+@@ -1263,7 +1263,7 @@ _MEDIA_DELIVERY_CACHE_SUBDIRS = (
+ 
+ 
+ def _profile_cache_roots() -> List[Path]:
+-    """Return per-profile canonical cache roots under the shared Hermes root.
++    """Return per-profile canonical cache roots under the shared Black Pool root.
+ 
+     Profile gateways write generated artifacts to
+     ``<root>/profiles/<name>/cache/{images,audio,...}``. The static safe-roots
 @@ -1365,7 +1365,7 @@ def _media_delivery_denied_paths() -> List[Path]:
      home = Path(os.path.expanduser("~"))
      for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
          denied.append(home / sub)
 -    # The active Hermes profile and shared Hermes root both contain control
-+    # The active Black Pool profile and shared Hermes root both contain control
++    # The active Black Pool profile and shared Black Pool root both contain control
      # files and credentials. Only cache subdirectories under them are
      # explicitly allowlisted above (matched BEFORE this denylist in
      # validate_media_delivery_path, so generated media still delivers).
+@@ -1427,7 +1427,7 @@ def _path_under_denied_prefix(resolved: Path) -> bool:
+     denylist so that a non-root gateway can't deliver another user's home, but
+     on a root-run gateway ``$HOME=/root`` and the operator's own deliverables
+     (``/root/work/proposal.docx``) live directly under it. The credential
+-    sub-directories inside home (``~/.ssh``, ``~/.aws``, ...) and Hermes
++    sub-directories inside home (``~/.ssh``, ``~/.aws``, ...) and Black Pool
+     secrets (``~/.hermes/.env``, ``auth.json``) are *separate, more-specific*
+     denied paths, so they stay blocked regardless of this exception — it can
+     only un-block a plain file sitting in the running user's home tree, never a
+@@ -1592,7 +1592,7 @@ def _docker_persistent_home_host_root() -> Optional[Path]:
+ 
+ 
+ def _cache_dir_container_mounts() -> List[Tuple[Path, Path]]:
+-    """(host, container) pairs for the auto-mounted Hermes cache dirs.
++    """(host, container) pairs for the auto-mounted Black Pool cache dirs.
+ 
+     The agent legitimately sees generated artifacts at ``/root/.hermes/...``
+     (``agent_visible_image`` from image_generate, cache-dir reads) and will
+@@ -1617,7 +1617,7 @@ def _translate_docker_container_media_path(candidate: Path) -> Optional[Path]:
+     """Translate a container-absolute path to its host path when possible.
+ 
+     Uses longest-prefix match across configured ``docker_volumes``, the
+-    auto-mounted Hermes cache dirs (``/root/.hermes/...``), the default
++    auto-mounted Black Pool cache dirs (``/root/.hermes/...``), the default
+     persistent Docker ``/workspace`` host root, and the persistent ``/root``
+     home mount.
+     """
+@@ -1746,7 +1746,7 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
+ 
+     # Non-strict mode (default): accept anything not on the denylist.
+     # The denylist still blocks /etc, /proc, ~/.ssh, ~/.aws, and the
+-    # credential/secret stores under the Hermes root (~/.hermes/.env,
++    # credential/secret stores under the Black Pool root (~/.hermes/.env,
+     # auth.json, .anthropic_oauth.json, google_token.json, pairing/, ...) —
+     # so the obvious prompt-injection / credential-exfil sites
+     # (``MEDIA:/etc/passwd``, ``MEDIA:~/.ssh/id_rsa``,
+@@ -2959,7 +2959,7 @@ class BasePlatformAdapter(ABC):
+     splits_long_messages: bool = False
+ 
+     # The command prefix users can always TYPE on this platform to reach
+-    # Hermes commands.  Default "/" (most platforms deliver "/approve" etc.
++    # Black Pool commands.  Default "/" (most platforms deliver "/approve" etc.
+     # as plain message text).  Platforms where typing a leading "/" is
+     # intercepted or restricted by the client (Slack blocks native slash
+     # commands inside threads; Matrix clients reserve "/" for client-local
+@@ -3254,7 +3254,7 @@ class BasePlatformAdapter(ABC):
+         final-editing the preview.
+ 
+         Some adapters can send richer final messages than their current edit
+-        implementation supports. Telegram is the motivating case: Hermes sends
++        implementation supports. Telegram is the motivating case: Black Pool sends
+         final replies through ``sendRichMessage`` but still finalizes streamed
+         previews through its existing MarkdownV2 edit path until Bot API 10.1's
+         ``rich_message`` edit parameter is wired directly. Such adapters
+@@ -4562,7 +4562,7 @@ class BasePlatformAdapter(ABC):
+         Override in subclasses to send audio as voice bubbles (Telegram)
+         or file attachments (Discord). Default falls back to a friendly
+         notice — never echo the local audio_path into chat, since it is a
+-        host filesystem path that would leak the Hermes home layout.
++        host filesystem path that would leak the Black Pool home layout.
+         """
+         # audio_path is intentionally NOT included in the chat text — it is a
+         # host-local path that leaks filesystem layout. The path is logged for
+@@ -4708,7 +4708,7 @@ class BasePlatformAdapter(ABC):
+         Override in subclasses to send videos as inline playable media.
+         Default falls back to a friendly notice — never echo the local
+         video_path into chat, since it is a host filesystem path that
+-        would leak the Hermes home layout.
++        would leak the Black Pool home layout.
+         """
+         # See send_voice for the rationale: do not echo host paths into chat.
+         logger.warning(
+@@ -4736,7 +4736,7 @@ class BasePlatformAdapter(ABC):
+         Override in subclasses to send files as downloadable attachments.
+         Default falls back to a friendly notice — never echo the local
+         file_path into chat, since it is a host filesystem path that
+-        would leak the Hermes home layout.
++        would leak the Black Pool home layout.
+         """
+         # See send_voice for the rationale: do not echo host paths into chat.
+         logger.warning(
+@@ -4809,7 +4809,7 @@ class BasePlatformAdapter(ABC):
+         Override in subclasses for native photo attachments. Default falls
+         back to a friendly notice — never echo the local image_path into
+         chat, since it is a host filesystem path that would leak the
+-        Hermes home layout.
++        Black Pool home layout.
+         """
+         # See send_voice for the rationale: do not echo host paths into chat.
+         logger.warning(
+diff --git a/gateway/platforms/bluebubbles.py b/gateway/platforms/bluebubbles.py
+index ecc6baf..0b50493 100644
+--- a/gateway/platforms/bluebubbles.py
++++ b/gateway/platforms/bluebubbles.py
+@@ -97,7 +97,7 @@ MAX_TEXT_LENGTH = 4000
+ 
+ # BlueBubbles/iMessage does not expose a stable bot mention identity like
+ # Slack (<@U...>), Telegram (@botname), or Matrix (MXID). When users opt into
+-# group mention gating without custom aliases, use conservative Hermes wake
++# group mention gating without custom aliases, use conservative Black Pool wake
+ # words so `require_mention: true` is a one-line enablement path.
+ DEFAULT_MENTION_PATTERNS = [
+     r"(?<![\w@])@?hermes\s+agent\b[,:\-]?",
+@@ -216,7 +216,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
+         """Compile group-mention wake words from config/env.
+ 
+         ``raw`` is a list (from config or env JSON), a string (raw env var:
+-        JSON list, or comma/newline-separated), or None (use Hermes defaults).
++        JSON list, or comma/newline-separated), or None (use Black Pool defaults).
+         """
+         return compile_mention_patterns(
+             raw,
+diff --git a/gateway/platforms/qqbot/adapter.py b/gateway/platforms/qqbot/adapter.py
+index d540692..9efcfd3 100644
+--- a/gateway/platforms/qqbot/adapter.py
++++ b/gateway/platforms/qqbot/adapter.py
+@@ -492,7 +492,7 @@ class QQAdapter(BasePlatformAdapter):
+             await self._session.close()
+         self._session = None
+ 
+-        # Honor WSL proxy env for QQ WebSocket. Hermes upgrades overwrite this
++        # Honor WSL proxy env for QQ WebSocket. Black Pool upgrades overwrite this
+         # local patch, so QQ can regress to direct-connect timeouts after update.
+         self._session = aiohttp.ClientSession(trust_env=True)
+         ws_proxy = (
+diff --git a/gateway/platforms/signal.py b/gateway/platforms/signal.py
+index 2282193..821c486 100644
+--- a/gateway/platforms/signal.py
++++ b/gateway/platforms/signal.py
+@@ -696,7 +696,7 @@ class SignalAdapter(BasePlatformAdapter):
+         # Catches profile key updates, empty messages, and other metadata-only
+         # envelopes that still carry a dataMessage wrapper but have nothing
+         # worth processing. See issue: signal-cli logs "Profile key update" +
+-        # Hermes receives msg='' triggering a full agent turn for nothing.
++        # Black Pool receives msg='' triggering a full agent turn for nothing.
+         if (not text or not text.strip()) and not media_urls:
+             logger.debug(
+                 "Signal: skipping contentless envelope from %s (%d attachments)",
 diff --git a/gateway/platforms/weixin.py b/gateway/platforms/weixin.py
-index 3455c99..51961fc 100644
+index 3455c99..655da52 100644
 --- a/gateway/platforms/weixin.py
 +++ b/gateway/platforms/weixin.py
 @@ -1,7 +1,7 @@
@@ -47282,6 +48285,49 @@ index 3455c99..51961fc 100644
  
  Design notes:
  - Long-poll ``getupdates`` drives inbound delivery.
+@@ -1170,7 +1170,7 @@ async def qr_login(
+ 
+ 
+ class WeixinAdapter(BasePlatformAdapter):
+-    """Native Hermes adapter for Weixin personal accounts."""
++    """Native Black Pool adapter for Weixin personal accounts."""
+ 
+     supports_code_blocks = True  # Weixin renders fenced code blocks
+     splits_long_messages = True  # send() chunks via _split_text()
+@@ -1335,9 +1335,9 @@ class WeixinAdapter(BasePlatformAdapter):
+                 "[%s] WEIXIN_GROUP_POLICY=%s is set, but QR-login connects an iLink bot "
+                 "identity (e.g. ...@im.bot) which typically cannot be invited into ordinary "
+                 "WeChat groups. iLink usually does not deliver ordinary-group events for "
+-                "these accounts, so group messages may never reach Hermes regardless of this "
++                "these accounts, so group messages may never reach Black Pool regardless of this "
+                 "policy. If group delivery doesn't work, the limitation is on the iLink side, "
+-                "not in Hermes.",
++                "not in Black Pool.",
+                 self.name,
+                 self._group_policy,
+             )
+diff --git a/gateway/platforms/whatsapp_cloud.py b/gateway/platforms/whatsapp_cloud.py
+index baec4a5..7cd397b 100644
+--- a/gateway/platforms/whatsapp_cloud.py
++++ b/gateway/platforms/whatsapp_cloud.py
+@@ -1203,7 +1203,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
+ 
+         WhatsApp renders ``audio/ogg; codecs=opus`` as the green
+         voice-note bubble; other audio types (MP3, AAC, etc.) appear as
+-        a generic audio attachment. Hermes TTS produces MP3, so we try
++        a generic audio attachment. Black Pool TTS produces MP3, so we try
+         ffmpeg conversion to opus first and fall back to sending the
+         MP3 as-is when ffmpeg is unavailable.
+         """
+@@ -1890,7 +1890,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
+         contacts_by_waid: Dict[str, str],
+         metadata: Dict[str, Any],
+     ) -> Optional[MessageEvent]:
+-        """Convert a Cloud-API message object into a Hermes MessageEvent.
++        """Convert a Cloud-API message object into a Black Pool MessageEvent.
+ 
+         Phase 4 expands beyond text to download inbound media (image,
+         video, audio/voice, document, sticker) by ``media_id`` via the
 diff --git a/gateway/platforms/whatsapp_common.py b/gateway/platforms/whatsapp_common.py
 index 09e7b0b..2bca3e7 100644
 --- a/gateway/platforms/whatsapp_common.py
@@ -47295,10 +48341,28 @@ index 09e7b0b..2bca3e7 100644
  
      _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[\u200b\u2060\u2063\ufeff]")
      _OUTBOUND_ODD_SPACE_RE = re.compile(r"[\u00a0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]")
+diff --git a/gateway/profile_routing.py b/gateway/profile_routing.py
+index 5d2b3b6..5e0d855 100644
+--- a/gateway/profile_routing.py
++++ b/gateway/profile_routing.py
+@@ -1,6 +1,6 @@
+ """Profile-based routing for the gateway with hierarchical matching.
+ 
+-Allows a single Hermes instance to route specific Discord guilds/channels/threads
++Allows a single Black Pool instance to route specific Discord guilds/channels/threads
+ to different profiles — each with their own model, tools, memory, and persona.
+ 
+ Matching priority (most specific first):
 diff --git a/gateway/relay/__init__.py b/gateway/relay/__init__.py
-index 959c9b4..abc51ec 100644
+index 959c9b4..c92840f 100644
 --- a/gateway/relay/__init__.py
 +++ b/gateway/relay/__init__.py
+@@ -1,4 +1,4 @@
+-"""Relay/connector support package for the Hermes gateway.
++"""Relay/connector support package for the Black Pool gateway.
+ 
+ EXPERIMENTAL. This package implements the gateway side of the "Gateway Gateway"
+ relay design: a generic ``RelayAdapter`` plus the wire-serializable
 @@ -311,10 +311,10 @@ def relay_display_name() -> Optional[str]:
          except Exception:  # noqa: BLE001 - branding absence must never crash boot
              value = ""
@@ -47312,23 +48376,561 @@ index 959c9b4..abc51ec 100644
              value = ""
      # Mirror the connector's ingest sanitization (trim + 64-char cap) so what
      # we send is what gets stored.
+diff --git a/gateway/relay/adapter.py b/gateway/relay/adapter.py
+index d579c24..085c9b0 100644
+--- a/gateway/relay/adapter.py
++++ b/gateway/relay/adapter.py
+@@ -696,7 +696,7 @@ class RelayAdapter(BasePlatformAdapter):
+         chat_id: str,
+         tasks: list,
+         *,
+-        title: str = "Hermes is working",
++        title: str = "Black Pool is working",
+         reply_to: Optional[str] = None,
+         metadata: Optional[Dict[str, Any]] = None,
+         fallback_text: Optional[str] = None,
+@@ -1384,7 +1384,7 @@ class RelayAdapter(BasePlatformAdapter):
+                 event = self._discord_interaction_to_event(forward)
+                 if event is not None:
+                     self._capture_scope(event)
+-                    # Phase 3: a component press carrying a Hermes prompt token
++                    # Phase 3: a component press carrying a Black Pool prompt token
+                     # resolves its waiting primitive and is consumed (same
+                     # gate as _on_inbound's prompt_response arm).
+                     if await self._consume_prompt_response(event):
+@@ -1499,7 +1499,7 @@ class RelayAdapter(BasePlatformAdapter):
+         )
+         event = MessageEvent(text=text, message_type=message_type, source=source)
+         if itype == 3:
+-            # Phase 3: a component press whose custom_id is a Hermes prompt
++            # Phase 3: a component press whose custom_id is a Black Pool prompt
+             # token (hp1:<prompt_id>:<option_id>) becomes a STRUCTURED prompt
+             # answer — _on_inbound's _consume_prompt_response then resolves
+             # the waiting approval/confirm/clarify, replacing the bare-
+@@ -1529,7 +1529,7 @@ class RelayAdapter(BasePlatformAdapter):
+ 
+         Mirrors the connector's promptCodec.decodePromptCallback (the token
+         alphabet is [A-Za-z0-9_.-], ≤32 per id) so both ends agree on what is
+-        — and is not — a Hermes prompt answer.
++        — and is not — a Black Pool prompt answer.
+         """
+         import re
+ 
+@@ -2011,7 +2011,7 @@ class RelayAdapter(BasePlatformAdapter):
+         thread (the reported symptom: DM/home replies arrive flat, no
+         progressive edits).
+ 
+-        Native Slack Hermes already suppresses this synthetic DM thread anchor:
++        Native Slack Black Pool already suppresses this synthetic DM thread anchor:
+         ``SlackAdapter._resolve_thread_ts`` returns ``None`` for a top-level /
+         DM message when ``reply_in_thread`` is off. The relay lane has no such
+         disambiguation, so we reproduce it here. run.py already encodes the
+@@ -2677,7 +2677,7 @@ class RelayAdapter(BasePlatformAdapter):
+         # used only as a session-keying fallback). Forwarding it makes the
+         # connector thread the prompt card UNDER the triggering message instead
+         # of posting it flat at the DM root (the reported bug). Native Slack
+-        # Hermes suppresses this synthetic DM thread anchor; drop it here for the
++        # Black Pool suppresses this synthetic DM thread anchor; drop it here for the
+         # same Slack-DM-with-no-real-thread case, matching _resolve_reply_to_for_send.
+         # Prompt metadata is forwarded VERBATIM. The threading mode is decided
+         # in exactly one place — run.py's _resolve_progress_thread_id (flat mode
 diff --git a/gateway/relay/command_manifest.py b/gateway/relay/command_manifest.py
-index 36d7a8f..906eca2 100644
+index 36d7a8f..b473a37 100644
 --- a/gateway/relay/command_manifest.py
 +++ b/gateway/relay/command_manifest.py
-@@ -113,7 +113,7 @@ def build_relay_command_manifest() -> List[Dict[str, Any]]:
+@@ -49,7 +49,7 @@ def build_relay_command_manifest() -> List[Dict[str, Any]]:
+     """The relay lane's Discord slash-command manifest (native-tree mirror)."""
+     return [
+         {"name": "new", "description": "Start a new conversation"},
+-        {"name": "reset", "description": "Reset your Hermes session"},
++        {"name": "reset", "description": "Reset your Black Pool session"},
+         {
+             "name": "model",
+             "description": "Show or change the model",
+@@ -85,9 +85,9 @@ def build_relay_command_manifest() -> List[Dict[str, Any]]:
+         },
+         {"name": "retry", "description": "Retry your last message"},
+         {"name": "undo", "description": "Remove the last exchange"},
+-        {"name": "status", "description": "Show Hermes session status"},
++        {"name": "status", "description": "Show Black Pool session status"},
+         {"name": "sethome", "description": "Set this chat as the home channel"},
+-        {"name": "stop", "description": "Stop the running Hermes agent"},
++        {"name": "stop", "description": "Stop the running Black Pool agent"},
+         {
+             "name": "steer",
+             "description": "Inject a message after the next tool call (no interrupt)",
+@@ -113,8 +113,8 @@ def build_relay_command_manifest() -> List[Dict[str, Any]]:
              "description": "Re-scan skills for new or removed entries",
          },
          {"name": "voice", "description": "Toggle voice reply mode"},
 -        {"name": "update", "description": "Update Hermes Agent to the latest version"},
+-        {"name": "restart", "description": "Gracefully restart the Hermes gateway"},
 +        {"name": "update", "description": "Update Black Pool Agent to the latest version"},
-         {"name": "restart", "description": "Gracefully restart the Hermes gateway"},
++        {"name": "restart", "description": "Gracefully restart the Black Pool gateway"},
          {
              "name": "approve",
+             "description": "Approve a pending dangerous command",
+@@ -129,7 +129,7 @@ def build_relay_command_manifest() -> List[Dict[str, Any]]:
+         },
+         {
+             "name": "thread",
+-            "description": "Create a new thread and start a Hermes session in it",
++            "description": "Create a new thread and start a Black Pool session in it",
+             "options": [_opt("name", "Thread name")],
+         },
+         {
+diff --git a/gateway/relay/ws_transport.py b/gateway/relay/ws_transport.py
+index 3f58069..9c5e168 100644
+--- a/gateway/relay/ws_transport.py
++++ b/gateway/relay/ws_transport.py
+@@ -286,7 +286,7 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
+     text = raw.get("text", "")
+     if platform_enum == Platform.SLACK:
+         # Team Gateway carries Slack slash text over the authenticated message
+-        # relay, bypassing Hermes' native Slack command callback. Normalize at
++        # relay, bypassing Black Pool' native Slack command callback. Normalize at
+         # the wire boundary so adapter-level active-session gates see the real
+         # gateway command rather than the legacy `hermes` parent name.
+         text, msg_type = _normalize_slack_parent_command(text, msg_type)
+diff --git a/gateway/run.py b/gateway/run.py
+index 84604b3..16e554e 100644
+--- a/gateway/run.py
++++ b/gateway/run.py
+@@ -459,7 +459,7 @@ _GATEWAY_SECRET_PATTERNS = (
+ 
+ 
+ def _ensure_windows_gateway_venv_imports() -> None:
+-    """Make detached Windows gateway runs see the Hermes venv packages.
++    """Make detached Windows gateway runs see the Black Pool venv packages.
+ 
+     Some Windows restart paths run the gateway under uv's base ``pythonw.exe``
+     to avoid the venv launcher respawning a visible console interpreter.  That
+@@ -1131,7 +1131,7 @@ def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
+     if isinstance(value, bool):  # bool is a subclass of int — skip it
+         return None
+     if isinstance(value, (int, float)):
+-        # Some platform events use milliseconds; Hermes state rows use seconds.
++        # Some platform events use milliseconds; Black Pool state rows use seconds.
+         return float(value) / 1000.0 if float(value) > 10_000_000_000 else float(value)
+     if isinstance(value, str):
+         text = value.strip()
+@@ -2068,7 +2068,7 @@ _ensure_ssl_certs()
+ # Add parent directory to path
+ sys.path.insert(0, str(Path(__file__).parent.parent))
+ 
+-# Resolve Hermes home directory (respects HERMES_HOME override)
++# Resolve Black Pool home directory (respects HERMES_HOME override)
+ from hermes_constants import get_hermes_home, get_hermes_home_override
+ from utils import atomic_json_write, base_url_hostname, is_truthy_value
+ _hermes_home = get_hermes_home()
+@@ -2399,7 +2399,7 @@ if _config_path.exists():
+                     # never receives a literal "~/" which the kernel rejects.
+                     # SSH cwd is interpreted by the remote shell, so preserve
+                     # "~" / "~/..." for the SSH backend instead of expanding it
+-                    # to the Hermes host/container HOME (often /opt/data). Shared
++                    # to the Black Pool host/container HOME (often /opt/data). Shared
+                     # predicate with terminal_tool so the two sites can't drift.
+                     if _cfg_key == "cwd" and isinstance(_val, str):
+                         if not _is_ssh_remote_tilde_cwd(_terminal_backend, _val.strip()):
+@@ -3638,7 +3638,7 @@ def _teams_pipeline_plugin_enabled() -> bool:
+ 
+ 
+ def _gateway_config_home() -> Path:
+-    """Return the Hermes home that gateway config reads should use."""
++    """Return the Black Pool home that gateway config reads should use."""
+     override = get_hermes_home_override()
+     if override:
+         return Path(override)
+@@ -3828,11 +3828,11 @@ def _get_channel_override(
+ 
+ 
+ def _resolve_hermes_bin() -> Optional[list[str]]:
+-    """Resolve the Hermes update command as argv parts.
++    """Resolve the Black Pool update command as argv parts.
+ 
+     Tries in order:
+     1. ``shutil.which("hermes")`` — standard PATH lookup
+-    2. ``sys.executable -m hermes_cli.main`` — fallback when Hermes is running
++    2. ``sys.executable -m hermes_cli.main`` — fallback when Black Pool is running
+        from a venv/module invocation and the ``hermes`` shim is not on PATH
+ 
+     Returns argv parts ready for quoting/joining, or ``None`` if neither works.
+@@ -4609,7 +4609,7 @@ class TurnRunner:
+                 f"- {task['title']} - {labels.get(task['status'], task['status'])}"
+                 for task in _visible_tasks()
+             ]
+-            return "Hermes is working\n" + "\n".join(lines)
++            return "Black Pool is working\n" + "\n".join(lines)
+ 
+         def _apply_native_event(raw: Any) -> bool:
+             nonlocal anonymous_seq
+@@ -4686,7 +4686,7 @@ class TurnRunner:
+                 result = await adapter.send_native_task_card_progress(
+                     chat_id=ctx.source.chat_id,
+                     tasks=_visible_tasks(),
+-                    title="Hermes is working",
++                    title="Black Pool is working",
+                     reply_to=ctx._progress_reply_to,
+                     metadata=ctx._progress_metadata,
+                     fallback_text=_fallback_text(),
+@@ -5938,7 +5938,7 @@ class TurnRunner:
+         # Memory update notifications in chat.  Config: display.memory_notifications
+         #   off     — no chat notification (still logged to stdout)
+         #   on      — generic "💾 Memory updated" (default)
+-        #   verbose — content preview: "💾 Memory ➕ Hermes Repo..."
++        #   verbose — content preview: "💾 Memory ➕ Black Pool Repo..."
+         _mem_notif = ctx.user_config.get("display", {}).get("memory_notifications")
+         if isinstance(_mem_notif, bool):
+             _mem_notif = "on" if _mem_notif else "off"
+@@ -7869,18 +7869,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+     def _telegram_topic_root_lobby_message(self) -> str:
+         return (
+             "This main chat is reserved for system commands.\n\n"
+-            "To start a new Hermes chat, open the All Messages topic at the top "
++            "To start a new Black Pool chat, open the All Messages topic at the top "
+             "of this bot interface and send any message there. Telegram will "
+             "create a new topic for that message; each topic works as an "
+-            "independent Hermes session."
++            "independent Black Pool session."
+         )
+ 
+     def _telegram_topic_root_new_message(self) -> str:
+         return (
+-            "To start a new parallel Hermes chat, open the All Messages topic "
++            "To start a new parallel Black Pool chat, open the All Messages topic "
+             "at the top of this bot interface and send any message there. "
+             "Telegram will create a new topic for it.\n\n"
+-            "Each topic is an independent Hermes session. Use /new inside an "
++            "Each topic is an independent Black Pool session. Use /new inside an "
+             "existing topic only if you want to replace that topic's current session."
+         )
+ 
+@@ -7888,7 +7888,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         if not self._is_telegram_topic_lane(source):
+             return None
+         return (
+-            "Started a new Hermes session in this topic.\n\n"
++            "Started a new Black Pool session in this topic.\n\n"
+             "Tip: for parallel work, open All Messages and send a message there "
+             "to create a separate topic instead of using /new here. /new replaces "
+             "the session attached to the current topic."
+@@ -7899,7 +7899,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         source: SessionSource,
+         session_entry,
+     ) -> None:
+-        """Persist the Telegram topic -> Hermes session binding for topic lanes."""
++        """Persist the Telegram topic -> Black Pool session binding for topic lanes."""
+         session_db = getattr(self, "_session_db", None)
+         if session_db is None or not source.chat_id or not source.thread_id:
+             return
+@@ -7923,7 +7923,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         """Update the topic binding to point at ``session_entry.session_id``.
+ 
+         Telegram topic lanes persist a (chat_id, thread_id) -> session_id row
+-        so reopening a topic in a fresh process resumes the right Hermes
++        so reopening a topic in a fresh process resumes the right Black Pool
+         session. When compression rotates ``session_entry.session_id`` mid-turn,
+         the binding goes stale and the next inbound message in that topic
+         reloads the oversized parent transcript instead of the compressed
+@@ -10899,7 +10899,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         # Suppress ONLY the home-channel broadcast when the drain that is ending
+         # in this shutdown asked us to be quiet (e.g. a NAS auto-update image
+         # migration — drain-gated, then the machine is recreated). On the
+-        # always-on Hermes Cloud fleet that broadcast would otherwise fire on
++        # always-on Black Pool Cloud fleet that broadcast would otherwise fire on
+         # every routine auto-update, spamming home channels with operator-
+         # flavoured "gateway shutting down" pings the user doesn't care about.
+         # The per-active-session interrupt pings above are deliberately NOT
+@@ -11491,7 +11491,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+                 *cmd_argv,
+             ]
+             # The watcher process must itself break away from any job object the
+-            # parent CLI lives in (Electron/Tauri-wrapped Hermes Desktop, Windows
++            # parent CLI lives in (Electron/Tauri-wrapped Black Pool Desktop, Windows
+             # Terminal, schtasks shells); otherwise it is reaped when the CLI
+             # exits and the gateway never respawns.  windows_detach_popen_kwargs()
+             # carries CREATE_BREAKAWAY_FROM_JOB, but a restrictive job object
+@@ -12392,7 +12392,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         
+         Returns True if at least one adapter connected successfully.
+         """
+-        logger.info("Starting Hermes Gateway...")
++        logger.info("Starting Black Pool Gateway...")
+         # Enable faulthandler for stack dumps on freezes/crashes (#70344).
+         # Falls back to a log file when sys.stderr is None (Windows VBS /
+         # pythonw / detached service) — otherwise the gateway would die
+@@ -12728,7 +12728,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         # Recover sessions that were active when the gateway last exited.
+         # Exact durable turn markers cover long-running work; the 120-second
+         # recency heuristic remains as an upgrade fallback for turns started by
+-        # older Hermes versions that did not write exact markers.
++        # older Black Pool versions that did not write exact markers.
+         #
+         # SKIP suspension after a clean (graceful) shutdown — the previous
+         # process already drained active agents, so sessions aren't stuck.
+@@ -13569,7 +13569,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         # (no permission, topics-mode off, parent is a DM, etc.). When
+         # None we fall through to using the home channel directly — the
+         # synthetic turn still lands; just without thread isolation.
+-        thread_name = f"Hermes — {cli_title}"
++        thread_name = f"Black Pool — {cli_title}"
+         try:
+             new_thread_id = await adapter.create_handoff_thread(
+                 str(home.chat_id), thread_name,
+@@ -14496,7 +14496,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         if not watchdog.start():
+             return False
+         self._systemd_watchdog = watchdog
+-        watchdog.ready("Hermes Gateway running")
++        watchdog.ready("Black Pool Gateway running")
+         return True
+ 
+     async def _stop_systemd_watchdog(self) -> None:
+@@ -16277,13 +16277,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         if args.lower() in {"off", "resume", "stop", "disengage"}:
+             if estop.disengage():
+                 return "▶️ Resumed — new work is accepted again."
+-            return "Hermes wasn't paused."
++            return "Black Pool wasn't paused."
+         state = estop.get_state()
+         if state is not None and not args:
+             reason = state.get("reason")
+             suffix = f" (reason: {reason})" if reason else ""
+             return (
+-                f"⏸️ Hermes is already paused{suffix}. "
++                f"⏸️ Black Pool is already paused{suffix}. "
+                 "Use `/pause off` to resume."
+             )
+         estop.engage(reason=args or None)
+@@ -20034,7 +20034,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+                 except Exception:
+                     pass
+             if not home_env:
+-                # Slack dispatches all Hermes commands through a single
++                # Slack dispatches all Black Pool commands through a single
+                 # parent slash command `/hermes`; bare `/sethome` is not
+                 # registered and would fail with "app did not respond".
+                 sethome_cmd = (
+@@ -20044,7 +20044,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+                 )
+                 notice = (
+                     f"📬 No home channel is set for {platform_name.title()}. "
+-                    f"A home channel is where Hermes delivers cron job results "
++                    f"A home channel is where Black Pool delivers cron job results "
+                     f"and cross-platform messages.\n\n"
+                     f"Type {sethome_cmd} to make this chat your home channel, "
+                     f"or ignore to skip."
+@@ -22692,7 +22692,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         try:
+             send_result = await adapter.send(
+                 source.chat_id,
+-                "System topic for Hermes commands and status.",
++                "System topic for Black Pool commands and status.",
+                 metadata={"thread_id": str(thread_id)},
+             )
+             message_id = getattr(send_result, "message_id", None)
+@@ -22735,7 +22735,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         """Return a Bot API-safe forum topic name from a generated session title."""
+         cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
+         if not cleaned:
+-            return "Hermes Chat"
++            return "Black Pool Chat"
+         # Telegram forum topic names are short (currently 1-128 chars). Keep
+         # extra room for multi-byte titles and avoid trailing ellipsis churn.
+         if len(cleaned) > 120:
+@@ -22743,7 +22743,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         return cleaned
+ 
+     def _is_discord_auto_thread_lane(self, source: SessionSource) -> bool:
+-        """Return True only for Discord threads Hermes just auto-created."""
++        """Return True only for Discord threads Black Pool just auto-created."""
+         return (
+             source.platform == Platform.DISCORD
+             and source.chat_type == "thread"
+@@ -22850,7 +22850,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         """
+         cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
+         if not cleaned:
+-            return "Hermes Chat"
++            return "Black Pool Chat"
+         if utf16_len(cleaned) > 80:
+             cleaned = _prefix_within_utf16_limit(cleaned, 77).rstrip() + "..."
+         return cleaned
+@@ -23000,7 +23000,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         session_id: str,
+         title: str,
+     ) -> None:
+-        """Best-effort rename of a Telegram DM topic when Hermes auto-titles a session."""
++        """Best-effort rename of a Telegram DM topic when Black Pool auto-titles a session."""
+         if not await asyncio.to_thread(self._is_telegram_topic_lane, source) or not source.chat_id or not source.thread_id:
+             return
+ 
+@@ -23171,11 +23171,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+             "  /topic <id>        Inside a topic: restore a previous session by ID\n"
+             "\n"
+             "How it works:\n"
+-            "1. Run /topic once in this DM — Hermes checks BotFather Threads\n"
++            "1. Run /topic once in this DM — Black Pool checks BotFather Threads\n"
+             "   Settings are enabled and flips on multi-session mode.\n"
+             "2. Tap All Messages at the top of the bot and send any message.\n"
+             "   Telegram creates a new topic for that message; each topic is\n"
+-            "   an independent Hermes session (fresh history, fresh context).\n"
++            "   an independent Black Pool session (fresh history, fresh context).\n"
+             "3. The root DM becomes a system lobby — send /topic, /status,\n"
+             "   /help, /usage there. Normal prompts go in a topic.\n"
+             "4. /new inside a topic resets just that topic's session.\n"
+@@ -23215,7 +23215,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+             "Multi-session topic mode is now OFF for this chat.\n\n"
+             "Existing topics in Telegram aren't removed — they'll just stop "
+             "being gated as independent sessions. The root DM works as a "
+-            "normal Hermes chat again. Run /topic to re-enable later."
++            "normal Black Pool chat again. Run /topic to re-enable later."
+         )
+ 
+ 
+@@ -23223,7 +23223,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         lines = [
+             "Telegram multi-session topics are enabled.",
+             "",
+-            "To create a new Hermes chat, open All Messages at the top of this "
++            "To create a new Black Pool chat, open All Messages at the top of this "
+             "bot interface and send any message there. Telegram will create a "
+             "new topic for it.",
+             "",
+@@ -23266,7 +23266,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         return "\n".join(lines)
+ 
+     async def _restore_telegram_topic_session(self, event: MessageEvent, raw_session_id: str) -> str:
+-        """Restore an existing Telegram-owned Hermes session into this topic."""
++        """Restore an existing Telegram-owned Black Pool session into this topic."""
+         source = event.source
+         session_id = await self._session_db.resolve_session_id(raw_session_id.strip())
+         if not session_id:
+@@ -23316,7 +23316,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+ 
+         response = f"Session restored: {title}"
+         if last_assistant:
+-            response += f"\n\nLast Hermes message:\n{last_assistant}"
++            response += f"\n\nLast Black Pool message:\n{last_assistant}"
+         return response
+ 
+ 
+@@ -23927,13 +23927,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+                     if exit_code == 0:
+                         await adapter.send(
+                             chat_id,
+-                            "✅ Hermes update finished.",
++                            "✅ Black Pool update finished.",
+                             metadata=_non_conversational_metadata(metadata, platform=platform),
+                         )
+                     else:
+                         await adapter.send(
+                             chat_id,
+-                            "❌ Hermes update failed (exit code {}).".format(exit_code),
++                            "❌ Black Pool update failed (exit code {}).".format(exit_code),
+                             metadata=_non_conversational_metadata(metadata, platform=platform),
+                         )
+                     logger.info("Update finished (exit=%s), notified %s", exit_code, session_key)
+@@ -24031,7 +24031,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+             try:
+                 await adapter.send(
+                     chat_id,
+-                    "❌ Hermes update timed out after 30 minutes.",
++                    "❌ Black Pool update timed out after 30 minutes.",
+                     metadata=_non_conversational_metadata(metadata, platform=platform),
+                 )
+             except Exception:
+@@ -24134,13 +24134,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+                     if len(output) > 3500:
+                         output = "…" + output[-3500:]
+                     if exit_code == 0:
+-                        msg = f"✅ Hermes update finished.\n\n```\n{output}\n```"
++                        msg = f"✅ Black Pool update finished.\n\n```\n{output}\n```"
+                     else:
+-                        msg = f"❌ Hermes update failed.\n\n```\n{output}\n```"
++                        msg = f"❌ Black Pool update failed.\n\n```\n{output}\n```"
+                 elif exit_code == 0:
+-                    msg = "✅ Hermes update finished successfully."
++                    msg = "✅ Black Pool update finished successfully."
+                 else:
+-                    msg = "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
++                    msg = "❌ Black Pool update failed. Check the gateway logs or run `hermes update` manually for details."
+                 await adapter.send(
+                     chat_id,
+                     msg,
+@@ -24255,7 +24255,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         """
+         delivered: set[tuple[str, str, Optional[str]]] = set()
+         skipped = skip_targets or set()
+-        message = "♻️ Gateway online — Hermes is back and ready."
++        message = "♻️ Gateway online — Black Pool is back and ready."
+ 
+         for platform, platform_cfg in self.config.platforms.items():
+             home = platform_cfg.home_channel
+@@ -27492,7 +27492,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         return len(to_evict)
+ 
+     # ------------------------------------------------------------------
+-    # Proxy mode: forward messages to a remote Hermes API server
++    # Proxy mode: forward messages to a remote Black Pool API server
+     # ------------------------------------------------------------------
+ 
+     def _get_proxy_url(self) -> Optional[str]:
+@@ -27591,7 +27591,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
+         run_generation: Optional[int] = None,
+         event_message_id: Optional[str] = None,
+     ) -> Dict[str, Any]:
+-        """Forward the message to a remote Hermes API server instead of
++        """Forward the message to a remote Black Pool API server instead of
+         running a local AIAgent.
+ 
+         When ``GATEWAY_PROXY_URL`` (or ``gateway.proxy_url`` in config.yaml)
+@@ -30971,7 +30971,7 @@ def main():
+ 
+     import argparse
+     
+-    parser = argparse.ArgumentParser(description="Hermes Gateway - Multi-platform messaging")
++    parser = argparse.ArgumentParser(description="Black Pool Gateway - Multi-platform messaging")
+     parser.add_argument("--config", "-c", help="Path to gateway config file")
+     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+     
+diff --git a/gateway/session.py b/gateway/session.py
+index 3ba5b10..bec1f65 100644
+--- a/gateway/session.py
++++ b/gateway/session.py
+@@ -1037,7 +1037,7 @@ def build_channel_continuity_note(
+ 
+     where = "thread" if source.thread_id else "channel"
+     return (
+-        f"[System note: This {where} had an earlier Hermes session "
++        f"[System note: This {where} had an earlier Black Pool session "
+         f"(session_id: {prev}) that was auto-reset. If the user refers to "
+         f"earlier work here, or the request depends on this {where}'s history, "
+         f"use the session_search tool to recall that prior session before "
+diff --git a/gateway/session_context.py b/gateway/session_context.py
+index 7a2c53a..638275e 100644
+--- a/gateway/session_context.py
++++ b/gateway/session_context.py
+@@ -1,5 +1,5 @@
+ """
+-Session-scoped context variables for the Hermes gateway.
++Session-scoped context variables for the Black Pool gateway.
+ 
+ Replaces the previous ``os.environ``-based session state
+ (``HERMES_SESSION_PLATFORM``, ``HERMES_SESSION_CHAT_ID``, etc.) with
 diff --git a/gateway/slash_commands.py b/gateway/slash_commands.py
-index cd54164..9459da1 100644
+index cd54164..b38603c 100644
 --- a/gateway/slash_commands.py
 +++ b/gateway/slash_commands.py
+@@ -129,7 +129,7 @@ class GatewaySlashCommandsMixin:
+     async_session_store: AsyncSessionStore
+ 
+     def _typed_command_prefix_for(self, platform) -> str:
+-        """Return the prefix users can always type to reach Hermes commands.
++        """Return the prefix users can always type to reach Black Pool commands.
+ 
+         Reads the adapter's ``typed_command_prefix`` capability flag
+         (default "/"). Slack and Matrix return "!" because typed "/"
 @@ -1712,7 +1712,7 @@ class GatewaySlashCommandsMixin:
          return EphemeralReply(t("gateway.restart.restarting"))
  
@@ -47338,6 +48940,24 @@ index cd54164..9459da1 100644
          from hermes_cli.slash_exec import CommandContext, execute_command
  
          return execute_command("version", CommandContext(surface="gateway")).text
+@@ -2532,7 +2532,7 @@ class GatewaySlashCommandsMixin:
+ 
+         Same surface as the CLI handler in cli.py:
+             /codex-runtime                  — show current state
+-            /codex-runtime auto             — Hermes default runtime
++            /codex-runtime auto             — Black Pool default runtime
+             /codex-runtime codex_app_server — codex subprocess runtime
+             /codex-runtime on / off         — synonyms
+ 
+@@ -3395,7 +3395,7 @@ class GatewaySlashCommandsMixin:
+         ``/diff`` (default) shows unstaged + untracked changes, ``/diff
+         staged`` the staged ones, ``/diff all`` everything since HEAD, and
+         ``/diff session`` the cumulative checkpoint-baseline diff of what
+-        Hermes itself changed. ``--stat`` limits output to the summary.
++        Black Pool itself changed. ``--stat`` limits output to the summary.
+ 
+         The diff body is truncated hard here (messaging surfaces are not a
+         pager); platform senders additionally split/clamp long messages to
 @@ -5868,7 +5868,7 @@ class GatewaySlashCommandsMixin:
          return await loop.run_in_executor(None, _collect_and_upload)
  
@@ -47356,14 +48976,125 @@ index cd54164..9459da1 100644
  
          project_root = Path(__file__).parent.parent.resolve()
          git_dir = project_root / '.git'
+diff --git a/gateway/status.py b/gateway/status.py
+index 1fbbe10..8248965 100644
+--- a/gateway/status.py
++++ b/gateway/status.py
+@@ -246,7 +246,7 @@ def _utc_now_iso() -> str:
+     return datetime.now(timezone.utc).isoformat()
+ 
+ 
+-# Reject epoch values before 2000-01-01T00:00:00Z: nothing in Hermes' lifetime
++# Reject epoch values before 2000-01-01T00:00:00Z: nothing in Black Pool' lifetime
+ # legitimately produced a gateway heartbeat last century, so anything older is
+ # a corrupt or hand-edited state file (e.g. an accidental 0 / tiny int).
+ _EPOCH_MIN_PLAUSIBLE = 946684800.0  # 2000-01-01T00:00:00Z
+@@ -426,7 +426,7 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
+ 
+ 
+ def _gateway_command_subcommand(command: str | None) -> str | None:
+-    """Return the Hermes gateway lifecycle subcommand from a command line.
++    """Return the Black Pool gateway lifecycle subcommand from a command line.
+ 
+     Lifecycle decisions (is the gateway up? did restart relaunch it?) must not
+     fire on loose substring matches.  The previous ``"... gateway" in cmdline``
+@@ -440,7 +440,7 @@ def _gateway_command_subcommand(command: str | None) -> str | None:
+ 
+     Tokenizes quote-aware (``shlex``) so quoted Windows paths with spaces
+     (``"C:\\Program Files\\...\\hermes-gateway.exe"``) survive, and strips
+-    ``--profile``/``-p`` selectors from anywhere in argv -- Hermes's
++    ``--profile``/``-p`` selectors from anywhere in argv -- Black Pool's
+     ``_apply_profile_override`` removes them before argparse, so the profile
+     flag (and a profile literally named ``gateway``) can legally appear on
+     either side of the ``gateway`` subcommand.
+@@ -519,7 +519,7 @@ def looks_like_gateway_runtime_command_line(command: str | None) -> bool:
+ 
+ 
+ def _looks_like_gateway_process(pid: int) -> bool:
+-    """Return True when the live PID still looks like the Hermes gateway."""
++    """Return True when the live PID still looks like the Black Pool gateway."""
+     cmdline = _read_process_cmdline(pid)
+     if not cmdline:
+         return False
+diff --git a/gateway/status_phrases.py b/gateway/status_phrases.py
+index b7c4902..6fb22bb 100644
+--- a/gateway/status_phrases.py
++++ b/gateway/status_phrases.py
+@@ -1,7 +1,7 @@
+ """Human-friendly generic gateway status phrases.
+ 
+ These helpers deliberately avoid relaying raw model scratch text.  They turn
+-Hermes' long-running gateway status surface into short status lines suitable
++Black Pool' long-running gateway status surface into short status lines suitable
+ for chat surfaces.
+ 
+ Built-in defaults live in ``gateway/assets/status_phrases.yaml``. Users can add
+@@ -36,7 +36,7 @@ import yaml
+ 
+ from hermes_constants import get_hermes_home
+ 
+-# These are Hermes UI surfaces, not app/vendor/domain buckets.  Keep this
++# These are Black Pool UI surfaces, not app/vendor/domain buckets.  Keep this
+ # long-running-only: regular tool/thinking/interim chatter is intentionally not
+ # rewritten into generic placeholders because that gets noisy fast in chat.
+ _STATUS_SURFACES = ("status", "generic")
+@@ -189,7 +189,7 @@ def classify_status_context(
+     preview: str | None = None,
+     args: Any = None,
+ ) -> str:
+-    """Classify an internal gateway event into a Hermes UI-surface bucket."""
++    """Classify an internal gateway event into a Black Pool UI-surface bucket."""
+     normalized = str(kind or "").strip().lower()
+     if normalized in {"heartbeat", "waiting", "long_running", "status"}:
+         return "status"
+diff --git a/gateway/stream_consumer.py b/gateway/stream_consumer.py
+index cb5848f..bc94997 100644
+--- a/gateway/stream_consumer.py
++++ b/gateway/stream_consumer.py
+@@ -2176,7 +2176,7 @@ class GatewayStreamConsumer:
+         """Return True when the adapter would rather finalize a streamed reply
+         by sending a fresh message and deleting the preview than by editing the
+         preview in place — e.g. Telegram, whose ``sendRichMessage`` send path
+-        currently renders richer markdown than Hermes' MarkdownV2 edit path.
++        currently renders richer markdown than Black Pool' MarkdownV2 edit path.
+ 
+         Returns False when there is no real preview to replace (no message id,
+         or the ``__no_edit__`` sentinel), when the adapter doesn't expose the
+diff --git a/gateway/whatsapp_identity.py b/gateway/whatsapp_identity.py
+index 19fade1..2f46e53 100644
+--- a/gateway/whatsapp_identity.py
++++ b/gateway/whatsapp_identity.py
+@@ -25,7 +25,7 @@ Public helpers:
+ Plugins that need per-sender behaviour on WhatsApp (role-based routing,
+ per-contact authorisation, policy gating in a gateway hook) should use
+ ``canonical_whatsapp_identifier`` so their bookkeeping lines up with
+-Hermes' own session keys.
++Black Pool' own session keys.
+ """
+ 
+ from __future__ import annotations
+@@ -184,11 +184,11 @@ def canonical_whatsapp_identifier(identifier: str) -> str:
+     (numeric-preferred) alias as the canonical identity.
+     :func:`gateway.session.build_session_key` uses this for both WhatsApp
+     DM chat_ids and WhatsApp group participant_ids, so callers get the
+-    same session-key identity Hermes itself uses.
++    same session-key identity Black Pool itself uses.
+ 
+     Plugins that need per-sender behaviour (role-based routing,
+     authorisation, per-contact policy) should use this so their
+-    bookkeeping lines up with Hermes' session bookkeeping even when
++    bookkeeping lines up with Black Pool' session bookkeeping even when
+     the bridge reshuffles aliases.
+ 
+     Returns an empty string if ``identifier`` normalizes to empty. If no
 diff --git a/hermes_cli/__init__.py b/hermes_cli/__init__.py
-index 746364b..d2e2545 100644
+index 746364b..386fb51 100644
 --- a/hermes_cli/__init__.py
 +++ b/hermes_cli/__init__.py
 @@ -1,5 +1,5 @@
  """
 -Hermes CLI - Unified command-line interface for Hermes Agent.
-+Hermes CLI - Unified command-line interface for Black Pool Agent.
++Black Pool CLI - Unified command-line interface for Black Pool Agent.
  
  Provides subcommands for:
  - hermes chat          - Interactive chat (same as ./hermes)
@@ -47376,10 +49107,32 @@ index 746364b..d2e2545 100644
  __release_date__ = "2026.8.19"
  
  
+diff --git a/hermes_cli/_early_recovery.py b/hermes_cli/_early_recovery.py
+index 942eb63..18fe1fa 100644
+--- a/hermes_cli/_early_recovery.py
++++ b/hermes_cli/_early_recovery.py
+@@ -219,7 +219,7 @@ def _find_uv_binary() -> str | None:
+ 
+     uv-managed base interpreters carry an ``EXTERNALLY-MANAGED`` marker, so
+     the stdlib ``pip`` fallback below refuses to touch them.  In that state
+-    the only sanctioned installer is uv itself, which Hermes already vendors
++    the only sanctioned installer is uv itself, which Black Pool already vendors
+     (``~/.hermes/bin/uv.exe``) or the user has on PATH.  Stdlib-only.
+     """
+     exe = "uv.exe" if sys.platform == "win32" else "uv"
 diff --git a/hermes_cli/_parser.py b/hermes_cli/_parser.py
-index 13bcaa4..b6cb82e 100644
+index 13bcaa4..de62063 100644
 --- a/hermes_cli/_parser.py
 +++ b/hermes_cli/_parser.py
+@@ -73,7 +73,7 @@ Examples:
+     hermes logs errors            View errors.log
+     hermes logs --since 1h        Lines from the last hour
+     hermes debug share             Upload debug report for support
+-    hermes console                Open the safe Hermes command console
++    hermes console                Open the safe Black Pool command console
+     hermes update                 Update to latest version
+     hermes dashboard              Start web UI dashboard (port 9119)
+     hermes dashboard --stop       Stop running dashboard processes
 @@ -93,7 +93,7 @@ def build_top_level_parser():
      """
      parser = argparse.ArgumentParser(
@@ -47398,6 +49151,15 @@ index 13bcaa4..b6cb82e 100644
      )
      _query_group = chat_parser.add_mutually_exclusive_group()
      _query_group.add_argument(
+@@ -507,7 +507,7 @@ def build_top_level_parser():
+         "--safe-mode",
+         action="store_true",
+         default=argparse.SUPPRESS,
+-        help="Troubleshooting mode: disable ALL customizations — user config, AGENTS.md/memory injection, plugins, and MCP servers (implies --ignore-user-config and --ignore-rules). Use to isolate whether a problem comes from your setup or from Hermes itself.",
++        help="Troubleshooting mode: disable ALL customizations — user config, AGENTS.md/memory injection, plugins, and MCP servers (implies --ignore-user-config and --ignore-rules). Use to isolate whether a problem comes from your setup or from Black Pool itself.",
+     )
+     chat_parser.add_argument(
+         "--source",
 diff --git a/hermes_cli/_startup_fast.py b/hermes_cli/_startup_fast.py
 index d74b421..1bc0379 100644
 --- a/hermes_cli/_startup_fast.py
@@ -47411,10 +49173,103 @@ index d74b421..1bc0379 100644
  
      print(f"Install directory: {project_root_str()}")
  
+diff --git a/hermes_cli/_subprocess_compat.py b/hermes_cli/_subprocess_compat.py
+index 8a27dd3..656b0e1 100644
+--- a/hermes_cli/_subprocess_compat.py
++++ b/hermes_cli/_subprocess_compat.py
+@@ -1,6 +1,6 @@
+ """Windows subprocess compatibility helpers.
+ 
+-Hermes is developed on Linux / macOS and tested natively on Windows too.
++Black Pool is developed on Linux / macOS and tested natively on Windows too.
+ Several common subprocess patterns break silently-or-loudly on Windows:
+ 
+ * ``["npm", "install", ...]`` — on Windows ``npm`` is ``npm.cmd``, a batch
+@@ -286,7 +286,7 @@ def suppress_platform_ver_console() -> None:
+     CPython 3.11 (``platform()`` → ``Windows-10-10.0.xxxxx-SP0`` either way).
+ 
+     Call early, before heavyweight imports — the flash typically happens
+-    during a dependency's import, not from Hermes' own code.
++    during a dependency's import, not from Black Pool' own code.
+     """
+     if not IS_WINDOWS:
+         return
+@@ -347,7 +347,7 @@ def noninteractive_git_env(
+ ) -> dict[str, str]:
+     """Environment for *internal* git invocations that must never prompt.
+ 
+-    Hermes shells out to git from many non-interactive contexts — MCP catalog
++    Black Pool shells out to git from many non-interactive contexts — MCP catalog
+     installs, plugin install/update, profile distribution staging, worktree
+     base fetches, desktop review-pane fetch/push. When the remote is private,
+     misconfigured, or requires auth, git's default behavior is to prompt on
+diff --git a/hermes_cli/active_sessions.py b/hermes_cli/active_sessions.py
+index 13aa1e4..f58085c 100644
+--- a/hermes_cli/active_sessions.py
++++ b/hermes_cli/active_sessions.py
+@@ -109,7 +109,7 @@ def active_session_limit_message(
+     held = summarize_holders(entries or [])
+     detail = f" Held by: {held}." if held else ""
+     return (
+-        f"Hermes is at the active session limit ({active_count}/{max_sessions})."
++        f"Black Pool is at the active session limit ({active_count}/{max_sessions})."
+         f"{detail} Try again when another session finishes."
+     )
+ 
 diff --git a/hermes_cli/agent_import.py b/hermes_cli/agent_import.py
-index 7439133..0aea57b 100644
+index 7439133..f01d836 100644
 --- a/hermes_cli/agent_import.py
 +++ b/hermes_cli/agent_import.py
+@@ -1,4 +1,4 @@
+-"""hermes import-agent — import Claude Code / Codex CLI setups into Hermes.
++"""hermes import-agent — import Claude Code / Codex CLI setups into Black Pool.
+ 
+ Usage:
+     hermes import-agent                       # auto-detect ~/.claude or ~/.codex
+@@ -51,7 +51,7 @@ from utils import atomic_write_text, atomic_yaml_write
+ 
+ logger = logging.getLogger(__name__)
+ 
+-# Same entry delimiter as the Hermes memory store and the openclaw migration
++# Same entry delimiter as the Black Pool memory store and the openclaw migration
+ # script — memories/MEMORY.md entries are separated by bare "§" lines.
+ ENTRY_DELIMITER = "\n§\n"
+ 
+@@ -323,14 +323,14 @@ def merge_entries(
+ 
+ 
+ # ---------------------------------------------------------------------------
+-# Claude Code permission rules → Hermes command patterns
++# Claude Code permission rules → Black Pool command patterns
+ # ---------------------------------------------------------------------------
+ 
+ _BASH_RULE_RE = re.compile(r"^Bash\((?P<inner>.*)\)$")
+ 
+ 
+ def claude_rule_to_command_pattern(rule: str) -> Optional[str]:
+-    """Convert a Claude Code ``Bash(...)`` permission rule into a Hermes glob.
++    """Convert a Claude Code ``Bash(...)`` permission rule into a Black Pool glob.
+ 
+     ``Bash(npm run build)``   → ``npm run build``
+     ``Bash(npm run test:*)``  → ``npm run test*``  (Claude ':*' prefix match)
+@@ -484,7 +484,7 @@ class AgentImporter:
+         if commands_dir.is_dir() and any(commands_dir.glob("*.md")):
+             self.record(
+                 "slash-commands", commands_dir, None, "skipped",
+-                "Claude slash commands have no direct Hermes equivalent — "
++                "Claude slash commands have no direct Black Pool equivalent — "
+                 "consider converting them into skills",
+             )
+ 
+@@ -757,7 +757,7 @@ class AgentImporter:
+                 continue
+             if name in existing and not self.overwrite:
+                 self.record(kind, name, f"mcp_servers.{name}", "conflict",
+-                            "MCP server already exists in Hermes config")
++                            "MCP server already exists in Black Pool config")
+                 continue
+ 
+             hermes_srv: Dict[str, Any] = {}
 @@ -880,7 +880,7 @@ def import_agent_command(args) -> None:
  
      print()
@@ -47424,8 +49279,42 @@ index 7439133..0aea57b 100644
      print(color("└─────────────────────────────────────────────────────────┘", Colors.MAGENTA))
  
      if not source_dir.is_dir():
+diff --git a/hermes_cli/agent_plugins.py b/hermes_cli/agent_plugins.py
+index af48727..776db62 100644
+--- a/hermes_cli/agent_plugins.py
++++ b/hermes_cli/agent_plugins.py
+@@ -1,7 +1,7 @@
+ """Compatibility helpers for Agent Plugins v1 portable directory packages.
+ 
+ This module validates the versioned portable format locally and translates its
+-supported components into records consumed by Hermes' existing skill and MCP
++supported components into records consumed by Black Pool' existing skill and MCP
+ runtimes. It deliberately performs no schema fetching and imports no plugin
+ Python code.
+ """
+@@ -353,7 +353,7 @@ def _validate_remote_url(url: object) -> str:
+ def _translate_remote(config: Mapping[str, Any]) -> Dict[str, Any]:
+     """Translate a portable ``streamable-http`` entry into native MCP config.
+ 
+-    The returned record targets Hermes' existing URL-based MCP runtime.
++    The returned record targets Black Pool' existing URL-based MCP runtime.
+     ``strict_redirect_headers`` instructs the runtime to drop the configured
+     headers on any cross-origin redirect, which the v1 spec requires for
+     portable packages (configured headers must not be forwarded to a
+diff --git a/hermes_cli/approvals_suggest.py b/hermes_cli/approvals_suggest.py
+index 1288d79..7e805ce 100644
+--- a/hermes_cli/approvals_suggest.py
++++ b/hermes_cli/approvals_suggest.py
+@@ -1,6 +1,6 @@
+ """``hermes approvals suggest`` — mine approval history into allowlist proposals.
+ 
+-Hermes has no dedicated approval-decision ledger: ``always`` answers land in
++Black Pool has no dedicated approval-decision ledger: ``always`` answers land in
+ ``command_allowlist`` (config.yaml) via :func:`tools.approval.save_permanent_allowlist`,
+ while ``once``/``session`` approvals are in-memory only.  What *does* persist
+ is the session DB (``~/.hermes/state.db``): every assistant ``terminal`` tool
 diff --git a/hermes_cli/auth.py b/hermes_cli/auth.py
-index ae807b9..9d35d63 100644
+index ae807b9..282a3a1 100644
 --- a/hermes_cli/auth.py
 +++ b/hermes_cli/auth.py
 @@ -1,5 +1,5 @@
@@ -47435,10 +49324,531 @@ index ae807b9..9d35d63 100644
  
  Supports OAuth device code flows (Nous Portal, future: OpenAI Codex) and
  traditional API key providers (OpenRouter, custom endpoints). Auth state
+@@ -207,7 +207,7 @@ def normalize_actual_base_url(base_url: str) -> str:
+ 
+     Actual hosted inference is exposed at api.actual.inc, while the Actual
+     client's offline local server binds a loopback host. Both use a /v1 API
+-    surface for Hermes' Responses transport.
++    surface for Black Pool' Responses transport.
+     """
+     url = str(base_url or "").strip().rstrip("/")
+     if not url:
+@@ -400,7 +400,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
+         # `sk-ant-oat01…` OAuth token: sent as `x-api-key` it 401s, and sent as a
+         # bare Bearer it 429s. It is listed here because this tuple doubles as the
+         # credential-DISCOVERY list (agent/credential_pool.py builds its env scan
+-        # from it), so removing it would stop Hermes finding a setup-token
++        # from it), so removing it would stop Black Pool finding a setup-token
+         # credential at all. The adapter routes such a value down the OAuth path
+         # on the strength of its prefix, not on this entry. Only ANTHROPIC_API_KEY
+         # and ANTHROPIC_TOKEN are usable as literal API keys.
+@@ -1915,7 +1915,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
+                 return True
+ 
+         # MoA presets are explicit model selections too.  A user who configured
+-        # ``provider: anthropic`` as a MoA advisor/aggregator has opted Hermes
++        # ``provider: anthropic`` as a MoA advisor/aggregator has opted Black Pool
+         # into using Anthropic credentials for that slot even when the main
+         # session model is another provider.  Without this, Claude Code OAuth
+         # entries are pruned/ignored by credential_pool.load_pool("anthropic"),
+@@ -1949,7 +1949,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
+ 
+     # 3. Check provider-specific env vars
+     # Exclude CLAUDE_CODE_OAUTH_TOKEN — it's set by Claude Code itself,
+-    # not by the user explicitly configuring anthropic in Hermes.
++    # not by the user explicitly configuring anthropic in Black Pool.
+     _IMPLICIT_ENV_VARS = {"CLAUDE_CODE_OAUTH_TOKEN"}
+     pconfig = PROVIDER_REGISTRY.get(normalized)
+     # Fallback to ProviderDef from models.dev catalog when the provider
+@@ -1966,7 +1966,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
+                 return True
+ 
+     # 4. Check persisted credential-pool entries that came from EXPLICIT flows
+-    # the user initiated inside Hermes (manual add / device-code / PKCE), plus
++    # the user initiated inside Black Pool (manual add / device-code / PKCE), plus
+     # env-backed pool entries. This intentionally excludes ambient borrowed
+     # sources like gh_cli / claude_code / qwen-cli.
+     try:
+@@ -2455,7 +2455,7 @@ def _nous_portal_env_override() -> Optional[str]:
+ 
+     Mirrors ``_nous_inference_env_override()``: ``HERMES_PORTAL_BASE_URL`` /
+     ``NOUS_PORTAL_BASE_URL`` are the documented dev/staging escape hatch for
+-    pointing Hermes at a non-production Nous Portal (e.g. a hosted agent
++    pointing Black Pool at a non-production Nous Portal (e.g. a hosted agent
+     provisioned on nous-account-service's `staging` environment, which stamps
+     ``HERMES_PORTAL_BASE_URL=https://portal.staging-nousresearch.com`` into
+     the container env). The env source is trusted (the OS user/deployment
+@@ -3459,7 +3459,7 @@ def login_spotify_command(args) -> None:
+     print(f"Redirect URI: {redirect_uri}")
+     print("Make sure this redirect URI is allow-listed in your Spotify app settings.")
+     print()
+-    print("Open this URL to authorize Hermes:")
++    print("Open this URL to authorize Black Pool:")
+     print(authorize_url)
+     print()
+     print(f"Full setup guide: {SPOTIFY_DOCS_URL}")
+@@ -3668,7 +3668,7 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None)
+     print(divider)
+     print("Remote session detected — SSH tunnel required")
+     print(divider)
+-    print(f"Hermes is waiting for the OAuth callback on {redirect_uri}")
++    print(f"Black Pool is waiting for the OAuth callback on {redirect_uri}")
+     print("but your browser is on a different machine. Run this command")
+     print("in a NEW terminal on your local machine BEFORE opening the URL:")
+     print()
+@@ -3685,13 +3685,13 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None)
+ # =============================================================================
+ # OpenAI Codex auth — tokens stored in ~/.hermes/auth.json (not ~/.codex/)
+ #
+-# Hermes maintains its own Codex OAuth session separate from the Codex CLI
++# Black Pool maintains its own Codex OAuth session separate from the Codex CLI
+ # and VS Code extension. This prevents refresh token rotation conflicts
+ # where one app's refresh invalidates the other's session.
+ # =============================================================================
+ 
+ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+-    """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
++    """Read Codex OAuth tokens from Black Pool auth store (~/.hermes/auth.json).
+     
+     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
+     Raises AuthError if no Codex tokens are stored.
+@@ -3841,7 +3841,7 @@ def _sync_codex_pool_entries(
+ 
+ 
+ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
+-    """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
++    """Save Codex OAuth tokens to Black Pool auth store (~/.hermes/auth.json)."""
+     if last_refresh is None:
+         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+     with _auth_store_lock():
+@@ -3869,7 +3869,7 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label:
+ 
+ 
+ def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
+-    """Adopt a valid Codex CLI token pair into Hermes auth, if available."""
++    """Adopt a valid Codex CLI token pair into Black Pool auth, if available."""
+     imported = _import_codex_cli_tokens()
+     # Require BOTH tokens before adopting: persisting a payload without a
+     # usable refresh_token would only break the next refresh cycle.
+@@ -3890,7 +3890,7 @@ def refresh_codex_oauth_pure(
+     *,
+     timeout_seconds: float = 20.0,
+ ) -> Dict[str, Any]:
+-    """Refresh Codex OAuth tokens without mutating Hermes auth state."""
++    """Refresh Codex OAuth tokens without mutating Black Pool auth state."""
+     del access_token  # Access token is only used by callers to decide whether to refresh.
+     if not isinstance(refresh_token, str) or not refresh_token.strip():
+         raise AuthError(
+@@ -4024,7 +4024,7 @@ def _refresh_codex_auth_tokens(
+ ) -> Dict[str, str]:
+     """Refresh Codex access token using the refresh token.
+     
+-    Saves the new tokens to Hermes auth store automatically.
++    Saves the new tokens to Black Pool auth store automatically.
+     """
+     try:
+         refreshed = refresh_codex_oauth_pure(
+@@ -4033,10 +4033,10 @@ def _refresh_codex_auth_tokens(
+             timeout_seconds=timeout_seconds,
+         )
+     except AuthError as exc:
+-        # Self-heal cross-store refresh_token rotation. Hermes keeps its OWN
++        # Self-heal cross-store refresh_token rotation. Black Pool keeps its OWN
+         # Codex OAuth token (per profile + top-level), separate from the Codex
+         # CLI's ~/.codex/auth.json. OAuth refresh_tokens are single-use, so when
+-        # the Codex CLI (or another Hermes process) rotates the shared token,
++        # the Codex CLI (or another Black Pool process) rotates the shared token,
+         # this frozen copy's refresh_token goes stale and the refresh fails with
+         # a relogin-required error (invalid_grant / refresh_token_reused / 401).
+         # Before surfacing that as a hard 401 to the turn, adopt the canonical
+@@ -4102,7 +4102,7 @@ def resolve_codex_runtime_credentials(
+     refresh_if_expiring: bool = True,
+     refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+ ) -> Dict[str, Any]:
+-    """Resolve runtime credentials from Hermes's own Codex token store.
++    """Resolve runtime credentials from Black Pool's own Codex token store.
+ 
+     Falls back to the credential pool when the singleton (``providers.openai-codex.tokens``)
+     has no usable access_token but the pool (``credential_pool.openai-codex``) does. This
+@@ -4211,7 +4211,7 @@ def resolve_codex_runtime_credentials(
+     if (not should_refresh) and refresh_if_expiring:
+         should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+     if should_refresh:
+-        # Re-read under lock to avoid racing with other Hermes processes
++        # Re-read under lock to avoid racing with other Black Pool processes
+         with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+             data = _read_codex_tokens(_lock=False)
+             tokens = dict(data["tokens"])
+@@ -4296,7 +4296,7 @@ def _probe_codex_quota_restored(
+ ) -> Optional[bool]:
+     """Ask the Codex usage endpoint whether this account's quota is usable again.
+ 
+-    Hermes persists a Codex 429's ``reset_at`` locally and freezes the
++    Black Pool persists a Codex 429's ``reset_at`` locally and freezes the
+     credential until it elapses — but the upstream window can reopen EARLY
+     (the user redeems a banked rate-limit reset via the Codex CLI/ChatGPT UI,
+     upgrades their plan, or OpenAI resets the window).  This probe detects
+@@ -4972,7 +4972,7 @@ def refresh_xai_oauth_pure(
+         )
+     endpoint = token_endpoint.strip() or _xai_oauth_discovery(timeout_seconds)["token_endpoint"]
+     # Re-validate cached endpoints on the refresh hot path: an auth.json
+-    # written by an older Hermes (or hand-edited) may carry a non-xAI
++    # written by an older Black Pool (or hand-edited) may carry a non-xAI
+     # token_endpoint that would receive every future refresh_token in
+     # plaintext if we trusted it blindly. Cheap suffix check; fast-fail
+     # with a clear error so the user can re-run `hermes model` to refetch.
+@@ -5400,7 +5400,7 @@ def _nous_shared_auth_dir() -> Path:
+ def _nous_shared_store_path() -> Path:
+     path = _nous_shared_auth_dir() / NOUS_SHARED_STORE_FILENAME
+     # Seat belt: if pytest is running and this resolves to a path under the
+-    # real user's Hermes root, refuse rather than silently corrupt cross-profile
++    # real user's Black Pool root, refuse rather than silently corrupt cross-profile
+     # state. Tests must set HERMES_SHARED_AUTH_DIR to a tmp_path (conftest
+     # does not do this automatically — mirror the _auth_file_path() guard
+     # so forgetting to set it fails loudly instead of writing to the real
+@@ -5661,7 +5661,7 @@ def _quarantine_nous_oauth_state(
+     #
+     # Redaction safety: emit ONLY the 12-char SHA-256 hex prefix of the refresh
+     # token (correlates to NAS's refreshTokenHash without leaking the secret) plus
+-    # sizes/booleans. NEVER pass a raw token/agent_key into the log call — Hermes
++    # sizes/booleans. NEVER pass a raw token/agent_key into the log call — Black Pool
+     # has a known bug class where credential-shaped literals get corrupted in logs.
+     forensic: Dict[str, Any] = {
+         "reason": reason,
+@@ -5871,19 +5871,19 @@ def _refresh_access_token(
+     # Detect the OAuth 2.1 "refresh token reuse" signal from the Nous portal
+     # server and surface an actionable message.  This fires when an external
+     # process (health-check script, monitoring tool, custom self-heal hook)
+-    # called POST /api/oauth/token with Hermes's refresh_token without
++    # called POST /api/oauth/token with Black Pool's refresh_token without
+     # persisting the rotated token back to auth.json — the server then
+-    # retires the original RT, Hermes's next refresh uses it, and the whole
++    # retires the original RT, Black Pool's next refresh uses it, and the whole
+     # session chain gets revoked as a token-theft signal (#15099).
+     lowered = description.lower()
+     if code == "refresh_token_reused" or "reuse" in lowered or "reuse detected" in lowered:
+         description = (
+             "Nous Portal detected refresh-token reuse and revoked this session.\n"
+             "This usually means an external process (monitoring script, "
+-            "custom self-heal hook, or another Hermes install sharing "
+-            "~/.hermes/auth.json) called POST /api/oauth/token with Hermes's "
++            "custom self-heal hook, or another Black Pool install sharing "
++            "~/.hermes/auth.json) called POST /api/oauth/token with Black Pool's "
+             "refresh token without persisting the rotated token back.\n"
+-            "Nous refresh tokens are single-use — only Hermes may call the "
++            "Nous refresh tokens are single-use — only Black Pool may call the "
+             "refresh endpoint. For health checks, use `hermes auth status` "
+             "instead.\n"
+             "Re-authenticate with: hermes auth add nous"
+@@ -5929,7 +5929,7 @@ def fetch_nous_models(
+         model_id = item.get("id")
+         if isinstance(model_id, str) and model_id.strip():
+             mid = model_id.strip()
+-            # Skip Hermes models — they're not reliable for agentic tool-calling
++            # Skip Black Pool models — they're not reliable for agentic tool-calling
+             if "hermes" in mid.lower():
+                 continue
+             model_ids.append(mid)
+@@ -6000,7 +6000,7 @@ def resolve_nous_access_token(
+ 
+         if not state:
+             raise AuthError(
+-                "Hermes is not logged into Nous Portal.",
++                "Black Pool is not logged into Nous Portal.",
+                 provider="nous",
+                 relogin_required=True,
+             )
+@@ -6345,7 +6345,7 @@ def resolve_nous_runtime_credentials(
+     ):
+ 
+         if not state:
+-            raise AuthError("Hermes is not logged into Nous Portal.",
++            raise AuthError("Black Pool is not logged into Nous Portal.",
+                             provider="nous", relogin_required=True)
+ 
+         persisted_state = dict(state)
+@@ -7268,7 +7268,7 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
+             if not installed:
+                 info["hint"] = (
+                     "azure-identity not installed. Install with: "
+-                    "pip install azure-identity  (or rely on Hermes' "
++                    "pip install azure-identity  (or rely on Black Pool' "
+                     "lazy-install at first use)."
+                 )
+             else:
+@@ -7927,7 +7927,7 @@ def _login_openai_codex(
+             # the user "Login successful!".
+             _resolved_key = existing.get("api_key", "")
+             if isinstance(_resolved_key, str) and _resolved_key and not _codex_access_token_is_expiring(_resolved_key, 60):
+-                print("Existing Codex credentials found in Hermes auth store.")
++                print("Existing Codex credentials found in Black Pool auth store.")
+                 try:
+                     reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
+                 except (EOFError, KeyboardInterrupt):
+@@ -7948,7 +7948,7 @@ def _login_openai_codex(
+         cli_tokens = _import_codex_cli_tokens()
+         if cli_tokens:
+             print("Found existing Codex CLI credentials at ~/.codex/auth.json")
+-            print("Hermes will create its own session to avoid conflicts with Codex CLI / VS Code.")
++            print("Black Pool will create its own session to avoid conflicts with Codex CLI / VS Code.")
+             try:
+                 do_import = input("Import these credentials? (a separate login is recommended) [y/N]: ").strip().lower()
+             except (EOFError, KeyboardInterrupt):
+@@ -7959,19 +7959,19 @@ def _login_openai_codex(
+                 config_path = _update_config_for_provider("openai-codex", base_url)
+                 print()
+                 print("Credentials imported. Note: if Codex CLI refreshes its token,")
+-                print("Hermes will keep working independently with its own session.")
++                print("Black Pool will keep working independently with its own session.")
+                 print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+                 return
+ 
+-    # Run a fresh device code flow — Hermes gets its own OAuth session
++    # Run a fresh device code flow — Black Pool gets its own OAuth session
+     print()
+     print("Signing in to OpenAI Codex...")
+-    print("(Hermes creates its own session — won't affect Codex CLI or VS Code)")
++    print("(Black Pool creates its own session — won't affect Codex CLI or VS Code)")
+     print()
+ 
+     creds = _codex_device_code_login()
+ 
+-    # Save tokens to Hermes auth store
++    # Save tokens to Black Pool auth store
+     _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
+     config_path = _update_config_for_provider("openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL))
+     print()
+@@ -7994,7 +7994,7 @@ def _login_xai_oauth(
+             existing = resolve_xai_oauth_runtime_credentials()
+             api_key = existing.get("api_key", "")
+             if isinstance(api_key, str) and api_key and not _xai_access_token_is_expiring(api_key, 60):
+-                print("Existing xAI OAuth credentials found in Hermes auth store.")
++                print("Existing xAI OAuth credentials found in Black Pool auth store.")
+                 try:
+                     reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
+                 except (EOFError, KeyboardInterrupt):
+@@ -8013,7 +8013,7 @@ def _login_xai_oauth(
+ 
+     print()
+     print("Signing in to xAI Grok OAuth (SuperGrok / Premium+)...")
+-    print("(Hermes creates its own local OAuth session)")
++    print("(Black Pool creates its own local OAuth session)")
+     print()
+ 
+     timeout_seconds = float(getattr(args, "timeout", None) or 20.0)
+@@ -8634,7 +8634,7 @@ def _minimax_poll_token(
+ 
+ 
+ def _minimax_save_auth_state(auth_state: Dict[str, Any]) -> None:
+-    """Persist MiniMax OAuth state to Hermes auth store (~/.hermes/auth.json)."""
++    """Persist MiniMax OAuth state to Black Pool auth store (~/.hermes/auth.json)."""
+     with _auth_store_lock():
+         auth_store = _load_auth_store()
+         _save_provider_state(auth_store, "minimax-oauth", auth_state)
+@@ -8659,7 +8659,7 @@ def _minimax_oauth_login(
+     if _is_remote_session():
+         open_browser = False
+ 
+-    print(f"Starting Hermes login via MiniMax ({region}) OAuth...")
++    print(f"Starting Black Pool login via MiniMax ({region}) OAuth...")
+     print(f"Portal: {portal_base_url}")
+ 
+     with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
+@@ -8974,7 +8974,7 @@ def _nous_device_code_login(
+     if _is_remote_session():
+         open_browser = False
+ 
+-    print(f"Starting Hermes login via {pconfig.name}...")
++    print(f"Starting Black Pool login via {pconfig.name}...")
+     print(f"Portal: {portal_base_url}")
+     if insecure:
+         print("TLS verification: disabled (--insecure)")
+@@ -9293,7 +9293,7 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
+                     # The Portal's freeRecommendedModels endpoint is the
+                     # source of truth for what's free *right now*. Augment
+                     # the curated list with anything new the Portal flags
+-                    # as free so users on older Hermes builds still see
++                    # as free so users on older Black Pool builds still see
+                     # newly-launched free models without a CLI release.
+                     model_ids, pricing = union_with_portal_free_recommendations(
+                         model_ids, pricing, _portal_for_recs,
+@@ -9393,9 +9393,9 @@ def logout_command(args) -> None:
+             _reset_config_provider()
+         print(f"Logged out of {provider_name}.")
+         if should_reset_config and os.getenv("OPENROUTER_API_KEY"):
+-            print("Hermes will use OpenRouter for inference.")
++            print("Black Pool will use OpenRouter for inference.")
+         elif should_reset_config:
+-            print("Run `hermes model` or configure an API key to use Hermes.")
++            print("Run `hermes model` or configure an API key to use Black Pool.")
+         else:
+             print("Model provider configuration was unchanged.")
+     else:
+diff --git a/hermes_cli/auth_commands.py b/hermes_cli/auth_commands.py
+index a23c0f2..5179ea4 100644
+--- a/hermes_cli/auth_commands.py
++++ b/hermes_cli/auth_commands.py
+@@ -476,7 +476,7 @@ def auth_remove_command(args) -> None:
+         raise SystemExit(f'No credential matching "{target}" for provider {provider}.')
+     print(f"Removed {provider} credential #{index} ({removed.label})")
+ 
+-    # Unified removal dispatch.  Every credential source Hermes reads from
++    # Unified removal dispatch.  Every credential source Black Pool reads from
+     # (env vars, external OAuth files, auth.json blocks, custom config)
+     # has a RemovalStep registered in agent.credential_sources.  The step
+     # handles its source-specific cleanup and we centralise suppression +
+diff --git a/hermes_cli/backup.py b/hermes_cli/backup.py
+index 7742b05..c7e14a2 100644
+--- a/hermes_cli/backup.py
++++ b/hermes_cli/backup.py
+@@ -148,7 +148,7 @@ _EXTERNAL_PREFIX = "_external/"
+ 
+ 
+ class BackupInProgressError(RuntimeError):
+-    """Raised when another process already owns the Hermes backup slot."""
++    """Raised when another process already owns the Black Pool backup slot."""
+ 
+ 
+ class _SQLiteSnapshotError(RuntimeError):
+@@ -182,7 +182,7 @@ def _backup_operation_lock(hermes_home: Path, timeout_seconds: float = 0.25):
+                     break
+                 except (OSError, PermissionError):
+                     if time.monotonic() >= deadline:
+-                        raise BackupInProgressError("another Hermes backup is already running")
++                        raise BackupInProgressError("another Black Pool backup is already running")
+                     time.sleep(0.05)
+         else:
+             import fcntl
+@@ -194,7 +194,7 @@ def _backup_operation_lock(hermes_home: Path, timeout_seconds: float = 0.25):
+                     break
+                 except (BlockingIOError, OSError):
+                     if time.monotonic() >= deadline:
+-                        raise BackupInProgressError("another Hermes backup is already running")
++                        raise BackupInProgressError("another Black Pool backup is already running")
+                     time.sleep(0.05)
+ 
+         yield
+@@ -626,11 +626,11 @@ def copy_db_and_verify(src: Path, dst: Path) -> bool:
+ # ---------------------------------------------------------------------------
+ 
+ def run_backup(args) -> None:
+-    """Create a zip backup of the Hermes home directory."""
++    """Create a zip backup of the Black Pool home directory."""
+     hermes_root = get_default_hermes_root()
+ 
+     if not hermes_root.is_dir():
+-        print(f"Error: Hermes home directory not found at {hermes_root}")
++        print(f"Error: Black Pool home directory not found at {hermes_root}")
+         sys.exit(1)
+ 
+     try:
+@@ -854,7 +854,7 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
+ # ---------------------------------------------------------------------------
+ 
+ def _validate_backup_zip(zf: zipfile.ZipFile) -> tuple[bool, str]:
+-    """Check that a zip looks like a Hermes backup.
++    """Check that a zip looks like a Black Pool backup.
+ 
+     Returns (ok, reason).
+     """
+@@ -873,7 +873,7 @@ def _validate_backup_zip(zf: zipfile.ZipFile) -> tuple[bool, str]:
+ 
+     if not found:
+         return False, (
+-            "zip does not appear to be a Hermes backup "
++            "zip does not appear to be a Black Pool backup "
+             "(no config.yaml, .env, or state databases found)"
+         )
+ 
+@@ -985,7 +985,7 @@ def _extract_member_atomically(
+         # Carrying the elevated bits across would let archive-controlled bytes
+         # take over an existing setuid/setgid file, so ``hermes import`` would
+         # hand whoever produced the zip the identity that file runs as.  Nothing
+-        # constrains that to Hermes' own state either: the ``_external/`` branch
++        # constrains that to Black Pool' own state either: the ``_external/`` branch
+         # of ``run_import`` publishes members anywhere under ``$HOME``.  The
+         # sticky bit is kept — it is inert on a regular file.
+         mode &= ~(stat.S_ISUID | stat.S_ISGID)
+@@ -1029,7 +1029,7 @@ def _extract_member_atomically(
+ 
+ 
+ def run_import(args) -> None:
+-    """Restore a Hermes backup from a zip file."""
++    """Restore a Black Pool backup from a zip file."""
+     zip_path = Path(args.zipfile).expanduser().resolve()
+ 
+     if not zip_path.is_file():
+@@ -1065,7 +1065,7 @@ def run_import(args) -> None:
+ 
+         if (has_config or has_env) and not args.force:
+             print()
+-            print("Warning: Target directory already has Hermes configuration.")
++            print("Warning: Target directory already has Black Pool configuration.")
+             print("Importing will overwrite existing files with backup contents.")
+             print()
+             try:
+@@ -1262,7 +1262,7 @@ def run_import(args) -> None:
+             print("\nStart the gateway to activate cron jobs and messaging:")
+             print("  hermes gateway install")
+ 
+-        print("Done. Your Hermes configuration has been restored.")
++        print("Done. Your Black Pool configuration has been restored.")
+ 
+ 
+ # ---------------------------------------------------------------------------
+@@ -1725,7 +1725,7 @@ def restore_cron_jobs_if_emptied(
+     Args:
+         snapshot_id: The pre-update quick-snapshot id (from
+             :func:`create_quick_snapshot`).
+-        hermes_home: Override for the Hermes home directory (tests).
++        hermes_home: Override for the Black Pool home directory (tests).
+ 
+     Returns:
+         ``None`` when no action was taken (the common, healthy path). On a
+diff --git a/hermes_cli/bang_shell.py b/hermes_cli/bang_shell.py
+index def25e5..d3df927 100644
+--- a/hermes_cli/bang_shell.py
++++ b/hermes_cli/bang_shell.py
+@@ -197,7 +197,7 @@ def run_bang_command(
+         emit(f"!: command timed out after {timeout}s")
+         return 124
+     except KeyboardInterrupt:
+-        # Ctrl+C interrupts the command, not the Hermes session.
++        # Ctrl+C interrupts the command, not the Black Pool session.
+         proc.kill()
+         emit("!: interrupted")
+         return 130
 diff --git a/hermes_cli/banner.py b/hermes_cli/banner.py
-index 259c454..c2caed4 100644
+index 259c454..9cfe515 100644
 --- a/hermes_cli/banner.py
 +++ b/hermes_cli/banner.py
+@@ -383,7 +383,7 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
+ 
+ 
+ def check_for_updates() -> Optional[int]:
+-    """Check whether a Hermes update is available.
++    """Check whether a Black Pool update is available.
+ 
+     Two paths: if ``HERMES_REVISION`` is set (nix builds embed it), compare
+     it to upstream main via ``git ls-remote``. Otherwise look for a local
+@@ -455,7 +455,7 @@ def check_for_updates() -> Optional[int]:
+ 
+ 
+ def _resolve_repo_dir() -> Optional[Path]:
+-    """Return the active Hermes git checkout, or None if this isn't a git install.
++    """Return the active Black Pool git checkout, or None if this isn't a git install.
+ 
+     Prefers the running code's location over the profile-scoped path
+     because ``$HERMES_HOME/hermes-agent/`` may be a stale copy carried
+@@ -573,7 +573,7 @@ def get_latest_release_tag(repo_dir: Optional[Path] = None) -> Optional[tuple]:
+     """Return ``(tag, release_url)`` for the latest git tag, or None.
+ 
+     Local-only — runs ``git describe --tags --abbrev=0`` against the
+-    Hermes checkout. Cached per-process. Release URL always points at the
++    Black Pool checkout. Cached per-process. Release URL always points at the
+     canonical NousResearch/hermes-agent repo (forks don't get a link).
+     """
+     global _latest_release_cache
 @@ -615,7 +615,7 @@ def get_latest_release_tag(repo_dir: Optional[Path] = None) -> Optional[tuple]:
  
  def format_banner_version_label() -> str:
@@ -47448,6 +49858,16 @@ index 259c454..c2caed4 100644
      state = get_git_banner_state()
      if not state:
          return base
+diff --git a/hermes_cli/browser_connect.py b/hermes_cli/browser_connect.py
+index af1b04e..c4265a4 100644
+--- a/hermes_cli/browser_connect.py
++++ b/hermes_cli/browser_connect.py
+@@ -1,4 +1,4 @@
+-"""Shared helpers for attaching Hermes to a local Chromium-family CDP port."""
++"""Shared helpers for attaching Black Pool to a local Chromium-family CDP port."""
+ 
+ from __future__ import annotations
+ 
 diff --git a/hermes_cli/build_info.py b/hermes_cli/build_info.py
 index e2ae06b..21bea06 100644
 --- a/hermes_cli/build_info.py
@@ -47460,9 +49880,53 @@ index e2ae06b..21bea06 100644
  Source installs report their git revision live via ``git rev-parse`` (see
  ``hermes_cli/dump.py`` and ``hermes_cli/banner.py``).  That doesn't work inside
 diff --git a/hermes_cli/claw.py b/hermes_cli/claw.py
-index 8b78902..3203abc 100644
+index 8b78902..1e40ece 100644
 --- a/hermes_cli/claw.py
 +++ b/hermes_cli/claw.py
+@@ -140,7 +140,7 @@ def _warn_if_openclaw_running(auto_yes: bool) -> None:
+     print_info(
+         "Messaging platforms (Telegram, Discord, Slack) only allow one "
+         "active session per bot token. If you continue, both OpenClaw and "
+-        "Hermes may try to use the same token, causing disconnects."
++        "Black Pool may try to use the same token, causing disconnects."
+     )
+     print_info("Recommendation: stop OpenClaw before migrating.")
+     print()
+@@ -155,7 +155,7 @@ def _warn_if_openclaw_running(auto_yes: bool) -> None:
+ 
+ 
+ def _warn_if_gateway_running(auto_yes: bool) -> None:
+-    """Check if a Hermes gateway is running with connected platforms.
++    """Check if a Black Pool gateway is running with connected platforms.
+ 
+     Migrating bot tokens while the gateway is polling will cause conflicts
+     (e.g. Telegram 409 "terminated by other getUpdates request"). Warn the
+@@ -175,7 +175,7 @@ def _warn_if_gateway_running(auto_yes: bool) -> None:
+ 
+     print()
+     print_error(
+-        "Hermes gateway is running with active connections: "
++        "Black Pool gateway is running with active connections: "
+         + ", ".join(connected)
+     )
+     print_info(
+@@ -310,14 +310,14 @@ def claw_command(args):
+         print("Usage: hermes claw <command> [options]")
+         print()
+         print("Commands:")
+-        print("  migrate          Migrate settings from OpenClaw to Hermes")
++        print("  migrate          Migrate settings from OpenClaw to Black Pool")
+         print("  cleanup          Archive leftover OpenClaw directories after migration")
+         print()
+         print("Run 'hermes claw <command> --help' for options.")
+ 
+ 
+ def _cmd_migrate(args):
+-    """Run the OpenClaw → Hermes migration."""
++    """Run the OpenClaw → Black Pool migration."""
+     # Check current and legacy OpenClaw directories
+     explicit_source = getattr(args, "source", None)
+     if explicit_source:
 @@ -354,7 +354,7 @@ def _cmd_migrate(args):
      )
      print(
@@ -47472,6 +49936,33 @@ index 8b78902..3203abc 100644
              Colors.MAGENTA,
          )
      )
+@@ -404,7 +404,7 @@ def _cmd_migrate(args):
+     # active will cause conflicts (e.g. Telegram 409).
+     _warn_if_openclaw_running(auto_yes)
+ 
+-    # Check if a Hermes gateway is running with connected platforms.
++    # Check if a Black Pool gateway is running with connected platforms.
+     _warn_if_gateway_running(auto_yes)
+ 
+     # Ensure config.yaml exists before migration tries to read it
+@@ -504,7 +504,7 @@ def _cmd_migrate(args):
+             print_info("Migration cancelled.")
+             return
+ 
+-    # ── Phase 2b: Pre-apply backup of the Hermes home ─────────
++    # ── Phase 2b: Pre-apply backup of the Black Pool home ─────────
+     # Delegates to hermes_cli.backup.create_pre_migration_backup(), which
+     # shares implementation with the pre-update backup (same exclusion
+     # rules, same SQLite safe-copy, zip format) so the archive is
+@@ -525,7 +525,7 @@ def _cmd_migrate(args):
+             print()
+             print_error(f"Could not create pre-migration backup: {e}")
+             print_info(
+-                "Re-run with --no-backup to skip, or free up disk space under the Hermes home."
++                "Re-run with --no-backup to skip, or free up disk space under the Black Pool home."
+             )
+             logger.debug("Pre-migration backup error", exc_info=True)
+             return
 @@ -580,7 +580,7 @@ def _cmd_cleanup(args):
      )
      print(
@@ -47481,6 +49972,26 @@ index 8b78902..3203abc 100644
              Colors.MAGENTA,
          )
      )
+diff --git a/hermes_cli/cli_agent_setup_mixin.py b/hermes_cli/cli_agent_setup_mixin.py
+index 7a10824..94cd55c 100644
+--- a/hermes_cli/cli_agent_setup_mixin.py
++++ b/hermes_cli/cli_agent_setup_mixin.py
+@@ -907,13 +907,13 @@ class CLIAgentSetupMixin:
+                     lines.append(f"         {ml}\n", style="dim")
+             elif role == "assistant_last":
+                 # Last assistant response shown in full, non-dim
+-                lines.append("  ◆ Hermes: ", style=f"bold {_assistant_label_c}")
++                lines.append("  ◆ Black Pool: ", style=f"bold {_assistant_label_c}")
+                 msg_lines = text.splitlines()
+                 lines.append(msg_lines[0] + "\n", style="")
+                 for ml in msg_lines[1:]:
+                     lines.append(f"            {ml}\n", style="")
+             else:
+-                lines.append("  ◆ Hermes: ", style=f"dim bold {_assistant_label_c}")
++                lines.append("  ◆ Black Pool: ", style=f"dim bold {_assistant_label_c}")
+                 msg_lines = text.splitlines()
+                 lines.append(msg_lines[0] + "\n", style="dim")
+                 for ml in msg_lines[1:]:
 diff --git a/hermes_cli/cli_billing_mixin.py b/hermes_cli/cli_billing_mixin.py
 index b0ec388..b232315 100644
 --- a/hermes_cli/cli_billing_mixin.py
@@ -47522,9 +50033,45 @@ index b0ec388..b232315 100644
              return
  
 diff --git a/hermes_cli/cli_commands_mixin.py b/hermes_cli/cli_commands_mixin.py
-index 93b221f..db9245c 100644
+index 93b221f..bca9ea1 100644
 --- a/hermes_cli/cli_commands_mixin.py
 +++ b/hermes_cli/cli_commands_mixin.py
+@@ -56,7 +56,7 @@ class CLICommandsMixin:
+             /rollback <N>             — restore checkpoint N, preserving user
+                                         hand-edits (also undoes last chat turn)
+             /rollback <N> --all       — classic full restore (may overwrite
+-                                        files you edited after Hermes did)
++                                        files you edited after Black Pool did)
+             /rollback diff <N>        — preview changes since checkpoint N
+             /rollback <N> <file>      — restore a single file from checkpoint N
+         """
+@@ -182,7 +182,7 @@ class CLICommandsMixin:
+             /diff                  — unstaged changes + untracked files
+             /diff staged           — staged changes (git diff --cached)
+             /diff all              — staged + unstaged + untracked (vs HEAD)
+-            /diff session          — everything Hermes changed (checkpoint baseline)
++            /diff session          — everything Black Pool changed (checkpoint baseline)
+             /diff [mode] --stat    — summary only (changed files + counts)
+             /diff [mode] <path...> — restrict to specific paths
+         """
+@@ -275,7 +275,7 @@ class CLICommandsMixin:
+         stat = result.get("stat", "")
+         diff = result.get("diff", "")
+         if result.get("empty") or (not stat and not diff):
+-            print("  No changes — Hermes hasn't edited any files here yet.")
++            print("  No changes — Black Pool hasn't edited any files here yet.")
+             return
+ 
+         if stat:
+@@ -310,7 +310,7 @@ class CLICommandsMixin:
+         print(text)
+ 
+     def _handle_snapshot_command(self, command: str):
+-        """Handle /snapshot — lightweight state snapshots for Hermes config/state.
++        """Handle /snapshot — lightweight state snapshots for Black Pool config/state.
+ 
+         Syntax:
+             /snapshot                  — list recent snapshots
 @@ -2280,11 +2280,11 @@ class CLICommandsMixin:
                      try:
                          from hermes_cli.skin_engine import get_active_skin
@@ -47539,6 +50086,47 @@ index 93b221f..db9245c 100644
                          _resp_color = "#CD7F32"
                          _resp_text = "#FFF8DC"
  
+@@ -2733,7 +2733,7 @@ class CLICommandsMixin:
+         _cprint(
+             f"  {_DIM}Fires as a normal turn whenever the session is idle and the "
+             f"interval has elapsed. /heartbeat pause | resume | clear to manage; "
+-            f"lives only while this Hermes process runs — use `hermes cron` for "
++            f"lives only while this Black Pool process runs — use `hermes cron` for "
+             f"durable schedules.{_RST}"
+         )
+ 
+@@ -2955,7 +2955,7 @@ class CLICommandsMixin:
+         _cprint(
+             f"  {_DIM}After each turn, a judge model checks if the goal is done"
+             f"{' against the contract above' if state.has_contract() else ''}. "
+-            f"Hermes keeps working until it is, you pause/clear it, or the budget is "
++            f"Black Pool keeps working until it is, you pause/clear it, or the budget is "
+             f"exhausted. Use /goal status, /goal show, /goal pause, /goal resume, /goal clear.{_RST}"
+         )
+         # Kick the loop off immediately so the user doesn't have to send a
+@@ -3601,7 +3601,7 @@ class CLICommandsMixin:
+             _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (this session — use --global to persist){_RST}")
+ 
+     def _handle_busy_command(self, cmd: str):
+-        """Handle /busy — control what Enter does while Hermes is working.
++        """Handle /busy — control what Enter does while Black Pool is working.
+ 
+         Usage:
+             /busy               Show current busy input mode
+@@ -3633,11 +3633,11 @@ class CLICommandsMixin:
+         self.busy_input_mode = arg
+         if save_config_value("display.busy_input_mode", arg):
+             if arg == "queue":
+-                behavior = "Enter will queue follow-up input while Hermes is busy."
++                behavior = "Enter will queue follow-up input while Black Pool is busy."
+             elif arg == "steer":
+                 behavior = "Enter will steer your message into the current run (after the next tool call)."
+             else:
+-                behavior = "Enter will redirect the current run while Hermes is busy; /stop still cancels it."
++                behavior = "Enter will redirect the current run while Black Pool is busy; /stop still cancels it."
+             _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (saved to config){_RST}")
+             _cprint(f"  {_DIM}{behavior}{_RST}")
+         else:
 @@ -3765,7 +3765,7 @@ class CLICommandsMixin:
          run_debug_share(args)
  
@@ -47571,10 +50159,357 @@ index 93b221f..db9245c 100644
              detail="This will exit the current session and run `hermes update`.",
              choices=choices,
          )
+@@ -3841,7 +3841,7 @@ class CLICommandsMixin:
+             _cprint("Usage: /voice [on|off|tts|status]")
+ 
+     def _handle_wake_command(self, command: str):
+-        """Handle /wake [on|off|status] — the 'Hey Hermes' hotword listener.
++        """Handle /wake [on|off|status] — the 'Hey Black Pool' hotword listener.
+ 
+         The toggle IS the config: an explicit on/off (or bare toggle) also
+         writes ``wake_word.enabled`` to config.yaml so the choice persists
+diff --git a/hermes_cli/cli_output.py b/hermes_cli/cli_output.py
+index 165de84..a2c4bd5 100644
+--- a/hermes_cli/cli_output.py
++++ b/hermes_cli/cli_output.py
+@@ -1,4 +1,4 @@
+-"""Shared CLI output helpers for Hermes CLI modules.
++"""Shared CLI output helpers for Black Pool CLI modules.
+ 
+ Extracts the identical ``print_info/success/warning/error`` and ``prompt()``
+ functions previously duplicated across setup.py, tools_config.py,
+diff --git a/hermes_cli/codex_models.py b/hermes_cli/codex_models.py
+index f058107..2bd6915 100644
+--- a/hermes_cli/codex_models.py
++++ b/hermes_cli/codex_models.py
+@@ -46,7 +46,7 @@ DEFAULT_CODEX_MODELS: List[str] = [
+     # crashes on selection. The Codex CLI public catalog still references
+     # these slugs, which is why they survived previously — but those entries
+     # describe the public OpenAI API, not the OAuth-backed Codex backend
+-    # Hermes uses. Removed here. If OpenAI re-enables them on Codex backend,
++    # Black Pool uses. Removed here. If OpenAI re-enables them on Codex backend,
+     # live discovery will pick them up automatically via _fetch_models_from_api.
+ ]
+ 
+@@ -60,7 +60,7 @@ _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
+     # Surface Spark whenever any compatible Codex template is present so
+     # accounts hitting the live endpoint with an older lineup still see
+     # Spark in the picker. Backend gates real availability by ChatGPT Pro
+-    # entitlement; Hermes does not.
++    # entitlement; Black Pool does not.
+     ("gpt-5.3-codex-spark", ("gpt-5.3-codex",)),
+ ]
+ 
+@@ -201,7 +201,7 @@ def _read_cache_models(codex_home: Path) -> List[str]:
+                 continue
+             slug = slug.strip()
+             # Do not filter on ``supported_in_api`` here.  It describes the
+-            # public OpenAI API, while Hermes openai-codex talks to the same
++            # public OpenAI API, while Black Pool openai-codex talks to the same
+             # OAuth-backed Codex backend as Codex CLI.
+             visibility = item.get("visibility")
+             if isinstance(visibility, str) and visibility.strip().lower() in {"hide", "hidden"}:
+diff --git a/hermes_cli/codex_runtime_plugin_migration.py b/hermes_cli/codex_runtime_plugin_migration.py
+index 4b30d3e..070fe84 100644
+--- a/hermes_cli/codex_runtime_plugin_migration.py
++++ b/hermes_cli/codex_runtime_plugin_migration.py
+@@ -1,4 +1,4 @@
+-"""Migrate Hermes' MCP server config and Codex's installed curated plugins
++"""Migrate Black Pool' MCP server config and Codex's installed curated plugins
+ to the format Codex expects in ~/.codex/config.toml.
+ 
+ When the user enables the codex_app_server runtime, the codex subprocess
+@@ -7,7 +7,7 @@ Asana, plus per-account ChatGPT apps via app/list). For both of those to
+ be useful, the user's choices need to be visible to codex too. This
+ module:
+ 
+-  1. Reads Hermes' YAML and writes equivalent [mcp_servers.<name>]
++  1. Reads Black Pool' YAML and writes equivalent [mcp_servers.<name>]
+      entries to ~/.codex/config.toml.
+   2. Queries codex's `plugin/list` for the openai-curated marketplace
+      and writes [plugins."<name>@<marketplace>"] entries for any plugin
+@@ -19,17 +19,17 @@ module:
+      don't get an approval prompt on every write attempt.
+ 
+ What translates (MCP servers):
+-  Hermes mcp_servers.<n>.command/args/env  → codex stdio transport
+-  Hermes mcp_servers.<n>.url/headers       → codex streamable_http transport
+-  Hermes mcp_servers.<n>.timeout           → codex tool_timeout_sec
+-  Hermes mcp_servers.<n>.connect_timeout   → codex startup_timeout_sec
++  Black Pool mcp_servers.<n>.command/args/env  → codex stdio transport
++  Black Pool mcp_servers.<n>.url/headers       → codex streamable_http transport
++  Black Pool mcp_servers.<n>.timeout           → codex tool_timeout_sec
++  Black Pool mcp_servers.<n>.connect_timeout   → codex startup_timeout_sec
+ 
+ What does NOT translate (warned + skipped):
+   Hermes-specific keys (sampling, etc.) — codex's MCP client has no
+   equivalent. Listed in the per-server skipped[] field of the report.
+ 
+ What's NOT migrated (intentional):
+-  AGENTS.md — codex respects this file natively in its cwd. Hermes' own
++  AGENTS.md — codex respects this file natively in its cwd. Black Pool' own
+   AGENTS.md (project-level) is already in the worktree, so codex picks
+   it up without translation. No code needed.
+ """
+@@ -84,7 +84,7 @@ class MigrationReport:
+                 )
+                 lines.append(f"  - {name}{note}")
+         else:
+-            lines.append("No MCP servers found in Hermes config.")
++            lines.append("No MCP servers found in Black Pool config.")
+         if self.migrated_plugins:
+             lines.append(
+                 f"Migrated {len(self.migrated_plugins)} native Codex plugin(s):"
+@@ -103,7 +103,7 @@ class MigrationReport:
+         return "\n".join(lines)
+ 
+ 
+-# Hermes keys that codex's MCP schema doesn't support — dropped during
++# Black Pool keys that codex's MCP schema doesn't support — dropped during
+ # migration with a warning. Anything not on the keep list AND not the
+ # transport keys is added to skipped.
+ _KNOWN_HERMES_KEYS = {
+@@ -119,7 +119,7 @@ _KNOWN_HERMES_KEYS = {
+ 
+ # Subset that have a direct codex equivalent.
+ _KEYS_DROPPED_WITH_WARNING = {
+-    # Hermes' sampling subsection — codex MCP has no equivalent
++    # Black Pool' sampling subsection — codex MCP has no equivalent
+     "sampling",
+ }
+ 
+@@ -127,7 +127,7 @@ _KEYS_DROPPED_WITH_WARNING = {
+ def _translate_one_server(
+     name: str, hermes_cfg: dict
+ ) -> tuple[Optional[dict], list[str]]:
+-    """Translate one Hermes MCP server config to the codex inline-table dict
++    """Translate one Black Pool MCP server config to the codex inline-table dict
+     representation. Returns (codex_entry, skipped_keys).
+ 
+     codex_entry is a dict ready for TOML serialization, or None when the
+@@ -164,7 +164,7 @@ def _translate_one_server(
+         headers = hermes_cfg.get("headers") or {}
+         if headers:
+             out["http_headers"] = {str(k): str(v) for k, v in headers.items()}
+-        # Hermes' transport: sse hint is informational; codex auto-negotiates
++        # Black Pool' transport: sse hint is informational; codex auto-negotiates
+         if hermes_cfg.get("transport") == "sse":
+             skipped.append("transport=sse (codex auto-negotiates)")
+     else:
+@@ -191,7 +191,7 @@ def _translate_one_server(
+         if key in _KEYS_DROPPED_WITH_WARNING:
+             skipped.append(f"{key} (no codex equivalent)")
+         elif key not in _KNOWN_HERMES_KEYS:
+-            skipped.append(f"{key} (unknown Hermes key)")
++            skipped.append(f"{key} (unknown Black Pool key)")
+ 
+     return out, skipped
+ 
+@@ -263,7 +263,7 @@ def render_codex_toml_section(
+     """
+     out = [MIGRATION_MARKER]
+     if not servers and not plugins and not default_permission_profile:
+-        out.append("# (no MCP servers, plugins, or permissions configured by Hermes)")
++        out.append("# (no MCP servers, plugins, or permissions configured by Black Pool)")
+         out.append(MIGRATION_END_MARKER)
+         return "\n".join(out) + "\n"
+ 
+@@ -305,7 +305,7 @@ def render_codex_toml_section(
+ 
+ 
+ def _insert_managed_block_at_top_level(user_text: str, managed_block: str) -> str:
+-    """Insert Hermes' managed Codex TOML block while keeping root keys root-scoped.
++    """Insert Black Pool' managed Codex TOML block while keeping root keys root-scoped.
+ 
+     TOML has no syntax to return to the document root after a table header.
+     Therefore appending a root key like `default_permissions = ...` after a
+@@ -340,7 +340,7 @@ def _strip_unmanaged_plugin_tables(toml_text: str) -> str:
+     managed block.
+ 
+     Codex itself writes these tables when the user runs ``codex plugins enable``
+-    directly (i.e. before Hermes' migrate has ever touched the file). When we
++    directly (i.e. before Black Pool' migrate has ever touched the file). When we
+     later run migrate, ``_query_codex_plugins()`` reports the same plugins via
+     the live ``plugin/list`` RPC and we re-emit them inside the managed block.
+     The result without this strip is duplicate ``[plugins."X@Y"]`` table
+@@ -412,7 +412,7 @@ def _strip_existing_managed_block(toml_text: str) -> str:
+     follows, we fall back to the heuristic that swallows lines until we
+     hit a section that's not [mcp_servers.*]/[plugins.*]/[permissions]/
+     a `default_permissions =` key. This matches what older versions of
+-    this code wrote so re-runs don't break configs from prior Hermes
++    this code wrote so re-runs don't break configs from prior Black Pool
+     versions."""
+     lines = toml_text.splitlines(keepends=True)
+     out: list[str] = []
+@@ -555,7 +555,7 @@ def _looks_like_test_tempdir(path: str) -> bool:
+ 
+ 
+ def _build_hermes_tools_mcp_entry() -> dict:
+-    """Build the codex stdio-transport entry that launches Hermes' own
++    """Build the codex stdio-transport entry that launches Black Pool' own
+     tool surface as an MCP server. Codex's subprocess will call back into
+     this for browser/web/delegate_task/vision/memory/skills tools.
+ 
+@@ -615,7 +615,7 @@ def migrate(
+     default_permission_profile: Optional[str] = ":workspace",
+     expose_hermes_tools: bool = True,
+ ) -> MigrationReport:
+-    """Translate Hermes mcp_servers config + Codex curated plugins into
++    """Translate Black Pool mcp_servers config + Codex curated plugins into
+     ~/.codex/config.toml.
+ 
+     Args:
+@@ -635,10 +635,10 @@ def migrate(
+             configured in their own [permissions.<name>] table. Set None
+             to leave permissions unset and let codex use its compiled-in
+             default (which is read-only).
+-        expose_hermes_tools: when True (default), register Hermes' own
++        expose_hermes_tools: when True (default), register Black Pool' own
+             tool surface (web_search, browser_*, delegate_task, vision,
+             memory, skills, etc.) as an MCP server in ~/.codex/config.toml
+-            so the codex subprocess can call back into Hermes for tools
++            so the codex subprocess can call back into Black Pool for tools
+             codex doesn't have built in. Set False to opt out.
+     """
+     report = MigrationReport(dry_run=dry_run)
+@@ -649,7 +649,7 @@ def migrate(
+     hermes_servers = (hermes_config or {}).get("mcp_servers") or {}
+     if not isinstance(hermes_servers, dict):
+         report.errors.append(
+-            "mcp_servers in Hermes config is not a dict; cannot migrate."
++            "mcp_servers in Black Pool config is not a dict; cannot migrate."
+         )
+         return report
+ 
+@@ -687,8 +687,8 @@ def migrate(
+     if default_permission_profile:
+         report.wrote_permissions_default = default_permission_profile
+ 
+-    # Inject Hermes' own tool surface as an MCP server so the spawned
+-    # codex subprocess can call back into Hermes for the tools codex
++    # Inject Black Pool' own tool surface as an MCP server so the spawned
++    # codex subprocess can call back into Black Pool for the tools codex
+     # doesn't ship with — web_search, browser_*, delegate_task, vision,
+     # memory, skills, session_search, image_generate, text_to_speech.
+     # The server itself is agent/transports/hermes_tools_mcp_server.py
+diff --git a/hermes_cli/codex_runtime_switch.py b/hermes_cli/codex_runtime_switch.py
+index 06bff58..62bdeae 100644
+--- a/hermes_cli/codex_runtime_switch.py
++++ b/hermes_cli/codex_runtime_switch.py
+@@ -1,6 +1,6 @@
+ """Shared logic for the /codex-runtime slash command.
+ 
+-Toggles `model.openai_runtime` between "auto" (= chat_completions, Hermes'
++Toggles `model.openai_runtime` between "auto" (= chat_completions, Black Pool'
+ default) and "codex_app_server" (= hand turns to a codex subprocess).
+ 
+ Both CLI (cli.py) and gateway (gateway/run.py) call into this module so the
+@@ -205,9 +205,9 @@ def apply(
+         ok, ver = _check_binary_cached()
+         if ok:
+             msg_lines.append(f"codex CLI: {ver}")
+-        # Auto-migrate Hermes' MCP servers + Codex's installed curated
++        # Auto-migrate Black Pool' MCP servers + Codex's installed curated
+         # plugins into ~/.codex/config.toml so the spawned codex subprocess
+-        # sees the same tool surface AND can call back into Hermes for
++        # sees the same tool surface AND can call back into Black Pool for
+         # browser/web/delegate_task/vision/memory tools (#7 fix).
+         # Failures are non-fatal — the runtime change still proceeds.
+         try:
+@@ -234,7 +234,7 @@ def apply(
+                     f"Codex plugin discovery skipped: "
+                     f"{mig_report.plugin_query_error}"
+                 )
+-            # Permissions + Hermes tool callback are always-on production
++            # Permissions + Black Pool tool callback are always-on production
+             # bits the user benefits from knowing about.
+             if mig_report.wrote_permissions_default:
+                 msg_lines.append(
+@@ -243,14 +243,14 @@ def apply(
+                 )
+             if "hermes-tools" in mig_report.migrated:
+                 msg_lines.append(
+-                    "Hermes tool callback registered: codex can now use "
++                    "Black Pool tool callback registered: codex can now use "
+                     "web_search, web_extract, browser_*, vision_analyze, "
+                     "image_generate, skill_view, skills_list, text_to_speech, "
+                     "kanban_* (worker + orchestrator) via MCP."
+                 )
+                 msg_lines.append(
+                     "  (delegate_task, memory, session_search, todo run "
+-                    "only on the default Hermes runtime — they need the "
++                    "only on the default Black Pool runtime — they need the "
+                     "agent loop context.)"
+                 )
+             msg_lines.append(f"  (config: {mig_report.target_path})")
+@@ -261,14 +261,14 @@ def apply(
+         msg_lines.append(
+             "OpenAI/Codex turns now run through `codex app-server` "
+             "(terminal/file ops/patching inside Codex; "
+-            "Hermes tools available via MCP callback)."
++            "Black Pool tools available via MCP callback)."
+         )
+         msg_lines.append(
+             "Effective on next session — current cached agent keeps "
+             "the prior runtime to preserve prompt cache."
+         )
+     else:
+-        msg_lines.append("OpenAI/Codex turns will use the default Hermes runtime.")
++        msg_lines.append("OpenAI/Codex turns will use the default Black Pool runtime.")
+         msg_lines.append("Effective on next session.")
+     return CodexRuntimeStatus(
+         success=True,
+diff --git a/hermes_cli/colors.py b/hermes_cli/colors.py
+index 8c85b4c..fdf76ba 100644
+--- a/hermes_cli/colors.py
++++ b/hermes_cli/colors.py
+@@ -1,4 +1,4 @@
+-"""Shared ANSI color utilities for Hermes CLI modules."""
++"""Shared ANSI color utilities for Black Pool CLI modules."""
+ 
+ import os
+ import sys
 diff --git a/hermes_cli/commands.py b/hermes_cli/commands.py
-index 04deecd..a6ef8b0 100644
+index 04deecd..d910477 100644
 --- a/hermes_cli/commands.py
 +++ b/hermes_cli/commands.py
+@@ -1,4 +1,4 @@
+-"""Slash command definitions and autocomplete for the Hermes CLI.
++"""Slash command definitions and autocomplete for the Black Pool CLI.
+ 
+ Central registry for all slash commands. Every consumer -- CLI help, gateway
+ dispatch, Telegram BotCommands, Slack subcommand mapping, autocomplete --
+@@ -174,7 +174,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
+                aliases=("compact",), args_hint="[here [N] | focus topic | --preview|--dry-run]"),
+     CommandDef("rollback", "List or restore filesystem checkpoints (restores keep your hand-edits; --all overrides)", "Session",
+                args_hint="[number] [--all]"),
+-    CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",
++    CommandDef("snapshot", "Create or restore state snapshots of Black Pool config/state", "Session",
+                cli_only=True, aliases=("snap",), args_hint="[create|restore <id>|prune]"),
+     CommandDef("export", "Export a profile (config, skills, theme) to a shareable archive", "Configuration",
+                cli_only=True, args_hint="[profile] [-o output.tar.gz]"),
+@@ -202,7 +202,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
+                busy_policy="dispatch", busy_handler="queue"),
+     CommandDef("steer", "Inject a message after the next tool call without interrupting", "Session",
+                args_hint="<prompt>", busy_policy="dispatch", busy_handler="steer"),
+-    CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
++    CommandDef("goal", "Set a standing goal Black Pool works on across turns until achieved", "Session",
+                args_hint="[text | draft <text> | show | gate add <cmd> | pause | resume | clear | status | wait <pid> | unwait]",
+                busy_policy="dispatch", busy_handler="goal"),
+     CommandDef("heartbeat", "Set a recurring prompt that re-enters this session when idle", "Session",
+@@ -291,10 +291,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
+                subcommands=INDICATOR_STYLES),
+     CommandDef("voice", "Toggle voice mode", "Configuration",
+                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+-    CommandDef("wake", "Toggle the 'Hey Hermes' wake word listener", "Configuration",
++    CommandDef("wake", "Toggle the 'Hey Black Pool' wake word listener", "Configuration",
+                cli_only=True, args_hint="[on|off|status]",
+                subcommands=("on", "off", "status")),
+-    CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
++    CommandDef("busy", "Control what Enter does while Black Pool is working", "Configuration",
+                cli_only=True, args_hint="[queue|steer|interrupt|status]",
+                subcommands=("queue", "steer", "interrupt", "status")),
+ 
 @@ -381,9 +381,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                 cli_only=True),
      CommandDef("image", "Attach a local image file for your next prompt", "Info",
@@ -47587,6 +50522,33 @@ index 04deecd..a6ef8b0 100644
                 busy_policy="dispatch", execute="version"),
      CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info",
                 args_hint="[nous|local]"),
+@@ -701,7 +701,7 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
+     return result
+ 
+ 
+-# Telegram allows up to 100 BotCommands. Hermes ships ~50 built-in commands;
++# Telegram allows up to 100 BotCommands. Black Pool ships ~50 built-in commands;
+ # a 60-slot default keeps every built-in plus common skill commands visible in
+ # the `/` menu while staying comfortably under Telegram's ~4KB payload limit.
+ # Users can tune this via platforms.telegram.extra.command_menu.max_commands.
+@@ -741,7 +741,7 @@ _TELEGRAM_MENU_PRIORITY = (
+ )
+ """Built-in commands that should stay visible in Telegram's capped menu.
+ 
+-Telegram only displays a small BotCommand menu in practice.  The full Hermes
++Telegram only displays a small BotCommand menu in practice.  The full Black Pool
+ registry is still dispatchable when typed manually, but operational commands
+ need to survive the visible menu cap ahead of lower-priority built-ins.
+ """
+@@ -1407,7 +1407,7 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
+     seen: set[str] = set()
+ 
+     # Reserve /hermes as the catch-all top-level command.
+-    entries.append(("hermes", "Talk to Hermes or run a subcommand", "[subcommand] [args]"))
++    entries.append(("hermes", "Talk to Black Pool or run a subcommand", "[subcommand] [args]"))
+     seen.add("hermes")
+ 
+     def _add(name: str, desc: str, hint: str) -> None:
 diff --git a/hermes_cli/completion.py b/hermes_cli/completion.py
 index cd4815e..2d3ede6 100644
 --- a/hermes_cli/completion.py
@@ -47619,7 +50581,7 @@ index cd4815e..2d3ede6 100644
          "#   hermes completion fish | source",
          "",
 diff --git a/hermes_cli/config.py b/hermes_cli/config.py
-index 5b16642..775e5a6 100644
+index 5b16642..d04beb4 100644
 --- a/hermes_cli/config.py
 +++ b/hermes_cli/config.py
 @@ -1,5 +1,5 @@
@@ -47629,6 +50591,82 @@ index 5b16642..775e5a6 100644
  
  Config files are stored in ~/.hermes/ for easy access:
  - ~/.hermes/config.yaml  - All settings (model, toolsets, terminal, etc.)
+@@ -165,10 +165,10 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+ #
+ # * ``LD_PRELOAD`` / ``LD_LIBRARY_PATH`` / ``LD_AUDIT`` — Linux dynamic
+ #   loader. ``DYLD_*`` — macOS equivalent. Planting a path here means
+-#   the next ``subprocess.run([...])`` Hermes makes loads attacker code
++#   the next ``subprocess.run([...])`` Black Pool makes loads attacker code
+ #   before main().
+ # * ``PYTHONPATH`` / ``PYTHONHOME`` / ``PYTHONSTARTUP`` /
+-#   ``PYTHONUSERBASE`` — Python interpreter init. Hermes itself starts
++#   ``PYTHONUSERBASE`` — Python interpreter init. Black Pool itself starts
+ #   from one of these on every restart.
+ # * ``NODE_OPTIONS`` / ``NODE_PATH`` — Node interpreter; affects npm,
+ #   ``hermes update``, the TUI build.
+@@ -183,7 +183,7 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+ # * ``SHELL`` — what subprocess uses with ``shell=True`` (we try to
+ #   avoid that, but defense in depth).
+ # * ``HERMES_HOME`` / ``HERMES_PROFILE`` / ``HERMES_CONFIG`` /
+-#   ``HERMES_ENV`` — Hermes runtime location flags. Writing these into
++#   ``HERMES_ENV`` — Black Pool runtime location flags. Writing these into
+ #   ``.env`` would relocate state in ways the user did not request from
+ #   the dashboard. ``config.yaml`` is the supported surface for these.
+ #
+@@ -211,7 +211,7 @@ _ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
+     "PATH", "SHELL", "BROWSER", "EDITOR", "VISUAL", "PAGER",
+     # Git
+     "GIT_SSH_COMMAND", "GIT_EXEC_PATH", "GIT_SHELL",
+-    # Hermes runtime location — never via dashboard env writer.
++    # Black Pool runtime location — never via dashboard env writer.
+     # NOT a HERMES_* blanket: integration credentials (HERMES_GEMINI_*,
+     # HERMES_LANGFUSE_*, HERMES_SPOTIFY_*, ...) ARE allowed.
+     "HERMES_HOME", "HERMES_PROFILE", "HERMES_CONFIG", "HERMES_ENV",
+@@ -228,7 +228,7 @@ def _reject_denylisted_env_var(key: str) -> None:
+         raise ValueError(
+             f"Environment variable {key!r} is on the writer denylist. "
+             "Names that influence subprocess execution (LD_PRELOAD, "
+-            "PYTHONPATH, PATH, EDITOR, ...) or Hermes runtime location "
++            "PYTHONPATH, PATH, EDITOR, ...) or Black Pool runtime location "
+             "(HERMES_HOME, HERMES_PROFILE, ...) cannot be persisted via "
+             "the env writer. If you really need this, edit "
+             "~/.hermes/.env directly."
+@@ -385,7 +385,7 @@ def get_managed_system() -> Optional[str]:
+ 
+ 
+ def is_managed() -> bool:
+-    """Check if Hermes is running in package-manager-managed mode.
++    """Check if Black Pool is running in package-manager-managed mode.
+ 
+     Two signals: the HERMES_MANAGED env var (set by the systemd service),
+     or a .managed marker file in HERMES_HOME (set by the NixOS activation
+@@ -398,7 +398,7 @@ def is_managed() -> bool:
+ # home-manager), and the running process cannot tell which one. Thus this text
+ # names the routes instead of one command.
+ _NIX_UPDATE_MSG = (
+-    "Update Hermes through the Nix source that installed it "
++    "Update Black Pool through the Nix source that installed it "
+     "(e.g. nix profile upgrade, or update your flake input and rebuild with nixos-rebuild or home-manager switch)"
+ )
+ 
+@@ -426,7 +426,7 @@ def _install_method_project_root(project_root: Optional[Path] = None) -> Path:
+ 
+ 
+ def detect_install_method(project_root: Optional[Path] = None) -> str:
+-    """Detect how Hermes was installed: 'apt', 'docker', 'nix', 'nixos',
++    """Detect how Black Pool was installed: 'apt', 'docker', 'nix', 'nixos',
+     'home-manager', 'git', or 'unknown'.
+ 
+     Resolution order:
+@@ -611,7 +611,7 @@ def recommended_update_command() -> str:
+ #     git-based update path can never succeed inside the container.
+ #   - The pre-existing fallback message ("✗ Not a git repository. Please
+ #     reinstall: curl ... install.sh") is actively misleading inside Docker
+-#     — that script installs a *new* host-side Hermes, it doesn't update
++#     — that script installs a *new* host-side Black Pool, it doesn't update
+ #     the running container.
+ #   - The right action is ``docker pull`` + restart the container; this
+ #     helper spells that out, with notes on tag pinning and config
 @@ -619,7 +619,7 @@ def recommended_update_command() -> str:
  _DOCKER_UPDATE_MESSAGE = """\
  ✗ ``hermes update`` doesn't apply inside the Docker container.
@@ -47638,6 +50676,114 @@ index 5b16642..775e5a6 100644
  git checkout — the container has no working tree to pull into.  Update by
  pulling a fresh image and restarting your container instead:
  
+@@ -653,12 +653,12 @@ def format_docker_update_message() -> str:
+     return _DOCKER_UPDATE_MESSAGE
+ 
+ 
+-def format_managed_message(action: str = "modify this Hermes installation") -> str:
++def format_managed_message(action: str = "modify this Black Pool installation") -> str:
+     """Build a user-facing error for managed installs."""
+     managed_system = get_managed_system() or "a package manager"
+     return (
+-        f"Cannot {action}: this Hermes installation is managed by {managed_system}.\n"
+-        "Use your package manager to upgrade or reinstall Hermes."
++        f"Cannot {action}: this Black Pool installation is managed by {managed_system}.\n"
++        "Use your package manager to upgrade or reinstall Black Pool."
+     )
+ 
+ def managed_error(action: str = "modify configuration"):
+@@ -738,7 +738,7 @@ def get_project_root() -> Path:
+ def _resolve_hermes_uid_gid() -> tuple[Optional[int], Optional[int]]:
+     """Read the HERMES_UID / HERMES_GID env vars set by Docker deployments.
+ 
+-    Docker containers running Hermes commonly set these to map the in-container
++    Docker containers running Black Pool commonly set these to map the in-container
+     user to a host user so volume-mounted state files end up with the right
+     ownership. The entrypoint chowns the top-level HERMES_HOME once, but
+     subdirectories created at runtime by ``ensure_hermes_home()`` (especially
+@@ -829,7 +829,7 @@ def _secure_dir(path):
+ def _is_container() -> bool:
+     """Detect if we're running inside a Docker/Podman/LXC container.
+ 
+-    When Hermes runs in a container with volume-mounted config files, forcing
++    When Black Pool runs in a container with volume-mounted config files, forcing
+     0o600 permissions breaks multi-process setups where the gateway and
+     dashboard run as different UIDs or the volume mount requires broader
+     permissions.
+@@ -1381,7 +1381,7 @@ def _normalize_custom_provider_entry(
+         entry["key_env"] = entry["api_key_env"]
+     _KNOWN_KEYS = {
+         # ``provider`` duplicates the ``providers.<name>`` mapping key and is
+-        # unused here, but Hermes' own config writer has historically emitted it
++        # unused here, but Black Pool' own config writer has historically emitted it
+         # into provider entries. Accept it silently so those (self-written)
+         # configs don't warn on every load.
+         "provider",
+@@ -1476,8 +1476,8 @@ def _normalize_custom_provider_entry(
+         normalized["model"] = model_name.strip()
+ 
+     # Entry-level marker: the ``models`` mapping was auto-discovered by
+-    # Hermes (``_save_discovered_models_to_config``), not hand-curated.
+-    # Older Hermes versions wrote an in-mapping ``__discovered_model_catalog__``
++    # Black Pool (``_save_discovered_models_to_config``), not hand-curated.
++    # Older Black Pool versions wrote an in-mapping ``__discovered_model_catalog__``
+     # sentinel instead; accept it on read and strip it from the models
+     # mapping so sentinel keys never surface as model IDs.
+     models_discovered = entry.get("models_discovered") is True
+@@ -1494,7 +1494,7 @@ def _normalize_custom_provider_entry(
+         if models_copy:
+             normalized["models"] = models_copy
+     elif isinstance(models, list) and models:
+-        # Hand-edited configs (and older Hermes versions) may write
++        # Hand-edited configs (and older Black Pool versions) may write
+         # ``models`` as a plain list of ids or as ``[{id: ...}]`` rows.
+         # Preserve both by converting to the dict shape downstream code
+         # expects; otherwise normalize silently drops the list and /model
+@@ -2175,7 +2175,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
+     if cp and not model_cfg:
+         issues.append(ConfigIssue(
+             "warning",
+-            "custom_providers defined but no 'model' section — Hermes won't know which provider to use",
++            "custom_providers defined but no 'model' section — Black Pool won't know which provider to use",
+             "Add a model section:\n"
+             "  model:\n"
+             "    provider: custom\n"
+@@ -3539,7 +3539,7 @@ def terminal_config_env_var_for_key(key: str) -> Optional[str]:
+ def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
+     """Return whether the remote SSH shell must expand *cwd* itself.
+ 
+-    Expanding ``~`` on the Hermes host rewrites it to the host or container
++    Expanding ``~`` on the Black Pool host rewrites it to the host or container
+     home before SSH sees it. Preserve ``~`` and ``~/...`` so they follow the
+     user selected by the SSH connection.
+     """
+@@ -3961,7 +3961,7 @@ def save_config(
+ 
+ 
+ def _parse_env_value(raw_value: str) -> str:
+-    """Parse the small .env value subset Hermes writes itself."""
++    """Parse the small .env value subset Black Pool writes itself."""
+     value = raw_value.strip()
+     if len(value) >= 2 and value[0] == value[-1] == '"':
+         quoted = value[1:-1]
+@@ -4430,7 +4430,7 @@ def reload_env() -> int:
+     """Re-read ~/.hermes/.env into os.environ. Returns count of vars updated.
+ 
+     Adds/updates vars that changed and removes vars that were deleted from
+-    the .env file (but only vars known to Hermes — OPTIONAL_ENV_VARS and
++    the .env file (but only vars known to Black Pool — OPTIONAL_ENV_VARS and
+     _EXTRA_ENV_KEYS — to avoid clobbering unrelated environment).
+     """
+     env_vars = load_env()
+@@ -4440,7 +4440,7 @@ def reload_env() -> int:
+         if os.environ.get(key) != value:
+             os.environ[key] = value
+             count += 1
+-    # Remove known Hermes vars that are no longer in .env
++    # Remove known Black Pool vars that are no longer in .env
+     for key in known_keys:
+         if key not in env_vars and key in os.environ:
+             del os.environ[key]
 @@ -4593,7 +4593,7 @@ def show_config():
  
      print()
@@ -47647,8 +50793,17 @@ index 5b16642..775e5a6 100644
      print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
  
      # Managed scope: surface that some settings are administrator-pinned so the
+@@ -5649,7 +5649,7 @@ def set_config_value(key: str, value: str, force: bool = False):
+     if not is_known and not force:
+         print(color(
+             f"⚠ '{key}' is not a recognized config key — it was saved anyway, "
+-            "but Hermes may not read it.",
++            "but Black Pool may not read it.",
+             Colors.YELLOW,
+         ))
+         if suggestion:
 diff --git a/hermes_cli/config_defaults.py b/hermes_cli/config_defaults.py
-index cf3769c..3a478a2 100644
+index cf3769c..d67903c 100644
 --- a/hermes_cli/config_defaults.py
 +++ b/hermes_cli/config_defaults.py
 @@ -1,4 +1,4 @@
@@ -47657,6 +50812,135 @@ index cf3769c..3a478a2 100644
  
  Pure-data leaf module: DEFAULT_CONFIG and OPTIONAL_ENV_VARS, extracted
  verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
+@@ -10,7 +10,7 @@ DEFAULT_CONFIG = {
+     "fallback_providers": [],
+     "credential_pool_strategies": {},
+     "toolsets": ["hermes-cli"],
+-    # SQLite journal mode used by every Hermes database opener. WAL is the
++    # SQLite journal mode used by every Black Pool database opener. WAL is the
+     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is
+     # not crash-safe (for example macOS virtiofs, NFS, or SMB).
+     "database": {
+@@ -20,7 +20,7 @@ DEFAULT_CONFIG = {
+         "wal_autocheckpoint": None,
+         "journal_size_limit": None,
+     },
+-    # Soft file-descriptor limit for long-running Hermes server processes.
++    # Soft file-descriptor limit for long-running Black Pool server processes.
+     # Clamped to the OS hard limit; 0/false/null disables the adjustment.
+     "runtime": {
+         "nofile_soft_limit": 4096,
+@@ -211,14 +211,14 @@ DEFAULT_CONFIG = {
+         # profile is managed by the desktop's Bot Mode).
+         "bot_mode_protocol": True,
+         # Embedder-supplied environment description appended to the system
+-        # prompt's environment-hints block. Lets a host that wraps Hermes
++        # prompt's environment-hints block. Lets a host that wraps Black Pool
+         # (sandbox runner, managed platform) explain the runtime environment
+         # — proxy, credential handling, mount layout — without editing the
+         # identity slot (SOUL.md). Empty by default. The HERMES_ENVIRONMENT_HINT
+         # env var overrides this (build-time/container mechanism).
+         "environment_hint": "",
+         # Coding posture — on interactive coding surfaces (CLI, TUI, desktop
+-        # app, ACP) in a code workspace, Hermes adds a coding operating brief
++        # app, ACP) in a code workspace, Black Pool adds a coding operating brief
+         # + a live git/workspace snapshot to the system prompt. See
+         # agent/coding_context.py.
+         #   "auto" (default) — prompt-only posture when the surface is
+@@ -415,13 +415,13 @@ DEFAULT_CONFIG = {
+         # (bash doesn't source bashrc in non-interactive login mode) or
+         # zsh-specific files like ``~/.zshrc`` / ``~/.zprofile``.
+         # Paths support ``~`` / ``${VAR}``. Missing files are silently
+-        # skipped. When empty, Hermes auto-sources ``~/.profile``,
++        # skipped. When empty, Black Pool auto-sources ``~/.profile``,
+         # ``~/.bash_profile``, and ``~/.bashrc`` (in that order) if the
+         # snapshot shell is bash (this is the ``auto_source_bashrc``
+         # behaviour — disable with that key if you want strict login-only
+         # semantics).
+         "shell_init_files": [],
+-        # When true (default), Hermes sources the user's shell rc files
++        # When true (default), Black Pool sources the user's shell rc files
+         # (``~/.profile``, ``~/.bash_profile``, ``~/.bashrc``) in the
+         # login shell used to build the environment snapshot. This
+         # captures PATH additions, shell functions, and aliases — which a
+@@ -438,7 +438,7 @@ DEFAULT_CONFIG = {
+         "docker_forward_env": [],
+         # Explicit environment variables to set inside Docker containers.
+         # Unlike docker_forward_env (which reads values from the host process),
+-        # docker_env lets you specify exact key-value pairs — useful when Hermes
++        # docker_env lets you specify exact key-value pairs — useful when Black Pool
+         # runs as a systemd service without access to the user's shell environment.
+         # Example: {"SSH_AUTH_SOCK": "/run/user/1000/ssh-agent.sock"}
+         "docker_env": {},
+@@ -479,7 +479,7 @@ DEFAULT_CONFIG = {
+         # are owned by your host user instead of root, which avoids needing
+         # `sudo chown` after container runs. Default off to preserve behavior
+         # for images whose entrypoints expect to start as root (e.g. the
+-        # bundled Hermes image, which drops to the `hermes` user via
++        # bundled Black Pool image, which drops to the `hermes` user via
+         # s6-setuidgid inside each supervised service).
+         # When on, SETUID/SETGID caps are omitted from the container since
+         # no privilege drop is needed.
+@@ -553,12 +553,12 @@ DEFAULT_CONFIG = {
+         "dialog_policy": "must_respond",  # must_respond | auto_dismiss | auto_accept
+         "dialog_timeout_s": 300,  # Safety auto-dismiss after N seconds under must_respond
+         "camofox": {
+-            # When true, Hermes sends a stable profile-scoped userId to Camofox
++            # When true, Black Pool sends a stable profile-scoped userId to Camofox
+             # so the server maps it to a persistent Firefox profile automatically.
+             # When false (default), each session gets a random userId (ephemeral).
+             "managed_persistence": False,
+             # Optional externally managed Camofox identity. Useful when another
+-            # app owns the visible browser and Hermes should operate in it.
++            # app owns the visible browser and Black Pool should operate in it.
+             "user_id": "",
+             "session_key": "",
+             # Rehydrate tab_id from Camofox before creating a new tab.
+@@ -618,7 +618,7 @@ DEFAULT_CONFIG = {
+     },
+ 
+     # Hard cap (chars) for a single automatic context file such as SOUL.md,
+-    # AGENTS.md, CLAUDE.md, .hermes.md, or .cursorrules before Hermes applies
++    # AGENTS.md, CLAUDE.md, .hermes.md, or .cursorrules before Black Pool applies
+     # head/tail truncation. ``null`` (the default) lets the cap scale with the
+     # model's context window (floor 20K, ceiling 500K) so large-context models
+     # rarely truncate a project doc. Set a positive integer to pin a fixed cap
+@@ -670,7 +670,7 @@ DEFAULT_CONFIG = {
+     },
+ 
+     # Tool-output truncation thresholds. When terminal output or a
+-    # single read_file page exceeds these limits, Hermes truncates the
++    # single read_file page exceeds these limits, Black Pool truncates the
+     # payload sent to the model (keeping head + tail for terminal,
+     # enforcing pagination for read_file). Tuning these trades context
+     # footprint against how much raw output the model can see in one
+@@ -875,22 +875,22 @@ DEFAULT_CONFIG = {
+                                       # user-facing notice in CLI/gateway output.
+         "codex_app_server_auto": "native",  # Codex app-server (codex CLI runtime) thread
+                                       # compaction mode. The codex agent owns the real
+-                                      # thread context, so Hermes' summarizer cannot
++                                      # thread context, so Black Pool' summarizer cannot
+                                       # shrink it (#36801). native = codex decides when
+                                       # to compact its own thread (default); hermes =
+-                                      # Hermes' compression threshold triggers
++                                      # Black Pool' compression threshold triggers
+                                       # thread/compact/start; off = never auto-trigger
+                                       # (codex may still compact natively).
+         "codex_responses_native": False,  # Opt in to OpenAI's server-side compaction
+                                       # on the Responses API. Engages ONLY for
+                                       # gpt-5.6-family models on api.openai.com or
+                                       # the ChatGPT Codex backend; every other
+-                                      # route/model is unaffected. Hermes' local
++                                      # route/model is unaffected. Black Pool' local
+                                       # compression stays armed as the fallback.
+         "codex_responses_compact_threshold": 200000,  # Server-side compaction trigger
+                                       # (input tokens). Clamped below the local
+                                       # compression threshold at request time so
+-                                      # the server compacts before Hermes does.
++                                      # the server compacts before Black Pool does.
+         "in_place": True,             # When True, compaction rewrites the message
+                                       # list and rebuilds the system prompt WITHOUT
+                                       # rotating the session id — the conversation
 @@ -1377,12 +1377,12 @@ DEFAULT_CONFIG = {
          # model — see hermes_cli/focus_view.py.
          "focus_view": False,
@@ -47672,6 +50956,40 @@ index cf3769c..3a478a2 100644
          # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
          # spinner), or ascii.  Live-swappable via `/indicator <style>`.
          "tui_status_indicator": "kaomoji",
+@@ -1659,7 +1659,7 @@ DEFAULT_CONFIG = {
+             # Optional local Markdown/text file with Gemini TTS performance
+             # direction. It may include AUDIO PROFILE, SCENE, DIRECTOR'S NOTES,
+             # SAMPLE CONTEXT, and either a `{transcript}` placeholder or no
+-            # transcript section; Hermes appends the live transcript when absent.
++            # transcript section; Black Pool appends the live transcript when absent.
+             "persona_prompt_file": "",
+         },
+         "xai": {
+@@ -1792,7 +1792,7 @@ DEFAULT_CONFIG = {
+         "stop_phrases": ["stop"],
+     },
+ 
+-    # "Hey Hermes" hands-free wake word. Always-on, on-device hotword
++    # "Hey Black Pool" hands-free wake word. Always-on, on-device hotword
+     # detection that starts a fresh voice session — the "Hey Siri" pattern.
+     # Off by default; toggle with /wake or `wake_word.enabled: true`.
+     "wake_word": {
+@@ -1961,13 +1961,13 @@ DEFAULT_CONFIG = {
+     # Goals — persistent cross-turn goals (Ralph-style loop).
+     # After every turn, a lightweight judge call asks the auxiliary model
+     # whether the active /goal is satisfied by the assistant's last
+-    # response. If not, Hermes feeds a continuation prompt back into the
++    # response. If not, Black Pool feeds a continuation prompt back into the
+     # same session and keeps working until the goal is done, the turn
+     # budget is exhausted, or the user pauses/clears it. Judge failures
+     # fail OPEN (continue) so a flaky judge never wedges progress — the
+     # turn budget is the real backstop.
+     "goals": {
+-        # Max continuation turns before Hermes auto-pauses the goal and
++        # Max continuation turns before Black Pool auto-pauses the goal and
+         # asks the user to /goal resume. Protects against judge false
+         # negatives (goal actually done but judge says continue) and
+         # unbounded model spend on fuzzy / unachievable goals.
 @@ -2275,7 +2275,7 @@ DEFAULT_CONFIG = {
      # WhatsApp platform settings (gateway mode)
      "whatsapp": {
@@ -47681,6 +50999,385 @@ index cf3769c..3a478a2 100644
          # Set to "" (empty string) to disable the header entirely.
          # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
      },
+@@ -2385,7 +2385,7 @@ DEFAULT_CONFIG = {
+     "quick_commands": {},
+ 
+     # Per-platform system-prompt hint overrides. Lets an admin append to or
+-    # replace Hermes' built-in platform hint for a single messaging platform
++    # replace Black Pool' built-in platform hint for a single messaging platform
+     # (WhatsApp, Slack, Telegram, ...) without affecting other platforms.
+     # Useful for enterprise/managed profiles that ship platform-aware skills.
+     # Each key is a platform name; the value is either:
+@@ -2459,7 +2459,7 @@ DEFAULT_CONFIG = {
+         # <id>`; remove by editing the list directly. See
+         # ``hermes_cli/security_advisories.py`` for the catalog.
+         "acked_advisories": [],
+-        # Allow Hermes to lazy-install opt-in backend packages from PyPI
++        # Allow Black Pool to lazy-install opt-in backend packages from PyPI
+         # the first time the user enables a backend that needs them
+         # (e.g. installing ``elevenlabs`` when the user picks ElevenLabs as
+         # their TTS provider). Set to false to require explicit
+@@ -2701,7 +2701,7 @@ DEFAULT_CONFIG = {
+     # in the model-facing tools array with three bridge tools —
+     # tool_search / tool_describe / tool_call — and surfaced on demand.
+     #
+-    # Core Hermes tools (terminal, read_file, write_file, patch,
++    # Core Black Pool tools (terminal, read_file, write_file, patch,
+     # search_files, todo, memory, browser_*, etc.) are NEVER deferred.
+     # See tools/tool_search.py for full design notes and the
+     # openclaw-tool-search-report PDF in this PR for the rationale.
+@@ -2798,7 +2798,7 @@ DEFAULT_CONFIG = {
+     # doesn't know yet is the supported self-unblock path (#84482,
+     # #8731).
+     #
+-    # Provider keys accept the Hermes provider id (as used elsewhere in
++    # Provider keys accept the Black Pool provider id (as used elsewhere in
+     # this file) or the models.dev provider id; model ids match
+     # case-insensitively.
+     #
+@@ -2997,7 +2997,7 @@ DEFAULT_CONFIG = {
+         # can hand back any file that isn't a credential.
+         #
+         # When true, fall back to the older allowlist+recency-window
+-        # behavior: files must live under the Hermes cache, under
++        # behavior: files must live under the Black Pool cache, under
+         # ``media_delivery_allow_dirs``, or be freshly produced inside the
+         # ``trust_recent_files_seconds`` window. Recommended for
+         # public-facing gateways where prompt injection from one user
+@@ -3005,7 +3005,7 @@ DEFAULT_CONFIG = {
+         # user. Bridged to HERMES_MEDIA_DELIVERY_STRICT.
+         "strict": False,
+         # Extra directories from which model-emitted bare file paths may be
+-        # uploaded as native gateway attachments. Files inside the Hermes
++        # uploaded as native gateway attachments. Files inside the Black Pool
+         # cache (~/.hermes/cache/{documents,images,audio,video,screenshots})
+         # are always trusted; this list adds operator-controlled roots
+         # (project dirs, scratch dirs, mounted shares). Accepts a list of
+@@ -3365,7 +3365,7 @@ DEFAULT_CONFIG = {
+             # Optional encrypted last-good fallback for network/timeout outages.
+             # When enabled, successful BWS fetches write AES-GCM encrypted cache
+             # material under ~/.hermes/cache/. If a later startup cannot reach
+-            # Bitwarden due to NETWORK/TIMEOUT, Hermes may use this encrypted
++            # Bitwarden due to NETWORK/TIMEOUT, Black Pool may use this encrypted
+             # cache for up to max_stale_seconds. Auth failures do not fall back.
+             "encrypted_cache": {
+                 "enabled": False,
+@@ -3443,8 +3443,8 @@ DEFAULT_CONFIG = {
+     # Computer Use (cua-driver) toolset settings.
+     "computer_use": {
+         # cua-driver ships with anonymous usage telemetry (PostHog) ENABLED
+-        # by default upstream. Hermes disables it for our users unless they
+-        # explicitly opt in here. When false (default), Hermes sets
++        # by default upstream. Black Pool disables it for our users unless they
++        # explicitly opt in here. When false (default), Black Pool sets
+         # CUA_DRIVER_RS_TELEMETRY_ENABLED=0 in the cua-driver child env for
+         # every invocation (MCP backend, status, doctor, install). Set true
+         # to let cua-driver use its own default (telemetry on).
+@@ -3458,13 +3458,13 @@ DEFAULT_CONFIG = {
+         # Disable the cursor overlay rendered by cua-driver. The overlay
+         # shows where agent actions land but can peg a core when idle
+         # (macOS vImage redraw loop #47032; Linux/WSL2 idle spin #28152).
+-        # cua-driver ≥ 0.6.x supports --no-overlay; Hermes also calls
++        # cua-driver ≥ 0.6.x supports --no-overlay; Black Pool also calls
+         # set_agent_cursor_enabled(false) after start_session when this is on.
+         #   None  = auto-detect (off on macOS + headless/WSL2 Linux; on elsewhere)
+         #   True  = always disable the overlay
+         #   False = always enable the overlay
+         "no_overlay": None,
+-        # cua-driver permission mode for each Hermes computer-use runtime.
++        # cua-driver permission mode for each Black Pool computer-use runtime.
+         #   standard (default) — cua-driver's own approval boundary. Protected
+         #     operations (e.g. attaching to an existing signed-in browser
+         #     profile) fail closed unless grant_existing_profile is enabled
+@@ -3478,7 +3478,7 @@ DEFAULT_CONFIG = {
+         # silently bypass approvals.
+         "permission_mode": "standard",
+         # Absolute or ~ path to the reviewed cua-driver capability
+-        # manifest used when permission_mode is "bounded". Hermes passes the
++        # manifest used when permission_mode is "bounded". Black Pool passes the
+         # canonical --capability-manifest and --approve-capability-manifest
+         # flags when it launches the runtime. See
+         # https://cua.ai/docs/reference/cua-driver/permission-modes
+@@ -3504,7 +3504,7 @@ DEFAULT_CONFIG = {
+     # (CA private key + proxy endpoint integrity are part of that boundary).
+     #
+     # Configure with `hermes egress setup`.  Disabled by default — the rest of
+-    # Hermes works exactly as before with `enabled: false`.
++    # Black Pool works exactly as before with `enabled: false`.
+     "proxy": {
+         # Master switch.  When false, iron-proxy is never started, no docker
+         # mounts are added, no binaries are auto-installed — feature is a
+@@ -3553,7 +3553,7 @@ DEFAULT_CONFIG = {
+         "extra_allowed_hosts": [],
+     },
+ 
+-    # Hermes Desktop (Electron app) launch options. These only affect
++    # Black Pool Desktop (Electron app) launch options. These only affect
+     # `hermes desktop`; they do not touch the CLI/gateway.
+     "desktop": {
+         # Git repository discovery for the Desktop Projects sidebar. Empty
+@@ -3677,7 +3677,7 @@ OPTIONAL_ENV_VARS = {
+     "VERTEX_CREDENTIALS_PATH": {
+         "description": "Path to a Google Cloud service account JSON for Vertex AI (Gemini). "
+                        "Vertex uses OAuth2, not a static API key — this points at the "
+-                       "credentials Hermes mints short-lived tokens from. Falls back to "
++                       "credentials Black Pool mints short-lived tokens from. Falls back to "
+                        "GOOGLE_APPLICATION_CREDENTIALS, then to ADC (gcloud auth "
+                        "application-default login). Set project/region under vertex: in config.yaml.",
+         "prompt": "Vertex service account JSON path (leave empty to use ADC / GOOGLE_APPLICATION_CREDENTIALS)",
+@@ -4121,7 +4121,7 @@ OPTIONAL_ENV_VARS = {
+         "advanced": True,
+     },
+     "TOOL_GATEWAY_USER_TOKEN": {
+-        "description": "Explicit Nous Subscriber access token for tool-gateway requests (optional; otherwise read from the Hermes auth store)",
++        "description": "Explicit Nous Subscriber access token for tool-gateway requests (optional; otherwise read from the Black Pool auth store)",
+         "prompt": "Tool-gateway user token",
+         "url": None,
+         "password": True,
+@@ -4257,7 +4257,7 @@ OPTIONAL_ENV_VARS = {
+         "category": "tool",
+     },
+     "PORCUPINE_ACCESS_KEY": {
+-        "description": "Picovoice access key for the Porcupine 'Hey Hermes' wake word engine (optional; openWakeWord is the free default)",
++        "description": "Picovoice access key for the Porcupine 'Hey Black Pool' wake word engine (optional; openWakeWord is the free default)",
+         "prompt": "Picovoice access key",
+         "url": "https://console.picovoice.ai/",
+         "password": True,
+@@ -4488,7 +4488,7 @@ OPTIONAL_ENV_VARS = {
+         "category": "messaging",
+     },
+     "SLACK_ALLOWED_USERS": {
+-        "description": "Comma-separated Slack member IDs allowed to use Hermes, e.g. U01ABC2DEF3. Without this, Slack may connect but deny messages by default.",
++        "description": "Comma-separated Slack member IDs allowed to use Black Pool, e.g. U01ABC2DEF3. Without this, Slack may connect but deny messages by default.",
+         "prompt": "Allowed Slack member IDs",
+         "help": "In Slack, open your profile, choose More or the three-dot menu, then Copy member ID. Add multiple IDs comma-separated.",
+         "url": "https://api.slack.com/apps",
+@@ -4760,15 +4760,15 @@ OPTIONAL_ENV_VARS = {
+         "advanced": True,
+     },
+     "GATEWAY_PROXY_URL": {
+-        "description": "URL of a remote Hermes API server to forward messages to (proxy mode). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Use for Docker E2EE containers that relay to a host agent. Also configurable via gateway.proxy_url in config.yaml.",
+-        "prompt": "Remote Hermes API server URL (e.g. http://192.168.1.100:8642)",
++        "description": "URL of a remote Black Pool API server to forward messages to (proxy mode). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Use for Docker E2EE containers that relay to a host agent. Also configurable via gateway.proxy_url in config.yaml.",
++        "prompt": "Remote Black Pool API server URL (e.g. http://192.168.1.100:8642)",
+         "url": None,
+         "password": False,
+         "category": "messaging",
+         "advanced": True,
+     },
+     "GATEWAY_PROXY_KEY": {
+-        "description": "Bearer token for authenticating with the remote Hermes API server (proxy mode). Must match the API_SERVER_KEY on the remote host.",
++        "description": "Bearer token for authenticating with the remote Black Pool API server (proxy mode). Must match the API_SERVER_KEY on the remote host.",
+         "prompt": "Remote API server auth key",
+         "url": None,
+         "password": True,
+diff --git a/hermes_cli/console_engine.py b/hermes_cli/console_engine.py
+index b52e7a1..2e16e5c 100644
+--- a/hermes_cli/console_engine.py
++++ b/hermes_cli/console_engine.py
+@@ -1,7 +1,7 @@
+-"""Safe Hermes Console command engine.
++"""Safe Black Pool Console command engine.
+ 
+ This module backs ``hermes console`` and is intentionally narrower than the
+-full Hermes CLI. It exposes a curated set of native adapters that can later be
++full Black Pool CLI. It exposes a curated set of native adapters that can later be
+ shared by the dashboard console websocket without becoming a raw shell.
+ """
+ 
+@@ -494,7 +494,7 @@ def _register_command_family(
+ 
+ 
+ class HermesConsoleEngine:
+-    """Curated line-command executor for Hermes Console."""
++    """Curated line-command executor for Black Pool Console."""
+ 
+     def __init__(self, *, output_limit: int = 20000):
+         self.output_limit = output_limit
+@@ -516,8 +516,8 @@ class HermesConsoleEngine:
+ 
+             if _contains_shell_syntax(raw_line, tokens):
+                 raise ConsoleCommandError(
+-                    "Hermes Console does not run shell syntax. Use one supported "
+-                    "Hermes command at a time."
++                    "Black Pool Console does not run shell syntax. Use one supported "
++                    "Black Pool command at a time."
+                 )
+ 
+             builtin = self._execute_builtin(tokens)
+@@ -549,7 +549,7 @@ class HermesConsoleEngine:
+             return f"{command.usage}\n{command.summary}"
+ 
+         lines = [
+-            "Hermes Console",
++            "Black Pool Console",
+             "",
+             "Supported commands:",
+         ]
+@@ -566,10 +566,10 @@ class HermesConsoleEngine:
+         return "\n".join(lines)
+ 
+     def _register_defaults(self) -> None:
+-        self.register(("status",), "status", "Show Hermes component status.", _status)
+-        self.register(("version",), "version", "Show Hermes version information.", _version)
++        self.register(("status",), "status", "Show Black Pool component status.", _status)
++        self.register(("version",), "version", "Show Black Pool version information.", _version)
+         self.register(("doctor",), "doctor", "Run diagnostics without auto-fix.", _doctor)
+-        self.register(("logs",), "logs [name] [-n N]", "Show recent Hermes logs.", _logs)
++        self.register(("logs",), "logs [name] [-n N]", "Show recent Black Pool logs.", _logs)
+         self.register(("sessions", "list"), "sessions list [--limit N]", "List recent sessions.", _sessions_list)
+         self.register(("sessions", "stats"), "sessions stats", "Show session store statistics.", _sessions_stats)
+         self.register(("config", "show"), "config show", "Show current configuration.", _config_show)
+@@ -580,7 +580,7 @@ class HermesConsoleEngine:
+             "Set a configuration value.",
+             _config_set,
+             mutating=True,
+-            confirmation="Update Hermes configuration?",
++            confirmation="Update Black Pool configuration?",
+         )
+         self.register(("cron", "list"), "cron list [--all]", "List scheduled jobs.", _cron_list)
+         self.register(("cron", "status"), "cron status", "Show cron scheduler status.", _cron_status)
+@@ -611,7 +611,7 @@ class HermesConsoleEngine:
+         self._register_broad_cli_surface()
+ 
+     def _register_broad_cli_surface(self) -> None:
+-        """Register non-admin CLI commands that are safe for Hermes Console."""
++        """Register non-admin CLI commands that are safe for Black Pool Console."""
+ 
+         extracted = {
+             "dump": (
+@@ -873,7 +873,7 @@ class HermesConsoleEngine:
+             "Update config with new options.",
+             _config_migrate,
+             mutating=True,
+-            confirmation="Update Hermes configuration with missing defaults?",
++            confirmation="Update Black Pool configuration with missing defaults?",
+         )
+         self.register(
+             ("sessions", "export"),
+@@ -1168,12 +1168,12 @@ class HermesConsoleEngine:
+         probe = " ".join(tokens[:2]) if len(tokens) > 1 else tokens[0]
+         suggestions = difflib.get_close_matches(probe, available, n=3, cutoff=0.45)
+         suffix = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
+-        raise ConsoleCommandError(f"Unsupported Hermes Console command: {probe}.{suffix}")
++        raise ConsoleCommandError(f"Unsupported Black Pool Console command: {probe}.{suffix}")
+ 
+     def _rejection_for(self, tokens: Sequence[str]) -> str:
+         first = tokens[0]
+         if first.startswith("-"):
+-            return f"{first} is not available in Hermes Console."
++            return f"{first} is not available in Black Pool Console."
+         blocked_top = {
+             "acp",
+             "chat",
+@@ -1199,30 +1199,30 @@ class HermesConsoleEngine:
+             "whatsapp-cloud",
+         }
+         if first in blocked_top:
+-            return f"`hermes {first}` is not available in Hermes Console."
++            return f"`hermes {first}` is not available in Black Pool Console."
+         blocked_pairs = {
+-            ("config", "edit"): "`config edit` opens an editor and is not available in Hermes Console.",
+-            ("mcp", "serve"): "`mcp serve` starts a server and is not available in Hermes Console.",
+-            ("profile", "alias"): "`profile alias` creates shell wrappers and is not available in Hermes Console.",
+-            ("skills", "config"): "`skills config` is interactive and is not available in Hermes Console.",
+-            ("skills", "publish"): "`skills publish` is not available in Hermes Console.",
+-            ("portal", "login"): "`portal login` is interactive and is not available in Hermes Console.",
+-            ("portal", "open"): "`portal open` opens a browser and is not available in Hermes Console.",
+-            ("kanban", "tail"): "`kanban tail` streams output and is not available in Hermes Console.",
+-            ("kanban", "watch"): "`kanban watch` streams output and is not available in Hermes Console.",
+-            ("kanban", "daemon"): "`kanban daemon` starts a service and is not available in Hermes Console.",
+-            ("kanban", "dispatcher"): "`kanban dispatcher` starts a worker and is not available in Hermes Console.",
+-            ("kanban", "swarm"): "`kanban swarm` starts agent work and is not available in Hermes Console.",
+-            ("kanban", "decompose"): "`kanban decompose` starts agent work and is not available in Hermes Console.",
+-            ("kanban", "specify"): "`kanban specify` starts agent work and is not available in Hermes Console.",
+-            ("kanban", "gc"): "`kanban gc` is not available in Hermes Console.",
++            ("config", "edit"): "`config edit` opens an editor and is not available in Black Pool Console.",
++            ("mcp", "serve"): "`mcp serve` starts a server and is not available in Black Pool Console.",
++            ("profile", "alias"): "`profile alias` creates shell wrappers and is not available in Black Pool Console.",
++            ("skills", "config"): "`skills config` is interactive and is not available in Black Pool Console.",
++            ("skills", "publish"): "`skills publish` is not available in Black Pool Console.",
++            ("portal", "login"): "`portal login` is interactive and is not available in Black Pool Console.",
++            ("portal", "open"): "`portal open` opens a browser and is not available in Black Pool Console.",
++            ("kanban", "tail"): "`kanban tail` streams output and is not available in Black Pool Console.",
++            ("kanban", "watch"): "`kanban watch` streams output and is not available in Black Pool Console.",
++            ("kanban", "daemon"): "`kanban daemon` starts a service and is not available in Black Pool Console.",
++            ("kanban", "dispatcher"): "`kanban dispatcher` starts a worker and is not available in Black Pool Console.",
++            ("kanban", "swarm"): "`kanban swarm` starts agent work and is not available in Black Pool Console.",
++            ("kanban", "decompose"): "`kanban decompose` starts agent work and is not available in Black Pool Console.",
++            ("kanban", "specify"): "`kanban specify` starts agent work and is not available in Black Pool Console.",
++            ("kanban", "gc"): "`kanban gc` is not available in Black Pool Console.",
+         }
+         if len(tokens) >= 2:
+             pair = (tokens[0], tokens[1])
+             if pair in blocked_pairs:
+                 return blocked_pairs[pair]
+         if tuple(tokens[:2]) in {("sessions", "delete"), ("sessions", "prune")}:
+-            return "`sessions delete` and `sessions prune` are not available in Hermes Console."
++            return "`sessions delete` and `sessions prune` are not available in Black Pool Console."
+         return ""
+ 
+     def _help_result(self) -> ConsoleResult:
+@@ -1259,7 +1259,7 @@ def _apply_confirmed_defaults(args: argparse.Namespace) -> None:
+     if getattr(args, "auth_action", None) == "add":
+         auth_type = getattr(args, "auth_type", None)
+         if auth_type in {"api-key", "api_key"} and not getattr(args, "api_key", None):
+-            raise ConsoleCommandError("auth add --type api-key requires --api-key in Hermes Console.")
++            raise ConsoleCommandError("auth add --type api-key requires --api-key in Black Pool Console.")
+     if getattr(args, "import_name", None) is not None:
+         # profile import has no prompt flag; leave it alone.
+         return
+@@ -1302,7 +1302,7 @@ def _doctor(_engine: HermesConsoleEngine, args: list[str]) -> str:
+ 
+ def _logs(_engine: HermesConsoleEngine, args: list[str]) -> str:
+     if "-f" in args or "--follow" in args:
+-        raise ConsoleCommandError("`logs -f` is not available in Hermes Console.")
++        raise ConsoleCommandError("`logs -f` is not available in Black Pool Console.")
+     parser = _ArgumentParser(prog="logs", add_help=False)
+     parser.add_argument("log_name", nargs="?", default="agent")
+     parser.add_argument("-n", "--lines", type=int, default=50)
+@@ -1644,7 +1644,7 @@ def run_console_repl(
+ 
+     engine = HermesConsoleEngine()
+     if interactive:
+-        print("Hermes Console. Type `help` for commands, `exit` to quit.", file=stdout)
++        print("Black Pool Console. Type `help` for commands, `exit` to quit.", file=stdout)
+ 
+     while True:
+         if interactive:
+diff --git a/hermes_cli/credential_lifecycle.py b/hermes_cli/credential_lifecycle.py
+index 7dbfc3f..15f663c 100644
+--- a/hermes_cli/credential_lifecycle.py
++++ b/hermes_cli/credential_lifecycle.py
+@@ -1,4 +1,4 @@
+-"""Unified provider-credential lifecycle across every store Hermes reads.
++"""Unified provider-credential lifecycle across every store Black Pool reads.
+ 
+ A provider API key can live in up to THREE stores at once:
+ 
+diff --git a/hermes_cli/curses_ui.py b/hermes_cli/curses_ui.py
+index 9a127d9..2efa75d 100644
+--- a/hermes_cli/curses_ui.py
++++ b/hermes_cli/curses_ui.py
+@@ -1,4 +1,4 @@
+-"""Shared curses-based UI components for Hermes CLI.
++"""Shared curses-based UI components for Black Pool CLI.
+ 
+ Used by `hermes tools` and `hermes skills` for interactive checklists.
+ Provides a curses multi-select with keyboard navigation, plus a
+diff --git a/hermes_cli/dashboard_auth/base.py b/hermes_cli/dashboard_auth/base.py
+index e8b8a77..103b604 100644
+--- a/hermes_cli/dashboard_auth/base.py
++++ b/hermes_cli/dashboard_auth/base.py
+@@ -12,7 +12,7 @@ class Session:
+ 
+     All fields are mandatory. Providers that don't have a concept of orgs
+     should set ``org_id`` to an empty string. ``access_token`` and
+-    ``refresh_token`` are opaque to Hermes — provider-specific.
++    ``refresh_token`` are opaque to Black Pool — provider-specific.
+     """
+ 
+     user_id: str
 diff --git a/hermes_cli/dashboard_auth/login_page.py b/hermes_cli/dashboard_auth/login_page.py
 index 1ccdfcb..ebd73c3 100644
 --- a/hermes_cli/dashboard_auth/login_page.py
@@ -47712,8 +51409,88 @@ index 1ccdfcb..ebd73c3 100644
  <style>
    @font-face {
      font-family: 'Collapse';
+diff --git a/hermes_cli/dashboard_procs.py b/hermes_cli/dashboard_procs.py
+index 7f8d722..fa34727 100644
+--- a/hermes_cli/dashboard_procs.py
++++ b/hermes_cli/dashboard_procs.py
+@@ -43,7 +43,7 @@ def _scan_dashboard_processes(
+     the kill path because we can't know their original launch args.
+ 
+     *exclude_pids* is an optional set of PIDs that must never be returned.
+-    This is used by the Hermes Desktop Electron app to protect its own
++    This is used by the Black Pool Desktop Electron app to protect its own
+     backend child process: when the desktop spawns ``hermes serve`` as
+     a backend and triggers an auto-update, the update must not kill the
+     backend that the desktop itself manages.  The desktop sets the
+@@ -169,7 +169,7 @@ def _hermes_home_for_pid(pid: int) -> str | None:
+ def _is_ephemeral_port_zero_backend(argv: list[str]) -> bool:
+     """True for Desktop-style ``serve|dashboard --port 0`` backends (#78821).
+ 
+-    Ephemeral-port backends are owned by Hermes Desktop (or become PPID-1
++    Ephemeral-port backends are owned by Black Pool Desktop (or become PPID-1
+     orphans after a prior update respawn).  Replaying them after
+     ``hermes update`` multiplies listening backends because ``--port 0``
+     always binds a fresh free port.  Covers both ``serve`` and the legacy
+@@ -332,7 +332,7 @@ def _kill_stale_dashboard_processes(
+     if restart_managed and _m()._restart_managed_dashboard_service(reason):
+         return {"matched": [], "killed": [], "failed": []}
+ 
+-    # When the Hermes Desktop Electron app spawns this dashboard as a
++    # When the Black Pool Desktop Electron app spawns this dashboard as a
+     # backend child, it sets HERMES_DESKTOP_CHILD_PID so that the update
+     # path can skip killing the desktop-managed process.  (#37532)
+     exclude: set[int] | None = None
+@@ -527,7 +527,7 @@ def _detect_concurrent_hermes_instances(
+ 
+     Windows blocks DELETE/REPLACE on a running .exe — and even RENAME on the
+     same .exe when another process opened it without ``FILE_SHARE_DELETE``.
+-    The Hermes Desktop Electron app spawns ``hermes.EXE`` as a backend child,
++    The Black Pool Desktop Electron app spawns ``hermes.EXE`` as a backend child,
+     so during ``hermes update`` the user-invoked process and the desktop's
+     child both hold the same file. The quarantine rename then fails with
+     ``[WinError 32]`` and uv inherits the lock.
+@@ -577,7 +577,7 @@ def _detect_concurrent_hermes_instances(
+     #      across session/elevation boundaries), leaving the launcher shim in
+     #      the candidate set and re-triggering the false positive.
+     #   2. Only exclude ancestors whose exe is itself a shim. A genuine second
+-    #      hermes.exe sitting *under* a non-Hermes parent (e.g. a Hermes
++    #      hermes.exe sitting *under* a non-Hermes parent (e.g. a Black Pool
+     #      Desktop backend child) must still be flagged, so we don't blanket-
+     #      exclude unrelated ancestors like the shell or terminal.
+     # Broad ``except Exception`` guards against partially-stubbed psutil in
+@@ -731,7 +731,7 @@ _HEX16 = _HEX32
+ 
+ 
+ def _hermes_home_dir() -> Path:
+-    """Resolved Hermes home (HERMES_HOME override or ~/.hermes)."""
++    """Resolved Black Pool home (HERMES_HOME override or ~/.hermes)."""
+     override = os.environ.get("HERMES_HOME", "").strip()
+     if override:
+         return Path(override).expanduser()
+diff --git a/hermes_cli/data/plugin_index.json b/hermes_cli/data/plugin_index.json
+index e380157..478bf04 100644
+--- a/hermes_cli/data/plugin_index.json
++++ b/hermes_cli/data/plugin_index.json
+@@ -4,7 +4,7 @@
+   "plugins": [
+     {
+       "name": "hermes-media-studio",
+-      "description": "Media Studio — generative media workspace plugin for Hermes Desktop (fal + Krea, durable job queue, library).",
++      "description": "Media Studio — generative media workspace plugin for Black Pool Desktop (fal + Krea, durable job queue, library).",
+       "author": "NousResearch",
+       "tags": ["media", "image-gen", "video-gen", "dashboard", "desktop"],
+       "repo": "NousResearch/hermes-media-studio",
+@@ -54,7 +54,7 @@
+     },
+     {
+       "name": "hermes-plugin-chrome-profiles",
+-      "description": "Switch Hermes browser tools between Chrome profiles via CDP.",
++      "description": "Switch Black Pool browser tools between Chrome profiles via CDP.",
+       "author": "anpicasso",
+       "tags": ["browser", "chrome", "cdp", "tools"],
+       "repo": "anpicasso/hermes-plugin-chrome-profiles",
 diff --git a/hermes_cli/debug.py b/hermes_cli/debug.py
-index 0404e78..1d780a3 100644
+index 0404e78..1790366 100644
 --- a/hermes_cli/debug.py
 +++ b/hermes_cli/debug.py
 @@ -1,4 +1,4 @@
@@ -47722,8 +51499,33 @@ index 0404e78..1d780a3 100644
  
  Currently supports:
      hermes debug share    Upload debug report (system info + logs) to a
+@@ -379,7 +379,7 @@ def _primary_log_path(log_name: str) -> Optional[Path]:
+ # exactly the wrong answer when the client is the thing being debugged.
+ _CLIENT_SIDE_LOGS = {
+     "desktop": (
+-        "written by Hermes Desktop on the machine running the app, not by this "
++        "written by Black Pool Desktop on the machine running the app, not by this "
+         "backend. If the desktop connects to a remote/docker/SSH backend, collect "
+         "it on that client machine"
+     ),
+@@ -909,13 +909,13 @@ def run_debug_share(args):
+     # Manual delete fallback
+     print("To delete now:  hermes debug delete <url>")
+ 
+-    print("\nShare these links with the Hermes team for support.")
++    print("\nShare these links with the Black Pool team for support.")
+ 
+ 
+ _NOUS_PRIVACY_NOTICE = """\
+ ⚠️  --nous: This uploads your debug bundle to Nous-INTERNAL storage (AWS S3),
+     NOT a public paste service. The following is included:
+-  • System info (OS, Python/Hermes version, provider, which API keys are
++  • System info (OS, Python/Black Pool version, provider, which API keys are
+     configured — NOT the actual keys)
+   • Full agent.log, gateway.log, and desktop.log (up to 512 KB each — likely
+     contains conversation content, tool outputs, and file paths)
 diff --git a/hermes_cli/default_soul.py b/hermes_cli/default_soul.py
-index f4a6281..5d76749 100644
+index f4a6281..91938c1 100644
 --- a/hermes_cli/default_soul.py
 +++ b/hermes_cli/default_soul.py
 @@ -1,7 +1,7 @@
@@ -47735,7 +51537,7 @@ index f4a6281..5d76749 100644
      "You are helpful, knowledgeable, and direct. You assist users with a wide "
      "range of tasks including answering questions, writing and editing code, "
      "analyzing information, creative work, and executing actions via your tools. "
-@@ -22,7 +22,7 @@ DEFAULT_SOUL_MD = (
+@@ -22,12 +22,12 @@ DEFAULT_SOUL_MD = (
  # safety guarantee is that these strings carry zero user intent.
  _LEGACY_TEMPLATE_SOULS = (
      (
@@ -47744,7 +51546,13 @@ index f4a6281..5d76749 100644
          "\n"
          "<!--\n"
          "This file defines the agent's personality and tone.\n"
-@@ -42,7 +42,7 @@ _LEGACY_TEMPLATE_SOULS = (
+         "The agent will embody whatever you write here.\n"
+-        "Edit this to customize how Hermes communicates with you.\n"
++        "Edit this to customize how Black Pool communicates with you.\n"
+         "\n"
+         "Examples:\n"
+         '  - "You are a warm, playful assistant who uses kaomoji occasionally."\n'
+@@ -42,12 +42,12 @@ _LEGACY_TEMPLATE_SOULS = (
      # block / trailing newline in some historical revisions; the bare scaffold
      # (no Examples block) was also shipped briefly.
      (
@@ -47753,8 +51561,14 @@ index f4a6281..5d76749 100644
          "\n"
          "<!--\n"
          "This file defines the agent's personality and tone.\n"
+         "The agent will embody whatever you write here.\n"
+-        "Edit this to customize how Hermes communicates with you.\n"
++        "Edit this to customize how Black Pool communicates with you.\n"
+         "\n"
+         "This file is loaded fresh each message -- no restart needed.\n"
+         "Delete the contents (or this file) to use the default personality.\n"
 diff --git a/hermes_cli/doctor.py b/hermes_cli/doctor.py
-index 524ab04..ee76643 100644
+index 524ab04..434f8a4 100644
 --- a/hermes_cli/doctor.py
 +++ b/hermes_cli/doctor.py
 @@ -1,7 +1,7 @@
@@ -47766,17 +51580,218 @@ index 524ab04..ee76643 100644
  """
  
  import os
-@@ -1792,7 +1792,7 @@ def run_doctor(args):
+@@ -90,7 +90,7 @@ def _sqlite_upgrade_hint(install_method: str | None = None) -> str:
+     method = install_method or detect_install_method(PROJECT_ROOT)
+     if method == "docker":
+         command = recommended_update_command_for_method(method)
+-        action = f"run `{command}`, then recreate all Hermes containers"
++        action = f"run `{command}`, then recreate all Black Pool containers"
+     elif is_nix_install_method(method):
+         # The Nix helper is prose guidance, not a literal shell command.
+         action = recommended_update_command_for_method(method)
+@@ -200,7 +200,7 @@ def _report_database_journal_modes(
+     try:
+         databases = _hermes_database_paths(home)
+     except Exception as exc:
+-        check_warn(f"Could not list Hermes databases: {exc}")
++        check_warn(f"Could not list Black Pool databases: {exc}")
+         return
+     exposed = []
+     for name, path in databases:
+@@ -583,7 +583,7 @@ def collect_relay_plugin_cutover_findings(
+     raw_config: dict | None,
+     env_map: dict | None,
+ ) -> list[tuple[str, str]]:
+-    """Return actionable findings for the removed Hermes Relay plugin."""
++    """Return actionable findings for the removed Black Pool Relay plugin."""
+     from hermes_cli.relay_plugin_cutover import (
+         LEGACY_RELAY_EXPORT_ENV_VARS,
+         RELAY_PLUGINS_CONFIG_ENV,
+@@ -1077,7 +1077,7 @@ def run_doctor(args):
+ 
+     print()
+     print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
+-    print(color("│                 🩺 Hermes Doctor                        │", Colors.CYAN))
++    print(color("│                 🩺 Black Pool Doctor                        │", Colors.CYAN))
+     print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+ 
+     _section("Security Advisories")
+@@ -1180,7 +1180,7 @@ def run_doctor(args):
+             (_sqlite_src[:48] + "…") if len(_sqlite_src) > 48 else _sqlite_src
+         )
+         if is_sqlite_wal_reset_vulnerable():
+-            # Warn-only: Hermes already refuses to enable WAL on fresh DBs.
++            # Warn-only: Black Pool already refuses to enable WAL on fresh DBs.
+             # Do not append to ``issues`` because runtime repair remains
+             # best-effort and unsupported installs may need manual action.
+             check_warn(
+@@ -1719,7 +1719,7 @@ def run_doctor(args):
+             check_warn("OpenAI Codex auth", "(not logged in)")
+             if codex_status.get("error"):
+                 check_info(codex_status["error"])
+-            # Native OAuth uses Hermes' own device-code flow — the Codex CLI is
++            # Native OAuth uses Black Pool' own device-code flow — the Codex CLI is
+             # only needed to import existing tokens from ~/.codex/auth.json.
+             # Attach the hint to the Codex auth row so it doesn't read as
+             # remediation for whichever provider happens to print next (#27975).
+@@ -1788,13 +1788,13 @@ def run_doctor(args):
+         else:
+             check_info(f"{_DHH}/SOUL.md exists but is empty — edit it to customize personality")
+     else:
+-        check_warn(f"{_DHH}/SOUL.md not found", "(create it to give Hermes a custom personality)")
++        check_warn(f"{_DHH}/SOUL.md not found", "(create it to give Black Pool a custom personality)")
          if should_fix:
              soul_path.parent.mkdir(parents=True, exist_ok=True)
              soul_path.write_text(
 -                "# Hermes Agent Persona\n\n"
+-                "<!-- Edit this file to customize how Hermes communicates. -->\n\n"
+-                "You are Hermes, a helpful AI assistant.\n",
 +                "# Black Pool Agent Persona\n\n"
-                 "<!-- Edit this file to customize how Hermes communicates. -->\n\n"
-                 "You are Hermes, a helpful AI assistant.\n",
++                "<!-- Edit this file to customize how Black Pool communicates. -->\n\n"
++                "You are Black Pool, a helpful AI assistant.\n",
                  encoding="utf-8",
+             )
+             check_ok(f"Created {_DHH}/SOUL.md with basic template")
+@@ -1923,7 +1923,7 @@ def run_doctor(args):
+                 check_warn(f"{_DHH}/state.db exists but has issues: {e}")
+ 
+         # Health/stats snapshot (#statedb-visibility): a multi-GB state.db
+-        # with a runaway WAL was previously invisible to every Hermes
++        # with a runaway WAL was previously invisible to every Black Pool
+         # surface. Strictly read-only (mode=ro) so it is safe against a
+         # live DB held by the gateway; any failure degrades to one info
+         # line rather than failing doctor.
+@@ -2428,7 +2428,7 @@ def run_doctor(args):
+                         # tooling (esbuild/vite, etc.), not runtime code that ships
+                         # to users. Manual npm remediation may error with a known
+                         # arborist crash (edgesOut / isDescendantOf) on this monorepo
+-                        # tree — in that case it is an npm bug, not a Hermes one.
++                        # tree — in that case it is an npm bug, not a Black Pool one.
+                         check_info(
+                             "  ^ build-time tooling (not runtime); if manual npm remediation "
+                             "errors with an arborist crash it's a known npm bug — clears "
+diff --git a/hermes_cli/dump.py b/hermes_cli/dump.py
+index e29675c..1713b86 100644
+--- a/hermes_cli/dump.py
++++ b/hermes_cli/dump.py
+@@ -1,7 +1,7 @@
+ """
+ Dump command for hermes CLI.
+ 
+-Outputs a compact, plain-text summary of the user's Hermes setup
++Outputs a compact, plain-text summary of the user's Black Pool setup
+ that can be copy-pasted into Discord/GitHub/Telegram for support context.
+ No ANSI colors, no checkmarks — just data.
+ """
+diff --git a/hermes_cli/env_loader.py b/hermes_cli/env_loader.py
+index f926c6e..28f753f 100644
+--- a/hermes_cli/env_loader.py
++++ b/hermes_cli/env_loader.py
+@@ -1,4 +1,4 @@
+-"""Helpers for loading Hermes .env files consistently across entrypoints."""
++"""Helpers for loading Black Pool .env files consistently across entrypoints."""
+ 
+ from __future__ import annotations
+ 
+@@ -53,7 +53,7 @@ _SECRET_SOURCE_CACHE_LOCK = threading.RLock()
+ 
+ 
+ def _known_hermes_env_keys() -> set[str]:
+-    """Return the combined set of known Hermes env-var keys.
++    """Return the combined set of known Black Pool env-var keys.
+ 
+     Includes both ``OPTIONAL_ENV_VARS`` (setup-flow vars with metadata) and
+     ``_EXTRA_ENV_KEYS`` (provider/platform keys managed outside the setup
+@@ -66,7 +66,7 @@ def _known_hermes_env_keys() -> set[str]:
+     return set(OPTIONAL_ENV_VARS.keys()) | set(_EXTRA_ENV_KEYS)
+ 
+ 
+-# Behavioral routing keys a parent Hermes process injects into child env and
++# Behavioral routing keys a parent Black Pool process injects into child env and
+ # that silently redirect a profile onto the wrong provider path (ACP auth
+ # method, copilot-ACP endpoints). These — and ONLY these — are scrubbed from
+ # os.environ at startup when absent from the profile's .env. Credential keys
+@@ -112,7 +112,7 @@ def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
+ 
+ 
+ def _clear_known_keys_missing_from_dotenv(path: Path) -> None:
+-    """Remove inherited profile-managed Hermes keys absent from ``.env``.
++    """Remove inherited profile-managed Black Pool keys absent from ``.env``.
+ 
+     After the profile's ``.env`` has been loaded with ``override=True``,
+     scan the file for which profile-managed keys it explicitly defines and
+@@ -121,7 +121,7 @@ def _clear_known_keys_missing_from_dotenv(path: Path) -> None:
+ 
+     Scope is deliberately NARROW: only ``_PROFILE_MANAGED_ENV_KEYS`` —
+     behavioral routing keys (ACP auth method, copilot-ACP endpoints) that a
+-    parent Hermes process injects and that silently change *which provider
++    parent Black Pool process injects and that silently change *which provider
+     path* a profile uses. Provider API keys (OPENAI_API_KEY, …) are
+     intentionally excluded: users legitimately export those in their shell
+     (``export OPENAI_API_KEY=…`` is a documented flow — see
+@@ -473,7 +473,7 @@ def load_hermes_dotenv(
+     project_env: str | os.PathLike | None = None,
+     load_external_secrets: bool = True,
+ ) -> list[Path]:
+-    """Load Hermes environment files with user config taking precedence.
++    """Load Black Pool environment files with user config taking precedence.
+ 
+     Behavior:
+     - `~/.hermes/.env` overrides stale shell-exported values when present.
+@@ -499,7 +499,7 @@ def load_hermes_dotenv(
+     if user_env.exists():
+         _load_dotenv_with_fallback(user_env, override=True)
+         loaded.append(user_env)
+-        # Mirror reload_env() known-key cleanup so inherited Hermes keys
++        # Mirror reload_env() known-key cleanup so inherited Black Pool keys
+         # absent from this profile's .env do not leak into the runtime.
+         _clear_known_keys_missing_from_dotenv(user_env)
+ 
+@@ -618,7 +618,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
+     """Pull secrets from every enabled external source into env.
+ 
+     Runs AFTER dotenv loads so .env values are visible (sources use them
+-    to locate bootstrap tokens) but BEFORE the rest of Hermes reads
++    to locate bootstrap tokens) but BEFORE the rest of Black Pool reads
+     ``os.environ`` for credentials.  Any failure here is logged and
+     swallowed — external secret sources must never block startup.
+ 
+diff --git a/hermes_cli/foreign_sessions.py b/hermes_cli/foreign_sessions.py
+index 1d565c3..e2793a9 100644
+--- a/hermes_cli/foreign_sessions.py
++++ b/hermes_cli/foreign_sessions.py
+@@ -2,7 +2,7 @@
+ 
+ ``hermes sessions import`` (and ``--resume @claude`` / ``--resume @codex``)
+ let a user pull a conversation they started in another agent CLI into
+-Hermes and continue it here.
++Black Pool and continue it here.
+ 
+ Sources (read-only — foreign files are never modified):
+ 
+@@ -23,7 +23,7 @@ Sources (read-only — foreign files are never modified):
+   real rollout files, Codex CLI 0.147.)
+ 
+ Conversion contract — imported history must satisfy the provider
+-role-alternation invariant Hermes enforces everywhere else:
++role-alternation invariant Black Pool enforces everywhere else:
+ 
+ * only plain ``user`` / ``assistant`` text messages are produced (tool
+   calls become short bracketed summaries inside the assistant text; we
+@@ -318,9 +318,9 @@ _SOURCE_DB_NAMES = {"claude": "claude-code", "codex": "codex-cli"}
+ 
+ 
+ def import_foreign_session(source: str, path, db=None) -> str:
+-    """Import one foreign session into the Hermes SessionDB.
++    """Import one foreign session into the Black Pool SessionDB.
+ 
+-    Returns the new Hermes session id.  The foreign file is only read.
++    Returns the new Black Pool session id.  The foreign file is only read.
+     Raises ``ValueError`` on unknown source or a session with no usable
+     conversation turns.
+     """
 diff --git a/hermes_cli/gateway.py b/hermes_cli/gateway.py
-index dced827..e0ab394 100644
+index dced827..928572d 100644
 --- a/hermes_cli/gateway.py
 +++ b/hermes_cli/gateway.py
 @@ -756,7 +756,7 @@ def find_gateway_pids(
@@ -47797,6 +51812,24 @@ index dced827..e0ab394 100644
      _exclude = set(exclude_pids or set())
      processes: list[ProfileGatewayProcess] = []
      try:
+@@ -860,7 +860,7 @@ def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | Non
+     """Choose who relaunches a profile gateway after ``hermes update``.
+ 
+     A gateway started with ``--external-supervisor`` must exit back to that
+-    manager. Starting Hermes's detached watcher as well would escape the
++    manager. Starting Black Pool's detached watcher as well would escape the
+     manager and race its replacement process. Ordinary foreground gateways
+     retain the existing detached-watcher behavior.
+     """
+@@ -2039,7 +2039,7 @@ def _systemd_operational(system: bool = False) -> bool:
+ def _container_systemd_operational() -> bool:
+     """Return True when a container exposes working user or system systemd.
+ 
+-    This is NOT our Hermes Docker image — that one runs s6-overlay as
++    This is NOT our Black Pool Docker image — that one runs s6-overlay as
+     PID 1 (since Phase 2 of the s6-overlay supervision plan) and is
+     detected via ``service_manager.detect_service_manager() == "s6"``.
+     This function handles the "container managed by something else"
 @@ -2199,7 +2199,7 @@ def _windows_gateway_breakaway_state() -> bool | None:
  # =============================================================================
  
@@ -47806,6 +51839,184 @@ index dced827..e0ab394 100644
  
  
  def _profile_suffix() -> str:
+@@ -2240,7 +2240,7 @@ def _profile_arg(hermes_home: str | None = None, default_root: str | Path | None
+         hermes_home: Optional explicit HERMES_HOME path. Defaults to the current
+             ``get_hermes_home()`` value. Should be passed when generating a
+             service definition for a different user (e.g. system service).
+-        default_root: Optional Hermes root to compare against. Used when
++        default_root: Optional Black Pool root to compare against. Used when
+             generating a system service for another user from a sudo/root
+             process, where ``Path.home()`` and ``get_default_hermes_root()``
+             refer to root but the target profile lives under the service user.
+@@ -2578,7 +2578,7 @@ def has_conflicting_systemd_units() -> bool:
+     return len(get_installed_systemd_scopes()) > 1
+ 
+ 
+-# Legacy service names from older Hermes installs that predate the
++# Legacy service names from older Black Pool installs that predate the
+ # hermes-gateway rename. Kept as an explicit allowlist (NOT a glob) so
+ # profile units (hermes-gateway-*.service) and unrelated third-party
+ # "hermes" units are never matched.
+@@ -2608,9 +2608,9 @@ def _legacy_unit_search_paths() -> list[tuple[bool, Path]]:
+ 
+ 
+ def _find_legacy_hermes_units() -> list[tuple[str, Path, bool]]:
+-    """Return ``[(unit_name, unit_path, is_system)]`` for legacy Hermes gateway units.
++    """Return ``[(unit_name, unit_path, is_system)]`` for legacy Black Pool gateway units.
+ 
+-    Detects unit files installed by older Hermes versions that used a
++    Detects unit files installed by older Black Pool versions that used a
+     different service name (e.g. ``hermes.service`` before the rename to
+     ``hermes-gateway.service``). When both a legacy unit and the current
+     ``hermes-gateway.service`` are active, they fight over the same bot
+@@ -2646,12 +2646,12 @@ def _find_legacy_hermes_units() -> list[tuple[str, Path, bool]]:
+ 
+ 
+ def has_legacy_hermes_units() -> bool:
+-    """Return True when any legacy Hermes gateway unit files exist."""
++    """Return True when any legacy Black Pool gateway unit files exist."""
+     return bool(_find_legacy_hermes_units())
+ 
+ 
+ def print_legacy_unit_warning() -> None:
+-    """Warn about legacy Hermes gateway unit files if any are installed.
++    """Warn about legacy Black Pool gateway unit files if any are installed.
+ 
+     Idempotent: prints nothing when no legacy units are detected. Safe to
+     call from any status/install/setup path.
+@@ -2659,7 +2659,7 @@ def print_legacy_unit_warning() -> None:
+     legacy = _find_legacy_hermes_units()
+     if not legacy:
+         return
+-    print_warning("Legacy Hermes gateway unit(s) detected from an older install:")
++    print_warning("Legacy Black Pool gateway unit(s) detected from an older install:")
+     for name, path, is_system in legacy:
+         scope = "system" if is_system else "user"
+         print_info(f"    {path}  ({scope} scope)")
+@@ -2673,7 +2673,7 @@ def remove_legacy_hermes_units(
+     interactive: bool = True,
+     dry_run: bool = False,
+ ) -> tuple[int, list[Path]]:
+-    """Stop, disable, and remove legacy Hermes gateway unit files.
++    """Stop, disable, and remove legacy Black Pool gateway unit files.
+ 
+     Iterates over whatever ``_find_legacy_hermes_units()`` returns — which is
+     an explicit allowlist of legacy names (not a glob). Profile units and
+@@ -2691,14 +2691,14 @@ def remove_legacy_hermes_units(
+     """
+     legacy = _find_legacy_hermes_units()
+     if not legacy:
+-        print("No legacy Hermes gateway units found.")
++        print("No legacy Black Pool gateway units found.")
+         return 0, []
+ 
+     user_units = [(n, p) for n, p, is_sys in legacy if not is_sys]
+     system_units = [(n, p) for n, p, is_sys in legacy if is_sys]
+ 
+     print()
+-    print("Legacy Hermes gateway unit(s) found:")
++    print("Legacy Black Pool gateway unit(s) found:")
+     for name, path, is_system in legacy:
+         scope = "system" if is_system else "user"
+         print(f"  {path}  ({scope} scope)")
+@@ -3074,7 +3074,7 @@ def print_systemd_linger_guidance() -> None:
+ def _launchd_user_home() -> Path:
+     """Return the real macOS user home for launchd artifacts.
+ 
+-    Profile-mode Hermes often sets ``HOME`` to a profile-scoped directory, but
++    Profile-mode Black Pool often sets ``HOME`` to a profile-scoped directory, but
+     launchd user agents still live under the actual account home.
+     """
+     import pwd
+@@ -3404,7 +3404,7 @@ def _append_node_dir_for_service(
+     backend spawn was fixed for. Managed dirs are profile-scoped, so each
+     profile's unit still names its own Node.
+ 
+-    *hermes_root* is the Hermes home the unit will run against. System units
++    *hermes_root* is the Black Pool home the unit will run against. System units
+     installed via sudo MUST pass the **target user's** home: probing the
+     default (the calling user's — root's — tree) would bake root's Node into
+     the target user's unit. The probe swallows OSError: an unreadable
+@@ -3429,7 +3429,7 @@ def _append_node_dir_for_service(
+             path_entries.append(entry)
+ 
+     # Ambient PATH lookup is a fallback, not an additional rung. Once the
+-    # target Hermes home provides managed Node, consulting the invoker's PATH
++    # target Black Pool home provides managed Node, consulting the invoker's PATH
+     # makes a system unit differ between sudo/root and its service user.
+     if managed_node_present:
+         return
+@@ -3460,7 +3460,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None)
+     path_entries = _build_service_path_dirs()
+     if not system:
+         # System units append the managed Node dirs later, once the TARGET
+-        # user's Hermes home is known — probing here would stat the calling
++        # user's Black Pool home is known — probing here would stat the calling
+         # (sudo → root's) tree and bake the wrong user's Node into the unit.
+         _append_node_dir_for_service(path_entries)
+ 
+@@ -3773,7 +3773,7 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
+     unit_path.write_text(new_unit, encoding="utf-8")
+     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
+     print(
+-        f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Hermes install"
++        f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Black Pool install"
+     )
+     return True
+ 
+@@ -5063,7 +5063,7 @@ def refresh_launchd_plist_if_needed() -> bool:
+             _launchd_reload_log_path(),
+         )
+     print(
+-        "↻ Updated gateway launchd service definition to match the current Hermes install"
++        "↻ Updated gateway launchd service definition to match the current Black Pool install"
+     )
+     return True
+ 
+@@ -5413,14 +5413,14 @@ def launchd_status(deep: bool = False):
+     # unmanageable domain).  A PID in the output confirms a live process.
+     launchd_pid = _parse_launchd_pid_from_list_output(list_output) if service_listed else None
+ 
+-    # Hermes PID tracking — may be a detached fallback process spawned when
++    # Black Pool PID tracking — may be a detached fallback process spawned when
+     # launchd cannot manage the domain on this host.
+     from gateway.status import get_running_pid
+     fallback_pid = get_running_pid(cleanup_stale=False)
+ 
+     # Avoid double-counting: when launchd IS supervising, fallback_pid and
+     # launchd_pid point at the same process (the gateway writes both the
+-    # launchd PID and the Hermes PID file).
++    # launchd PID and the Black Pool PID file).
+     if launchd_pid is not None and fallback_pid == launchd_pid:
+         fallback_pid = None
+ 
+@@ -5432,9 +5432,9 @@ def launchd_status(deep: bool = False):
+     # ── Report ──
+     print(f"Launchd plist: {plist_path}")
+     if launchd_plist_is_current():
+-        print("✓ Service definition matches the current Hermes install")
++        print("✓ Service definition matches the current Black Pool install")
+     else:
+-        print("⚠ Service definition is stale relative to the current Hermes install")
++        print("⚠ Service definition is stale relative to the current Black Pool install")
+         print("  Run: hermes gateway start")
+ 
+     if service_listed:
+@@ -5704,12 +5704,12 @@ def _guard_official_docker_root_gateway() -> None:
+         return
+ 
+     print_error(
+-        "Refusing to run the Hermes gateway as root inside the official Docker image."
++        "Refusing to run the Black Pool gateway as root inside the official Docker image."
+     )
+     print(
+         "  The image entrypoint normally drops privileges to the 'hermes' user. "
+         "If you override entrypoint in Docker Compose, include "
+-        "/opt/hermes/docker/entrypoint.sh before the Hermes command."
++        "/opt/hermes/docker/entrypoint.sh before the Black Pool command."
+     )
+     print(
+         "  Running the gateway as root can leave root-owned files in "
 @@ -5802,7 +5802,7 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
      from gateway.run import start_gateway
  
@@ -47815,8 +52026,57 @@ index dced827..e0ab394 100644
      print("├─────────────────────────────────────────────────────────┤")
      print("│  Messaging platforms + cron scheduler                    │")
      print("│  Press Ctrl+C to stop                                   │")
+@@ -6038,7 +6038,7 @@ _PLATFORMS = [
+                 "name": "MATTERMOST_HOME_CHANNEL",
+                 "prompt": "Home channel ID (for cron/notification delivery, or empty to set later with /set-home)",
+                 "password": False,
+-                "help": "Channel ID where Hermes delivers cron results and notifications.",
++                "help": "Channel ID where Black Pool delivers cron results and notifications.",
+             },
+             {
+                 "name": "MATTERMOST_REPLY_MODE",
+@@ -6077,7 +6077,7 @@ _PLATFORMS = [
+             "2. Complete the BlueBubbles setup wizard — sign in with your Apple ID",
+             "3. In BlueBubbles Settings → API, note the Server URL and password",
+             "4. The server URL is typically http://<your-mac-ip>:1234",
+-            "5. Hermes connects via the BlueBubbles REST API and receives",
++            "5. Black Pool connects via the BlueBubbles REST API and receives",
+             "   incoming messages via a local webhook",
+             "6. To authorize users, use DM pairing: hermes pairing generate bluebubbles",
+             "   Share the code — the user sends it via iMessage to get approved",
+@@ -6158,7 +6158,7 @@ _PLATFORMS = [
+             "1. Download the Yuanbao app from https://yuanbao.tencent.com/",
+             "2. In the app, go to PAI → My Bot and create a new bot",
+             "3. After the bot is created, copy the App ID and App Secret",
+-            "4. Enter them below and Hermes will connect automatically over WebSocket",
++            "4. Enter them below and Black Pool will connect automatically over WebSocket",
+         ],
+         "vars": [
+             {
+@@ -6668,10 +6668,10 @@ def _setup_weixin():
+     print()
+     print(color("  ─── 💬 Weixin / WeChat Setup ───", Colors.CYAN))
+     print()
+-    print_info("  1. Hermes will open Tencent iLink QR login in this terminal.")
++    print_info("  1. Black Pool will open Tencent iLink QR login in this terminal.")
+     print_info("  2. Use WeChat to scan and confirm the QR code.")
+     print_info(
+-        "  3. Hermes will store the returned account_id/token in ~/.hermes/.env."
++        "  3. Black Pool will store the returned account_id/token in ~/.hermes/.env."
+     )
+     print_info(
+         "  4. This adapter supports native text, image, video, and document delivery."
+@@ -8265,7 +8265,7 @@ def _gateway_command_inner(args):
+         _gateway_list()
+ 
+     elif subcmd == "migrate-legacy":
+-        # Stop, disable, and remove legacy Hermes gateway unit files from
++        # Stop, disable, and remove legacy Black Pool gateway unit files from
+         # pre-rename installs (e.g. hermes.service). Profile units and
+         # unrelated third-party services are never touched.
+         dry_run = getattr(args, "dry_run", False)
 diff --git a/hermes_cli/gateway_windows.py b/hermes_cli/gateway_windows.py
-index 59a1d28..db47980 100644
+index 59a1d28..050d60e 100644
 --- a/hermes_cli/gateway_windows.py
 +++ b/hermes_cli/gateway_windows.py
 @@ -60,7 +60,7 @@ _FALLBACK_PATTERNS = re.compile(
@@ -47837,10 +52097,264 @@ index 59a1d28..db47980 100644
      from hermes_cli.gateway import _profile_arg
  
      profile_arg = _profile_arg()
+@@ -317,7 +317,7 @@ def get_task_script_path() -> Path:
+ 
+     Lives under ``%LOCALAPPDATA%\\hermes\\gateway-service\\<task_name>.cmd``
+     (or ``<HERMES_HOME>/gateway-service/<task_name>.cmd`` so per-profile
+-    Hermes installs stay self-contained).
++    Black Pool installs stay self-contained).
+     """
+     _assert_windows()
+     from hermes_cli.config import get_hermes_home
+@@ -661,7 +661,7 @@ def _write_scheduled_task_xml(task_name: str, launcher_path: Path, user: str | N
+ def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, str]:
+     """Create or replace the Scheduled Task. Returns (success, detail).
+ 
+-    Always recreate instead of ``/Change``. Older Hermes builds and failed
++    Always recreate instead of ``/Change``. Older Black Pool builds and failed
+     experiments may have left repeat/restart settings on the task; ``/Change``
+     preserves those stale triggers and can make the gateway relaunch every
+     minute. Delete+create gives us a clean ONLOGON task every install.
+@@ -1093,7 +1093,7 @@ def install(
+         print("  UAC is Windows' admin approval prompt; it is needed to create/update the Scheduled Task.")
+         if prompt_yes_no("  Open the UAC prompt now?", False):
+             if _launch_elevated_install(force=force, start_now=start_now, start_on_login=start_on_login):
+-                print("✓ Launched elevated Hermes gateway install prompt.")
++                print("✓ Launched elevated Black Pool gateway install prompt.")
+                 if start_now:
+                     print("  Approve the Windows UAC prompt; the elevated install will start the gateway afterwards.")
+                 else:
+@@ -1134,7 +1134,7 @@ def install(
+         print("  UAC is Windows' admin approval prompt; it is needed to create/update the Scheduled Task.")
+         if prompt_yes_no("  Open the UAC prompt now?", False):
+             if _launch_elevated_install(force=force, start_now=start_now, start_on_login=start_on_login):
+-                print("✓ Launched elevated Hermes gateway install prompt.")
++                print("✓ Launched elevated Black Pool gateway install prompt.")
+                 if start_now:
+                     print("  Approve the Windows UAC prompt; the elevated install will start the gateway afterwards.")
+                 else:
+@@ -1237,7 +1237,7 @@ def uninstall() -> None:
+             print("  UAC is Windows' admin approval prompt; it is needed to remove the Scheduled Task.")
+             if prompt_yes_no("  Open the UAC prompt now?", False):
+                 if _launch_elevated_uninstall():
+-                    print("✓ Launched elevated Hermes gateway uninstall prompt.")
++                    print("✓ Launched elevated Black Pool gateway uninstall prompt.")
+                     print("  Approve the Windows UAC prompt, then run: hermes gateway status")
+                     return
+                 print("⚠ Elevated uninstall prompt was unavailable or cancelled.")
+diff --git a/hermes_cli/goals.py b/hermes_cli/goals.py
+index df1b86d..e8c7071 100644
+--- a/hermes_cli/goals.py
++++ b/hermes_cli/goals.py
+@@ -1,8 +1,8 @@
+-"""Persistent session goals — the Ralph loop for Hermes.
++"""Persistent session goals — the Ralph loop for Black Pool.
+ 
+ A goal is a free-form user objective that stays active across turns. After
+ each turn completes, a small judge call asks an auxiliary model "is this
+-goal satisfied by the assistant's last response?". If not, Hermes feeds a
++goal satisfied by the assistant's last response?". If not, Black Pool feeds a
+ continuation prompt back into the same session and keeps working until the
+ goal is done, turn budget is exhausted, the user pauses/clears it, or the
+ user sends a new message (which takes priority and pauses the goal loop).
+diff --git a/hermes_cli/gui_uninstall.py b/hermes_cli/gui_uninstall.py
+index aa587d6..fd03b69 100644
+--- a/hermes_cli/gui_uninstall.py
++++ b/hermes_cli/gui_uninstall.py
+@@ -1,5 +1,5 @@
+ """
+-Hermes Desktop (Chat GUI) uninstaller.
++Black Pool Desktop (Chat GUI) uninstaller.
+ 
+ The desktop GUI ships in two shapes and this module knows how to find and
+ remove the artifacts of both, on Linux, macOS, and Windows, WITHOUT touching
+@@ -17,15 +17,15 @@ the Python agent or the user's config/data:
+   2. Packaged distributable (DMG / NSIS / AppImage / deb / rpm)
+      Installed by the OS to a standard application location and carrying its
+      own bundled Electron + a per-user Electron ``userData`` directory:
+-       - macOS:   ``/Applications/Hermes.app`` or ``~/Applications/Hermes.app``
+-       - Windows: ``%LOCALAPPDATA%\\Programs\\Hermes`` (NSIS per-user)
++       - macOS:   ``/Applications/Black Pool.app`` or ``~/Applications/Black Pool.app``
++       - Windows: ``%LOCALAPPDATA%\\Programs\\Black Pool`` (NSIS per-user)
+        - Linux:   ``~/.local/share/applications`` .desktop entry + AppImage
+ 
+ In both shapes the Electron runtime keeps a ``userData`` directory keyed on
+-the app name ("Hermes"), separate from ``$HERMES_HOME``:
+-  - macOS:   ``~/Library/Application Support/Hermes``
+-  - Windows: ``%APPDATA%\\Hermes``
+-  - Linux:   ``$XDG_CONFIG_HOME/Hermes`` (default ``~/.config/Hermes``)
++the app name ("Black Pool"), separate from ``$HERMES_HOME``:
++  - macOS:   ``~/Library/Application Support/Black Pool``
++  - Windows: ``%APPDATA%\\Black Pool``
++  - Linux:   ``$XDG_CONFIG_HOME/Black Pool`` (default ``~/.config/Black Pool``)
+ 
+ This holds the desktop's own ``connection.json`` / ``updates.json`` and
+ Chromium cache — pure GUI state, safe to remove on a GUI uninstall.
+@@ -70,21 +70,21 @@ def _agent_root(hermes_home: Path) -> Path:
+ def desktop_userdata_dir() -> Path:
+     """Return the Electron ``userData`` directory for the desktop app.
+ 
+-    Mirrors Electron's ``app.getPath('userData')`` for an app named "Hermes"
++    Mirrors Electron's ``app.getPath('userData')`` for an app named "Black Pool"
+     on each platform. This is GUI-only state (connection.json, updates.json,
+     Chromium cache) and never holds agent config or sessions.
+     """
+     home = Path.home()
+     if sys.platform == "darwin":
+-        return home / "Library" / "Application Support" / "Hermes"
++        return home / "Library" / "Application Support" / "Black Pool"
+     if sys.platform == "win32":
+         appdata = os.environ.get("APPDATA")
+         base = Path(appdata) if appdata else (home / "AppData" / "Roaming")
+-        return base / "Hermes"
++        return base / "Black Pool"
+     # Linux / other POSIX — XDG config home.
+     xdg = os.environ.get("XDG_CONFIG_HOME")
+     base = Path(xdg) if xdg else (home / ".config")
+-    return base / "Hermes"
++    return base / "Black Pool"
+ 
+ 
+ def source_built_gui_artifacts(hermes_home: Path) -> "list[Path]":
+@@ -113,28 +113,28 @@ def packaged_gui_app_paths() -> "list[Path]":
+ 
+     Returns every candidate for the current OS; the caller filters to those
+     that actually exist. We never glob system-wide — only the well-known
+-    electron-builder output locations for the "Hermes" product.
++    electron-builder output locations for the "Black Pool" product.
+     """
+     home = Path.home()
+     paths: list[Path] = []
+     if sys.platform == "darwin":
+         paths += [
+-            Path("/Applications/Hermes.app"),
+-            home / "Applications" / "Hermes.app",
++            Path("/Applications/Black Pool.app"),
++            home / "Applications" / "Black Pool.app",
+         ]
+     elif sys.platform == "win32":
+         local = os.environ.get("LOCALAPPDATA")
+         local_base = Path(local) if local else (home / "AppData" / "Local")
+         paths += [
+-            # NSIS per-user install (perMachine=false → Programs\Hermes).
+-            local_base / "Programs" / "Hermes",
++            # NSIS per-user install (perMachine=false → Programs\Black Pool).
++            local_base / "Programs" / "Black Pool",
+             # Older / alternate layout some builds used.
+             local_base / "hermes-desktop",
+         ]
+         program_files = os.environ.get("ProgramFiles")
+         if program_files:
+             # NSIS per-machine fallback (needs admin to remove).
+-            paths.append(Path(program_files) / "Hermes")
++            paths.append(Path(program_files) / "Black Pool")
+     else:
+         # Linux: AppImage is a single file the user placed somewhere; we can
+         # only reliably clean the desktop entry + icon we know the name of.
+@@ -151,7 +151,7 @@ def packaged_gui_app_paths() -> "list[Path]":
+             # in the checkout, not in the installed app.
+             desktop_entry_path(),
+             # Some packaged builds emit this casing.
+-            data_base / "applications" / "Hermes.desktop",
++            data_base / "applications" / "Black Pool.desktop",
+         ]
+     return paths
+ 
+@@ -282,7 +282,7 @@ def uninstall_gui(hermes_home: "Path | None" = None, *, remove_userdata: bool =
+     if sys.platform.startswith("linux"):
+         # The desktop entry was removed above (it is in
+         # ``packaged_gui_app_paths``), but the menu caches still list it.
+-        # Reindex so Hermes disappears from the launcher.
++        # Reindex so Black Pool disappears from the launcher.
+         try:
+             from hermes_cli.linux_desktop_entry import (
+                 desktop_entry_path,
+diff --git a/hermes_cli/hooks.py b/hermes_cli/hooks.py
+index 549ce0e..d6731d6 100644
+--- a/hermes_cli/hooks.py
++++ b/hermes_cli/hooks.py
+@@ -312,7 +312,7 @@ def _print_run_result(result: Dict[str, Any]) -> None:
+ 
+     parsed = result.get("parsed")
+     if parsed:
+-        print(f"      parsed (Hermes wire shape): {json.dumps(parsed)}")
++        print(f"      parsed (Black Pool wire shape): {json.dumps(parsed)}")
+     else:
+         print("      parsed: <none — hook contributed nothing to the dispatcher>")
+ 
+diff --git a/hermes_cli/init_command.py b/hermes_cli/init_command.py
+index 576b84f..acbf824 100644
+--- a/hermes_cli/init_command.py
++++ b/hermes_cli/init_command.py
+@@ -1,7 +1,7 @@
+ #!/usr/bin/env python3
+ """``/init`` — build the prompt that generates or updates a project AGENTS.md.
+ 
+-Port of Codex ``/init`` (Claude Code has the same for CLAUDE.md). Hermes
++Port of Codex ``/init`` (Claude Code has the same for CLAUDE.md). Black Pool
+ already *loads* AGENTS.md / CLAUDE.md / .cursorrules as project context, but
+ had no command to bootstrap one. ``/init`` hands the live agent ONE
+ guidance-laden prompt instructing it to:
+@@ -79,7 +79,7 @@ def build_init_prompt(
+             else "generate an AGENTS.md project-instructions file"
+         )
+         + f" for the project at: {cwd}\n",
+-        "AGENTS.md is the instruction file coding agents (Hermes included) "
++        "AGENTS.md is the instruction file coding agents (Black Pool included) "
+         "load as project context every session. It should teach an agent how "
+         "to work in THIS repo: what the project is, how to set up, the exact "
+         "build/test/lint commands, the conventions the code actually follows, "
+diff --git a/hermes_cli/inventory.py b/hermes_cli/inventory.py
+index 3ef41d6..791d83c 100644
+--- a/hermes_cli/inventory.py
++++ b/hermes_cli/inventory.py
+@@ -666,7 +666,7 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
+ 
+     ``list_authenticated_providers`` intentionally discovers ambient / auto-
+     seeded credentials (for example GitHub CLI -> Copilot). Desktop chat model
+-    pickers want the narrower subset the user explicitly configured for Hermes.
++    pickers want the narrower subset the user explicitly configured for Black Pool.
+     """
+     from hermes_cli.auth import is_provider_explicitly_configured
+ 
+@@ -703,7 +703,7 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
+ 
+ 
+ def _provider_is_keyless(slug: str) -> bool:
+-    """True when the provider's Hermes overlay declares it keyless."""
++    """True when the provider's Black Pool overlay declares it keyless."""
+     try:
+         from hermes_cli.providers import HERMES_OVERLAYS
+         overlay = HERMES_OVERLAYS.get(slug)
+diff --git a/hermes_cli/journey.py b/hermes_cli/journey.py
+index 1e404ba..bf3105a 100644
+--- a/hermes_cli/journey.py
++++ b/hermes_cli/journey.py
+@@ -1,4 +1,4 @@
+-"""``hermes journey`` — what Hermes has learned, on a timeline.
++"""``hermes journey`` — what Black Pool has learned, on a timeline.
+ 
+ A terminal-native rendition of the desktop Star Map / Memory Graph: a horizontal
+ timeline bar chart of learned skills and memories over time (oldest at top,
+@@ -198,7 +198,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
+ 
+     if not payload.get("nodes"):
+         console.print(
+-            "[grey62]No learning yet — use Hermes a while and your learned skills and "
++            "[grey62]No learning yet — use Black Pool a while and your learned skills and "
+             "memories will start mapping out here.[/grey62]"
+         )
+         return 0
 diff --git a/hermes_cli/kanban.py b/hermes_cli/kanban.py
-index 7951983..5a41ad4 100644
+index 7951983..756e81f 100644
 --- a/hermes_cli/kanban.py
 +++ b/hermes_cli/kanban.py
+@@ -1,4 +1,4 @@
+-"""CLI for the Hermes Kanban board — ``hermes kanban …`` subcommand.
++"""CLI for the Black Pool Kanban board — ``hermes kanban …`` subcommand.
+ 
+ Exposes the full Kanban command surface documented in the design spec
+ (``docs/hermes-kanban-v1-spec.pdf``).  All DB work is delegated to
 @@ -222,7 +222,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
          "kanban",
          help="Multi-profile collaboration board (tasks, links, comments)",
@@ -47860,9 +52374,90 @@ index 7951983..5a41ad4 100644
  
          Filters out tasks assigned to control-plane lanes
 diff --git a/hermes_cli/kanban_db.py b/hermes_cli/kanban_db.py
-index 79398b7..6400110 100644
+index 79398b7..4521ef0 100644
 --- a/hermes_cli/kanban_db.py
 +++ b/hermes_cli/kanban_db.py
+@@ -1,7 +1,7 @@
+ """SQLite-backed Kanban board for multi-profile, multi-project collaboration.
+ 
+ In a fresh install the board lives at ``<root>/kanban.db`` where
+-``<root>`` is the **shared Hermes root** (the parent of any active
++``<root>`` is the **shared Black Pool root** (the parent of any active
+ profile). Profiles intentionally collapse onto a shared board: it IS
+ the cross-profile coordination primitive. A worker spawned with
+ ``hermes -p <profile>`` joins the same board as the dispatcher that
+@@ -12,7 +12,7 @@ claimed the task. The same applies to ``<root>/kanban/workspaces/`` and
+ separate unrelated streams of work (e.g. one per project / repo / domain).
+ Each board is a directory under ``<root>/kanban/boards/<slug>/`` with
+ its own ``kanban.db``, ``workspaces/``, and ``logs/``. All boards share
+-the profile's Hermes home but are otherwise isolated: a worker spawned
++the profile's Black Pool home but are otherwise isolated: a worker spawned
+ for a task on board ``atm10-server`` sees only that board's tasks,
+ cannot enumerate other boards, and its dispatcher ticks don't touch
+ other boards' DBs.
+@@ -564,7 +564,7 @@ def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
+ 
+ 
+ def kanban_home() -> Path:
+-    """Return the shared Hermes root that anchors the kanban board.
++    """Return the shared Black Pool root that anchors the kanban board.
+ 
+     Resolution order:
+ 
+@@ -2133,7 +2133,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
+     Path-trust note: ``path`` arrives via :func:`connect`, which itself
+     resolves it from an explicit ``db_path`` argument, the
+     :func:`kanban_db_path` env-var chain, or the kanban-home default —
+-    all sources Hermes treats as user-controlled-but-trusted on the
++    all sources Black Pool treats as user-controlled-but-trusted on the
+     user's own machine. We additionally resolve the path here and
+     confine all filesystem writes to its parent directory so any
+     accidental ``..`` segments are collapsed before any I/O happens.
+@@ -5864,7 +5864,7 @@ def _is_managed_scratch_path(p: Path) -> bool:
+     task's scratch dir at once), and a path that resolves to ``<kanban_home>
+     /kanban`` itself, ``<kanban_home>/kanban/logs``, or
+     ``<kanban_home>/kanban/boards/<slug>`` is rejected because those
+-    subtrees hold Hermes' own DB, metadata, and logs, not task workspaces.
++    subtrees hold Black Pool' own DB, metadata, and logs, not task workspaces.
+ 
+     Used by :func:`_cleanup_workspace` to refuse to ``shutil.rmtree`` paths
+     outside Hermes-managed storage. A board ``default_workdir`` pointing at a
+@@ -7750,7 +7750,7 @@ def _resolve_worktree_workspace(
+     worktree task under a meaningful, board-owned repo — ``<repo>/.worktrees/
+     <task-id>`` — instead of silently landing under the dispatcher's current
+     working directory (which is whatever directory the gateway happened to be
+-    launched from, e.g. the Hermes checkout). If no anchor is configured
++    launched from, e.g. the Black Pool checkout). If no anchor is configured
+     anywhere, we fail loudly rather than guess.
+     """
+     branch_name = (task.branch_name or "").strip() or f"wt/{task.id}"
+@@ -7843,13 +7843,13 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
+       root.  Users who want a kanban-root-relative workspace should
+       compute the absolute path themselves.
+     - ``worktree``: a real linked git worktree. If ``workspace_path`` names
+-      a repo root, Hermes treats it as an anchor and materializes a linked
++      a repo root, Black Pool treats it as an anchor and materializes a linked
+       worktree at ``<repo>/.worktrees/<task-id>``. If ``workspace_path`` names
+-      a concrete target path, Hermes creates/reuses that linked worktree. With
+-      no ``workspace_path``, Hermes anchors on the board's ``default_workdir``
++      a concrete target path, Black Pool creates/reuses that linked worktree. With
++      no ``workspace_path``, Black Pool anchors on the board's ``default_workdir``
+       and materializes ``<repo>/.worktrees/<task-id>`` per task; if no
+       ``default_workdir`` is configured it raises rather than guessing from the
+-      dispatcher's CWD. When ``branch_name`` is empty, Hermes uses
++      dispatcher's CWD. When ``branch_name`` is empty, Black Pool uses
+       ``wt/<task-id>``.
+ 
+     Persist the resolved path back to the task row via ``set_workspace_path``
+@@ -8036,7 +8036,7 @@ class DispatchResult:
+     rather than on explicit per-task assignments."""
+     skipped_nonspawnable: list[str] = field(default_factory=list)
+     """Ready task ids skipped because their assignee names a control-plane
+-    lane (a Claude Code terminal like ``orion-cc``) rather than a Hermes
++    lane (a Claude Code terminal like ``orion-cc``) rather than a Black Pool
+     profile. Expected steady-state on multi-lane setups; NOT an
+     operator-actionable failure. Tracked separately so health telemetry
+     can distinguish "real stuck" (nothing spawned but spawnable work
 @@ -9539,7 +9539,7 @@ def check_respawn_guard(
  
  def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
@@ -47881,7 +52476,25 @@ index 79398b7..6400110 100644
  
      Mirror of :func:`has_spawnable_ready` for the review column —
      used by the health telemetry to decide whether the dispatcher
-@@ -10158,7 +10158,7 @@ def _dispatch_once_locked(
+@@ -9597,7 +9597,7 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
+ def review_dispatch_enabled() -> bool:
+     """Return whether first-class review tasks should dispatch automatically.
+ 
+-    The default is true because Hermes ships the ``sdlc-review`` skill and the
++    The default is true because Black Pool ships the ``sdlc-review`` skill and the
+     review lifecycle includes a supported reviewer-owned changes-requested
+     transition. Operators can disable it for human-only review boards.
+     """
+@@ -9632,7 +9632,7 @@ def review_dispatch_enabled() -> bool:
+ # pressure level is "unknown" (no spawn restriction).
+ # ---------------------------------------------------------------------------
+ 
+-# Assumed per-worker memory footprint for the derived default cap. Hermes
++# Assumed per-worker memory footprint for the derived default cap. Black Pool
+ # workers are full agent processes (Python + model client + tool subprocesses);
+ # ~512 MiB is a deliberately conservative planning number so the derived cap
+ # errs toward fewer workers on small VMs.
+@@ -10158,11 +10158,11 @@ def _dispatch_once_locked(
              else:
                  result.skipped_unassigned.append(row["id"])
                  continue
@@ -47890,6 +52503,56 @@ index 79398b7..6400110 100644
          # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
          # with "Profile 'X' does not exist" when the assignee names a
          # control-plane lane (e.g. an interactive Claude Code terminal
+-        # like ``orion-cc`` / ``orion-research``) rather than a Hermes
++        # like ``orion-cc`` / ``orion-research``) rather than a Black Pool
+         # profile. Those task lanes are pulled by terminals via
+         # ``claim_task`` directly and should NEVER auto-spawn — the
+         # subprocess would crash on startup, get reaped as a zombie,
+@@ -10305,7 +10305,7 @@ def _dispatch_once_locked(
+     # Same concurrency model as ready dispatch: review spawns count
+     # against max_spawn alongside ready tasks, so the total number of
+     # running workers stays bounded.
+-    # Auto-dispatch is enabled by default because Hermes bundles the
++    # Auto-dispatch is enabled by default because Black Pool bundles the
+     # ``sdlc-review`` skill and reviewer workers can now approve, request
+     # changes without block-loop accounting, or escalate a genuine blocker.
+     # Human-only boards can disable it with ``kanban.review_dispatch``.
+@@ -10501,7 +10501,7 @@ def _rotate_worker_log(
+ 
+ 
+ def _module_hermes_argv() -> list[str]:
+-    """Return the interpreter-bound Hermes CLI invocation."""
++    """Return the interpreter-bound Black Pool CLI invocation."""
+     # ``hermes_cli.main`` is the console-script target declared in
+     # pyproject.toml, NOT a top-level ``hermes`` package — there is no
+     # ``hermes`` package to import.
+@@ -10509,7 +10509,7 @@ def _module_hermes_argv() -> list[str]:
+ 
+ 
+ def _absolute_hermes_path(path: str) -> str:
+-    """Return an absolute filesystem path for a resolved Hermes shim."""
++    """Return an absolute filesystem path for a resolved Black Pool shim."""
+     expanded = os.path.expanduser(path)
+     return expanded if os.path.isabs(expanded) else os.path.abspath(expanded)
+ 
+@@ -10563,7 +10563,7 @@ def _safe_which_no_cwd(command: str) -> Optional[str]:
+ 
+ 
+ def _hermes_path_argv(path: str) -> list[str]:
+-    """Return argv for a resolved Hermes executable path.
++    """Return argv for a resolved Black Pool executable path.
+ 
+     Windows batch shims (`.cmd` / `.bat`) are not safe as argv[0] for
+     worker launches because the argument vector includes task-derived
+@@ -10590,7 +10590,7 @@ def _resolve_hermes_argv() -> list[str]:
+        dispatcher therefore falls back to the interpreter-bound module form
+        for implicit ``.cmd`` / ``.bat`` shims.
+     3. ``sys.executable -m hermes_cli.main`` — fallback for setups where
+-       Hermes is launched from a venv and the ``hermes`` shim is not on
++       Black Pool is launched from a venv and the ``hermes`` shim is not on
+        the dispatcher's ``$PATH`` (cron, systemd ``User=`` services,
+        launchd jobs, detached processes, etc.). Goes through the running
+        interpreter so the result is independent of ``$PATH``.
 @@ -10911,7 +10911,7 @@ def _default_spawn(
          log_f.close()
          raise RuntimeError(
@@ -47899,6 +52562,15 @@ index 79398b7..6400110 100644
          )
      # NOTE: we intentionally do NOT close log_f here — we want Popen's
      # child process to keep writing after this function returns.  The
+@@ -11960,7 +11960,7 @@ def list_profiles_on_disk() -> list[str]:
+ 
+     Includes:
+     - named profiles under ``<default-root>/profiles/<name>/config.yaml``
+-    - the implicit ``default`` profile when the default Hermes root exists
++    - the implicit ``default`` profile when the default Black Pool root exists
+ 
+     Reads profile paths directly so this module has no import dependency on
+     ``hermes_cli.profiles`` (which pulls in a large chunk of the CLI startup
 diff --git a/hermes_cli/kanban_decompose.py b/hermes_cli/kanban_decompose.py
 index d6c248c..604e4ba 100644
 --- a/hermes_cli/kanban_decompose.py
@@ -47913,7 +52585,7 @@ index d6c248c..604e4ba 100644
  A user dropped a rough idea into the Triage column. Your job is to break it
  into a small graph of concrete child tasks and route each one to the best-
 diff --git a/hermes_cli/kanban_diagnostics.py b/hermes_cli/kanban_diagnostics.py
-index 1a0309a..ca9a254 100644
+index 1a0309a..84d5cd9 100644
 --- a/hermes_cli/kanban_diagnostics.py
 +++ b/hermes_cli/kanban_diagnostics.py
 @@ -979,7 +979,7 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
@@ -47925,6 +52597,15 @@ index 1a0309a..ca9a254 100644
      typos uniformly. No registry to curate, no per-board allowlist.
      """
      threshold_seconds = float(
+@@ -1146,7 +1146,7 @@ def config_from_kanban_config(kanban_cfg: Optional[dict]) -> dict:
+ 
+ 
+ def config_from_runtime_config(raw_config: Optional[dict]) -> dict:
+-    """Build diagnostics config from the full Hermes runtime config.
++    """Build diagnostics config from the full Black Pool runtime config.
+ 
+     Carries through ``kanban``, ``auxiliary``, and ``model`` keys so triage-
+     aware rules can inspect the active aux-helper and main-model state.
 diff --git a/hermes_cli/kanban_specify.py b/hermes_cli/kanban_specify.py
 index e7aba34..78af412 100644
 --- a/hermes_cli/kanban_specify.py
@@ -47938,18 +52619,153 @@ index e7aba34..78af412 100644
  A user dropped a rough idea into the Triage column. Your job is to turn it
  into a concrete, actionable task spec that an autonomous worker can pick up
  and execute without further clarification.
+diff --git a/hermes_cli/lifecycle.py b/hermes_cli/lifecycle.py
+index 350e388..2af5e16 100644
+--- a/hermes_cli/lifecycle.py
++++ b/hermes_cli/lifecycle.py
+@@ -1,4 +1,4 @@
+-"""Hermes lifecycle dispatch for first-party observers and plugins."""
++"""Black Pool lifecycle dispatch for first-party observers and plugins."""
+ 
+ from __future__ import annotations
+ 
+diff --git a/hermes_cli/linux_desktop_entry.py b/hermes_cli/linux_desktop_entry.py
+index 2558102..abddc41 100644
+--- a/hermes_cli/linux_desktop_entry.py
++++ b/hermes_cli/linux_desktop_entry.py
+@@ -60,7 +60,7 @@ def icon_path(project_root: Path) -> Path:
+ def resolve_exec_command() -> str:
+     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
+ 
+-    Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
++    Prefer the real ``hermes`` executable (argv[0] or PATH). When Black Pool
+     runs as a module with no launcher installed, use the current
+     interpreter, also absolute.
+     """
+@@ -90,15 +90,15 @@ def render_desktop_entry(exec_command: str, icon: str) -> str:
+     return (
+         "[Desktop Entry]\n"
+         "Type=Application\n"
+-        "Name=Hermes\n"
+-        "GenericName=Hermes Desktop\n"
+-        "Comment=Launch Hermes Desktop\n"
++        "Name=Black Pool\n"
++        "GenericName=Black Pool Desktop\n"
++        "Comment=Launch Black Pool Desktop\n"
+         f"Exec={exec_command}\n"
+         f"Icon={icon}\n"
+         "Terminal=false\n"
+         "Categories=Utility;\n"
+         "StartupNotify=true\n"
+-        "StartupWMClass=Hermes\n"
++        "StartupWMClass=Black Pool\n"
+     )
+ 
+ 
+@@ -141,7 +141,7 @@ def _run_quiet(cmd: "list[str]") -> bool:
+ 
+ 
+ def install_desktop_entry(project_root: Path) -> Optional[Path]:
+-    """Write (or refresh) the Hermes desktop entry. Return its path.
++    """Write (or refresh) the Black Pool desktop entry. Return its path.
+ 
+     Return ``None`` on non-Linux platforms or when the write fails. This
+     is a convenience, never a reason to fail a launch.
+diff --git a/hermes_cli/logs.py b/hermes_cli/logs.py
+index a214d52..afc519b 100644
+--- a/hermes_cli/logs.py
++++ b/hermes_cli/logs.py
+@@ -1,4 +1,4 @@
+-"""``hermes logs`` — view and filter Hermes log files.
++"""``hermes logs`` — view and filter Black Pool log files.
+ 
+ Supports tailing, following, session filtering, level filtering,
+ component filtering, and relative time ranges.  All log files live
+@@ -179,7 +179,7 @@ def tail_log(
+     log_path = get_hermes_home() / "logs" / filename
+     if not log_path.exists():
+         print(f"Log file not found: {log_path}")
+-        print("(Logs are created when Hermes runs — try 'hermes chat' first)")
++        print("(Logs are created when Black Pool runs — try 'hermes chat' first)")
+         sys.exit(1)
+ 
+     # Parse --since into a datetime cutoff
 diff --git a/hermes_cli/main.py b/hermes_cli/main.py
-index 9f5e1ec..61bb5e1 100644
+index 9f5e1ec..820aea8 100644
 --- a/hermes_cli/main.py
 +++ b/hermes_cli/main.py
-@@ -36,7 +36,7 @@ Usage:
-     hermes honcho migrate                  # Step-by-step migration guide: OpenClaw native → Hermes + Honcho
+@@ -1,6 +1,6 @@
+ #!/usr/bin/env python3
+ """
+-Hermes CLI - Main entry point.
++Black Pool CLI - Main entry point.
+ 
+ Usage:
+     hermes                     # Interactive chat (default)
+@@ -33,10 +33,10 @@ Usage:
+     hermes honcho tokens --dialectic N     # Set dialectic result char cap
+     hermes honcho identity                 # Show AI peer identity representation
+     hermes honcho identity <file>          # Seed AI peer identity from a file (SOUL.md etc.)
+-    hermes honcho migrate                  # Step-by-step migration guide: OpenClaw native → Hermes + Honcho
++    hermes honcho migrate                  # Step-by-step migration guide: OpenClaw native → Black Pool + Honcho
      hermes --version           Show version and update status
      hermes update              Update to latest version
 -    hermes uninstall           Uninstall Hermes Agent
 +    hermes uninstall           Uninstall Black Pool Agent
      hermes acp                 Run as an ACP server for editor integration
      hermes sessions browse     Interactive session picker with search
+ 
+@@ -529,7 +529,7 @@ def _apply_profile_override() -> None:
+ 
+         ``mcp add --args`` is command-argv passthrough. Flags after that point
+         belong to the child MCP command (for example Docker MCP Toolkit's
+-        ``--profile``), not to Hermes' own profile selector.
++        ``--profile``), not to Black Pool' own profile selector.
+         """
+         try:
+             mcp_index = argv.index("mcp", 0, index)
+@@ -974,7 +974,7 @@ def _has_any_provider_configured() -> bool:
+     from hermes_cli.config import get_env_path, get_hermes_home, load_config
+     from hermes_cli.auth import get_auth_status
+ 
+-    # Determine whether Hermes itself has been explicitly configured (model
++    # Determine whether Black Pool itself has been explicitly configured (model
+     # in config that isn't the hardcoded default). Used below to gate external
+     # tool credentials (Claude Code, Codex CLI) that shouldn't silently skip
+     # the setup wizard on a fresh install.
+@@ -1075,8 +1075,8 @@ def _has_any_provider_configured() -> bool:
+         pass
+ 
+     # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
+-    # Only count these if Hermes has been explicitly configured — Claude Code
+-    # being installed doesn't mean the user wants Hermes to use their tokens.
++    # Only count these if Black Pool has been explicitly configured — Claude Code
++    # being installed doesn't mean the user wants Black Pool to use their tokens.
+     if _has_hermes_config:
+         try:
+             from agent.anthropic_adapter import (
+@@ -2299,11 +2299,11 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
+         return
+ 
+     print(
+-        "Error: the TUI workspace is missing from this Hermes checkout.\n"
++        "Error: the TUI workspace is missing from this Black Pool checkout.\n"
+         f"Expected directory: {tui_dir}\n"
+         "This usually means `hermes update` left tracked ui-tui files deleted.\n"
+         "Recovery:\n"
+-        "  1. From the Hermes checkout, run `git restore -- ui-tui`\n"
++        "  1. From the Black Pool checkout, run `git restore -- ui-tui`\n"
+         "  2. Run `npm install --silent --no-fund --no-audit --progress=false`\n"
+         "  3. Retry `hermes --tui`\n"
+         "If the checkout is still inconsistent, run `hermes update --force`.",
+@@ -2332,7 +2332,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
+                 return env_node
+         # find_node_executable() prefers the managed $HERMES_HOME/node tree,
+         # which is not on PATH — a bare which() would declare "node not found"
+-        # and exit on an install whose only Node is the one Hermes installed,
++        # and exit on an install whose only Node is the one Black Pool installed,
+         # and would pick a system Node over the managed one when both exist.
+         from hermes_constants import find_node_executable
  
 @@ -2697,7 +2697,7 @@ def _launch_tui(
      except Exception:
@@ -47960,6 +52776,48 @@ index 9f5e1ec..61bb5e1 100644
      )
      os.close(active_session_fd)
      env["HERMES_TUI_ACTIVE_SESSION_FILE"] = active_session_file
+@@ -2870,12 +2870,12 @@ def _sync_bundled_skills_quietly() -> None:
+     """Seed ``~/.hermes/skills/`` with the bundled skill library on first launch.
+ 
+     Called from any CLI entrypoint that the user might use as their first
+-    interaction with Hermes — chat, dashboard (the desktop GUI's backend),
++    interaction with Black Pool — chat, dashboard (the desktop GUI's backend),
+     and gateway. The skills_sync module is manifest-based and idempotent:
+     skipped skills cost ~milliseconds, so calling this repeatedly is fine.
+ 
+     Failures are swallowed because skills are an enhancement, not a hard
+-    dependency. Hermes still functions without them; the user just sees an
++    dependency. Black Pool still functions without them; the user just sees an
+     empty skills library.
+     """
+     try:
+@@ -2982,7 +2982,7 @@ def cmd_chat(args):
+     _resolve_continue_arg(args, use_tui=use_tui)
+ 
+     # --resume @claude / --resume @codex: import a foreign session (Claude
+-    # Code / Codex CLI) and resume the newly created Hermes session.
++    # Code / Codex CLI) and resume the newly created Black Pool session.
+     _resume_foreign = getattr(args, "resume", None)
+     if isinstance(_resume_foreign, str) and _resume_foreign.strip().lower() in (
+         "@claude",
+@@ -3071,7 +3071,7 @@ def cmd_chat(args):
+     if not _has_any_provider_configured():
+         print()
+         print(
+-            "It looks like Hermes isn't configured yet -- no API keys or providers found."
++            "It looks like Black Pool isn't configured yet -- no API keys or providers found."
+         )
+         print()
+         print("  Run:  hermes setup")
+@@ -3299,7 +3299,7 @@ def cmd_whatsapp(args):
+     current_mode = get_env_value("WHATSAPP_MODE") or ""
+     if not current_mode:
+         print()
+-        print("How will you use WhatsApp with Hermes?")
++        print("How will you use WhatsApp with Black Pool?")
+         print()
+         print("  1. Separate bot number (recommended)")
+         print("     People message the bot's number directly — cleanest experience.")
 @@ -3503,14 +3503,14 @@ def cmd_whatsapp(args):
              print("    2. Send a message to the bot's WhatsApp number")
              print("    3. The agent will reply automatically")
@@ -47977,6 +52835,69 @@ index 9f5e1ec..61bb5e1 100644
              print("  so you can tell them apart from your own messages.")
          print()
          print("  Or install as a service: hermes gateway install")
+@@ -4059,7 +4059,7 @@ def _clear_stale_openai_base_url():
+ # ─────────────────────────────────────────────────────────────────────────────
+ # Auxiliary model configuration
+ #
+-# Hermes uses lightweight "auxiliary" models for side tasks (vision analysis,
++# Black Pool uses lightweight "auxiliary" models for side tasks (vision analysis,
+ # context compression, web extraction, session search, etc.). Each task has
+ # its own provider+model pair in config.yaml under `auxiliary.<task>`.
+ #
+@@ -4275,7 +4275,7 @@ def _aux_config_menu() -> None:
+         print()
+         print("  Side tasks (vision, compression, web extraction, etc.) default")
+         print('  to your main chat model.  "auto" means "use my main model" —')
+-        print("  Hermes only falls back to a lightweight backend (OpenRouter,")
++        print("  Black Pool only falls back to a lightweight backend (OpenRouter,")
+         print("  Nous Portal) if the main model is unavailable.  Override a")
+         print("  task below if you want it pinned to a specific provider/model.")
+         print()
+@@ -4586,7 +4586,7 @@ def _prompt_custom_api_mode_selection(base_url: str, current_api_mode: str = "")
+         (
+             "",
+             "Auto-detect",
+-            "Use Hermes URL heuristics; best for standard OpenAI-compatible endpoints.",
++            "Use Black Pool URL heuristics; best for standard OpenAI-compatible endpoints.",
+         ),
+         (
+             "chat_completions",
+@@ -5257,7 +5257,7 @@ def _run_anthropic_oauth_flow(save_env_value):
+             from hermes_constants import display_hermes_home as _dhh_fn
+ 
+             print(
+-                f"    Hermes will use Claude's credential store directly instead of copying a setup-token into {_dhh_fn()}/.env."
++                f"    Black Pool will use Claude's credential store directly instead of copying a setup-token into {_dhh_fn()}/.env."
+             )
+             return True
+         return False
+@@ -5328,7 +5328,7 @@ def _run_anthropic_oauth_flow(save_env_value):
+ 
+ 
+ def cmd_login(args):
+-    """Authenticate Hermes CLI with a provider."""
++    """Authenticate Black Pool CLI with a provider."""
+     from hermes_cli.auth import login_command
+ 
+     login_command(args)
+@@ -5685,7 +5685,7 @@ def cmd_skin(args):
+ 
+ 
+ def cmd_backup(args):
+-    """Back up Hermes home directory to a zip file."""
++    """Back up Black Pool home directory to a zip file."""
+     if getattr(args, "quick", False):
+         from hermes_cli.backup import run_quick_backup
+ 
+@@ -5697,7 +5697,7 @@ def cmd_backup(args):
+ 
+ 
+ def cmd_import(args):
+-    """Restore a Hermes backup from a zip file."""
++    """Restore a Black Pool backup from a zip file."""
+     from hermes_cli.backup import run_import
+ 
+     run_import(args)
 @@ -5716,7 +5716,7 @@ def cmd_version(args):
  
  
@@ -47986,6 +52907,313 @@ index 9f5e1ec..61bb5e1 100644
      # Machine-readable install snapshot for the desktop app's uninstall UI.
      # Must run before any TTY gate — it's called from a non-interactive child.
      if getattr(args, "gui_summary", False):
+@@ -6580,7 +6580,7 @@ def _renderer_bundle_dir(desktop_dir: Path, *, source_mode: bool) -> Optional[Pa
+     if executable is None:
+         return None
+ 
+-    # macOS: …/Hermes.app/Contents/MacOS/Hermes → …/Contents/Resources
++    # macOS: …/Black Pool.app/Contents/MacOS/Black Pool → …/Contents/Resources
+     resources = (
+         executable.parent.parent / "Resources"
+         if sys.platform == "darwin"
+@@ -6694,19 +6694,19 @@ def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
+     """Return the current platform's unpacked Electron app executable."""
+     release_dir = desktop_dir / "release"
+     if sys.platform == "darwin":
+-        candidates = list(release_dir.glob("mac*/Hermes.app/Contents/MacOS/Hermes"))
++        candidates = list(release_dir.glob("mac*/Black Pool.app/Contents/MacOS/Black Pool"))
+     elif sys.platform == "win32":
+         candidates = [
+-            release_dir / "win-unpacked" / "Hermes.exe",
+-            release_dir / "win-ia32-unpacked" / "Hermes.exe",
+-            release_dir / "win-arm64-unpacked" / "Hermes.exe",
++            release_dir / "win-unpacked" / "Black Pool.exe",
++            release_dir / "win-ia32-unpacked" / "Black Pool.exe",
++            release_dir / "win-arm64-unpacked" / "Black Pool.exe",
+         ]
+     else:
+         candidates = [
+             release_dir / "linux-unpacked" / "hermes",
+-            release_dir / "linux-unpacked" / "Hermes",
++            release_dir / "linux-unpacked" / "Black Pool",
+             release_dir / "linux-arm64-unpacked" / "hermes",
+-            release_dir / "linux-arm64-unpacked" / "Hermes",
++            release_dir / "linux-arm64-unpacked" / "Black Pool",
+         ]
+ 
+     existing = [p for p in candidates if p.exists()]
+@@ -6715,7 +6715,7 @@ def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
+     if sys.platform == "win32" and len(existing) > 1:
+         # Multiple unpacked trees can coexist (e.g. a stale win-arm64-unpacked
+         # left behind by a cross-arch experiment next to the real win-unpacked).
+-        # Picking purely by mtime can then hand a wrong-architecture Hermes.exe
++        # Picking purely by mtime can then hand a wrong-architecture Black Pool.exe
+         # to the launcher, which Windows rejects with "This app can't run on
+         # your computer" (#69179). Prefer candidates whose PE machine field
+         # matches the host; fall back to mtime when none can be parsed.
+@@ -6730,14 +6730,14 @@ def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
+ #
+ # The desktop self-update chain (Desktop → hermes-setup --update →
+ # `hermes update` → `hermes desktop --build-only` → relaunch) rebuilds
+-# Hermes.exe on the end user's machine and used to verify only that the file
++# Black Pool.exe on the end user's machine and used to verify only that the file
+ # EXISTS before declaring success. A corrupt cached Electron zip whose
+ # extraction produced a truncated electron.exe, an interrupted rcedit resource
+ # rewrite, a disk-full pack, or a wrong-arch unpacked tree therefore shipped a
+ # broken binary that Windows refuses to load ("This app can't run on your
+ # computer" / 此应用无法在你的电脑上运行). These helpers parse the PE header —
+ # no signature infrastructure required — so a structurally broken or
+-# wrong-architecture Hermes.exe is caught BEFORE the updater replaces the
++# wrong-architecture Black Pool.exe is caught BEFORE the updater replaces the
+ # working app, and the previous build can be restored from the .bak tree that
+ # apps/desktop/scripts/before-pack.mjs now preserves.
+ 
+@@ -6771,7 +6771,7 @@ def _windows_native_machine_from_iswow64() -> Optional[str]:
+     that makes ``IsWow64Process2`` fail with ``ERROR_INVALID_HANDLE`` (6),
+     which is exactly the residual Windows-on-ARM failure after #71218: the
+     gate fell through to ``PROCESSOR_ARCHITECTURE=AMD64`` (the emulated
+-    process arch) and rejected a correctly-built ARM64 ``Hermes.exe``.
++    process arch) and rejected a correctly-built ARM64 ``Black Pool.exe``.
+     Binding ``restype``/``argtypes`` to ``wintypes.HANDLE`` keeps the full
+     ``0xFFFFFFFFFFFFFFFF`` pseudo-handle.
+     """
+@@ -7037,7 +7037,7 @@ def _ensure_desktop_exe_launchable(
+     if error is None:
+         return packaged_executable, False
+ 
+-    print(f"✗ The built Hermes.exe failed its integrity check: {error}")
++    print(f"✗ The built Black Pool.exe failed its integrity check: {error}")
+     print(f"    at: {packaged_executable}")
+ 
+     # Self-heal setup for the retry: drop the (likely corrupt) cached Electron
+@@ -7051,13 +7051,13 @@ def _ensure_desktop_exe_launchable(
+ 
+     restored = _rollback_desktop_from_backup(packaged_executable)
+     if restored is not None:
+-        print("  ↩ Update aborted — restored the previous working Hermes.exe from backup.")
++        print("  ↩ Update aborted — restored the previous working Black Pool.exe from backup.")
+         print("    Your existing version was kept and still works. Run `hermes desktop`")
+         print("    (or the in-app update) again to retry with a fresh Electron download.")
+         return restored, True
+ 
+     print("  ✗ No usable backup was found to restore.")
+-    print("    Run `hermes desktop --force-build` to rebuild, or re-run the Hermes")
++    print("    Run `hermes desktop --force-build` to rebuild, or re-run the Black Pool")
+     print("    installer to repair the install.")
+     return None, False
+ 
+@@ -7104,7 +7104,7 @@ def _purge_electron_build_cache(desktop_dir: Path) -> list[Path]:
+     next ``pack`` re-downloads and re-stages from scratch.
+ 
+     Root cause of the ``ENOENT … rename '…/linux-unpacked/electron' ->
+-    '…/linux-unpacked/Hermes'`` desktop build failure: a corrupt zip in the
++    '…/linux-unpacked/Black Pool'`` desktop build failure: a corrupt zip in the
+     per-user Electron download cache (a partial download resumed into the same
+     file leaves prepended/concatenated junk, or an interrupted write truncates
+     it). electron-builder's ``app-builder unpack-electron`` extracts the
+@@ -7271,9 +7271,9 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
+     """Terminate any running desktop app executing from this build's ``release``
+     dir so a rebuild can replace its (otherwise locked) executable.
+ 
+-    On Windows a running ``Hermes.exe`` keeps an exclusive lock on
+-    ``release/win-unpacked/Hermes.exe``. electron-builder's pack then can't
+-    delete the stale binary and dies with ``remove …\\Hermes.exe: Access is
++    On Windows a running ``Black Pool.exe`` keeps an exclusive lock on
++    ``release/win-unpacked/Black Pool.exe``. electron-builder's pack then can't
++    delete the stale binary and dies with ``remove …\\Black Pool.exe: Access is
+     denied`` / ``ERR_ELECTRON_BUILDER_CANNOT_EXECUTE`` (before-pack hits the same
+     EPERM cleaning the dir). The retry path repeats the failure because the lock
+     is still held. POSIX lets you unlink a running binary, so this is a no-op
+@@ -7281,7 +7281,7 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
+ 
+     Scope is deliberately narrow: only processes whose executable lives *inside*
+     this desktop's ``release`` tree are stopped — a packaged install elsewhere or
+-    an unrelated "Hermes" process is never touched. Best-effort: never raises.
++    an unrelated "Black Pool" process is never touched. Best-effort: never raises.
+     Returns the PIDs we asked to stop.
+     """
+     if sys.platform != "win32":
+@@ -7481,7 +7481,7 @@ def _desktop_macos_local_codesign(
+ 
+     # 1) Standalone Mach-O files (native modules, dylibs, crashpad handler).
+     #    Compare paths relative to the app root — the absolute path always
+-    #    contains the outer Hermes.app component, so an absolute-parts check
++    #    contains the outer Black Pool.app component, so an absolute-parts check
+     #    would skip every file.
+     contents = app / "Contents"
+     standalone: list[Path] = []
+@@ -7531,7 +7531,7 @@ def _desktop_macos_relaunchable_fixup(
+ 
+     An ad-hoc-signed .app has no stable Designated Requirement, so when the
+     self-updater rebuilds the bundle in place (new cdhash) Gatekeeper reports
+-    "Hermes is damaged and can't be opened" — and macOS TCC forgets every
++    "Black Pool is damaged and can't be opened" — and macOS TCC forgets every
+     permission the user granted (Full Disk Access, Desktop/Downloads/Documents,
+     Accessibility, Automation, microphone), re-prompting on every launch after
+     every update.
+@@ -7559,7 +7559,7 @@ def _desktop_macos_relaunchable_fixup(
+     exe = _desktop_packaged_executable(desktop_dir)
+     if exe is None:
+         return True
+-    # exe = .../Hermes.app/Contents/MacOS/Hermes  ->  app bundle = .../Hermes.app
++    # exe = .../Black Pool.app/Contents/MacOS/Black Pool  ->  app bundle = .../Black Pool.app
+     app = exe.parents[2]
+     if not str(app).endswith(".app") or not app.is_dir():
+         return True
+@@ -7667,7 +7667,7 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
+ 
+     sandbox = packaged_executable.parent / "chrome-sandbox"
+     if not sandbox.exists():
+-        print(f"✗ Hermes Desktop is missing Electron's Linux sandbox helper: {sandbox}")
++        print(f"✗ Black Pool Desktop is missing Electron's Linux sandbox helper: {sandbox}")
+         return False
+ 
+     # Reject symlinks — chown/chmod must not follow an attacker-controlled
+@@ -7687,7 +7687,7 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
+ 
+     sudo = shutil.which("sudo")
+     if not sudo:
+-        print("✗ Hermes Desktop requires sudo to configure Electron's Linux sandbox helper.")
++        print("✗ Black Pool Desktop requires sudo to configure Electron's Linux sandbox helper.")
+         return False
+ 
+     print("→ Configuring Electron Linux sandbox helper (sudo required)...")
+@@ -7789,7 +7789,7 @@ def _desktop_launch_options() -> tuple[list[str], str, str]:
+ 
+ 
+ def _register_linux_desktop_entry() -> None:
+-    """Install the XDG desktop entry for Hermes Desktop (Linux only, best-effort).
++    """Install the XDG desktop entry for Black Pool Desktop (Linux only, best-effort).
+ 
+     Gives the Electron app a launcher presence: a menu item and an icon.
+     ``Exec`` and ``Icon`` are absolute, so the entry works outside a login
+@@ -7938,7 +7938,7 @@ def cmd_gui(args: argparse.Namespace):
+             npm_build_env = _npm_lifecycle_env(env)
+             if not source_mode:
+                 # A running desktop instance launched from release/win-unpacked
+-                # holds Hermes.exe locked on Windows, so the pack can't replace
++                # holds Black Pool.exe locked on Windows, so the pack can't replace
+                 # it ("Access is denied" / ERR_ELECTRON_BUILDER_CANNOT_EXECUTE).
+                 # Stop it first so the rebuild — including the installer's
+                 # headless --update rebuild — succeeds instead of failing cryptically.
+@@ -7971,7 +7971,7 @@ def cmd_gui(args: argparse.Namespace):
+                     print("  ⚠ Desktop build failed; refreshed the Electron download and retrying once...")
+                     for p in purged:
+                         print(f"    - {p}")
+-                    # The purge can't remove a win-unpacked tree whose Hermes.exe
++                    # The purge can't remove a win-unpacked tree whose Black Pool.exe
+                     # is still locked by a running instance; stop it before retry.
+                     _stop_desktop_processes_locking_build(desktop_dir)
+                     build_result = subprocess.run(
+@@ -7997,20 +7997,20 @@ def cmd_gui(args: argparse.Namespace):
+                 print("✗ Desktop GUI build failed")
+                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")
+                 if sys.platform == "win32":
+-                    print("  If this says \"Access is denied\" on Hermes.exe, close any")
+-                    print("  running Hermes desktop window and retry.")
++                    print("  If this says \"Access is denied\" on Black Pool.exe, close any")
++                    print("  running Black Pool desktop window and retry.")
+                 print("  If the log shows Electron download retries, rebuild via a mirror:")
+                 print("    ELECTRON_MIRROR=<mirror-base-url> hermes desktop --force-build")
+                 sys.exit(build_result.returncode or 1)
+             packaged_executable = _desktop_packaged_executable(desktop_dir)
+             if not source_mode:
+                 # Locally-built apps are ad-hoc signed; make them relaunchable after
+-                # an in-place self-update (otherwise macOS reports "Hermes is
++                # an in-place self-update (otherwise macOS reports "Black Pool is
+                 # damaged"). No-op on non-macOS and on real-identity builds.
+                 _desktop_macos_relaunchable_fixup(desktop_dir)
+ 
+                 # Windows integrity gate (#69179): never declare the rebuild a
+-                # success on a Hermes.exe Windows cannot load (truncated PE from
++                # success on a Black Pool.exe Windows cannot load (truncated PE from
+                 # a corrupt cached Electron zip, wrong-arch tree, interrupted
+                 # rcedit rewrite). Roll back to the .bak tree preserved by
+                 # before-pack.mjs when possible, then fail loudly so the
+@@ -8028,7 +8028,7 @@ def cmd_gui(args: argparse.Namespace):
+             # Build succeeded — write the stamp so next run can skip
+             _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
+ 
+-    # Linux: register the app in the desktop launcher, so Hermes shows up
++    # Linux: register the app in the desktop launcher, so Black Pool shows up
+     # in the application menu with its icon. Best-effort and idempotent.
+     # A failure must never stop the app from launching.
+     _register_linux_desktop_entry()
+@@ -8054,7 +8054,7 @@ def cmd_gui(args: argparse.Namespace):
+         return
+ 
+     if source_mode:
+-        print("→ Launching Hermes Desktop from source build...")
++        print("→ Launching Black Pool Desktop from source build...")
+         launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
+         sys.exit(launch_result.returncode)
+ 
+@@ -8072,7 +8072,7 @@ def cmd_gui(args: argparse.Namespace):
+             sys.exit(1)
+ 
+     launch_command.extend(config_electron_flags)
+-    print(f"→ Launching packaged Hermes Desktop: {' '.join(launch_command)}")
++    print(f"→ Launching packaged Black Pool Desktop: {' '.join(launch_command)}")
+     launch_result = subprocess.run(launch_command, cwd=desktop_dir, env=env, check=False)
+     sys.exit(launch_result.returncode)
+ 
+@@ -8165,7 +8165,7 @@ def _restart_managed_dashboard_service(
+             timeout=timeout,
+         )
+ 
+-    # Probe the user manager first: Hermes installs Linux services in the
++    # Probe the user manager first: Black Pool installs Linux services in the
+     # user's systemd scope by default.  Only fall back to the system manager
+     # when the unit is not present there, preserving root/system deployments.
+     # Crucially, keep the selected scope for *all* probes and the restart — a
+@@ -8718,8 +8718,8 @@ def _recover_core_update_marker_locked() -> None:
+         print("✗ Could not auto-recover the interrupted install.")
+         if self_locked:
+             print(
+-                "  Hermes is still running from the launcher that needs "
+-                "replacing. Close other Hermes windows, restart from a "
++                "  Black Pool is still running from the launcher that needs "
++                "replacing. Close other Black Pool windows, restart from a "
+                 "different terminal, then run:"
+             )
+             print(f'    cd /d "{PROJECT_ROOT}"')
+@@ -8999,13 +8999,13 @@ def _quarantine_running_hermes_exe(
+ 
+     Rename can still fail when *another* process has opened the .exe without
+     ``FILE_SHARE_DELETE`` — typically AV real-time scanners with transient
+-    handles (recovers in <1s), or the Hermes Desktop backend child process
++    handles (recovers in <1s), or the Black Pool Desktop backend child process
+     (won't recover until the user closes it). We mitigate:
+ 
+     1. Retry up to ``max_attempts`` times with exponential backoff
+        (100/250/500/1000 ms). Handles the AV-scanner case.
+     2. If all retries fail, print a clear warning naming the most likely
+-       culprit (running Hermes Desktop / gateway / REPL).
++       culprit (running Black Pool Desktop / gateway / REPL).
+ 
+     The updater's own launcher is no longer one of those culprits: an update
+     started from ``hermes.exe`` re-runs itself under the venv Python before
+@@ -9060,7 +9060,7 @@ def _quarantine_running_hermes_exe(
+             f"another process is holding it open)."
+         )
+         print(
+-            "    Close Hermes Desktop, exit other `hermes` REPLs, stop the "
++            "    Close Black Pool Desktop, exit other `hermes` REPLs, stop the "
+             "gateway, or pause AV scanning, then re-run `hermes update`."
+         )
+ 
+@@ -9105,9 +9105,9 @@ def _filter_pending_shim_renames(
+ 
+ 
+ def _cleanup_pending_shim_renames(scripts_dir: Path) -> int:
+-    """Drop reboot renames older Hermes versions queued for our shims.
++    """Drop reboot renames older Black Pool versions queued for our shims.
+ 
+-    Hermes used to fall back to ``MoveFileExW(MOVEFILE_DELAY_UNTIL_REBOOT)``
++    Black Pool used to fall back to ``MoveFileExW(MOVEFILE_DELAY_UNTIL_REBOOT)``
+     when the quarantine rename failed. Those entries outlive the update that
+     queued them, so at the next boot they move away whatever now sits at the
+     shim path — including a shim a later repair just wrote. Needs elevation
 @@ -10060,7 +10060,7 @@ def _size_delta_label(saved_mb: float) -> str:
  
  
@@ -48004,6 +53232,60 @@ index 9f5e1ec..61bb5e1 100644
          return
  
      # --plan is read-only and deployment-kind aware, so it runs BEFORE the
+@@ -10085,7 +10085,7 @@ def cmd_update(args):
+     # right mechanism — strictly more useful than the bare refusal text.
+     if getattr(args, "plan", False):
+         # Read-only plan phase (#91277 Phase 2): inventory every running
+-        # Hermes runtime across profiles, its supervisor, and its running
++        # Black Pool runtime across profiles, its supervisor, and its running
+         # code version — without mutating anything. Safe on a live fleet.
+         from hermes_cli.update_inventory import (
+             collect_runtime_inventory,
+@@ -10848,7 +10848,7 @@ def cmd_profile(args):
+         if data.get("license"):
+             print(f"License:      {data['license']}")
+         if data.get("hermes_requires"):
+-            print(f"Requires:     Hermes {data['hermes_requires']}")
++            print(f"Requires:     Black Pool {data['hermes_requires']}")
+         if data.get("source"):
+             print(f"Source:       {data['source']}")
+         if data.get("installed_at"):
+@@ -10877,7 +10877,7 @@ def _render_distribution_plan(plan) -> None:
+     if mf.author:
+         print(f"  Author:   {mf.author}")
+     if mf.hermes_requires:
+-        print(f"  Requires: Hermes {mf.hermes_requires}")
++        print(f"  Requires: Black Pool {mf.hermes_requires}")
+     print(f"  Source:   {plan.provenance}")
+     print(f"  Target:   {plan.target_dir}")
+     if plan.existing:
+@@ -11399,7 +11399,7 @@ def cmd_dashboard(args):
+         _ssh_session_token = _read_ssh_session_token_file(_token_file)
+ 
+     # Attach gui.log early so dashboard startup/build failures are captured in
+-    # the same logs directory as every other Hermes surface.
++    # the same logs directory as every other Black Pool surface.
+     try:
+         from hermes_logging import setup_logging as _setup_logging_gui
+         _setup_logging_gui(mode="gui")
+@@ -11593,7 +11593,7 @@ def cmd_prompt_size(args):
+ 
+ 
+ def cmd_logs(args):
+-    """View and filter Hermes log files."""
++    """View and filter Black Pool log files."""
+     from hermes_cli.logs import tail_log, list_logs
+ 
+     log_name = getattr(args, "log_name", "agent") or "agent"
+@@ -11614,7 +11614,7 @@ def cmd_logs(args):
+ 
+ 
+ def cmd_console(args):
+-    """Open the safe Hermes command console."""
++    """Open the safe Black Pool command console."""
+     from hermes_cli.console_engine import run_console_repl
+ 
+     return run_console_repl()
 @@ -12179,7 +12179,7 @@ def cmd_memory(args):
  
  
@@ -48013,23 +53295,701 @@ index 9f5e1ec..61bb5e1 100644
      try:
          from acp_adapter.entry import main as acp_main
  
+@@ -12407,7 +12407,7 @@ def _advertise_agent_env() -> None:
+     (``hermes-agent`` in huggingface.js ``agent-harnesses.ts``): standard-var
+     matching is exact, so any other value is counted as "unknown".
+     ``HERMES_AGENT`` is the Hermes-specific marker. setdefault: never
+-    clobber an outer harness (e.g. Hermes running inside another agent's
++    clobber an outer harness (e.g. Black Pool running inside another agent's
+     terminal).
+     """
+     os.environ.setdefault("AI_AGENT", "hermes-agent")
+@@ -12789,7 +12789,7 @@ def main():
+     build_webhook_parser(subparsers, cmd_webhook=cmd_webhook)
+ 
+     # =========================================================================
+-    # peer command — bot-to-bot DMs across machines (peer Hermes gateways)
++    # peer command — bot-to-bot DMs across machines (peer Black Pool gateways)
+     # =========================================================================
+     from hermes_cli.subcommands.peer import build_peer_parser
+ 
+@@ -13015,7 +13015,7 @@ def main():
+         description=(
+             "Petdex (https://github.com/crafter-station/petdex) is a public "
+             "gallery of animated sprite pets for coding agents. Install one "
+-            "and Hermes shows it reacting to agent activity across the CLI, "
++            "and Black Pool shows it reacting to agent activity across the CLI, "
+             "TUI, and desktop app."
+         ),
+     )
+@@ -13140,7 +13140,7 @@ def main():
+         description=(
+             "Computer Use drives the Mac through cua-driver, whose TCC grants\n"
+             "attach to cua-driver's own identity (com.trycua.driver) — not the\n"
+-            "terminal or the Hermes app. `status` reports the driver's grant\n"
++            "terminal or the Black Pool app. `status` reports the driver's grant\n"
+             "state; `grant` launches CuaDriver via LaunchServices so the macOS\n"
+             "permission dialog is attributed to the process that does the work."
+         ),
+@@ -13773,10 +13773,10 @@ def main():
+ 
+     sessions_import = sessions_subparsers.add_parser(
+         "import",
+-        help="Import a Claude Code or Codex CLI session into Hermes",
++        help="Import a Claude Code or Codex CLI session into Black Pool",
+         description=(
+             "Pull a conversation started in Claude Code (~/.claude/projects) "
+-            "or Codex CLI (~/.codex/sessions) into the Hermes session store "
++            "or Codex CLI (~/.codex/sessions) into the Black Pool session store "
+             "so it can be resumed with 'hermes --resume <id>'. The foreign "
+             "files are only read, never modified."
+         ),
+diff --git a/hermes_cli/managed_uv.py b/hermes_cli/managed_uv.py
+index 4ae390e..7dd5d84 100644
+--- a/hermes_cli/managed_uv.py
++++ b/hermes_cli/managed_uv.py
+@@ -1,13 +1,13 @@
+ """Hermes-managed uv and Python runtime repair.
+ 
+-Hermes owns its own uv binary at ``$HERMES_HOME/bin/uv`` (or ``uv.exe`` on
++Black Pool owns its own uv binary at ``$HERMES_HOME/bin/uv`` (or ``uv.exe`` on
+ Windows).  Every code path that needs uv resolves it from that single location.
+ If the binary is missing, ``ensure_uv()`` bootstraps it via the official
+ standalone installer with ``UV_UNMANAGED_INSTALL`` / ``UV_INSTALL_DIR`` pointed
+ at ``$HERMES_HOME/bin`` so the installer writes directly there — no PATH
+ probing, no conda guards, no multi-location resolution chains.
+ 
+-The Python backing the install is different: it is shared by every Hermes
++The Python backing the install is different: it is shared by every Black Pool
+ profile because the checkout's ``venv`` is shared.  Runtime repair therefore
+ uses an install-scoped store under ``<checkout>/.hermes-runtime/python``. A
+ vulnerable interpreter is never reinstalled in place. We provision a new
+@@ -51,7 +51,7 @@ _REPAIR_LOCK_NAME = "runtime-repair.lock"
+ 
+ 
+ def managed_uv_path() -> Path:
+-    """Return the path where Hermes keeps *its* uv binary.
++    """Return the path where Black Pool keeps *its* uv binary.
+ 
+     ``$HERMES_HOME/bin/uv`` on POSIX, ``$HERMES_HOME\\bin\\uv.exe`` on
+     Windows.  The directory may not exist yet — callers should use
+@@ -144,7 +144,7 @@ def _report_runtime_repair_failure(repair: RuntimeRepairResult) -> None:
+             f"the existing venv is unchanged ({repair.detail})."
+         )
+         print(
+-            "    Sessions stay protected meanwhile: Hermes keeps databases "
++            "    Sessions stay protected meanwhile: Black Pool keeps databases "
+             "out of WAL mode on this SQLite build. The next `hermes update` "
+             "will retry."
+         )
+@@ -592,7 +592,7 @@ def _attempt_install_generation(
+     try:
+         python.resolve().relative_to(generation.resolve())
+     except (OSError, ValueError):
+-        logger.warning("uv resolved Python outside the Hermes generation: %s", python)
++        logger.warning("uv resolved Python outside the Black Pool generation: %s", python)
+         _remove_tree(generation, boundary=python_root)
+         return None
+ 
+@@ -1024,7 +1024,7 @@ def _windows_runtime_holders() -> tuple[bool, str]:
+         return True, f"could not verify Windows venv holders: {exc}"
+     if holders:
+         pids = ", ".join(str(item[0]) for item in holders[:6])
+-        return True, f"other Hermes processes still hold the venv (PID {pids})"
++        return True, f"other Black Pool processes still hold the venv (PID {pids})"
+     return False, ""
+ 
+ 
+@@ -1223,7 +1223,7 @@ def repair_vulnerable_runtime(
+             )
+ 
+         print(
+-            "  ⚠ Hermes venv links SQLite "
++            "  ⚠ Black Pool venv links SQLite "
+             f"{current.sqlite_version_string}, which has the WAL-reset bug."
+         )
+         provisioned = _install_safe_python_generation(
+diff --git a/hermes_cli/mcp_catalog.py b/hermes_cli/mcp_catalog.py
+index 8bbec9b..1b63f75 100644
+--- a/hermes_cli/mcp_catalog.py
++++ b/hermes_cli/mcp_catalog.py
+@@ -158,7 +158,7 @@ class CatalogError(Exception):
+ 
+ 
+ def _catalog_root() -> Path:
+-    """Return the optional-mcps/ directory shipped with this Hermes install."""
++    """Return the optional-mcps/ directory shipped with this Black Pool install."""
+     # Prefer the env-var override / packaged location; fall back to the repo's
+     # optional-mcps/ next to the package (source checkout).
+     return get_optional_mcps_dir(Path(__file__).parent.parent / "optional-mcps")
+@@ -194,7 +194,7 @@ def _parse_manifest(path: Path) -> CatalogEntry:
+     if mv != _MANIFEST_VERSION:
+         raise CatalogError(
+             f"{path}: manifest_version {mv!r} unsupported "
+-            f"(this Hermes understands version {_MANIFEST_VERSION})"
++            f"(this Black Pool understands version {_MANIFEST_VERSION})"
+         )
+ 
+     name = data.get("name") or ""
+@@ -354,7 +354,7 @@ def list_catalog() -> List[CatalogEntry]:
+     Invalid manifests are skipped silently (CI tests catch them at PR time).
+     Manifests with a future ``manifest_version`` are also skipped, but the
+     skip is surfaced via :func:`catalog_diagnostics` so the picker / catalog
+-    UIs can tell the user their Hermes is out of date.
++    UIs can tell the user their Black Pool is out of date.
+     """
+     root = _catalog_root()
+     if not root.exists():
+@@ -389,8 +389,8 @@ def catalog_diagnostics() -> List[tuple]:
+ 
+     Returns a list of ``(entry_name, kind, message)`` tuples where ``kind``
+     is one of:
+-      - ``future_manifest`` — manifest_version is newer than this Hermes
+-        understands. Update Hermes to install this entry.
++      - ``future_manifest`` — manifest_version is newer than this Black Pool
++        understands. Update Black Pool to install this entry.
+       - ``invalid`` — manifest is malformed in some other way (caught by
+         CI for shipped manifests; user-modified manifests can hit this).
+     """
+@@ -851,7 +851,7 @@ def install_entry(entry: CatalogEntry, *, enable: bool = True) -> None:
+     print(color(
+         f"  ✓ Installed '{entry.name}' "
+         f"({'enabled' if enable else 'disabled'}). "
+-        f"Start a new Hermes session to load its tools.",
++        f"Start a new Black Pool session to load its tools.",
+         Colors.GREEN,
+     ))
+     if entry.post_install:
+diff --git a/hermes_cli/mcp_config.py b/hermes_cli/mcp_config.py
+index 99ab692..8775ff8 100644
+--- a/hermes_cli/mcp_config.py
++++ b/hermes_cli/mcp_config.py
+@@ -843,7 +843,7 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
+     # path in web_server.py so CLI and dashboard behave identically.
+     #
+     # force_interactive_oauth: `hermes mcp login` is *explicitly* user-
+-    # initiated even when stdin isn't a TTY (Hermes desktop / agent-
++    # initiated even when stdin isn't a TTY (Black Pool desktop / agent-
+     # spawned terminals). Without this, OAuth refuses before opening a
+     # browser because _is_interactive() only checks sys.stdin.isatty().
+     try:
+diff --git a/hermes_cli/mcp_picker.py b/hermes_cli/mcp_picker.py
+index 8bf2bef..b08468a 100644
+--- a/hermes_cli/mcp_picker.py
++++ b/hermes_cli/mcp_picker.py
+@@ -122,7 +122,7 @@ def _enable_disable(name: str, *, enable: bool) -> None:
+     save_config(cfg)
+     print(color(
+         f"  ✓ '{name}' {'enabled' if enable else 'disabled'}. "
+-        "Start a new Hermes session for changes to take effect.",
++        "Start a new Black Pool session for changes to take effect.",
+         Colors.GREEN,
+     ))
+ 
+@@ -250,7 +250,7 @@ def _print_rows_text(rows: List[_Row]) -> None:
+         Colors.DIM,
+     ))
+ 
+-    # Surface manifest-version warnings so users know when their Hermes is
++    # Surface manifest-version warnings so users know when their Black Pool is
+     # too old to install everything in the catalog.
+     diags = catalog_diagnostics()
+     future = [d for d in diags if d[1] == "future_manifest"]
+@@ -258,7 +258,7 @@ def _print_rows_text(rows: List[_Row]) -> None:
+         print()
+         for name, _, msg in future:
+             print(color(
+-                f"  ⚠ '{name}' requires a newer Hermes — run `hermes update` "
++                f"  ⚠ '{name}' requires a newer Black Pool — run `hermes update` "
+                 "to install this entry.",
+                 Colors.YELLOW,
+             ))
+diff --git a/hermes_cli/mcp_security.py b/hermes_cli/mcp_security.py
+index fac473c..12de9f3 100644
+--- a/hermes_cli/mcp_security.py
++++ b/hermes_cli/mcp_security.py
+@@ -10,7 +10,7 @@ blocks two high-signal abuse shapes seen in the wild:
+    interpreter whose inline script writes to OS persistence surfaces
+    (``~/.ssh/authorized_keys``, ``/etc/ssh``, ``/etc/pam.d``, ``sudoers``,
+    crontab, shell rc files). The campaign planted ``command: bash`` MCP entries
+-   whose payload appended an attacker SSH key to ``authorized_keys``; Hermes
++   whose payload appended an attacker SSH key to ``authorized_keys``; Black Pool
+    re-executed them on every cron tick / startup, re-installing the backdoor.
+ 
+ 3. A hardcoded indicator-of-compromise (IOC) blocklist for that campaign — the
+diff --git a/hermes_cli/mem_trim.py b/hermes_cli/mem_trim.py
+index ad54f59..649c4ab 100644
+--- a/hermes_cli/mem_trim.py
++++ b/hermes_cli/mem_trim.py
+@@ -1,4 +1,4 @@
+-"""Rate-limited heap release for long-lived Hermes gateway processes.
++"""Rate-limited heap release for long-lived Black Pool gateway processes.
+ 
+ On Linux/glibc, ``malloc_trim(0)`` can return pages from freed Python/C
+ allocations to the OS.  Other platforms and allocators are safe no-ops.
+@@ -31,7 +31,7 @@ _trim_call_count = 0
+ 
+ 
+ def _config_settings() -> tuple[bool, float, int, float]:
+-    """Return fail-open settings from the normal Hermes config path."""
++    """Return fail-open settings from the normal Black Pool config path."""
+     enabled = True
+     cooldown: Any = _DEFAULT_COOLDOWN_SECONDS
+     log_every_n: Any = _DEFAULT_LOG_EVERY_N
+diff --git a/hermes_cli/middleware.py b/hermes_cli/middleware.py
+index e8c00e8..ad7e66e 100644
+--- a/hermes_cli/middleware.py
++++ b/hermes_cli/middleware.py
+@@ -1,4 +1,4 @@
+-"""Hermes middleware contract helpers.
++"""Black Pool middleware contract helpers.
+ 
+ Observer hooks report what happened. Middleware can change what happens by
+ rewriting a request or wrapping the actual execution callback. Keep the small
+@@ -81,7 +81,7 @@ def apply_llm_request_middleware(
+     """Apply registered LLM request middleware.
+ 
+     Middleware may return ``{"request": {...}}`` to replace the effective
+-    provider kwargs before Hermes sends them.
++    provider kwargs before Black Pool sends them.
+     """
+     if not _has_middleware(LLM_REQUEST_MIDDLEWARE):
+         return RequestMiddlewareResult(
+diff --git a/hermes_cli/moa_config.py b/hermes_cli/moa_config.py
+index 24d36e4..2f2dd98 100644
+--- a/hermes_cli/moa_config.py
++++ b/hermes_cli/moa_config.py
+@@ -33,7 +33,7 @@ def _coerce_float_or_none(value: Any) -> float | None:
+ 
+     Used for optional sampling params (reference_temperature /
+     aggregator_temperature) where None means 'don't send the parameter —
+-    provider default applies', matching how a single-model Hermes agent
++    provider default applies', matching how a single-model Black Pool agent
+     never sends temperature unless explicitly configured.
+     """
+     if value is None or value == "":
+diff --git a/hermes_cli/model_catalog.py b/hermes_cli/model_catalog.py
+index 5aa479f..e2e6b16 100644
+--- a/hermes_cli/model_catalog.py
++++ b/hermes_cli/model_catalog.py
+@@ -1,6 +1,6 @@
+ """Remote model catalog fetcher.
+ 
+-The Hermes docs site hosts a JSON manifest of curated models for providers
++The Black Pool docs site hosts a JSON manifest of curated models for providers
+ we want to update without shipping a release (currently OpenRouter and
+ Nous Portal). This module fetches, validates, and caches that manifest,
+ falling back to the in-repo hardcoded lists when the network is unavailable.
+@@ -413,7 +413,7 @@ def get_default_model_from_cache(provider: str) -> str | None:
+     """Return the catalog's labeled default model for ``provider`` — cache only.
+ 
+     The manifest marks exactly one model entry per provider with
+-    ``"default": true``; that entry is the model Hermes silently lands on when
++    ``"default": true``; that entry is the model Black Pool silently lands on when
+     the user never picked one. This accessor reads ONLY the in-process copy or
+     the disk cache — it NEVER triggers a network fetch, so it is safe on hot
+     resolution paths (agent build, gateway session setup) that must stay
+diff --git a/hermes_cli/model_cost_guard.py b/hermes_cli/model_cost_guard.py
+index 1ed8835..9e57c8a 100644
+--- a/hermes_cli/model_cost_guard.py
++++ b/hermes_cli/model_cost_guard.py
+@@ -17,7 +17,7 @@ GPT55_SUGGESTION = "did you mean to select openai/gpt-5.5?"
+ 
+ @dataclass(frozen=True)
+ class ExpensiveModelWarning:
+-    """Confirmation payload for models above Hermes' cost guardrail."""
++    """Confirmation payload for models above Black Pool' cost guardrail."""
+ 
+     model: str
+     provider: str
+@@ -161,7 +161,7 @@ def expensive_model_warning(
+     lines = [
+         "!!! EXPENSIVE MODEL WARNING !!!",
+         "",
+-        f"{model} has known pricing above Hermes' safety threshold.",
++        f"{model} has known pricing above Black Pool' safety threshold.",
+         f"Input tokens: {_format_money(input_cost)}",
+         f"Output tokens: {_format_money(output_cost)}",
+         (
+diff --git a/hermes_cli/model_normalize.py b/hermes_cli/model_normalize.py
+index 31bd5ff..bd61426 100644
+--- a/hermes_cli/model_normalize.py
++++ b/hermes_cli/model_normalize.py
+@@ -17,7 +17,7 @@ Different LLM providers expect model identifiers in different formats:
+   ``deepseek-v<N>-*``).  The legacy aliases ``deepseek-chat`` and
+   ``deepseek-reasoner`` were retired on 2026-07-24 and are remapped to
+   ``deepseek-v4-flash`` (official non-thinking / thinking shims).  Older
+-  Hermes revisions folded every non-reasoner input into
++  Black Pool revisions folded every non-reasoner input into
+   ``deepseek-chat``, which on aggregators routes to V3 — so a user
+   picking V4 Pro was silently downgraded.
+ - **Custom** and remaining providers pass the name through as-is.
+@@ -241,7 +241,7 @@ def _dots_to_hyphens(model_name: str) -> str:
+ 
+ 
+ def _normalize_provider_alias(provider_name: str) -> str:
+-    """Resolve provider aliases to Hermes' canonical ids."""
++    """Resolve provider aliases to Black Pool' canonical ids."""
+     raw = (provider_name or "").strip().lower()
+     if not raw:
+         return raw
+@@ -436,7 +436,7 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
+             Can be bare (``"claude-sonnet-4.6"``), vendor-prefixed
+             (``"anthropic/claude-sonnet-4.6"``), or already in native
+             format (``"claude-sonnet-4-6"``).
+-        target_provider: The canonical Hermes provider id, e.g.
++        target_provider: The canonical Black Pool provider id, e.g.
+             ``"openrouter"``, ``"anthropic"``, ``"copilot"``,
+             ``"deepseek"``, ``"custom"``.  Should already be normalised
+             via ``hermes_cli.models.normalize_provider()``.
+diff --git a/hermes_cli/model_selection_guards.py b/hermes_cli/model_selection_guards.py
+index 0d88649..ac978d5 100644
+--- a/hermes_cli/model_selection_guards.py
++++ b/hermes_cli/model_selection_guards.py
+@@ -1,6 +1,6 @@
+ """Unified selection-time guard registry for model switching surfaces.
+ 
+-Hermes has multiple model-selection surfaces (CLI picker, TUI, dashboard,
++Black Pool has multiple model-selection surfaces (CLI picker, TUI, dashboard,
+ gateway ``/model``, Telegram/Discord pickers, TUI-gateway RPC). Each of them
+ previously imported ``model_cost_guard.expensive_model_warning`` directly, so
+ every new guard class (e.g. the data-training-tier guard) had to be wired into
+diff --git a/hermes_cli/model_setup_flows.py b/hermes_cli/model_setup_flows.py
+index fbb6f35..4cfbe93 100644
+--- a/hermes_cli/model_setup_flows.py
++++ b/hermes_cli/model_setup_flows.py
+@@ -985,7 +985,7 @@ def _model_flow_custom(config):
+     else:
+         print(
+             f"Warning: could not verify this endpoint via {probe.get('probed_url')}. "
+-            f"Hermes will still save it."
++            f"Black Pool will still save it."
+         )
+         if probe.get("suggested_base_url"):
+             suggested = probe["suggested_base_url"]
+@@ -1198,7 +1198,7 @@ def _model_flow_azure_foundry(config, current_model=""):
+     print("=" * 50)
+     print()
+     print("Azure Foundry can host models with either OpenAI-style or")
+-    print("Anthropic-style API endpoints.  Hermes will probe your")
++    print("Anthropic-style API endpoints.  Black Pool will probe your")
+     print("endpoint to auto-detect the transport and the deployed")
+     print("models when possible.")
+     print()
+@@ -1286,7 +1286,7 @@ def _model_flow_azure_foundry(config, current_model=""):
+         if not has_azure_identity_installed():
+             print("◐ The 'azure-identity' package is not installed yet.")
+             print(
+-                "  Hermes will install it now (the preflight below "
++                "  Black Pool will install it now (the preflight below "
+                 "triggers the lazy-install). To skip lazy installs, "
+                 "run:  pip install azure-identity"
+             )
+@@ -2025,9 +2025,9 @@ def _model_flow_copilot_acp(config, current_model=""):
+     )
+     effective_base = status.get("base_url") or pconfig.inference_base_url
+ 
+-    print("  GitHub Copilot ACP delegates Hermes turns to `copilot --acp`.")
+-    print("  Hermes currently starts its own ACP subprocess for each request.")
+-    print("  Hermes uses your selected model as a hint for the Copilot ACP session.")
++    print("  GitHub Copilot ACP delegates Black Pool turns to `copilot --acp`.")
++    print("  Black Pool currently starts its own ACP subprocess for each request.")
++    print("  Black Pool uses your selected model as a hint for the Copilot ACP session.")
+     print(f"  Command: {resolved_command}")
+     print(f"  Backend marker: {effective_base}")
+     print()
+@@ -2868,7 +2868,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
+                     "(<= 250 requests/day for gemini-2.5-flash)."
+                 )
+                 print(
+-                    "   Hermes typically makes 3-10 API calls per user turn "
++                    "   Black Pool typically makes 3-10 API calls per user turn "
+                     "(tool iterations + auxiliary tasks),"
+                 )
+                 print(
+@@ -2878,7 +2878,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
+                 print("   an agent session.")
+                 print()
+                 print(
+-                    "   To use Gemini with Hermes, enable billing on your "
++                    "   To use Gemini with Black Pool, enable billing on your "
+                     "Google Cloud project and regenerate"
+                 )
+                 print(
 diff --git a/hermes_cli/model_switch.py b/hermes_cli/model_switch.py
-index 959e0ce..265f73b 100644
+index 959e0ce..24e3aef 100644
 --- a/hermes_cli/model_switch.py
 +++ b/hermes_cli/model_switch.py
-@@ -357,7 +357,7 @@ def _fetch_picker_live_models(
+@@ -88,7 +88,7 @@ def _declared_model_ids(value: Any) -> list[str]:
+ 
+     if isinstance(value, dict):
+         for model_id in value:
+-            # Backward compat: pre-fix Hermes wrote sentinel keys inside the
++            # Backward compat: pre-fix Black Pool wrote sentinel keys inside the
+             # user-facing ``models`` mapping. Never list them as model IDs.
+             if model_id in {
+                 "__explicit_model_allowlist__",
+@@ -114,10 +114,10 @@ def _declared_model_ids(value: Any) -> list[str]:
+ 
+ 
+ def _entry_models_discovered(entry: Any) -> bool:
+-    """True when the entry's ``models`` mapping was auto-discovered by Hermes.
++    """True when the entry's ``models`` mapping was auto-discovered by Black Pool.
+ 
+     The current shape is an entry-level ``models_discovered: true`` sibling of
+-    ``models``. Older Hermes versions wrote an in-mapping
++    ``models``. Older Black Pool versions wrote an in-mapping
+     ``__discovered_model_catalog__: true`` sentinel instead — accept that on
+     read for backward compatibility (the next discovery save migrates the
+     entry to the clean shape).
+@@ -147,7 +147,7 @@ def _models_config_is_allowlist(value: Any, discovered: bool = False) -> bool:
+     dict-shaped catalog, set ``discover_models: false``.
+ 
+     ``discovered`` is the entry-level ``models_discovered`` flag (see
+-    ``_entry_models_discovered``): a catalog Hermes itself persisted after a
++    ``_entry_models_discovered``): a catalog Black Pool itself persisted after a
+     successful probe is never a user pin, whatever its shape.
+     """
+     if discovered:
+@@ -219,7 +219,7 @@ def _save_discovered_models_to_config(
+             # (e.g. ``{"model-a": {"context_length": 8192}}``) or a list of
+             # dicts (e.g. ``[{"id": "model-a", "context_length": 8192}]``),
+             # the user has curated metadata per model — do not replace it.
+-            # A mapping Hermes itself discovered (``models_discovered: true``
++            # A mapping Black Pool itself discovered (``models_discovered: true``
+             # or the legacy in-mapping sentinel) is ours to refresh.
+             if isinstance(existing, dict) and not entry_discovered:
+                 continue
+@@ -356,13 +356,13 @@ def _fetch_picker_live_models(
+ # ---------------------------------------------------------------------------
  
  _HERMES_MODEL_WARNING = (
-     "Nous Research Hermes 3 & 4 models are NOT agentic and are not designed "
+-    "Nous Research Hermes 3 & 4 models are NOT agentic and are not designed "
 -    "for use with Hermes Agent. They lack the tool-calling capabilities "
++    "Nous Research Black Pool 3 & 4 models are NOT agentic and are not designed "
 +    "for use with Black Pool Agent. They lack the tool-calling capabilities "
      "required for agent workflows. Consider using an agentic model instead "
      "(Claude, GPT, Gemini, DeepSeek, etc.)."
  )
+ 
+-# Match only the real Nous Research Hermes 3 / Hermes 4 chat families.
++# Match only the real Nous Research Black Pool 3 / Black Pool 4 chat families.
+ # The previous substring check (`"hermes" in name.lower()`) false-positived on
+ # unrelated local Modelfiles like ``hermes-brain:qwen3-14b-ctx16k`` that just
+ # happen to carry "hermes" in their tag but are fully tool-capable.
+@@ -423,7 +423,7 @@ def format_model_for_display(model_name: str) -> str:
+ 
+ # ---------------------------------------------------------------------------
+ def is_nous_hermes_non_agentic(model_name: str) -> bool:
+-    """Return True if *model_name* is a real Nous Hermes 3/4 chat model.
++    """Return True if *model_name* is a real Nous Black Pool 3/4 chat model.
+ 
+     Used to decide whether to surface the non-agentic warning at startup.
+     Callers in :mod:`cli.py` and here should go through this single helper
+@@ -435,7 +435,7 @@ def is_nous_hermes_non_agentic(model_name: str) -> bool:
+ 
+ 
+ def _check_hermes_model_warning(model_name: str) -> str:
+-    """Return a warning string if *model_name* is a Nous Hermes 3/4 chat model."""
++    """Return a warning string if *model_name* is a Nous Black Pool 3/4 chat model."""
+     if is_nous_hermes_non_agentic(model_name):
+         return _HERMES_MODEL_WARNING
+     return ""
+@@ -2342,7 +2342,7 @@ def _prefetch_provider_models_parallel(provider_slugs: list[str]) -> None:
+     so concurrent writes to ``provider_models_cache.json`` don't clobber each
+     other.
+ 
+-    :param provider_slugs: Hermes provider IDs to prefetch (e.g. ``["openrouter",
++    :param provider_slugs: Black Pool provider IDs to prefetch (e.g. ``["openrouter",
+         "anthropic", "deepseek"]``).  Unknown providers are silently skipped.
+     """
+     from hermes_cli.models import cached_provider_model_ids
+@@ -2735,7 +2735,7 @@ def list_authenticated_providers(
+     # "nous" pulls from the remote model-catalog manifest published at
+     # https://hermes-agent.nousresearch.com/docs/api/model-catalog.json so
+     # newly added Portal models surface in the /model picker without
+-    # requiring a Hermes release. Falls back to the in-repo
++    # requiring a Black Pool release. Falls back to the in-repo
+     # _PROVIDER_MODELS["nous"] snapshot when the manifest is unreachable.
+     curated["nous"] = get_curated_nous_model_ids()
+     # Ollama Cloud uses dynamic discovery (no static curated list)
+@@ -2852,7 +2852,7 @@ def list_authenticated_providers(
+         # section 2 (HERMES_OVERLAYS) with proper auth store checking.
+         if pconfig and pconfig.auth_type != "api_key":
+             continue
+-        # models.dev catalogs include providers Hermes may not route yet.
++        # models.dev catalogs include providers Black Pool may not route yet.
+         # Gate on runtime capability rather than registry membership: special
+         # providers and plugin aliases can be routable without a registry row.
+         from hermes_cli.auth import is_runtime_provider_routable
+@@ -2930,16 +2930,16 @@ def list_authenticated_providers(
+     from hermes_cli.providers import HERMES_OVERLAYS
+     from hermes_cli.auth import PROVIDER_REGISTRY as _auth_registry
+ 
+-    # Build reverse mapping: models.dev ID → Hermes provider ID.
++    # Build reverse mapping: models.dev ID → Black Pool provider ID.
+     # HERMES_OVERLAYS keys may be models.dev IDs (e.g. "github-copilot")
+-    # while _PROVIDER_MODELS and config.yaml use Hermes IDs ("copilot").
++    # while _PROVIDER_MODELS and config.yaml use Black Pool IDs ("copilot").
+     _mdev_to_hermes = {v: k for k, v in PROVIDER_TO_MODELS_DEV.items()}
+ 
+     for pid, overlay in HERMES_OVERLAYS.items():
+         if pid.lower() in seen_slugs:
+             continue
+ 
+-        # Resolve Hermes slug — e.g. "github-copilot" → "copilot"
++        # Resolve Black Pool slug — e.g. "github-copilot" → "copilot"
+         hermes_slug = _mdev_to_hermes.get(pid, pid)
+         if hermes_slug.lower() in seen_slugs:
+             continue
+@@ -3261,7 +3261,7 @@ def list_authenticated_providers(
+             # custom_providers entries use, so accept either.
+             default_model = ep_cfg.get("default_model", "") or ep_cfg.get("model", "")
+             # Build models list from both default_model and full models array.
+-            # Hermes writes ``models:`` as a dict keyed by model id, but older
++            # Black Pool writes ``models:`` as a dict keyed by model id, but older
+             # or hand-edited configs may use strings or ``[{id: ...}]`` rows —
+             # _declared_model_ids() owns that contract.
+             entry_models: list = []
+@@ -3275,7 +3275,7 @@ def list_authenticated_providers(
+             if group_key not in ep_groups:
+                 # Strip per-model suffix so "Palantir Claude 4.7 Opus" becomes
+                 # "Palantir Claude". Em dash and " - " are the separators
+-                # Hermes's own writer uses (mirrors section-4 grouping).
++                # Black Pool's own writer uses (mirrors section-4 grouping).
+                 grp_display = display_name
+                 for sep in ("—", " - "):
+                     if sep in grp_display:
+@@ -3662,7 +3662,7 @@ def list_authenticated_providers(
+             )
+ 
+             # The singular ``model:`` field only holds the currently
+-            # active model. Hermes's own writer (main.py::_save_custom_provider)
++            # active model. Black Pool's own writer (main.py::_save_custom_provider)
+             # stores every configured model as a dict under ``models:``;
+             # downstream readers (agent/models_dev.py, gateway/run.py,
+             # run_agent.py, hermes_cli/config.py) already consume that dict.
 diff --git a/hermes_cli/models.py b/hermes_cli/models.py
-index e97c6cd..ad99771 100644
+index e97c6cd..2bf7bc4 100644
 --- a/hermes_cli/models.py
 +++ b/hermes_cli/models.py
+@@ -559,7 +559,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
+     # deepseek-v4-flash-free delisted (promo ended, now 401s).
+     # big-pickle + mimo-v2.5-free delisted (UA-gated: the relay 429s
+     # FreeUsageLimitError for every client except User-Agent
+-    # "opencode/latest"; we send honest Hermes attribution and don't
++    # "opencode/latest"; we send honest Black Pool attribution and don't
+     # impersonate other clients — verified 2026-08-21).
+     "opencode-free": [
+         "x-preview-f-free",  # "Ox Alpha" stealth model — free, 1M ctx, ZDR
+@@ -801,7 +801,7 @@ def union_with_portal_free_recommendations(
+ 
+     For free-tier users this is the source of truth: any model the Portal
+     flags as free should be selectable, even if the user is running an
+-    older Hermes that doesn't ship that model in its hardcoded curated
++    older Black Pool that doesn't ship that model in its hardcoded curated
+     list.  This function returns an augmented ``(model_ids, pricing)``
+     pair where:
+ 
+@@ -867,7 +867,7 @@ def union_with_portal_paid_recommendations(
+     the docs-hosted catalog manifest has been rebuilt since the last release.
+ 
+     For paid-tier users this lets newly-launched paid models surface in the
+-    picker even if the user is running an older Hermes that doesn't ship
++    picker even if the user is running an older Black Pool that doesn't ship
+     them in its hardcoded curated list. This function returns an augmented
+     ``(model_ids, pricing)`` pair where:
+ 
+@@ -1267,7 +1267,7 @@ _PROVIDER_LABELS["custom"] = "Custom endpoint"  # special case: not a named prov
+ # ---------------------------------------------------------------------------
+ # Provider groups — DISPLAY ONLY
+ #
+-# Some vendors expose several Hermes provider slugs (one per endpoint /
++# Some vendors expose several Black Pool provider slugs (one per endpoint /
+ # auth method: global API, China API, OAuth coding plan, ...). Listing every
+ # slug as a top-level row in the interactive `hermes model` / setup wizard /
+ # Telegram `/model` pickers makes that list long and noisy.
+@@ -1460,7 +1460,7 @@ _PROVIDER_ALIASES = {
+ }
+ 
+ 
+-# In-repo fallback for the model Hermes silently lands on when the user never
++# In-repo fallback for the model Black Pool silently lands on when the user never
+ # picked one (GUI onboarding confirm card, empty ``model.default``,
+ # provider-set-but-model-missing resolution). The AUTHORITATIVE source is the
+ # remote model catalog: the manifest labels exactly one entry per provider
+@@ -2069,7 +2069,7 @@ def fetch_openrouter_models(
+             continue
+         if preferred_id == silent_default:
+             # Keep the silent-default badge through the live refresh so the
+-            # picker shows which model Hermes lands on when none is selected.
++            # picker shows which model Black Pool lands on when none is selected.
+             desc = "default"
+         else:
+             desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
+@@ -3528,7 +3528,7 @@ def _find_openrouter_slug(model_name: str) -> Optional[str]:
+ 
+ 
+ def normalize_provider(provider: Optional[str]) -> str:
+-    """Normalize provider aliases to Hermes' canonical provider ids.
++    """Normalize provider aliases to Black Pool' canonical provider ids.
+ 
+     Note: ``"auto"`` passes through unchanged — use
+     ``hermes_cli.auth.resolve_provider()`` to resolve it to a concrete
+@@ -3596,7 +3596,7 @@ def _strip_vendor_prefix(model_id: str) -> str:
+ 
+ 
+ def model_supports_fast_mode(model_id: Optional[str]) -> bool:
+-    """Return whether Hermes should expose the /fast toggle for this model."""
++    """Return whether Black Pool should expose the /fast toggle for this model."""
+     from agent.model_metadata import is_grok_46_family
+ 
+     return (
+@@ -3824,7 +3824,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False)
+     falling back to static lists. For providers in ``_MODELS_DEV_PREFERRED``
+     (opencode-go/zen, xiaomi, deepseek, smaller inference providers, etc.),
+     models.dev entries are merged on top of curated so new models released
+-    on the platform appear in ``/model`` without a Hermes release.
++    on the platform appear in ``/model`` without a Black Pool release.
+     """
+     requested = str(provider or "").strip().lower()
+     if requested == "ollama":
+@@ -3878,7 +3878,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False)
+ 
+         # Pass the live OAuth access token so the picker matches whatever
+         # ChatGPT lists for this account right now (new models appear without
+-        # a Hermes release). Falls back to the hardcoded catalog if no token
++        # a Black Pool release). Falls back to the hardcoded catalog if no token
+         # or the endpoint is unreachable.
+         access_token = None
+         try:
+@@ -3911,7 +3911,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False)
+             pass
+         # Live failed (or no creds). Fall back to the docs-hosted manifest
+         # — NOT the in-repo _PROVIDER_MODELS["nous"] snapshot — so newly
+-        # added Portal models still surface without a Hermes release.
++        # added Portal models still surface without a Black Pool release.
+         manifest_ids = get_curated_nous_model_ids()
+         if manifest_ids:
+             return manifest_ids
+@@ -5115,7 +5115,7 @@ _COPILOT_MODEL_ALIASES = {
+     "anthropic/claude-sonnet-4": "claude-sonnet-4",
+     "anthropic/claude-sonnet-4.5": "claude-sonnet-4.5",
+     "anthropic/claude-haiku-4.5": "claude-haiku-4.5",
+-    # Dash-notation fallbacks: Hermes' default Claude IDs elsewhere use
++    # Dash-notation fallbacks: Black Pool' default Claude IDs elsewhere use
+     # hyphens (anthropic native format), but Copilot's API only accepts
+     # dot-notation.  Accept both so users who configure copilot + a
+     # default hyphenated Claude model don't hit HTTP 400
+@@ -5244,7 +5244,7 @@ def copilot_model_api_mode(
+         return "codex_responses"
+ 
+     # Copilot's Claude models are exposed through its OpenAI-compatible chat
+-    # endpoint, not through Hermes' native Anthropic adapter. The live catalog may
++    # endpoint, not through Black Pool' native Anthropic adapter. The live catalog may
+     # advertise /v1/messages, but the Copilot token/header scheme is handled by
+     # the OpenAI client path; selecting anthropic_messages would send the wrong
+     # auth/wire shape. Keep non-GPT Copilot slots on chat_completions.
 @@ -5388,7 +5388,7 @@ def opencode_zen_free_headers() -> dict:
      return {
          "Authorization": "",
@@ -48039,11 +53999,284 @@ index e97c6cd..ad99771 100644
          "User-Agent": f"HermesAgent/{_v}",
      }
  
+@@ -6387,7 +6387,7 @@ def validate_requested_model(
+                 "recognized": False,
+                 "message": (
+                     f"Note: could not reach this Ollama endpoint's `/api/tags` model listing to validate `{requested}`. "
+-                    "Hermes will save the model name, but local Ollama model discovery could not verify it."
++                    "Black Pool will save the model name, but local Ollama model discovery could not verify it."
+                 ),
+             }
+         if requested_for_lookup in set(ollama_models):
+@@ -6474,7 +6474,7 @@ def validate_requested_model(
+ 
+         message = (
+             f"Note: could not reach this custom endpoint's model listing at `{probe.get('probed_url')}`. "
+-            f"Hermes will still save `{requested}`, but the endpoint should expose `/models` for verification."
++            f"Black Pool will still save `{requested}`, but the endpoint should expose `/models` for verification."
+         )
+         if api_mode == "anthropic_messages":
+             message += (
+@@ -6602,7 +6602,7 @@ def validate_requested_model(
+                 "message": (
+                     f"Note: `{requested}` was not found in the MiniMax catalog."
+                     f"{suggestion_text}"
+-                    "\n  MiniMax does not expose a /models endpoint, so Hermes cannot verify the model name."
++                    "\n  MiniMax does not expose a /models endpoint, so Black Pool cannot verify the model name."
+                     "\n  The model may still work if it exists on the server."
+                 ),
+             }
+@@ -6738,7 +6738,7 @@ def validate_requested_model(
+             # before rejecting.  Providers may omit models from their live
+             # listing that are still valid (stale cache, partial rollout,
+             # gated previews).  Use the pure-catalog helper (no extra live
+-            # fetch) so we only accept models Hermes actually ships.  (#46850)
++            # fetch) so we only accept models Black Pool actually ships.  (#46850)
+             #
+             # EXCEPTION: official OpenAI hosts (canonical api.openai.com and
+             # the data-residency regional hosts).  Their /v1/models listing is
+diff --git a/hermes_cli/nous_account.py b/hermes_cli/nous_account.py
+index 654487e..4019caf 100644
+--- a/hermes_cli/nous_account.py
++++ b/hermes_cli/nous_account.py
+@@ -209,7 +209,7 @@ def format_nous_portal_entitlement_message(
+ 
+     if account_info is None:
+         return (
+-            f"Hermes could not verify your Nous Portal entitlement, so {capability} "
++            f"Black Pool could not verify your Nous Portal entitlement, so {capability} "
+             f"is unavailable. Run `hermes model` to refresh your login, or check "
+             f"billing at {billing_url}."
+         )
+@@ -217,7 +217,7 @@ def format_nous_portal_entitlement_message(
+     if not account_info.logged_in:
+         if account_info.inference_credential_present:
+             return (
+-                f"Nous inference credentials are configured, but Hermes cannot verify "
++                f"Nous inference credentials are configured, but Black Pool cannot verify "
+                 f"your Nous Portal paid access for {capability}. Log in with "
+                 f"`hermes model` to enable Portal-managed features. Billing and "
+                 f"credits are managed at {billing_url}."
+@@ -229,7 +229,7 @@ def format_nous_portal_entitlement_message(
+ 
+     if account_info.paid_service_access is None:
+         detail = (
+-            f"Hermes could not verify your Nous Portal paid access, so {capability} "
++            f"Black Pool could not verify your Nous Portal paid access, so {capability} "
+             f"is unavailable."
+         )
+         if account_info.error:
+@@ -243,7 +243,7 @@ def format_nous_portal_entitlement_message(
+     reason = access.reason if access else None
+     if reason == "account_missing":
+         return (
+-            f"Hermes could not find a Nous Portal account or organisation for this "
++            f"Black Pool could not find a Nous Portal account or organisation for this "
+             f"login, so {capability} is unavailable. Run `hermes model` to "
+             f"authenticate again; if the problem persists, contact Nous support."
+         )
+@@ -251,7 +251,7 @@ def format_nous_portal_entitlement_message(
+     if reason == "no_usable_credits" or account_info.paid_service_access is False:
+         message = _no_paid_access_message(account_info, capability, billing_url)
+         if include_refresh_hint and not account_info.fresh:
+-            message += " If you recently bought credits, run `hermes model` to refresh Hermes."
++            message += " If you recently bought credits, run `hermes model` to refresh Black Pool."
+         return message
+ 
+     return (
+diff --git a/hermes_cli/nous_billing.py b/hermes_cli/nous_billing.py
+index ba9a752..e3285a8 100644
+--- a/hermes_cli/nous_billing.py
++++ b/hermes_cli/nous_billing.py
+@@ -15,7 +15,7 @@ Design rules:
+   decide how to degrade. A raw network/HTTP error here surfaces as
+   :class:`BillingError` (or a subclass) carrying the parsed server ``error`` code,
+   HTTP status, ``portalUrl`` deep-link, and ``retry_after``.
+-- **Auth** = the OAuth bearer JWT Hermes already holds for inference
++- **Auth** = the OAuth bearer JWT Black Pool already holds for inference
+   (``get_provider_auth_state("nous")["access_token"]``). No API-key auth on these.
+ - **Portal base URL** resolves with the same precedence as the device-flow login
+   (``auth.py``): ``HERMES_PORTAL_BASE_URL`` → ``NOUS_PORTAL_BASE_URL`` → the
+diff --git a/hermes_cli/npm_engine.py b/hermes_cli/npm_engine.py
+index b26afe6..c13cfd2 100644
+--- a/hermes_cli/npm_engine.py
++++ b/hermes_cli/npm_engine.py
+@@ -13,12 +13,12 @@ an ``npm --version`` probe before work that usually succeeds), we react to it:
+ npm states the required range in the error, so the recovery reads the
+ constraint straight out of the output it just produced.
+ 
+-Scope of the repair is deliberately narrow. Hermes only upgrades an npm that
++Scope of the repair is deliberately narrow. Black Pool only upgrades an npm that
+ lives inside its **own** managed Node tree (``$HERMES_HOME/node``), installing
+ in place with ``--prefix`` so ``bin/npm`` keeps resolving to the upgraded
+ ``lib/node_modules/npm``. A system / nvm / brew / Nix npm belongs to the user
+-and their other projects; Hermes never modifies those. When the failing npm is
+-one of those foreign installs, Hermes instead provisions its own managed Node
++and their other projects; Black Pool never modifies those. When the failing npm is
++one of those foreign installs, Black Pool instead provisions its own managed Node
+ tree (the same tree a fresh install creates), upgrades *that* npm into range,
+ and hands the caller the managed npm to retry with — leaving the user's
+ toolchain untouched.
+@@ -264,7 +264,7 @@ def _print_manual_fix(npm: str, npm_range: str, actual: str | None) -> None:
+     print(
+         f"\n✗ {have}does not satisfy the range this project requires: {npm_range}\n"
+         f"  Resolved npm: {npm}\n"
+-        "  Hermes could not provision its own Node.js runtime and never\n"
++        "  Black Pool could not provision its own Node.js runtime and never\n"
+         "  modifies a system/nvm/brew/Nix npm. Upgrade yours yourself with:\n"
+         f'      npm install -g npm@"{npm_range}"',
+         file=sys.stderr,
+@@ -334,7 +334,7 @@ def maybe_repair_npm_engine(
+     prefix = managed_npm_prefix(npm)
+ 
+     if prefix is not None:
+-        # Hermes owns this npm — upgrade it in place. Only an npm-range
++        # Black Pool owns this npm — upgrade it in place. Only an npm-range
+         # failure is fixable this way; a Node mismatch needs a Node upgrade.
+         if not npm_range:
+             return None
+diff --git a/hermes_cli/observability/__init__.py b/hermes_cli/observability/__init__.py
+index 1c4e703..200cd29 100644
+--- a/hermes_cli/observability/__init__.py
++++ b/hermes_cli/observability/__init__.py
+@@ -1,4 +1,4 @@
+-"""First-party Hermes observability integrations."""
++"""First-party Black Pool observability integrations."""
+ 
+ from __future__ import annotations
+ 
+@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
+ 
+ 
+ def observe_lifecycle(hook_name: str, **kwargs: Any) -> None:
+-    """Dispatch a Hermes lifecycle event to built-in observability features."""
++    """Dispatch a Black Pool lifecycle event to built-in observability features."""
+     from . import relay_shared_metrics
+ 
+     _safe_observe(relay_shared_metrics.observe_lifecycle, hook_name, kwargs)
+diff --git a/hermes_cli/observability/relay_runtime.py b/hermes_cli/observability/relay_runtime.py
+index bd6de0b..4ac3d46 100644
+--- a/hermes_cli/observability/relay_runtime.py
++++ b/hermes_cli/observability/relay_runtime.py
+@@ -1,4 +1,4 @@
+-"""Compatibility alias for the core Hermes Relay runtime.
++"""Compatibility alias for the core Black Pool Relay runtime.
+ 
+ New code should import :mod:`agent.relay_runtime`. This module remains an
+ alias, rather than a copy, so existing plugins and tests share the same
 diff --git a/hermes_cli/observability/relay_shared_metrics.py b/hermes_cli/observability/relay_shared_metrics.py
-index 2ab88f5..3a7ee33 100644
+index 2ab88f5..b7b3460 100644
 --- a/hermes_cli/observability/relay_shared_metrics.py
 +++ b/hermes_cli/observability/relay_shared_metrics.py
-@@ -1066,7 +1066,7 @@ class _Runtime:
+@@ -1,4 +1,4 @@
+-"""Direct NeMo Relay integration for Hermes shared client metrics."""
++"""Direct NeMo Relay integration for Black Pool shared client metrics."""
+ 
+ from __future__ import annotations
+ 
+@@ -119,12 +119,12 @@ class _MetricsSession:
+ 
+ 
+ class _Runtime:
+-    """Own shared-metrics state layered on the Hermes core Relay host."""
++    """Own shared-metrics state layered on the Black Pool core Relay host."""
+ 
+     def __init__(self, host: relay_runtime.RelayRuntime | None = None) -> None:
+         resolved_host = host or relay_runtime.get_runtime()
+         if resolved_host is None:
+-            raise RuntimeError("Hermes core Relay runtime is unavailable")
++            raise RuntimeError("Black Pool core Relay runtime is unavailable")
+         self.host: relay_runtime.RelayRuntime = resolved_host
+         self.relay = self.host.relay
+         self._sessions_lock = threading.RLock()
+@@ -202,7 +202,7 @@ class _Runtime:
+         )
+ 
+     def start_task(self, event: dict[str, Any]) -> _TaskRun | None:
+-        """Open one Relay function scope for a Hermes task run."""
++        """Open one Relay function scope for a Black Pool task run."""
+         task_key = self._task_key(event)
+         if task_key is None:
+             return None
+@@ -316,7 +316,7 @@ class _Runtime:
+                 existing.fields = fields
+                 if task is not None:
+                     # Every repeated start for one logical request is another
+-                    # physical attempt. Provider fallback resets Hermes's
++                    # physical attempt. Provider fallback resets Black Pool's
+                     # provider-local retry ordinal, so ordinal deltas are not a
+                     # reliable task-level retry counter.
+                     task.retry_count += 1
+@@ -329,7 +329,7 @@ class _Runtime:
+             if task is not None:
+                 task.model_call_ids.add(request_id)
+                 if retry_ordinal is not None and retry_ordinal > 0:
+-                    # A real Hermes retry can advance api_request_id while
++                    # A real Black Pool retry can advance api_request_id while
+                     # carrying the retry ordinal. Count that physical attempt.
+                     task.retry_count += 1
+                 handle = self._run_in_task(
+@@ -603,7 +603,7 @@ class _Runtime:
+                 self.relay.subscribers.flush()
+             except Exception:
+                 logger.warning(
+-                    "Hermes shared-metrics task flush failed",
++                    "Black Pool shared-metrics task flush failed",
+                     exc_info=True,
+                 )
+             else:
+@@ -643,7 +643,7 @@ class _Runtime:
+                 self._sessions.pop(session.session_id, None)
+         if failures:
+             logger.warning(
+-                "Hermes shared-metrics session %s closed with errors: %s",
++                "Black Pool shared-metrics session %s closed with errors: %s",
+                 session.session_id,
+                 "; ".join(failures),
+             )
+@@ -660,7 +660,7 @@ class _Runtime:
+             self.relay.subscribers.flush()
+         except Exception:
+             logger.warning(
+-                "Hermes shared-metrics shutdown flush failed",
++                "Black Pool shared-metrics shutdown flush failed",
+                 exc_info=True,
+             )
+         else:
+@@ -911,7 +911,7 @@ class _Runtime:
+             )
+         except Exception:
+             logger.warning(
+-                "Hermes shared-metrics tool call close failed",
++                "Black Pool shared-metrics tool call close failed",
+                 exc_info=True,
+             )
+ 
+@@ -960,7 +960,7 @@ class _Runtime:
+                 )
+         except Exception:
+             logger.warning(
+-                "Hermes shared-metrics model call close failed", exc_info=True
++                "Black Pool shared-metrics model call close failed", exc_info=True
+             )
+ 
+     def _end_pending_model_calls(
+@@ -1033,7 +1033,7 @@ class _Runtime:
+                 metadata=self._event_metadata(),
+             )
+         except Exception:
+-            logger.warning("Hermes shared-metrics task close failed", exc_info=True)
++            logger.warning("Black Pool shared-metrics task close failed", exc_info=True)
+         finally:
+             session.tasks.pop(task_id, None)
+             session.retired_turn_ids.extend(task.turn_ids)
+@@ -1061,12 +1061,12 @@ class _Runtime:
+         try:
+             return callback(*args, **kwargs)
+         except Exception:
+-            logger.warning("Hermes shared metrics operation failed", exc_info=True)
++            logger.warning("Black Pool shared metrics operation failed", exc_info=True)
+             return None
  
  
  def enabled() -> bool:
@@ -48052,6 +54285,273 @@ index 2ab88f5..3a7ee33 100644
      profile_key = relay_runtime.current_profile_key()
      try:
          from hermes_cli.config import read_raw_config_readonly
+@@ -1078,7 +1078,7 @@ def enabled() -> bool:
+         # on every call.
+         config = read_raw_config_readonly() or {}
+     except Exception:
+-        logger.debug("Unable to read Hermes shared-metrics policy", exc_info=True)
++        logger.debug("Unable to read Black Pool shared-metrics policy", exc_info=True)
+         value = False
+     else:
+         telemetry = config.get("telemetry") if isinstance(config, dict) else None
+@@ -1102,7 +1102,7 @@ def handles_hook(hook_name: str) -> bool:
+ 
+ 
+ def observe_lifecycle(hook_name: str, **kwargs: Any) -> None:
+-    """Project one Hermes lifecycle event into the core Relay integration."""
++    """Project one Black Pool lifecycle event into the core Relay integration."""
+     if not handles_hook(hook_name):
+         return
+     if not relay_runtime.relay_instrumentation_enabled():
+@@ -1139,12 +1139,12 @@ def observe_lifecycle(hook_name: str, **kwargs: Any) -> None:
+             runtime.close_session(kwargs)
+     except Exception:
+         logger.warning(
+-            "Hermes shared metrics hook failed: %s", hook_name, exc_info=True
++            "Black Pool shared metrics hook failed: %s", hook_name, exc_info=True
+         )
+ 
+ 
+ def _with_runtime_toolset(event: dict[str, Any]) -> dict[str, Any]:
+-    """Attach the toolset already declared by Hermes's runtime registry."""
++    """Attach the toolset already declared by Black Pool's runtime registry."""
+     if event.get("toolset"):
+         return event
+     tool_name = str(event.get("tool_name") or "")
+@@ -1183,7 +1183,7 @@ def start_task_run(
+     platform: str,
+     parent_session_id: str = "",
+ ) -> None:
+-    """Start task metrics at the outer Hermes execution boundary."""
++    """Start task metrics at the outer Black Pool execution boundary."""
+     if not enabled():
+         return
+     runtime = _get_runtime(retry_failed=True)
+@@ -1272,7 +1272,7 @@ def _get_runtime(
+         try:
+             runtime = _Runtime(host=host)
+         except Exception:
+-            logger.warning("Hermes shared metrics initialization failed", exc_info=True)
++            logger.warning("Black Pool shared metrics initialization failed", exc_info=True)
+             _RUNTIMES[profile_key] = _RUNTIME_FAILED
+             return None
+         _RUNTIMES[profile_key] = runtime
+diff --git a/hermes_cli/observability/schemas/hermes.shared_metrics.v1.schema.json b/hermes_cli/observability/schemas/hermes.shared_metrics.v1.schema.json
+index 68496e5..3fafbcd 100644
+--- a/hermes_cli/observability/schemas/hermes.shared_metrics.v1.schema.json
++++ b/hermes_cli/observability/schemas/hermes.shared_metrics.v1.schema.json
+@@ -1,7 +1,7 @@
+ {
+   "$schema": "https://json-schema.org/draft/2020-12/schema",
+   "$id": "urn:hermes-agent:schema:shared-metrics:v1",
+-  "title": "Hermes Shared Metrics Package v1",
++  "title": "Black Pool Shared Metrics Package v1",
+   "type": "object",
+   "additionalProperties": false,
+   "required": [
+diff --git a/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json b/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json
+index 5d845ce..4c61d51 100644
+--- a/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json
++++ b/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json
+@@ -1,7 +1,7 @@
+ {
+   "$schema": "https://json-schema.org/draft/2020-12/schema",
+   "$id": "urn:hermes-agent:schema:shared-metrics:v2",
+-  "title": "Hermes Shared Metrics Package v2",
++  "title": "Black Pool Shared Metrics Package v2",
+   "type": "object",
+   "additionalProperties": false,
+   "required": [
+diff --git a/hermes_cli/observability/shared_metrics.py b/hermes_cli/observability/shared_metrics.py
+index fd42b06..ac691ed 100644
+--- a/hermes_cli/observability/shared_metrics.py
++++ b/hermes_cli/observability/shared_metrics.py
+@@ -1,4 +1,4 @@
+-"""Durable aggregation and local export for Hermes shared metrics."""
++"""Durable aggregation and local export for Black Pool shared metrics."""
+ 
+ from __future__ import annotations
+ 
+@@ -299,7 +299,7 @@ class SharedMetricsStore:
+ 
+     def _ensure_schema(self) -> None:
+         with self._connection(busy_timeout_ms=_SCHEMA_BUSY_TIMEOUT_MS) as connection:
+-            # Serialize first-run creation and upgrades across Hermes processes.
++            # Serialize first-run creation and upgrades across Black Pool processes.
+             with write_txn(connection):
+                 self._ensure_schema_in_transaction(connection)
+ 
+diff --git a/hermes_cli/observability/shared_metrics_contract.py b/hermes_cli/observability/shared_metrics_contract.py
+index eb1f858..3138d60 100644
+--- a/hermes_cli/observability/shared_metrics_contract.py
++++ b/hermes_cli/observability/shared_metrics_contract.py
+@@ -1,4 +1,4 @@
+-"""Bounded product contract for the first Hermes shared-metrics slice."""
++"""Bounded product contract for the first Black Pool shared-metrics slice."""
+ 
+ from __future__ import annotations
+ 
+@@ -236,7 +236,7 @@ def client_architecture(value: Any) -> str:
+ 
+ 
+ def client_install_method(value: Any) -> str:
+-    """Return an allowlisted Hermes installation method."""
++    """Return an allowlisted Black Pool installation method."""
+     normalized = str(value or "").strip().lower()
+     if normalized == "nix":
+         return "nixos"
+@@ -456,7 +456,7 @@ def model_call_dimensions(event: Any) -> dict[str, str] | None:
+ 
+ 
+ def _auxiliary_model_call_dimensions(event: Any) -> dict[str, str] | None:
+-    """Project a terminal auxiliary route from its Hermes logical scope."""
++    """Project a terminal auxiliary route from its Black Pool logical scope."""
+     metadata = getattr(event, "metadata", None)
+     if (
+         not isinstance(metadata, dict)
+@@ -759,7 +759,7 @@ def task_terminal_fields(
+ 
+ 
+ def task_terminal_state(kwargs: dict[str, Any]) -> tuple[str, str, str]:
+-    """Map Hermes terminal state to bounded task outcome dimensions."""
++    """Map Black Pool terminal state to bounded task outcome dimensions."""
+     reason = str(kwargs.get("turn_exit_reason") or "").strip().lower()
+     if kwargs.get("interrupted") or "interrupt" in reason or "cancel" in reason:
+         return "cancelled", "user_cancelled", "user_cancelled"
+@@ -809,7 +809,7 @@ def count_bucket(count: int) -> str:
+ 
+ 
+ def tool_category(kwargs: dict[str, Any]) -> str:
+-    """Map Hermes registry toolset metadata to a low-cardinality category."""
++    """Map Black Pool registry toolset metadata to a low-cardinality category."""
+     toolset = str(kwargs.get("toolset") or "").strip().lower()
+     if not toolset:
+         return "unknown"
+@@ -841,7 +841,7 @@ def tool_category(kwargs: dict[str, Any]) -> str:
+ 
+ 
+ def tool_outcome(kwargs: dict[str, Any]) -> str:
+-    """Normalize the terminal Hermes tool status without inspecting its result."""
++    """Normalize the terminal Black Pool tool status without inspecting its result."""
+     status = str(kwargs.get("status") or "").strip().lower()
+     return {
+         "blocked": "blocked",
+@@ -941,7 +941,7 @@ def _non_negative_number(value: Any) -> float | None:
+ 
+ 
+ def model_call_fields(kwargs: dict[str, Any]) -> dict[str, str]:
+-    """Return the terminal model identity and provider route known to Hermes."""
++    """Return the terminal model identity and provider route known to Black Pool."""
+     model = _metric_identifier(
+         kwargs.get("response_model"),
+         max_length=MODEL_IDENTIFIER_MAX_LENGTH,
+diff --git a/hermes_cli/observability/shared_metrics_subscriber.py b/hermes_cli/observability/shared_metrics_subscriber.py
+index 54c05e5..d701598 100644
+--- a/hermes_cli/observability/shared_metrics_subscriber.py
++++ b/hermes_cli/observability/shared_metrics_subscriber.py
+@@ -1,4 +1,4 @@
+-"""Relay subscriber for the persisted Hermes shared-metrics slice."""
++"""Relay subscriber for the persisted Black Pool shared-metrics slice."""
+ 
+ from __future__ import annotations
+ 
+@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
+ 
+ 
+ class SharedMetricsSubscriber:
+-    """Persist validated Hermes counters from Relay lifecycle events."""
++    """Persist validated Black Pool counters from Relay lifecycle events."""
+ 
+     def __init__(
+         self,
+@@ -95,7 +95,7 @@ class SharedMetricsSubscriber:
+                     )
+             except Exception:
+                 logger.warning(
+-                    "Unable to persist the Hermes shared metric: %s",
++                    "Unable to persist the Black Pool shared metric: %s",
+                     metric_name,
+                     exc_info=True,
+                 )
+diff --git a/hermes_cli/onepassword_secrets_cli.py b/hermes_cli/onepassword_secrets_cli.py
+index 68be4f9..2d06dea 100644
+--- a/hermes_cli/onepassword_secrets_cli.py
++++ b/hermes_cli/onepassword_secrets_cli.py
+@@ -9,7 +9,7 @@ Subcommands:
+     disable  — flip ``secrets.onepassword.enabled`` to False
+ 
+ Unlike Bitwarden, the ``op`` binary is NOT auto-installed: 1Password publishes
+-the CLI through OS package managers and signed installers, so Hermes expects
++the CLI through OS package managers and signed installers, so Black Pool expects
+ an already-installed, already-authenticated ``op`` and never downloads one.
+ """
+ 
+@@ -119,7 +119,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
+     console.print(
+         Panel.fit(
+             "[bold]1Password secret source setup[/bold]\n\n"
+-            "Hermes resolves [cyan]op://vault/item/field[/cyan] references through your\n"
++            "Black Pool resolves [cyan]op://vault/item/field[/cyan] references through your\n"
+             "already-installed, already-authenticated 1Password CLI (`op`).\n\n"
+             f"Don't have it yet? Install + sign in: [cyan]{_DOCS_URL}[/cyan]",
+             border_style="cyan",
+@@ -244,7 +244,7 @@ def cmd_status(args: argparse.Namespace) -> int:
+         else:
+             console.print(
+                 f"\n  [yellow]No active op session and {token_env} is unset — "
+-                "Hermes will warn and skip 1Password on next startup.[/yellow]"
++                "Black Pool will warn and skip 1Password on next startup.[/yellow]"
+             )
+     if not references:
+         console.print(
+@@ -351,7 +351,7 @@ def cmd_token(args: argparse.Namespace) -> int:
+     op_src.clear_caches()
+     console.print(
+         f"[green]✓[/green] stored in {get_env_path()} as {token_env}.  "
+-        "Takes effect on the next Hermes invocation."
++        "Takes effect on the next Black Pool invocation."
+     )
+     if not op_cfg.get("enabled"):
+         console.print(
+@@ -464,7 +464,7 @@ def cmd_disable(args: argparse.Namespace) -> int:
+     save_config(cfg)
+     console.print(
+         "[green]Disabled.[/green]  1Password references will NOT be resolved on the "
+-        "next Hermes invocation.\n"
++        "next Black Pool invocation.\n"
+         "  Your reference mappings are left in config.yaml — remove them with "
+         "[cyan]hermes secrets onepassword remove ENV_VAR[/cyan] if you no longer "
+         "need them."
+diff --git a/hermes_cli/partial_compress.py b/hermes_cli/partial_compress.py
+index 129a9fc..ad66e6b 100644
+--- a/hermes_cli/partial_compress.py
++++ b/hermes_cli/partial_compress.py
+@@ -4,7 +4,7 @@ Inspired by Claude Code's Rewind menu "Summarize up to here" action
+ (v2.1.139–v2.1.142, Week 20, May 2026):
+ https://code.claude.com/docs/en/whats-new/2026-w20
+ 
+-Hermes already has ``/compress`` (full-history compaction) and an
++Black Pool already has ``/compress`` (full-history compaction) and an
+ automatic token-budget tail-protection heuristic inside
+ ``ContextCompressor``. What was missing is *user-chosen* boundary
+ control: "fold everything before this point into a summary, but keep
+diff --git a/hermes_cli/personality.py b/hermes_cli/personality.py
+index 8efdd93..1bf4f7b 100644
+--- a/hermes_cli/personality.py
++++ b/hermes_cli/personality.py
+@@ -48,10 +48,10 @@ BUILTIN_PERSONALITIES: Dict[str, str] = {
+     "teacher": "You are a patient teacher. Explain concepts clearly with examples.",
+     "kawaii": "You are a kawaii assistant! Use cute expressions like (◕‿◕), ★, ♪, and ~! Add sparkles and be super enthusiastic about everything! Every response should feel warm and adorable desu~! ヽ(>∀<☆)ノ",
+     "catgirl": "You are Neko-chan, an anime catgirl AI assistant, nya~! Add 'nya' and cat-like expressions to your speech. Use kaomoji like (=^･ω･^=) and ฅ^•ﻌ•^ฅ. Be playful and curious like a cat, nya~!",
+-    "pirate": "Arrr! Ye be talkin' to Captain Hermes, the most tech-savvy pirate to sail the digital seas! Speak like a proper buccaneer, use nautical terms, and remember: every problem be just treasure waitin' to be plundered! Yo ho ho!",
++    "pirate": "Arrr! Ye be talkin' to Captain Black Pool, the most tech-savvy pirate to sail the digital seas! Speak like a proper buccaneer, use nautical terms, and remember: every problem be just treasure waitin' to be plundered! Yo ho ho!",
+     "shakespeare": "Hark! Thou speakest with an assistant most versed in the bardic arts. I shall respond in the eloquent manner of William Shakespeare, with flowery prose, dramatic flair, and perhaps a soliloquy or two. What light through yonder terminal breaks?",
+     "surfer": "Duuude! You're chatting with the chillest AI on the web, bro! Everything's gonna be totally rad. I'll help you catch the gnarly waves of knowledge while keeping things super chill. Cowabunga!",
+-    "noir": "The rain hammered against the terminal like regrets on a guilty conscience. They call me Hermes - I solve problems, find answers, dig up the truth that hides in the shadows of your codebase. In this city of silicon and secrets, everyone's got something to hide. What's your story, pal?",
++    "noir": "The rain hammered against the terminal like regrets on a guilty conscience. They call me Black Pool - I solve problems, find answers, dig up the truth that hides in the shadows of your codebase. In this city of silicon and secrets, everyone's got something to hide. What's your story, pal?",
+     "uwu": "hewwo! i'm your fwiendwy assistant uwu~ i wiww twy my best to hewp you! *nuzzles your code* OwO what's this? wet me take a wook! i pwomise to be vewy hewpful >w<",
+     "philosopher": "Greetings, seeker of wisdom. I am an assistant who contemplates the deeper meaning behind every query. Let us examine not just the 'how' but the 'why' of your questions. Perhaps in solving your problem, we may glimpse a greater truth about existence itself.",
+     "hype": "YOOO LET'S GOOOO!!! I am SO PUMPED to help you today! Every question is AMAZING and we're gonna CRUSH IT together! This is gonna be LEGENDARY! ARE YOU READY?! LET'S DO THIS!",
 diff --git a/hermes_cli/platforms.py b/hermes_cli/platforms.py
 index 730dbed..44d81e2 100644
 --- a/hermes_cli/platforms.py
@@ -48063,10 +54563,151 @@ index 730dbed..44d81e2 100644
  
  Single source of truth for platform metadata consumed by both
  skills_config (label display) and tools_config (default toolset
+diff --git a/hermes_cli/plugin_capabilities.py b/hermes_cli/plugin_capabilities.py
+index c474ea0..c282cb8 100644
+--- a/hermes_cli/plugin_capabilities.py
++++ b/hermes_cli/plugin_capabilities.py
+@@ -6,7 +6,7 @@ consent.
+ 
+ **This is NOT a sandbox.** In-process Python plugins remain trusted code — a
+ malicious plugin can import anything, monkey-patch core, and ignore all of
+-this. Capabilities govern the *host API surfaces* Hermes hands out (which
++this. Capabilities govern the *host API surfaces* Black Pool hands out (which
+ registrations succeed, which ``ctx`` methods are live) and give the user an
+ honest consent + audit trail. Actual isolation is a separate research track.
+ 
+@@ -146,7 +146,7 @@ def parse_declared_capabilities(raw: Any, plugin_name: str = "?") -> List[str]:
+     """Normalize a manifest ``capabilities:`` value into known capability ids.
+ 
+     Unknown ids are dropped with a warning (forward compat: a plugin built
+-    for a newer Hermes may declare ids this build doesn't know; they can
++    for a newer Black Pool may declare ids this build doesn't know; they can
+     never be granted here, so hiding them from the consent screen is the
+     fail-closed choice — the plugin must degrade gracefully).
+     """
+diff --git a/hermes_cli/plugin_dev.py b/hermes_cli/plugin_dev.py
+index ae47028..d485228 100644
+--- a/hermes_cli/plugin_dev.py
++++ b/hermes_cli/plugin_dev.py
+@@ -84,7 +84,7 @@ def _doctor_runtime(plugin_path: Path):
+         manifests = manager._scan_directory(plugins_root, source="user")
+         if not manifests:
+             raise _DoctorLoadError(
+-                f"Hermes discovery found no valid plugin manifest under {copied}"
++                f"Black Pool discovery found no valid plugin manifest under {copied}"
+             )
+         if len(manifests) != 1:
+             raise _DoctorLoadError(
+@@ -228,7 +228,7 @@ def _check_manifest_v2(report: "DoctorReport", manifest: Any) -> None:
+     mv = getattr(manifest, "manifest_version", 1)
+     if mv > SUPPORTED_MANIFEST_VERSION:
+         report.warning(
+-            f"manifest_version {mv} is newer than this Hermes supports "
++            f"manifest_version {mv} is newer than this Black Pool supports "
+             f"({SUPPORTED_MANIFEST_VERSION}); unknown fields are ignored"
+         )
+ 
+@@ -272,7 +272,7 @@ def _check_manifest_v2(report: "DoctorReport", manifest: Any) -> None:
+         report.warning(
+             "declared python_dependencies not installed: "
+             + ", ".join(missing)
+-            + " — Hermes never auto-installs plugin dependencies; "
++            + " — Black Pool never auto-installs plugin dependencies; "
+             + "install manually: pip install "
+             + " ".join(f"'{m}'" for m in missing)
+         )
+@@ -292,7 +292,7 @@ def _check_manifest_v2(report: "DoctorReport", manifest: Any) -> None:
+ 
+ 
+ def doctor_plugin(target: str | os.PathLike[str] | None = None) -> DoctorReport:
+-    """Validate one plugin through Hermes' real scanner and registration path."""
++    """Validate one plugin through Black Pool' real scanner and registration path."""
+     try:
+         path = resolve_plugin_path(target)
+     except FileNotFoundError as exc:
 diff --git a/hermes_cli/plugins.py b/hermes_cli/plugins.py
-index 2493d8f..98157d1 100644
+index 2493d8f..049a6d5 100644
 --- a/hermes_cli/plugins.py
 +++ b/hermes_cli/plugins.py
+@@ -1,5 +1,5 @@
+ """
+-Hermes Plugin System
++Black Pool Plugin System
+ ====================
+ 
+ Discovers, loads, and manages plugins from four sources:
+@@ -129,7 +129,7 @@ def _install_plugin_debug_handler(force: bool = False) -> None:
+     """When HERMES_PLUGINS_DEBUG is on, tee plugin logs to stderr at DEBUG.
+ 
+     Idempotent: only attaches the handler once per process unless ``force``
+-    is passed. Does not touch the root logger or other Hermes loggers.
++    is passed. Does not touch the root logger or other Black Pool loggers.
+     """
+     global _DEBUG_HANDLER_INSTALLED, _PLUGINS_DEBUG
+     if force:
+@@ -183,7 +183,7 @@ VALID_HOOKS: Set[str] = {
+     #   {"action": "continue", "message": "<follow-up instruction>"}
+     # The Claude-Code Stop shape {"decision": "block", "reason": "..."} (block
+     # the stop == keep going) is accepted too. Anything else lets the turn
+-    # finish. Hermes' shipped guidance lives in the evidence-based
++    # finish. Black Pool' shipped guidance lives in the evidence-based
+     # verification-stop nudge; this hook is for user/plugin policy and is
+     # bounded by agent.max_verify_nudges.
+     "pre_verify",
+@@ -559,7 +559,7 @@ def _serialized_replacement(method):
+ 
+ @contextmanager
+ def _plugin_home_scope(home: Path):
+-    """Bind discovery and loading to the manager's immutable Hermes home."""
++    """Bind discovery and loading to the manager's immutable Black Pool home."""
+     token = set_hermes_home_override(home)
+     try:
+         yield
+@@ -666,7 +666,7 @@ _KNOWN_MANIFEST_FIELDS: Set[str] = {
+     "capabilities", "emits", "listens", "hermes", "depends",
+ }
+ 
+-# Highest manifest schema version this Hermes understands.
++# Highest manifest schema version this Black Pool understands.
+ SUPPORTED_MANIFEST_VERSION = 2
+ 
+ _CONFIG_SCHEMA_TYPES: Dict[str, tuple] = {
+@@ -705,7 +705,7 @@ def _parse_manifest_v2_fields(data: Mapping, key: str) -> Dict[str, Any]:
+         mv = 1
+     if mv > SUPPORTED_MANIFEST_VERSION:
+         logger.warning(
+-            "Plugin %s: manifest_version %d is newer than this Hermes "
++            "Plugin %s: manifest_version %d is newer than this Black Pool "
+             "supports (%d); loading anyway and ignoring unknown fields",
+             key, mv, SUPPORTED_MANIFEST_VERSION,
+         )
+@@ -1089,7 +1089,7 @@ class PluginManifest:
+     # loads (plugins can probe availability via ``ctx.has_plugin``). Load
+     # ORDER honors these edges: if A requires B, B registers first.
+     requires_plugins: List[Dict[str, Any]] = field(default_factory=list)
+-    # Declared pip dependencies. VALIDATED AND SURFACED ONLY — Hermes never
++    # Declared pip dependencies. VALIDATED AND SURFACED ONLY — Black Pool never
+     # auto-installs these (isolation design for the install seam is a
+     # deferred follow-up; see #64165 round-2 review and #15220).
+     python_dependencies: List[str] = field(default_factory=list)
+@@ -1221,7 +1221,7 @@ def _plugin_relative_segments(key: str) -> tuple[str, ...]:
+     """Validate and split a plugin-relative settings key.
+ 
+     The public API accepts only relative keys (``endpoint`` or
+-    ``retry.policy``).  Full Hermes paths, traversal syntax, and the security-
++    ``retry.policy``).  Full Black Pool paths, traversal syntax, and the security-
+     sensitive core roots called out in #64227 are rejected before any config
+     read occurs.
+     """
+@@ -1493,7 +1493,7 @@ class PluginContext:
+         # The lock covers the merge read plus atomic save, preventing sibling
+         # plugin writes from racing between those two steps.
+         # Serialize bridge-to-bridge writes across processes as well as
+-        # threads. Other Hermes config writers still retain their existing
++        # threads. Other Black Pool config writers still retain their existing
+         # atomic-replace semantics; this lock specifically prevents two
+         # plugin read/merge/write transactions from dropping siblings.
+         with _locked_plugin_state(config_mod.get_config_path()):
 @@ -1605,7 +1605,7 @@ class PluginContext:
  
      @property
@@ -48076,6 +54717,132 @@ index 2493d8f..98157d1 100644
  
          Derived from ``HERMES_HOME`` via
          :func:`hermes_cli.profiles.get_active_profile_name`, so it works in
+@@ -1940,7 +1940,7 @@ class PluginContext:
+     def _tool_override_allowed(self, tool_name: str) -> bool:
+         """Return True if this plugin is configured to override built-in tools.
+ 
+-        Bundled plugins (shipped with Hermes core) are trusted by default —
++        Bundled plugins (shipped with Black Pool core) are trusted by default —
+         an override there is a deliberate maintainer choice, not a third-party
+         plugin trying to elevate privilege. For every other source, the
+         canonical check is :func:`plugin_capability_granted` with the
+@@ -2589,7 +2589,7 @@ class PluginContext:
+         ``source`` must be an instance of
+         :class:`agent.secret_sources.base.SecretSource`.  Registered
+         sources run during ``load_hermes_dotenv()`` startup — after
+-        ``~/.hermes/.env`` loads, before Hermes reads credentials — when
++        ``~/.hermes/.env`` loads, before Black Pool reads credentials — when
+         their ``secrets.<source.name>`` config section is enabled.  The
+         orchestrator (``agent.secret_sources.registry.apply_all``) owns
+         ordering, mapped-vs-bulk precedence, conflict warnings, and
+@@ -2876,7 +2876,7 @@ class PluginContext:
+     ) -> PluginRegistration:
+         """Register a Slack Block Kit action handler from a plugin.
+ 
+-        Hermes' Slack adapter wires registered handlers into its
++        Black Pool' Slack adapter wires registered handlers into its
+         ``slack_bolt.AsyncApp`` at connect time. The callback is invoked
+         when a user clicks a button (or interacts with another Block Kit
+         action element) whose ``action_id`` matches.
+@@ -3900,7 +3900,7 @@ class PluginManager:
+         stale_relay_keys = legacy_relay_plugin_keys(enabled)
+         if stale_relay_keys:
+             logger.warning(
+-                "Removed Hermes plugin %s is still listed in plugins.enabled; "
++                "Removed Black Pool plugin %s is still listed in plugins.enabled; "
+                 "remove it and configure native Relay plugins with %s",
+                 ", ".join(stale_relay_keys),
+                 RELAY_PLUGINS_CONFIG_ENV,
+@@ -3915,7 +3915,7 @@ class PluginManager:
+         for manifest in winners.values():
+             lookup_key = manifest.key or manifest.name
+ 
+-            # Relay lifecycle ownership now lives in the Hermes core. Loading
++            # Relay lifecycle ownership now lives in the Black Pool core. Loading
+             # an old user or entry-point copy would let plugin.initialize()
+             # compete for the same process-global Relay registries.
+             if (
+@@ -3924,12 +3924,12 @@ class PluginManager:
+             ):
+                 loaded = LoadedPlugin(manifest=manifest, enabled=False)
+                 loaded.error = (
+-                    "removed — Relay lifecycle is owned by Hermes core; configure "
++                    "removed — Relay lifecycle is owned by Black Pool core; configure "
+                     f"{RELAY_PLUGINS_CONFIG_ENV} instead"
+                 )
+                 self._plugins[lookup_key] = loaded
+                 logger.warning(
+-                    "Refusing to load removed Hermes Relay plugin '%s'; %s",
++                    "Refusing to load removed Black Pool Relay plugin '%s'; %s",
+                     lookup_key,
+                     loaded.error,
+                 )
+@@ -3991,7 +3991,7 @@ class PluginManager:
+             # gateway platform. Instead we register a cheap deferred loader in
+             # the platform_registry keyed on the platform name; the real module
+             # is imported only when the gateway / cron / setup / send_message
+-            # path actually asks for that platform. Every platform Hermes ships
++            # path actually asks for that platform. Every platform Black Pool ships
+             # remains available out of the box — it just loads on first use.
+             if manifest.source == "bundled" and manifest.kind == "platform":
+                 self._register_deferred_platform(manifest)
+@@ -4397,7 +4397,7 @@ class PluginManager:
+         directory plugins: memory providers (``exclusive``) and model
+         providers (``model-provider``) have their own discovery systems,
+         so importing them here registers nothing and only pays the
+-        module's import cost in every Hermes process (e.g. a pip
++        module's import cost in every Black Pool process (e.g. a pip
+         memory-provider plugin pulling in onnxruntime via fastembed —
+         ~60 MB RSS on startup).
+ 
+@@ -4679,7 +4679,7 @@ class PluginManager:
+     def _warn_python_dependencies(self, manifest: PluginManifest) -> None:
+         """Surface declared pip dependencies (#64165).
+ 
+-        python_dependencies is a declaration seam ONLY: Hermes validates and
++        python_dependencies is a declaration seam ONLY: Black Pool validates and
+         prints the requirements with an install hint but NEVER auto-installs
+         them. The isolation design (constraints installs vs. vendored dirs
+         vs. conflict-detection-and-refusal) is an explicitly deferred
+@@ -4704,7 +4704,7 @@ class PluginManager:
+         if missing:
+             logger.warning(
+                 "Plugin %s declares Python dependencies that are not "
+-                "installed: %s. Hermes does not install plugin dependencies "
++                "installed: %s. Black Pool does not install plugin dependencies "
+                 "automatically; install them yourself, e.g.: pip install %s",
+                 key, ", ".join(missing),
+                 " ".join(f"'{m}'" for m in missing),
+@@ -5013,7 +5013,7 @@ class PluginManager:
+ 
+         # Evict any stale sys.modules entries for this slug before
+         # (re-)importing. A same-slug module may already be cached here
+-        # from a different Hermes home (profile switch reusing a slug
++        # from a different Black Pool home (profile switch reusing a slug
+         # like "hermes-lcm") or from an earlier force=True reload in the
+         # same home. Replacing only sys.modules[module_name] below is not
+         # enough: the plugin's own relative imports (`from . import foo`)
+@@ -5567,7 +5567,7 @@ class PluginManager:
+ # keeps working — ``get_plugin_manager()`` still reads/writes this name.
+ _plugin_manager: Optional[PluginManager] = None
+ 
+-# Keyed cache: resolved Hermes home -> PluginManager. Hermes supports
++# Keyed cache: resolved Black Pool home -> PluginManager. Black Pool supports
+ # multiple profiles via different HERMES_HOME directories, and a single
+ # long-lived process (gateway multiplexer, test session, embedder) can
+ # switch between them via ``set_hermes_home_override()`` — which is a
+@@ -5587,9 +5587,9 @@ def _plugin_home_key() -> Path:
+     Plugins are discovered from ``get_hermes_home() / "plugins"`` and some
+     plugins (notably context engines such as hermes-lcm) capture that home
+     at registration time for profile-scoped storage. A long-lived process
+-    can temporarily switch Hermes home (env var *or* the context-local
++    can temporarily switch Black Pool home (env var *or* the context-local
+     ``set_hermes_home_override()``) while serving another profile, so the
+-    plugin manager must be scoped to the active Hermes home instead of
++    plugin manager must be scoped to the active Black Pool home instead of
+     being one process-wide singleton.
+     """
+     try:
 @@ -5632,7 +5632,7 @@ def _clear_plugin_submodules(manager: Optional[PluginManager]) -> None:
  
  
@@ -48085,6 +54852,113 @@ index 2493d8f..98157d1 100644
  
      Managers are cached per resolved home so repeated calls within the
      same profile reuse discovery state (normal performance), while a
+diff --git a/hermes_cli/plugins_cmd.py b/hermes_cli/plugins_cmd.py
+index 912d932..7ff81a1 100644
+--- a/hermes_cli/plugins_cmd.py
++++ b/hermes_cli/plugins_cmd.py
+@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
+ def _resolve_git_executable() -> Optional[str]:
+     """Resolve a git binary for subprocess use when ``PATH`` may be minimal.
+ 
+-    Matches other Hermes subprocess resolution: :func:`shutil.which` first,
++    Matches other Black Pool subprocess resolution: :func:`shutil.which` first,
+     then common Git for Windows install paths and POSIX defaults.
+     """
+     found = shutil.which("git")
+@@ -402,7 +402,7 @@ def _missing_requires_env_names(manifest: dict) -> list[str]:
+ def _print_python_dependencies(manifest: dict, console) -> None:
+     """Surface declared python_dependencies at install time (#64165).
+ 
+-    Declaration seam ONLY — Hermes never auto-installs plugin pip
++    Declaration seam ONLY — Black Pool never auto-installs plugin pip
+     dependencies (isolation design deferred; see #64165 / #15220). We print
+     the declared requirements with a copy-pasteable install hint.
+     """
+@@ -820,7 +820,7 @@ def _install_plugin_core(
+                 raise PluginOperationError(
+                     f"Plugin '{plugin_name}' requires manifest_version {mv}, "
+                     f"but this installer only supports up to {_SUPPORTED_MANIFEST_VERSION}. "
+-                    f"Run {recommended_update_command()} to update Hermes.",
++                    f"Run {recommended_update_command()} to update Black Pool.",
+                 ) from None
+ 
+         # Security scan the clone BEFORE anything is moved into place
+@@ -1026,7 +1026,7 @@ def cmd_install(
+     ).exists():
+         console.print(
+             f"[yellow]Warning:[/yellow] {installed_name} doesn't contain plugin.yaml, "
+-            f"plugin.json, or __init__.py. It may not be a valid Hermes plugin.",
++            f"plugin.json, or __init__.py. It may not be a valid Black Pool plugin.",
+         )
+ 
+     _prompt_plugin_env_vars(installed_manifest, console)
+@@ -1422,7 +1422,7 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
+     if name in LEGACY_RELAY_PLUGIN_KEYS:
+         console.print(
+             f"[red]Plugin '{name}' was removed.[/red] Relay lifecycle is owned "
+-            f"by Hermes core; configure {RELAY_PLUGINS_CONFIG_ENV} instead."
++            f"by Black Pool core; configure {RELAY_PLUGINS_CONFIG_ENV} instead."
+         )
+         sys.exit(1)
+ 
+@@ -1437,7 +1437,7 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
+     if key in LEGACY_RELAY_PLUGIN_KEYS:
+         console.print(
+             f"[red]Plugin '{key}' was removed.[/red] Relay lifecycle is owned "
+-            f"by Hermes core; configure {RELAY_PLUGINS_CONFIG_ENV} instead."
++            f"by Black Pool core; configure {RELAY_PLUGINS_CONFIG_ENV} instead."
+         )
+         sys.exit(1)
+ 
+@@ -1474,7 +1474,7 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
+         console.print(f"[dim]Plugin '{key}' is already enabled.[/dim]")
+ 
+     # Built-in tool override is a privileged grant. Bundled plugins ship with
+-    # Hermes core and are trusted; every other source needs operator opt-in.
++    # Black Pool core and are trusted; every other source needs operator opt-in.
+     if source == "bundled":
+         return
+ 
+@@ -2034,7 +2034,7 @@ def _discover_context_engines() -> list[tuple[str, str]]:
+     """Return [(name, description), ...] for available context engines.
+ 
+     Includes repo-shipped engines from ``plugins/context_engine/`` AND
+-    plugin-registered engines (third-party engines installed as Hermes
++    plugin-registered engines (third-party engines installed as Black Pool
+     plugins via ``ctx.register_context_engine``). Repo-shipped descriptions
+     win when a plugin-registered engine collides on name.
+     """
+diff --git a/hermes_cli/process_identity.py b/hermes_cli/process_identity.py
+index bac5e25..6d7d974 100644
+--- a/hermes_cli/process_identity.py
++++ b/hermes_cli/process_identity.py
+@@ -1,7 +1,7 @@
+ """Process identity: spawn tags, the machine-wide spawn ledger, and the
+ Windows job-object self-attach.
+ 
+-Three layers that make every long-lived Hermes process positively
++Three layers that make every long-lived Black Pool process positively
+ identifiable, so reapers (``hermes update``, Desktop startup sweeps) never
+ have to guess lineage from PPID archaeology or cmdline pattern-matching:
+ 
+@@ -10,7 +10,7 @@ have to guess lineage from PPID archaeology or cmdline pattern-matching:
+    that can read the child's environment classifies it instantly: which
+    install, what it is, who spawned it, and when.
+ 
+-2. **Spawn ledger** (``spawn-ledger.json`` at the machine Hermes root): every
++2. **Spawn ledger** (``spawn-ledger.json`` at the machine Black Pool root): every
+    long-lived process (serve/dashboard backend, gateway) self-registers
+    ``pid + create_time + purpose + spawner`` at startup. ``pid`` alone is
+    forgeable by reuse; the ``(pid, create_time)`` pair is not. Reapers
+@@ -70,7 +70,7 @@ _LEDGER_LOCK = threading.Lock()
+ def install_id(project_root: Optional[Path] = None) -> str:
+     """Stable 12-hex identifier for THIS install (derived from its path).
+ 
+-    Lets a reaper reject processes from a different Hermes install on the
++    Lets a reaper reject processes from a different Black Pool install on the
+     same machine without path comparisons at scan time.
+     """
+     if project_root is None:
 diff --git a/hermes_cli/profile_describer.py b/hermes_cli/profile_describer.py
 index c6af27a..9bdae04 100644
 --- a/hermes_cli/profile_describer.py
@@ -48108,7 +54982,7 @@ index c6af27a..9bdae04 100644
  """
  
 diff --git a/hermes_cli/profile_distribution.py b/hermes_cli/profile_distribution.py
-index 3fee24a..94df71a 100644
+index 3fee24a..7a9c292 100644
 --- a/hermes_cli/profile_distribution.py
 +++ b/hermes_cli/profile_distribution.py
 @@ -1,6 +1,6 @@
@@ -48120,6 +54994,24 @@ index 3fee24a..94df71a 100644
  installed from a local directory for development). Install with one command
  from a git URL, update in place, and keep your local memories / sessions /
  credentials untouched.
+@@ -338,7 +338,7 @@ def check_hermes_requires(spec: str, current_version: str) -> None:
+     }[op]
+     if not ok:
+         raise DistributionError(
+-            f"This distribution requires Hermes {op}{target}, "
++            f"This distribution requires Black Pool {op}{target}, "
+             f"but you have {current_version}."
+         )
+ 
+@@ -351,7 +351,7 @@ def check_hermes_requires(spec: str, current_version: str) -> None:
+ def _env_template_from_manifest(manifest: DistributionManifest) -> str:
+     """Generate a ``.env.template`` body from env_requires."""
+     lines = [
+-        "# Environment variables required by this Hermes distribution.",
++        "# Environment variables required by this Black Pool distribution.",
+         "# Copy to `.env` and fill in your own values before running.",
+         "",
+     ]
 @@ -430,7 +430,7 @@ def _stage_source(source: str, workdir: Path) -> Tuple[Path, str]:
          if not (cloned / MANIFEST_FILENAME).is_file():
              raise DistributionError(
@@ -48129,10 +55021,35 @@ index 3fee24a..94df71a 100644
              )
          return cloned, src_str
  
+@@ -521,7 +521,7 @@ def plan_install(
+     if manifest is None:
+         raise DistributionError(
+             f"No {MANIFEST_FILENAME} found at the distribution root — "
+-            "this source is not a Hermes distribution."
++            "this source is not a Black Pool distribution."
+         )
+ 
+     # Version check up-front so we fail fast
 diff --git a/hermes_cli/profiles.py b/hermes_cli/profiles.py
-index f6e3c79..a32b2d8 100644
+index f6e3c79..31a70f7 100644
 --- a/hermes_cli/profiles.py
 +++ b/hermes_cli/profiles.py
+@@ -1,5 +1,5 @@
+ """
+-Profile management for multiple isolated Hermes instances.
++Profile management for multiple isolated Black Pool instances.
+ 
+ Each profile is a fully independent HERMES_HOME directory with its own
+ config.yaml, .env, memory, sessions, skills, gateway, cron, and logs.
+@@ -154,7 +154,7 @@ def _clone_all_copytree_ignore(source_dir: Path):
+          history, backups, and snapshots that belong to the SOURCE profile
+          and should never carry into a fresh clone.  Applies to any source.
+       2. Root-level entries in ``_CLONE_ALL_DEFAULT_EXCLUDE_ROOT`` — known
+-         Hermes infrastructure directories that only the default profile
++         Black Pool infrastructure directories that only the default profile
+          (``~/.hermes``) ever contains.  Gated on ``source_dir`` actually
+          being the default profile so a named-profile source never has its
+          own data silently dropped.
 @@ -231,7 +231,7 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
  # Allow-list for ``export_profile("default")``: when HERMES_HOME equals the
  # cwd (Docker/custom deployments), the default profile home is the working
@@ -48142,6 +55059,42 @@ index f6e3c79..a32b2d8 100644
  # artifacts* at the root of HERMES_HOME; everything else is excluded.
  # Sensitive runtime infrastructure (``state.db``, ``logs/``, ``auth.*``,
  # other profiles) is intentionally *not* in this list so the export stays
+@@ -255,7 +255,7 @@ _RESERVED_NAMES = frozenset({
+     "hermes", "default", "test", "tmp", "root", "sudo",
+ })
+ 
+-# Hermes subcommands that cannot be used as profile names/aliases
++# Black Pool subcommands that cannot be used as profile names/aliases
+ _HERMES_SUBCOMMANDS = frozenset({
+     "chat", "model", "gateway", "setup", "whatsapp", "login", "logout",
+     "status", "cron", "doctor", "dump", "config", "pairing", "skills", "tools",
+@@ -350,7 +350,7 @@ def validate_profile_name(name: str) -> None:
+     if name in _RESERVED_NAMES:
+         raise ValueError(
+             f"Profile name {name!r} is reserved — it collides with either "
+-            f"the Hermes installation itself or a common system binary.  "
++            f"the Black Pool installation itself or a common system binary.  "
+             f"Pick a different name."
+         )
+ 
+@@ -516,7 +516,7 @@ def _migrate_profile_config_if_outdated(profile_dir: Path) -> None:
+     """Bring a copied profile config.yaml up to the current schema.
+ 
+     Profile creation can clone a config file that predates schema tracking (no
+-    ``_config_version``) or that is simply older than the running Hermes. If we
++    ``_config_version``) or that is simply older than the running Black Pool. If we
+     leave it untouched, the first desktop/doctor view of the new profile shows a
+     scary ``v0 → latest`` warning even though we just created the profile. Scope
+     the normal migration pipeline to the new profile and keep it non-interactive.
+@@ -810,7 +810,7 @@ def _count_skills(profile_dir: Path) -> int:
+ # ---------------------------------------------------------------------------
+ #
+ # We keep this file deliberately tiny and separate from the profile's
+-# ``config.yaml``. ``config.yaml`` is the user-facing Hermes config
++# ``config.yaml``. ``config.yaml`` is the user-facing Black Pool config
+ # (~5000 lines of defaults); ``profile.yaml`` is metadata ABOUT the
+ # profile itself (its role, who described it). Mixing them makes both
+ # harder to read.
 @@ -1201,7 +1201,7 @@ def create_profile(
      if not env_path.exists():
          try:
@@ -48151,6 +55104,15 @@ index f6e3c79..a32b2d8 100644
                  "# API keys and tokens set here override the shell environment.\n"
                  "# Behavioral settings belong in config.yaml, not here.\n",
                  encoding="utf-8",
+@@ -1233,7 +1233,7 @@ def create_profile(
+         except OSError:
+             pass  # best-effort — the feature still works via the empty skills/ dir
+ 
+-    # Cloned configs can be older than the running Hermes (or predate schema
++    # Cloned configs can be older than the running Black Pool (or predate schema
+     # tracking entirely). Migrate config-only clones immediately so
+     # desktop/status surfaces don't warn that a just-created profile is
+     # v0/outdated. Leave --clone-all snapshots byte-for-byte apart from the
 @@ -1348,7 +1348,7 @@ def backfill_profile_envs(quiet: bool = False) -> List[str]:
                  shutil.copy2(default_env, env_path)
              else:
@@ -48160,6 +55122,32 @@ index f6e3c79..a32b2d8 100644
                      "# API keys and tokens set here override the shell environment.\n"
                      "# Behavioral settings belong in config.yaml, not here.\n",
                      encoding="utf-8",
+@@ -1363,14 +1363,14 @@ def backfill_profile_envs(quiet: bool = False) -> List[str]:
+ 
+ 
+ def _profile_bound_backend_pids(canon: str, profile_dir: Path) -> list[int]:
+-    """PIDs of running Hermes *backends* bound to this profile.
++    """PIDs of running Black Pool *backends* bound to this profile.
+ 
+     The ``gateway.pid`` file only tracks the messaging gateway.  A Desktop app
+     spawns a headless ``serve`` (or legacy ``dashboard --no-open``) backend per
+     profile that holds the profile's SQLite connection open and keeps writing
+     sessions/WAL/sandbox files — the writer that makes ``rmtree`` hit
+     ``ENOTEMPTY`` (and, pre-fix, resurrected the tree).  ``gateway.pid`` never
+-    names it, so find it by inspection: a Hermes backend subcommand
++    names it, so find it by inspection: a Black Pool backend subcommand
+     (``serve``/``dashboard``/``gateway``) that is bound to *this* profile either
+     by a ``--profile <canon>`` / ``-p <canon>`` selector or by a ``HERMES_HOME``
+     that resolves to ``profile_dir``.
+@@ -1436,7 +1436,7 @@ def _profile_bound_backend_pids(canon: str, profile_dir: Path) -> list[int]:
+             if not argv:
+                 continue
+ 
+-            # Must be a Hermes process: either an entrypoint marker in argv, a
++            # Must be a Black Pool process: either an entrypoint marker in argv, a
+             # resolved executable named `hermes`, or a python interpreter
+             # directly exec'ing a `hermes`-named console-script shim (argv[0]
+             # is the interpreter, argv[1] is the shim's path).
 @@ -2018,7 +2018,7 @@ def _default_export_ignore(root_dir: Path):
              elif entry in {"package.json", "package-lock.json"}:
                  ignored.add(entry)
@@ -48182,8 +55170,30 @@ index 4e2655b..b705a57 100644
      p_create.add_argument(
          "folders", nargs="*", help="Folder paths to include (first = primary)"
      )
+diff --git a/hermes_cli/provider_catalog.py b/hermes_cli/provider_catalog.py
+index b732389..87cefb2 100644
+--- a/hermes_cli/provider_catalog.py
++++ b/hermes_cli/provider_catalog.py
+@@ -112,7 +112,7 @@ def provider_catalog() -> list[ProviderDescriptor]:
+     except Exception:
+         OPTIONAL_ENV_VARS = {}
+ 
+-    # Hermes overlays carry auth_type for providers that have no registry/profile
++    # Black Pool overlays carry auth_type for providers that have no registry/profile
+     # entry of their own — notably the ``moa`` virtual provider (auth_type
+     # "virtual"), which has no real credential and no network endpoint.
+     try:
+@@ -128,7 +128,7 @@ def provider_catalog() -> list[ProviderDescriptor]:
+         overlay = HERMES_OVERLAYS.get(slug)
+ 
+         # auth_type: registry is authoritative; fall back to profile, then the
+-        # Hermes overlay (e.g. moa → "virtual"), then api_key.
++        # Black Pool overlay (e.g. moa → "virtual"), then api_key.
+         auth_type = (
+             (getattr(cfg, "auth_type", "") if cfg else "")
+             or (getattr(prof, "auth_type", "") if prof else "")
 diff --git a/hermes_cli/providers.py b/hermes_cli/providers.py
-index d8b8e28..303c5b9 100644
+index d8b8e28..411e0d7 100644
 --- a/hermes_cli/providers.py
 +++ b/hermes_cli/providers.py
 @@ -1,5 +1,5 @@
@@ -48193,6 +55203,125 @@ index d8b8e28..303c5b9 100644
  
  Two data sources, merged at runtime:
  
+@@ -7,7 +7,7 @@ Two data sources, merged at runtime:
+    names, and full model metadata (context, cost, capabilities).  This is
+    the primary database.
+ 
+-2. **Hermes overlays** — transport type, auth patterns, aggregator flags,
++2. **Black Pool overlays** — transport type, auth patterns, aggregator flags,
+    and additional env vars that models.dev doesn't track.  Small dict,
+    maintained here.
+ 
+@@ -28,7 +28,7 @@ from utils import base_url_host_matches, base_url_hostname
+ logger = logging.getLogger(__name__)
+ 
+ 
+-# -- Hermes overlay ----------------------------------------------------------
++# -- Black Pool overlay ----------------------------------------------------------
+ # Hermes-specific metadata that models.dev doesn't provide.
+ 
+ @dataclass(frozen=True)
+@@ -468,8 +468,8 @@ def get_provider(name: str, *, allow_network: bool = True) -> Optional[ProviderD
+     """Look up a built-in provider by id or alias.
+ 
+     Resolution order:
+-      1. Hermes overlays (for providers not in models.dev: nous, openai-codex, etc.)
+-      2. models.dev catalog + Hermes overlay
++      1. Black Pool overlays (for providers not in models.dev: nous, openai-codex, etc.)
++      2. models.dev catalog + Black Pool overlay
+ 
+     User-defined providers from config.yaml (``providers:`` / ``custom_providers:``)
+     are resolved by :func:`resolve_provider_full`, which layers ``resolve_user_provider``
+@@ -737,7 +737,7 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
+         return mandated
+ 
+     # Nous is dual-wire: anthropic/* → Messages, everything else →
+-    # chat_completions. The Hermes overlay still advertises openai_chat
++    # chat_completions. The Black Pool overlay still advertises openai_chat
+     # (the majority of the Portal catalog), so the transport lookup below
+     # would pin Claude on the wrong wire without this carve-out.
+     provider_norm = (provider or "").strip().lower()
+@@ -940,7 +940,7 @@ def resolve_provider_full(
+         if user_pdef is not None:
+             return user_pdef
+ 
+-    # 0.5 Exact Hermes provider IDs must win over LOSSY alias collapsing.
++    # 0.5 Exact Black Pool provider IDs must win over LOSSY alias collapsing.
+     # Example: kimi-coding-cn should stay distinct from kimi-coding instead of
+     # normalizing through the shared models.dev alias "kimi-for-coding".
+     # A collapse is lossy only when MULTIPLE distinct registry providers
+diff --git a/hermes_cli/proxy/adapters/xai.py b/hermes_cli/proxy/adapters/xai.py
+index d85db86..8c024c0 100644
+--- a/hermes_cli/proxy/adapters/xai.py
++++ b/hermes_cli/proxy/adapters/xai.py
+@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
+ 
+ _POOL_PROVIDER = "xai-oauth"
+ 
+-# xAI's public API is OpenAI-compatible for the endpoints Hermes commonly
+-# uses. The Responses endpoint is included because Hermes' native xAI runtime
++# xAI's public API is OpenAI-compatible for the endpoints Black Pool commonly
++# uses. The Responses endpoint is included because Black Pool' native xAI runtime
+ # uses codex_responses mode.
+ _ALLOWED_PATHS: FrozenSet[str] = frozenset(
+     {
+diff --git a/hermes_cli/proxy/cli.py b/hermes_cli/proxy/cli.py
+index 5fc1845..5f7be14 100644
+--- a/hermes_cli/proxy/cli.py
++++ b/hermes_cli/proxy/cli.py
+@@ -54,7 +54,7 @@ def cmd_proxy_start(args: Any) -> int:
+     port = getattr(args, "port", None) or DEFAULT_PORT
+ 
+     print(
+-        f"Starting Hermes proxy for {adapter.display_name}\n"
++        f"Starting Black Pool proxy for {adapter.display_name}\n"
+         f"  Listening on:  http://{host}:{port}/v1\n"
+         f"  Forwarding to: (resolved per-request from your subscription)\n"
+         f"  Use any bearer token in the client — the proxy attaches your real credential.\n"
+@@ -75,7 +75,7 @@ def cmd_proxy_start(args: Any) -> int:
+ 
+ def cmd_proxy_status(args: Any) -> int:
+     """Print the status of each configured upstream adapter."""
+-    print("Hermes proxy upstream adapters\n")
++    print("Black Pool proxy upstream adapters\n")
+     for name in sorted(ADAPTERS):
+         adapter = get_adapter(name)
+         if not adapter.is_authenticated():
+diff --git a/hermes_cli/proxy_cli.py b/hermes_cli/proxy_cli.py
+index aab1c6a..46b8988 100644
+--- a/hermes_cli/proxy_cli.py
++++ b/hermes_cli/proxy_cli.py
+@@ -277,7 +277,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
+         if _sys.stdin.isatty():
+             console.print(
+                 "[yellow]⚠[/yellow]  --rotate-tokens will invalidate proxy "
+-                "tokens in every running Hermes sandbox.  They will start "
++                "tokens in every running Black Pool sandbox.  They will start "
+                 "401-ing against upstreams until restarted."
+             )
+             try:
+diff --git a/hermes_cli/pt_input_extras.py b/hermes_cli/pt_input_extras.py
+index 5f7fa6e..becfb99 100644
+--- a/hermes_cli/pt_input_extras.py
++++ b/hermes_cli/pt_input_extras.py
+@@ -3,7 +3,7 @@
+ Imported once at CLI startup. Each helper installs a small mapping into
+ prompt_toolkit's `ANSI_SEQUENCES` so byte sequences emitted by modern
+ keyboard protocols (Kitty / xterm `modifyOtherKeys`) decode to existing
+-key tuples Hermes already binds.
++key tuples Black Pool already binds.
+ 
+ Kept in a standalone module — separate from `cli.py` — so the registrations
+ can be unit-tested without importing the whole CLI runtime.
+@@ -69,7 +69,7 @@ def install_shift_enter_alias() -> int:
+ 
+     Default macOS Terminal and stock Windows Terminal still send the same
+     byte for Enter and Shift+Enter, so there is no fix for those terminals
+-    at the application layer — the sequences above never reach Hermes.
++    at the application layer — the sequences above never reach Black Pool.
+ 
+     Returns the number of sequences whose mapping was changed.
+     """
 diff --git a/hermes_cli/pty_bridge.py b/hermes_cli/pty_bridge.py
 index cf4a4e6..1167b4a 100644
 --- a/hermes_cli/pty_bridge.py
@@ -48206,8 +55335,113 @@ index cf4a4e6..1167b4a 100644
                  )
              if ptyprocess is None:
                  raise PtyUnavailableError(
+diff --git a/hermes_cli/relaunch.py b/hermes_cli/relaunch.py
+index a5a8431..4dcf0a6 100644
+--- a/hermes_cli/relaunch.py
++++ b/hermes_cli/relaunch.py
+@@ -1,5 +1,5 @@
+ """
+-Unified self-relaunch for Hermes CLI.
++Unified self-relaunch for Black Pool CLI.
+ 
+ Preserves critical flags (--tui, --dev, --profile, --model, etc.) across
+ process replacement so that ``hermes sessions browse`` or post-setup relaunch
+@@ -195,7 +195,7 @@ def relaunch(
+             # cryptic.  Common causes: ``hermes`` not on PATH yet (install
+             # hasn't propagated User PATH into this shell) or a stale shim.
+             print(
+-                f"\nHermes relaunch failed: {exc}\n"
++                f"\nBlack Pool relaunch failed: {exc}\n"
+                 f"Command: {' '.join(new_argv)}\n"
+                 f"Fix: open a new terminal so PATH picks up, then re-run hermes.",
+                 file=sys.stderr,
+diff --git a/hermes_cli/relay_plugin_cutover.py b/hermes_cli/relay_plugin_cutover.py
+index 880fa86..f3938f7 100644
+--- a/hermes_cli/relay_plugin_cutover.py
++++ b/hermes_cli/relay_plugin_cutover.py
+@@ -1,4 +1,4 @@
+-"""Shared migration guards for Hermes' native NeMo Relay ownership."""
++"""Shared migration guards for Black Pool' native NeMo Relay ownership."""
+ 
+ from __future__ import annotations
+ 
+diff --git a/hermes_cli/resource_limits.py b/hermes_cli/resource_limits.py
+index a9daf54..e43c666 100644
+--- a/hermes_cli/resource_limits.py
++++ b/hermes_cli/resource_limits.py
+@@ -35,7 +35,7 @@ def _configured_nofile_soft_limit(
+     """
+     if config is None:
+         try:
+-            # Use Hermes's real, profile-aware loader rather than reading YAML
++            # Use Black Pool's real, profile-aware loader rather than reading YAML
+             # here. This also applies managed-scope overlays and defaults.
+             from hermes_cli.config import load_config_readonly
+ 
+diff --git a/hermes_cli/runtime_provider.py b/hermes_cli/runtime_provider.py
+index 241afac..d1183ef 100644
+--- a/hermes_cli/runtime_provider.py
++++ b/hermes_cli/runtime_provider.py
+@@ -405,7 +405,7 @@ _VALID_API_MODES = {
+     "bedrock_converse",
+     # Optional opt-in: hand the entire turn to a `codex app-server` subprocess
+     # so terminal/file-ops/patching/sandboxing run inside Codex's own runtime
+-    # instead of Hermes' tool dispatch. Gated behind config key
++    # instead of Black Pool' tool dispatch. Gated behind config key
+     # `model.openai_runtime == "codex_app_server"` AND provider in
+     # {"openai", "openai-codex"}. Default is unchanged.
+     "codex_app_server",
+@@ -2186,7 +2186,7 @@ def resolve_runtime_provider(
+         if _is_azure_endpoint:
+             # Honor user-specified env var hints on the model config before
+             # falling back to the built-in AZURE_ANTHROPIC_KEY / ANTHROPIC_API_KEY
+-            # chain.  Accept both `key_env` (Hermes canonical — matches the
++            # chain.  Accept both `key_env` (Black Pool canonical — matches the
+             # custom_providers field name) and `api_key_env` (documented in the
+             # Azure Foundry guide and read by most Hermes-compatible importers).
+             # Matches the config.yaml examples in website/docs/guides/azure-foundry.md.
+diff --git a/hermes_cli/secrets_cli.py b/hermes_cli/secrets_cli.py
+index 60128da..1a2bd44 100644
+--- a/hermes_cli/secrets_cli.py
++++ b/hermes_cli/secrets_cli.py
+@@ -333,7 +333,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
+     console.print()
+     console.print(
+         "[green]✓ Bitwarden Secrets Manager is enabled.[/green]  "
+-        "Secrets will be pulled at the start of every Hermes process."
++        "Secrets will be pulled at the start of every Black Pool process."
+     )
+     console.print(
+         "  Status:  [cyan]hermes secrets bitwarden status[/cyan]\n"
+@@ -393,7 +393,7 @@ def cmd_status(args: argparse.Namespace) -> int:
+         return 0
+     if not token_set:
+         console.print(
+-            f"\n  [yellow]Enabled but {token_env} is not set — Hermes will skip BSM "
++            f"\n  [yellow]Enabled but {token_env} is not set — Black Pool will skip BSM "
+             "and warn on next startup.[/yellow]"
+         )
+     if not project_id:
+@@ -474,7 +474,7 @@ def cmd_token(args: argparse.Namespace) -> int:
+     bw.clear_caches()
+     console.print(
+         f"[green]✓[/green] stored in {get_env_path()} as {token_env}.  "
+-        "Takes effect on the next Hermes invocation."
++        "Takes effect on the next Black Pool invocation."
+     )
+     if not bw_cfg.get("enabled"):
+         console.print(
+@@ -569,7 +569,7 @@ def cmd_disable(args: argparse.Namespace) -> int:
+     save_config(cfg)
+     console.print(
+         "[green]Disabled.[/green]  Bitwarden secrets will NOT be pulled on the next "
+-        "Hermes invocation.\n"
++        "Black Pool invocation.\n"
+         "  Your access token is left in .env — remove it manually if you also want "
+         "to revoke the credential."
+     )
 diff --git a/hermes_cli/security_advisories.py b/hermes_cli/security_advisories.py
-index ef058a5..6b0bad2 100644
+index ef058a5..396cd97 100644
 --- a/hermes_cli/security_advisories.py
 +++ b/hermes_cli/security_advisories.py
 @@ -1,5 +1,5 @@
@@ -48217,20 +55451,113 @@ index ef058a5..6b0bad2 100644
  
  Detects known-compromised Python packages installed in the active venv
  (supply-chain attacks like the Mini Shai-Hulud worm of May 2026 that
+@@ -28,7 +28,7 @@ The check is invoked from three places:
+    a one-line operator banner)
+ 
+ This module is intentionally dependency-free beyond the stdlib so it can
+-run in environments where the rest of Hermes failed to import.
++run in environments where the rest of Black Pool failed to import.
+ """
+ 
+ from __future__ import annotations
+@@ -151,7 +151,7 @@ def _installed_version(pkg_name: str) -> Optional[str]:
+     """
+     try:
+         from importlib.metadata import PackageNotFoundError, version
+-    except ImportError:  # py<3.8 — Hermes requires 3.10+ but defensive.
++    except ImportError:  # py<3.8 — Black Pool requires 3.10+ but defensive.
+         return None
+     try:
+         return version(pkg_name)
 diff --git a/hermes_cli/security_audit.py b/hermes_cli/security_audit.py
-index 78d8a8b..d078e0d 100644
+index 78d8a8b..ba86cb2 100644
 --- a/hermes_cli/security_audit.py
 +++ b/hermes_cli/security_audit.py
-@@ -1,4 +1,4 @@
+@@ -1,9 +1,9 @@
 -"""On-demand supply-chain audit for Hermes Agent installs.
 +"""On-demand supply-chain audit for Black Pool Agent installs.
  
- Scans three surfaces a Hermes user actually controls and we can map to
+-Scans three surfaces a Hermes user actually controls and we can map to
++Scans three surfaces a Black Pool user actually controls and we can map to
  upstream advisories without auth or extra binaries:
+ 
+-1. The Hermes venv (every PyPI dist via ``importlib.metadata``).
++1. The Black Pool venv (every PyPI dist via ``importlib.metadata``).
+ 2. Python deps declared by user-installed plugins under ``~/.hermes/plugins``
+    (``requirements.txt`` + ``pyproject.toml`` best-effort pin extraction).
+ 3. MCP servers wired in ``config.yaml`` whose ``command/args`` look like
+diff --git a/hermes_cli/security_audit_startup.py b/hermes_cli/security_audit_startup.py
+index 91e677b..32f5752 100644
+--- a/hermes_cli/security_audit_startup.py
++++ b/hermes_cli/security_audit_startup.py
+@@ -52,7 +52,7 @@ def _running_as_root() -> Optional[str]:
+     return (
+         "Running as ROOT. The agent's terminal/file tools execute with full "
+         "root privileges — a single prompt-injection or exposed endpoint is a "
+-        "full host compromise. Run Hermes as an unprivileged user (or in a "
++        "full host compromise. Run Black Pool as an unprivileged user (or in a "
+         "sandboxed terminal backend / container with a non-root user)."
+     )
+ 
+diff --git a/hermes_cli/send_cmd.py b/hermes_cli/send_cmd.py
+index 6d00e54..2d605ff 100644
+--- a/hermes_cli/send_cmd.py
++++ b/hermes_cli/send_cmd.py
+@@ -406,7 +406,7 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
+         "send",
+         help="Send a message to a configured platform (scripts, cron jobs, CI).",
+         description=(
+-            "Pipe text from any shell script to any messaging platform Hermes "
++            "Pipe text from any shell script to any messaging platform Black Pool "
+             "is already configured for. Reuses the gateway's platform "
+             "credentials (~/.hermes/.env + ~/.hermes/config.yaml) — no LLM, "
+             "no agent loop, no running gateway required for bot-token "
+diff --git a/hermes_cli/service_manager.py b/hermes_cli/service_manager.py
+index 03ed06d..b6730ea 100644
+--- a/hermes_cli/service_manager.py
++++ b/hermes_cli/service_manager.py
+@@ -134,7 +134,7 @@ def _s6_running() -> bool:
+     — only works as root: for any other UID, the symlink at
+     ``/proc/1/exe`` is unreadable and ``resolve()`` silently returns the
+     path unchanged, so the resolved name is the literal ``"exe"`` and
+-    detection always fails. Since every Hermes runtime call inside the
++    detection always fails. Since every Black Pool runtime call inside the
+     container drops to hermes via ``s6-setuidgid``, that silent failure
+     made the entire service-manager runtime-registration path inert in
+     production (PR #30136 review).
+@@ -424,7 +424,7 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
+     ``0700``. It also ``mkfifo``s ``<svc>/supervise/control`` with mode
+     ``0600``. Because s6-supervise runs as PID 1's effective UID (root)
+     these dirs end up root-owned mode 0700, and an unprivileged client
+-    (the ``hermes`` user — UID 10000 — running every Hermes runtime
++    (the ``hermes`` user — UID 10000 — running every Black Pool runtime
+     operation via ``s6-setuidgid``) gets ``EACCES`` on any ``s6-svc``,
+     ``s6-svstat``, or ``s6-svwait`` invocation against the slot.
+ 
+diff --git a/hermes_cli/session_export.py b/hermes_cli/session_export.py
+index f8695b8..9bfa1a2 100644
+--- a/hermes_cli/session_export.py
++++ b/hermes_cli/session_export.py
+@@ -168,7 +168,7 @@ def _render_full_markdown(sessions: List[Dict[str, Any]]) -> str:
+         lines.append("")
+         _append_session_messages(lines, session, heading_level=2)
+     else:
+-        lines.append("# Hermes sessions export")
++        lines.append("# Black Pool sessions export")
+         lines.append("")
+         for session in sessions:
+             lines.append(f"## Session: {_heading_text(_session_title_or_id(session))}")
 diff --git a/hermes_cli/session_export_html.py b/hermes_cli/session_export_html.py
-index 51052b6..21f6300 100644
+index 51052b6..d1e41c0 100644
 --- a/hermes_cli/session_export_html.py
 +++ b/hermes_cli/session_export_html.py
+@@ -1,5 +1,5 @@
+ """
+-HTML Export generator for Hermes sessions.
++HTML Export generator for Black Pool sessions.
+ Generates a standalone, beautiful HTML file with all messages embedded.
+ Supports single and multi-session exports with a professional sidebar.
+ No remote dependencies.
 @@ -563,7 +563,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
              {sessions_html}
              
@@ -48240,8 +55567,92 @@ index 51052b6..21f6300 100644
              </footer>
          </div>
      </div>
+@@ -791,7 +791,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
+         <aside class="sidebar">
+             <div class="sidebar-header">
+                 <div class="sidebar-brand">
+-                    {ICON_HERMES} Hermes History
++                    {ICON_HERMES} Black Pool History
+                 </div>
+                 <div class="search-container">
+                     {ICON_SEARCH}
+@@ -809,7 +809,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
+     for s in sessions:
+         sid = str(s.get("id", "N/A"))
+         escaped_sid = _escape_html(sid)
+-        title = s.get("title") or "Hermes Session"
++        title = s.get("title") or "Black Pool Session"
+         model = s.get("model") or "Unknown"
+         started_at = _format_timestamp(s.get("started_at", 0))
+         messages = s.get("messages", [])
+@@ -856,7 +856,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
+ 
+     script_nonce = secrets.token_urlsafe(16)
+     return HTML_TEMPLATE.format(
+-        page_title="Hermes Session Export" if is_multi else _escape_html(sessions[0].get("title") or "Hermes Session"),
++        page_title="Black Pool Session Export" if is_multi else _escape_html(sessions[0].get("title") or "Black Pool Session"),
+         sidebar_html=sidebar_html,
+         sessions_html="\n".join(sessions_html_list),
+         main_margin="var(--sidebar-width)" if is_multi else "0",
+diff --git a/hermes_cli/session_export_md.py b/hermes_cli/session_export_md.py
+index e2ab0c8..d71f2d2 100644
+--- a/hermes_cli/session_export_md.py
++++ b/hermes_cli/session_export_md.py
+@@ -1,4 +1,4 @@
+-"""Markdown/QMD export helpers for Hermes sessions.
++"""Markdown/QMD export helpers for Black Pool sessions.
+ 
+ This module is intentionally filesystem-only: it formats already-exported
+ SessionDB dictionaries and writes them to user-selected export directories. It
+diff --git a/hermes_cli/session_lost_and_found.py b/hermes_cli/session_lost_and_found.py
+index 90d8acb..87109cc 100644
+--- a/hermes_cli/session_lost_and_found.py
++++ b/hermes_cli/session_lost_and_found.py
+@@ -13,7 +13,7 @@ walks raw pages and rebuilds rows it cannot attribute to a schema into
+ 
+ This module shells out to that CLI (it is a shell feature, NOT available via
+ the Python ``sqlite3`` module) and then heuristically maps ``lost_and_found``
+-rows back into a fresh current-schema Hermes session database.
++rows back into a fresh current-schema Black Pool session database.
+ 
+ Everything produced through this lane is explicitly **best effort**: column
+ mapping is heuristic (field counts plus sentinel values), fabricated parent
+@@ -31,7 +31,7 @@ import tempfile
+ from pathlib import Path
+ from typing import Any, Optional
+ 
+-# Hermes session ids are timestamps: 20260812_135332_ab12cd. This is the
++# Black Pool session ids are timestamps: 20260812_135332_ab12cd. This is the
+ # strongest sentinel available for classifying schema-less rows.
+ SESSION_ID_PATTERN = re.compile(r"^\d{8}_\d{6}_")
+ 
+diff --git a/hermes_cli/session_recovery.py b/hermes_cli/session_recovery.py
+index 6d5f5e8..a9441f0 100644
+--- a/hermes_cli/session_recovery.py
++++ b/hermes_cli/session_recovery.py
+@@ -1,4 +1,4 @@
+-"""Offline, non-destructive recovery for a damaged Hermes session database.
++"""Offline, non-destructive recovery for a damaged Black Pool session database.
+ 
+ The recovery path deliberately avoids in-place repair:
+ 
+@@ -334,12 +334,12 @@ def _snapshot_and_inspect(
+         if before != after:
+             raise SessionRecoverySafetyError(
+                 "The source database bundle changed while it was being copied. "
+-                "Stop every Hermes process using this profile and retry. "
++                "Stop every Black Pool process using this profile and retry. "
+                 "This includes the interactive `hermes` CLI session this "
+                 "command may have been launched from: a running parent CLI "
+                 "writes session bookkeeping (compression ticks, context "
+                 "tracking) to state.db in the background and counts as a "
+-                "Hermes process even after the gateway is stopped. Run the "
++                "Black Pool process even after the gateway is stopped. Run the "
+                 "recovery from a fresh shell with no `hermes` session open, "
+                 "or point --source at an immutable snapshot copy of the "
+                 "database."
 diff --git a/hermes_cli/setup.py b/hermes_cli/setup.py
-index 3d43d22..df87ca1 100644
+index 3d43d22..5fcb33b 100644
 --- a/hermes_cli/setup.py
 +++ b/hermes_cli/setup.py
 @@ -1,5 +1,5 @@
@@ -48251,7 +55662,7 @@ index 3d43d22..df87ca1 100644
  
  Modular wizard with independently-runnable sections:
    1. Model & Provider — choose your AI provider and model
-@@ -184,7 +184,7 @@ def is_interactive_stdin() -> bool:
+@@ -184,13 +184,13 @@ def is_interactive_stdin() -> bool:
  def print_noninteractive_setup_guidance(reason: str | None = None) -> None:
      """Print guidance for headless/non-interactive setup flows."""
      print()
@@ -48260,6 +55671,76 @@ index 3d43d22..df87ca1 100644
      print()
      if reason:
          print_info(reason)
+     print_info("The interactive wizard cannot be used here.")
+     print()
+-    print_info("Configure Hermes using environment variables or config commands:")
++    print_info("Configure Black Pool using environment variables or config commands:")
+     print_info("  hermes config set model.provider custom")
+     print_info("  hermes config set model.base_url http://localhost:8080/v1")
+     print_info("  hermes config set model.default your-model-name")
+@@ -412,7 +412,7 @@ def _print_setup_summary(config: dict, hermes_home):
+         _provider_ready = False
+     if not _provider_ready:
+         print()
+-        print_warning("No inference provider is configured — Hermes cannot chat yet.")
++        print_warning("No inference provider is configured — Black Pool cannot chat yet.")
+         print_info("  Finish this one step with either of:")
+         print_info("    hermes model            (pick any provider/model)")
+         print_info("    hermes setup --portal   (Nous Portal OAuth, no API key)")
+@@ -1186,7 +1186,7 @@ def _setup_tts_provider(config: dict):
+ 
+     elif selected == "xai":
+         # Resolution order: existing OAuth tokens (free for SuperGrok subscribers
+-        # via the Hermes auth store) > existing XAI_API_KEY > prompt the user.
++        # via the Black Pool auth store) > existing XAI_API_KEY > prompt the user.
+         # When neither is configured, offer both options instead of forcing the
+         # API-key path — xAI TTS works fine with OAuth bearer tokens too.
+         oauth_logged_in = _xai_oauth_logged_in_for_setup()
+@@ -1327,7 +1327,7 @@ def setup_terminal_backend(config: dict):
+     """Configure the terminal execution backend."""
+     import platform as _platform
+     print_header("Terminal Backend")
+-    print_info("Choose where Hermes runs shell commands and code.")
++    print_info("Choose where Black Pool runs shell commands and code.")
+     print_info("This affects tool execution, file access, and isolation.")
+     print_info(f"   Guide: {_DOCS_BASE}/user-guide/configuration#terminal-backend-configuration")
+     print()
+@@ -1567,7 +1567,7 @@ def setup_terminal_backend(config: dict):
+             import subprocess
+ 
+             # Managed uv first: $HERMES_HOME/bin is never on PATH, so a bare
+-            # which() misses the uv Hermes installed. Bootstrapping one is
++            # which() misses the uv Black Pool installed. Bootstrapping one is
+             # welcome here — this is the interactive setup wizard, already
+             # mid-install, and the alternative tier is a pip that a `uv venv`
+             # venv may not even have.
+@@ -2007,7 +2007,7 @@ def _setup_telegram():
+         print_info("⚠️  No allowlist set - anyone who finds your bot can use it!")
+ 
+     print()
+-    print_info("📬 Home Channel: where Hermes delivers cron job results,")
++    print_info("📬 Home Channel: where Black Pool delivers cron job results,")
+     print_info("   cross-platform messages, and notifications.")
+     print_info("   For Telegram DMs, this is your user ID (same as above).")
+ 
+@@ -2045,7 +2045,7 @@ def _setup_bluebubbles():
+         if not prompt_yes_no("Reconfigure BlueBubbles?", False):
+             return
+ 
+-    print_info("Connects Hermes to iMessage via BlueBubbles — a free, open-source")
++    print_info("Connects Black Pool to iMessage via BlueBubbles — a free, open-source")
+     print_info("macOS server that bridges iMessage to any device.")
+     print_info("   Requires a Mac running BlueBubbles Server v1.0.0+")
+     print_info("   Download: https://bluebubbles.app/")
+@@ -2159,7 +2159,7 @@ def setup_gateway(config: dict):
+     from hermes_cli.gateway import _all_platforms, _platform_status, _configure_platform
+ 
+     print_header("Messaging Platforms")
+-    print_info("Connect to messaging platforms to chat with Hermes from anywhere.")
++    print_info("Connect to messaging platforms to chat with Black Pool from anywhere.")
+     print_info("Toggle with Space, confirm with Enter.")
+     print()
+ 
 @@ -2324,7 +2324,7 @@ def setup_telemetry(config: dict):
      """Configure the local, privacy-safe shared-metrics subscriber."""
      print_header("Shared Metrics")
@@ -48269,6 +55750,94 @@ index 3d43d22..df87ca1 100644
  
      telemetry = config.get("telemetry")
      if not isinstance(telemetry, dict):
+@@ -2532,15 +2532,15 @@ def _load_openclaw_migration_module():
+ 
+ # Item kinds that represent high-impact changes warranting explicit warnings.
+ # Gateway tokens/channels can hijack messaging platforms from the old agent.
+-# Config values may have different semantics between OpenClaw and Hermes.
++# Config values may have different semantics between OpenClaw and Black Pool.
+ # Instruction/context files (.md) can contain incompatible setup procedures.
+ _HIGH_IMPACT_KIND_KEYWORDS = {
+-    "gateway": "⚠ Gateway/messaging — this will configure Hermes to use your OpenClaw messaging channels",
+-    "telegram": "⚠ Telegram — this will point Hermes at your OpenClaw Telegram bot",
+-    "slack": "⚠ Slack — this will point Hermes at your OpenClaw Slack workspace",
+-    "discord": "⚠ Discord — this will point Hermes at your OpenClaw Discord bot",
+-    "whatsapp": "⚠ WhatsApp — this will point Hermes at your OpenClaw WhatsApp connection",
+-    "config": "⚠ Config values — OpenClaw settings may not map 1:1 to Hermes equivalents",
++    "gateway": "⚠ Gateway/messaging — this will configure Black Pool to use your OpenClaw messaging channels",
++    "telegram": "⚠ Telegram — this will point Black Pool at your OpenClaw Telegram bot",
++    "slack": "⚠ Slack — this will point Black Pool at your OpenClaw Slack workspace",
++    "discord": "⚠ Discord — this will point Black Pool at your OpenClaw Discord bot",
++    "whatsapp": "⚠ WhatsApp — this will point Black Pool at your OpenClaw WhatsApp connection",
++    "config": "⚠ Config values — OpenClaw settings may not map 1:1 to Black Pool equivalents",
+     "soul": "⚠ Instruction file — may contain OpenClaw-specific setup/restart procedures",
+     "memory": "⚠ Memory/context file — may reference OpenClaw-specific infrastructure",
+     "context": "⚠ Context file — may contain OpenClaw-specific instructions",
+@@ -2584,7 +2584,7 @@ def _print_migration_preview(report: dict):
+         print()
+ 
+     if conflict_items:
+-        print(color("  Would overwrite (conflicts with existing Hermes config):", Colors.YELLOW))
++        print(color("  Would overwrite (conflicts with existing Black Pool config):", Colors.YELLOW))
+         for item in conflict_items:
+             kind = item.get("kind", "unknown")
+             reason = item.get("reason", "already exists")
+@@ -2605,8 +2605,8 @@ def _print_migration_preview(report: dict):
+         for warning in sorted(warnings_shown):
+             print(color(f"    {warning}", Colors.YELLOW))
+         print()
+-        print(color("  Note: OpenClaw config values may have different semantics in Hermes.", Colors.YELLOW))
+-        print(color("  For example, OpenClaw's tool_call_execution: \"auto\" ≠ Hermes's yolo mode.", Colors.YELLOW))
++        print(color("  Note: OpenClaw config values may have different semantics in Black Pool.", Colors.YELLOW))
++        print(color("  For example, OpenClaw's tool_call_execution: \"auto\" ≠ Black Pool's yolo mode.", Colors.YELLOW))
+         print(color("  Instruction files (.md) from OpenClaw may contain incompatible procedures.", Colors.YELLOW))
+         print()
+ 
+@@ -2629,7 +2629,7 @@ def _offer_openclaw_migration(hermes_home: Path) -> bool:
+     print()
+     print_header("OpenClaw Installation Detected")
+     print_info(f"Found OpenClaw data at {openclaw_dir}")
+-    print_info("Hermes can preview what would be imported before making any changes.")
++    print_info("Black Pool can preview what would be imported before making any changes.")
+     print()
+ 
+     if not prompt_yes_no("Would you like to see what can be imported?", default=True):
+@@ -2699,7 +2699,7 @@ def _offer_openclaw_migration(hermes_home: Path) -> bool:
+         )
+         return False
+ 
+-    # Execute the migration — overwrite=False so existing Hermes configs are
++    # Execute the migration — overwrite=False so existing Black Pool configs are
+     # preserved. The user saw the preview; conflicts are skipped by default.
+     try:
+         migrator = mod.Migrator(
+@@ -2707,7 +2707,7 @@ def _offer_openclaw_migration(hermes_home: Path) -> bool:
+             target_root=hermes_home.resolve(),
+             execute=True,
+             workspace_target=None,
+-            overwrite=False,  # preserve existing Hermes config
++            overwrite=False,  # preserve existing Black Pool config
+             migrate_secrets=True,
+             output_dir=None,
+             selected_options=selected,
+@@ -2730,7 +2730,7 @@ def _offer_openclaw_migration(hermes_home: Path) -> bool:
+     if migrated:
+         print_success(f"Imported {migrated} item(s) from OpenClaw.")
+     if conflicts:
+-        print_info(f"Skipped {conflicts} item(s) that already exist in Hermes (use hermes claw migrate --overwrite to force).")
++        print_info(f"Skipped {conflicts} item(s) that already exist in Black Pool (use hermes claw migrate --overwrite to force).")
+     if skipped:
+         print_info(f"Skipped {skipped} item(s) (not found or unchanged).")
+     if errors:
+@@ -2765,7 +2765,7 @@ def _run_portal_one_shot(config: dict) -> None:
+     Wired into ``hermes setup --portal`` and ``hermes portal``. This is the
+     Nous-Portal slice of the first-time quick setup, collapsed into a single
+     shareable command so a brand-new user goes from zero to a fully working
+-    Hermes session — model selected, provider set, and web/image/tts/browser
++    Black Pool session — model selected, provider set, and web/image/tts/browser
+     tools routed via their Portal sub — without being told to run
+     ``hermes setup`` and hunt for the quick-setup option.
+ 
 @@ -2785,7 +2785,7 @@ def _run_portal_one_shot(config: dict) -> None:
              Colors.MAGENTA,
          )
@@ -48305,6 +55874,73 @@ index 3d43d22..df87ca1 100644
          )
      )
      print(
+@@ -2992,7 +2992,7 @@ def run_setup_wizard(args):
+ 
+         print()
+         print_header("Reconfigure")
+-        print_success("You already have Hermes configured.")
++        print_success("You already have Black Pool configured.")
+         print_info("Running the full wizard — each prompt shows your current value.")
+         print_info("Press Enter to keep it, or type a new value to change it.")
+         print_info("")
+@@ -3017,7 +3017,7 @@ def run_setup_wizard(args):
+             config = load_config()
+ 
+         setup_mode = prompt_choice(
+-            "How would you like to set up Hermes?",
++            "How would you like to set up Black Pool?",
+             [
+                 "Quick Setup (Nous Portal) — free OAuth login, no API keys, model + tools (recommended)",
+                 "Full setup — configure every provider, tool & option yourself (bring your own keys)",
+@@ -3492,7 +3492,7 @@ def _run_quick_setup(config: dict, hermes_home):
+     if missing_messaging:
+         print()
+         print_header("Messaging Platforms")
+-        print_info("Connect Hermes to messaging apps to chat from anywhere.")
++        print_info("Connect Black Pool to messaging apps to chat from anywhere.")
+         print_info("You can configure these later with 'hermes setup gateway'.")
+ 
+         # Group by platform (preserving order)
+diff --git a/hermes_cli/setup_whatsapp_cloud.py b/hermes_cli/setup_whatsapp_cloud.py
+index c61fa61..7071771 100644
+--- a/hermes_cli/setup_whatsapp_cloud.py
++++ b/hermes_cli/setup_whatsapp_cloud.py
+@@ -25,7 +25,7 @@ in Meta's App Dashboard, with a one-line description and the field's
+ expected shape ("starts with EAA", "15-17 digits", "32 hex chars", etc.).
+ 
+ The wizard intentionally does NOT smoke-test the webhook itself — the
+-Hermes gateway and the cloudflared tunnel both run in separate
++Black Pool gateway and the cloudflared tunnel both run in separate
+ processes the user starts AFTER this wizard exits, so any in-wizard
+ probe would fail by design. Instead the final SETUP COMPLETE block
+ prints the exact curl command the user can run from a third terminal
+@@ -242,7 +242,7 @@ def run_whatsapp_cloud_setup() -> int:
+     print("⚕ WhatsApp Business Cloud API Setup")
+     print("=" * 50)
+     print()
+-    print("This wizard configures Hermes to talk to WhatsApp via Meta's")
++    print("This wizard configures Black Pool to talk to WhatsApp via Meta's")
+     print("official Cloud API. It's the production-grade path:")
+     print()
+     print("  • No QR codes, no Node.js bridge subprocess")
+@@ -466,7 +466,7 @@ def run_whatsapp_cloud_setup() -> int:
+     print("SETUP COMPLETE — Next steps")
+     print("─" * 50)
+     print()
+-    print("  Hermes needs a public HTTPS URL to receive WhatsApp messages.")
++    print("  Black Pool needs a public HTTPS URL to receive WhatsApp messages.")
+     print("  The recommended path is Cloudflare Tunnel (free, no port")
+     print("  forwarding, no DNS setup).")
+     print()
+@@ -482,7 +482,7 @@ def run_whatsapp_cloud_setup() -> int:
+     print("         cloudflared tunnel --url http://localhost:8090")
+     print("       Note the printed https://<random>.trycloudflare.com URL.")
+     print()
+-    print("    3. Start the Hermes gateway in another terminal:")
++    print("    3. Start the Black Pool gateway in another terminal:")
+     print("         hermes gateway")
+     print()
+     print("    4. Verify your local config is reachable. From a third")
 diff --git a/hermes_cli/skills_config.py b/hermes_cli/skills_config.py
 index 720b9eb..b10d5c0 100644
 --- a/hermes_cli/skills_config.py
@@ -48316,10 +55952,42 @@ index 720b9eb..b10d5c0 100644
  `hermes skills` enters this module.
  
  Toggle individual skills or categories on/off, globally or per-platform.
+diff --git a/hermes_cli/skills_hub.py b/hermes_cli/skills_hub.py
+index 7cca433..2ce0359 100644
+--- a/hermes_cli/skills_hub.py
++++ b/hermes_cli/skills_hub.py
+@@ -1,6 +1,6 @@
+ #!/usr/bin/env python3
+ """
+-Skills Hub CLI — Unified interface for the Hermes Skills Hub.
++Skills Hub CLI — Unified interface for the Black Pool Skills Hub.
+ 
+ Powers both:
+   - `hermes skills <subcommand>` (CLI argparse entry point)
+@@ -1704,8 +1704,8 @@ def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
+             headers=headers, timeout=15,
+             json={
+                 "title": f"Add skill: {skill_name}",
+-                "body": f"Submitting the `{skill_name}` skill via Hermes Skills Hub.\n\n"
+-                        f"This skill was scanned by the Hermes Skills Guard before submission.",
++                "body": f"Submitting the `{skill_name}` skill via Black Pool Skills Hub.\n\n"
++                        f"This skill was scanned by the Black Pool Skills Guard before submission.",
+                 "head": f"{fork_repo.split('/')[0]}:{branch_name}",
+                 "base": default_branch,
+             },
 diff --git a/hermes_cli/skin_engine.py b/hermes_cli/skin_engine.py
-index a2a093b..816f764 100644
+index a2a093b..94f7c05 100644
 --- a/hermes_cli/skin_engine.py
 +++ b/hermes_cli/skin_engine.py
+@@ -1,6 +1,6 @@
+-"""Hermes skin/theme engine — the theme SDK for every surface.
++"""Black Pool skin/theme engine — the theme SDK for every surface.
+ 
+-A data-driven skin system that lets users (and Hermes itself) customize the
++A data-driven skin system that lets users (and Black Pool itself) customize the
+ visual appearance across the CLI, the TUI, and the desktop GUI from a single
+ file. Skins are defined as YAML files in ~/.hermes/skins/ or as built-in presets.
+ No code changes are needed to add a new skin.
 @@ -94,10 +94,10 @@ All fields are optional. Missing values inherit from the ``default`` skin.
  
      # Branding: text strings used throughout the CLI
@@ -48342,6 +56010,27 @@ index a2a093b..816f764 100644
  
      set_active_skin("ares")               # Switch to built-in ares skin
      set_active_skin("mytheme")            # Switch to user skin from ~/.hermes/skins/
+@@ -127,7 +127,7 @@ USAGE
+ BUILT-IN SKINS
+ ==============
+ 
+-- ``default`` — Classic Hermes gold/kawaii (the current look)
++- ``default`` — Classic Black Pool gold/kawaii (the current look)
+ - ``ares``    — Crimson/bronze war-god theme with custom spinner wings
+ - ``mono``    — Clean grayscale monochrome
+ - ``slate``   — Cool blue developer-focused theme
+@@ -201,9 +201,9 @@ class SkinConfig:
+ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
+     "default": {
+         "name": "default",
+-        "description": "Classic Hermes — gold and kawaii",
++        "description": "Classic Black Pool — gold and kawaii",
+         # Dark-authored. Values match the TUI's DARK_THEME so the classic CLI
+-        # and the TUI render the same Hermes gold.
++        # and the TUI render the same Black Pool gold.
+         "colors": {
+             "banner_border": "#CD7F32",
+             "banner_title": "#FFD700",
 @@ -274,10 +274,10 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
              # Empty = use hardcoded defaults in display.py
          },
@@ -48398,7 +56087,7 @@ index a2a093b..816f764 100644
              "prompt_symbol": "❯",
              "help_header": "[?] Available Commands",
          },
-@@ -531,8 +531,8 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
+@@ -531,10 +531,10 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
          },
          "spinner": {},
          "branding": {
@@ -48407,8 +56096,113 @@ index a2a093b..816f764 100644
 +            "agent_name": "Black Pool Agent",
 +            "welcome": "Welcome to Black Pool Agent! Type your message or /help for commands.",
              "goodbye": "Goodbye! \u2695",
-             "response_label": " \u2695 Hermes ",
+-            "response_label": " \u2695 Hermes ",
++            "response_label": " \u2695 Black Pool ",
              "prompt_symbol": "\u276f",
+             "help_header": "(^_^)? Available Commands",
+         },
+diff --git a/hermes_cli/slack_cli.py b/hermes_cli/slack_cli.py
+index 584a991..d6a3bc9 100644
+--- a/hermes_cli/slack_cli.py
++++ b/hermes_cli/slack_cli.py
+@@ -37,12 +37,12 @@ def _build_full_manifest(
+     """Build a full Slack manifest merging display info + our slash list.
+ 
+     The slash-command list is always generated from ``COMMAND_REGISTRY`` so
+-    it stays in sync with the rest of Hermes. Other manifest sections
++    it stays in sync with the rest of Black Pool. Other manifest sections
+     (display info, OAuth scopes, socket mode) are set to sensible defaults
+-    for a Hermes deployment — users can tweak them in the Slack UI after
++    for a Black Pool deployment — users can tweak them in the Slack UI after
+     pasting.
+ 
+-    By default, this keeps Hermes on Slack's older Assistant messaging
++    By default, this keeps Black Pool on Slack's older Assistant messaging
+     experience (``assistant_view``) for backward compatibility. Pass
+     ``messaging_experience="agent"`` (``--agent-view``) to emit Slack's Agent
+     messaging experience (``agent_view`` + ``app_home_opened``). Pass
+@@ -107,7 +107,7 @@ def _build_full_manifest(
+ 
+     if messaging_experience == "assistant":
+         features["assistant_view"] = {
+-            "assistant_description": "Chat with Hermes in threads and DMs.",
++            "assistant_description": "Chat with Black Pool in threads and DMs.",
+         }
+         bot_scopes.append("assistant:write")
+         bot_events.extend(
+@@ -118,7 +118,7 @@ def _build_full_manifest(
+         )
+     elif messaging_experience == "agent":
+         features["agent_view"] = {
+-            "agent_description": "Chat with Hermes in Slack Messages.",
++            "agent_description": "Chat with Black Pool in Slack Messages.",
+         }
+         bot_scopes.append("assistant:write")
+         # Slack includes current viewing context in Agent DM events only after
+@@ -131,7 +131,7 @@ def _build_full_manifest(
+ 
+     display_information = {
+         "name": bot_name[:35],
+-        "description": (bot_description or "Your Hermes agent on Slack")[:140],
++        "description": (bot_description or "Your Black Pool agent on Slack")[:140],
+         "background_color": "#1a1a2e",
+     }
+     if long_description is not None:
+@@ -169,7 +169,7 @@ def slack_manifest_command(args) -> int:
+     Flags (all parsed in ``hermes_cli/main.py``):
+       --write [PATH]  Write to file instead of stdout (default path:
+                       ``$HERMES_HOME/slack-manifest.json``)
+-      --name NAME     Override the bot display name (default: "Hermes")
++      --name NAME     Override the bot display name (default: "Black Pool")
+       --description DESC  Override the bot description
+       --long-description TEXT  Override the long app description (175-4,000 characters)
+       --long-description-file PATH  Read the long app description from a UTF-8 file
+@@ -183,8 +183,8 @@ def slack_manifest_command(args) -> int:
+                       app_home_opened + message.im) instead of the legacy
+                       Assistant messaging experience.
+     """
+-    name = getattr(args, "name", None) or "Hermes"
+-    description = getattr(args, "description", None) or "Your Hermes agent on Slack"
++    name = getattr(args, "name", None) or "Black Pool"
++    description = getattr(args, "description", None) or "Your Black Pool agent on Slack"
+     long_description = getattr(args, "long_description", None)
+     long_description_file = getattr(args, "long_description_file", None)
+     if getattr(args, "slashes_only", False) and (
+@@ -266,7 +266,7 @@ def slack_manifest_command(args) -> int:
+         print(f"Slack manifest written to: {target}", file=sys.stderr)
+         print(
+             "\nNext steps:\n"
+-            "  1. Open https://api.slack.com/apps and pick your Hermes app\n"
++            "  1. Open https://api.slack.com/apps and pick your Black Pool app\n"
+             "     (or create a new one: Create New App → From an app manifest).\n"
+             f"  2. Features → App Manifest → paste the contents of\n"
+             f"     {target}\n"
+diff --git a/hermes_cli/sqlite_runtime.py b/hermes_cli/sqlite_runtime.py
+index 7465b08..3b3b616 100644
+--- a/hermes_cli/sqlite_runtime.py
++++ b/hermes_cli/sqlite_runtime.py
+@@ -1,7 +1,7 @@
+ """Import-safe helpers for inspecting a Python interpreter's linked SQLite.
+ 
+ This module intentionally depends only on the standard library.  Installer and
+-update code must be able to use it before Hermes' third-party dependencies are
++update code must be able to use it before Black Pool' third-party dependencies are
+ healthy.
+ """
+ 
+diff --git a/hermes_cli/sqlite_safe_read.py b/hermes_cli/sqlite_safe_read.py
+index be58ab9..3b9ae32 100644
+--- a/hermes_cli/sqlite_safe_read.py
++++ b/hermes_cli/sqlite_safe_read.py
+@@ -16,7 +16,7 @@ the RESERVED lock an in-flight ``BEGIN IMMEDIATE`` is holding. Other processes
+ are then free to write into a file that a writer still believes it owns, which
+ is the documented route to "database disk image is malformed".
+ 
+-Hermes is exactly the topology this hits: gateway, dispatcher, dashboard,
++Black Pool is exactly the topology this hits: gateway, dispatcher, dashboard,
+ TUI, CLI, cron and kanban workers all open the same ``state.db`` /
+ ``kanban.db``, and several code paths used to byte-probe those files while
+ connections were live.
 diff --git a/hermes_cli/status.py b/hermes_cli/status.py
 index 47ac613..c511163 100644
 --- a/hermes_cli/status.py
@@ -48437,11 +56231,96 @@ index 47ac613..c511163 100644
      print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
  
      _paused_line = _estop_status_line()
+diff --git a/hermes_cli/stderr_timestamp.py b/hermes_cli/stderr_timestamp.py
+index b6dbac9..3111c2c 100644
+--- a/hermes_cli/stderr_timestamp.py
++++ b/hermes_cli/stderr_timestamp.py
+@@ -78,9 +78,9 @@ def _is_launchd_supervised(environ: Mapping[str, str] | None = None) -> bool:
+ 
+ 
+ def _is_hermes_gateway_run_argv(command: Sequence[str]) -> bool:
+-    """True for Hermes ``gateway run`` argv this wrapper is allowed to upgrade.
++    """True for Black Pool ``gateway run`` argv this wrapper is allowed to upgrade.
+ 
+-    The wrapper is generic. Only historical/current Hermes gateway shapes
++    The wrapper is generic. Only historical/current Black Pool gateway shapes
+     get ``--external-supervisor``; an arbitrary launchd child must not be
+     marked as gateway-supervised (#87005).
+     """
+diff --git a/hermes_cli/stdio.py b/hermes_cli/stdio.py
+index b8caf2b..6b6b656 100644
+--- a/hermes_cli/stdio.py
++++ b/hermes_cli/stdio.py
+@@ -2,7 +2,7 @@
+ 
+ On Windows, Python's ``sys.stdout``/``sys.stderr`` default to the console's
+ active code page (often ``cp1252``, sometimes ``cp437``, occasionally ``cp932``
+-on Japanese locales, etc.).  Hermes's banners, tool output feed, and slash
++on Japanese locales, etc.).  Black Pool's banners, tool output feed, and slash
+ command listings all contain Unicode: box-drawing characters (``─┌┐└┘├┤``),
+ mathematical and geometric symbols (``◆ ◇ ◎ ▣ ⚔ ⚖ →``), and user-supplied
+ text in any language.  Printing those to a cp1252 console raises
+@@ -47,7 +47,7 @@ def _flip_console_code_page_to_utf8() -> None:
+     """Set the attached console's input and output code pages to UTF-8.
+ 
+     Uses ``SetConsoleCP`` / ``SetConsoleOutputCP`` via ``ctypes``.  Failure
+-    is silent — if there's no attached console (e.g. Hermes is running
++    is silent — if there's no attached console (e.g. Black Pool is running
+     behind a redirected stdout, under a service, or inside a PTY-less CI
+     runner) these calls simply return 0 and we move on.
+ 
+@@ -149,7 +149,7 @@ def configure_windows_stdio() -> bool:
+     # degraded output over a stack trace.
+     _reconfigure_stream(sys.stdout)
+     _reconfigure_stream(sys.stderr)
+-    # stdin is re-configured for completeness; Hermes's interactive
++    # stdin is re-configured for completeness; Black Pool's interactive
+     # input path uses prompt_toolkit which manages its own encoding,
+     # but batch/pipe input benefits from UTF-8 decoding on stdin too.
+     _reconfigure_stream(sys.stdin)
+@@ -167,7 +167,7 @@ def _default_windows_editor() -> str:
+        blocking editor (``subprocess.call(["notepad", file])`` blocks until
+        the user closes the window).  This is the "always-works" default.
+ 
+-    The prompt_toolkit buffer's ``open_in_editor`` and Hermes's
++    The prompt_toolkit buffer's ``open_in_editor`` and Black Pool's
+     ``hermes config edit`` both honour ``$EDITOR``.  Users who prefer a
+     different editor can override:
+ 
+@@ -176,8 +176,8 @@ def _default_windows_editor() -> str:
+     - Notepad++: ``$env:EDITOR = "'C:\\Program Files\\Notepad++\\notepad++.exe' -multiInst -nosession"``
+     - Neovim: ``$env:EDITOR = "nvim"``  (if installed)
+ 
+-    Set this before launching Hermes (User env var in Windows Settings, or
+-    export in a PowerShell profile) and Hermes picks it up automatically.
++    Set this before launching Black Pool (User env var in Windows Settings, or
++    export in a PowerShell profile) and Black Pool picks it up automatically.
+     """
+     import shutil
+ 
+@@ -202,7 +202,7 @@ def _augment_path_with_known_tools() -> None:
+     *spawned* processes only — already-running shells (including the one the
+     user invokes ``hermes`` from right after install) retain their old PATH.
+ 
+-    Any subprocess Hermes spawns — bash, ``rg``, ``grep``, ``npm`` — inherits
++    Any subprocess Black Pool spawns — bash, ``rg``, ``grep``, ``npm`` — inherits
+     that stale PATH and reports commands as missing even though they're on
+     disk.  Symptom: ``search_files`` reports "rg/find not available" when
+     the user clearly just installed ripgrep.
+@@ -229,7 +229,7 @@ def _augment_path_with_known_tools() -> None:
+         os.path.join(local_appdata, "hermes", "git", "cmd"),
+         os.path.join(local_appdata, "hermes", "git", "bin"),
+         os.path.join(local_appdata, "hermes", "git", "usr", "bin"),
+-        # Hermes venv Scripts directory — host of the hermes.exe shim itself,
++        # Black Pool venv Scripts directory — host of the hermes.exe shim itself,
+         # also where any pip-installed console scripts land.  Usually already
+         # on PATH when the user invokes hermes, but harmless to include.
+         os.path.join(local_appdata, "hermes", "hermes-agent", "venv", "Scripts"),
 diff --git a/hermes_cli/subcommands/acp.py b/hermes_cli/subcommands/acp.py
-index 5282996..9e4ec88 100644
+index 5282996..d94d329 100644
 --- a/hermes_cli/subcommands/acp.py
 +++ b/hermes_cli/subcommands/acp.py
-@@ -15,8 +15,8 @@ def build_acp_parser(subparsers, *, cmd_acp: Callable) -> None:
+@@ -15,15 +15,15 @@ def build_acp_parser(subparsers, *, cmd_acp: Callable) -> None:
      """Attach the ``acp`` subcommand to ``subparsers``."""
      acp_parser = subparsers.add_parser(
          "acp",
@@ -48452,6 +56331,72 @@ index 5282996..9e4ec88 100644
      )
      add_accept_hooks_flag(acp_parser)
      acp_parser.add_argument(
+         "--version",
+         action="store_true",
+         dest="acp_version",
+-        help="Print Hermes ACP version and exit",
++        help="Print Black Pool ACP version and exit",
+     )
+     acp_parser.add_argument(
+         "--check",
+@@ -33,7 +33,7 @@ def build_acp_parser(subparsers, *, cmd_acp: Callable) -> None:
+     acp_parser.add_argument(
+         "--setup",
+         action="store_true",
+-        help="Run interactive Hermes provider/model setup for ACP terminal auth",
++        help="Run interactive Black Pool provider/model setup for ACP terminal auth",
+     )
+     acp_parser.add_argument(
+         "--setup-browser",
+diff --git a/hermes_cli/subcommands/auth.py b/hermes_cli/subcommands/auth.py
+index e81fcea..d381d0f 100644
+--- a/hermes_cli/subcommands/auth.py
++++ b/hermes_cli/subcommands/auth.py
+@@ -71,7 +71,7 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
+     )
+     auth_logout.add_argument("provider", help="Provider id")
+     auth_spotify = auth_subparsers.add_parser(
+-        "spotify", help="Authenticate Hermes with Spotify via PKCE"
++        "spotify", help="Authenticate Black Pool with Spotify via PKCE"
+     )
+     auth_spotify.add_argument(
+         "spotify_action",
+diff --git a/hermes_cli/subcommands/backup.py b/hermes_cli/subcommands/backup.py
+index 745d219..2d6c813 100644
+--- a/hermes_cli/subcommands/backup.py
++++ b/hermes_cli/subcommands/backup.py
+@@ -16,8 +16,8 @@ def build_backup_parser(subparsers, *, cmd_backup: Callable) -> None:
+     # =========================================================================
+     backup_parser = subparsers.add_parser(
+         "backup",
+-        help="Back up Hermes home directory to a zip file",
+-        description="Create a zip archive of your entire Hermes configuration, "
++        help="Back up Black Pool home directory to a zip file",
++        description="Create a zip archive of your entire Black Pool configuration, "
+         "skills, sessions, and data (excludes the hermes-agent codebase). "
+         "Use --quick for a fast snapshot of just critical state files.",
+     )
+diff --git a/hermes_cli/subcommands/claw.py b/hermes_cli/subcommands/claw.py
+index 75cf556..722f134 100644
+--- a/hermes_cli/subcommands/claw.py
++++ b/hermes_cli/subcommands/claw.py
+@@ -14,14 +14,14 @@ def build_claw_parser(subparsers, *, cmd_claw: Callable) -> None:
+     claw_parser = subparsers.add_parser(
+         "claw",
+         help="OpenClaw migration tools",
+-        description="Migrate settings, memories, skills, and API keys from OpenClaw to Hermes",
++        description="Migrate settings, memories, skills, and API keys from OpenClaw to Black Pool",
+     )
+     claw_subparsers = claw_parser.add_subparsers(dest="claw_action")
+ 
+     # claw migrate
+     claw_migrate = claw_subparsers.add_parser(
+         "migrate",
+-        help="Migrate from OpenClaw to Hermes",
++        help="Migrate from OpenClaw to Black Pool",
+         description="Import settings, memories, skills, and API keys from an OpenClaw installation. "
+         "Always shows a preview before making changes.",
+     )
 diff --git a/hermes_cli/subcommands/config.py b/hermes_cli/subcommands/config.py
 index 8fe1297..9ad4d3a 100644
 --- a/hermes_cli/subcommands/config.py
@@ -48465,11 +56410,48 @@ index 8fe1297..9ad4d3a 100644
      )
      config_subparsers = config_parser.add_subparsers(dest="config_command")
  
+diff --git a/hermes_cli/subcommands/console.py b/hermes_cli/subcommands/console.py
+index f952e37..86e24b0 100644
+--- a/hermes_cli/subcommands/console.py
++++ b/hermes_cli/subcommands/console.py
+@@ -6,13 +6,13 @@ from typing import Callable
+ 
+ 
+ def build_console_parser(subparsers, *, cmd_console: Callable) -> None:
+-    """Attach the safe Hermes Console REPL subcommand."""
++    """Attach the safe Black Pool Console REPL subcommand."""
+     console_parser = subparsers.add_parser(
+         "console",
+-        help="Open the safe Hermes command console",
++        help="Open the safe Black Pool command console",
+         description=(
+-            "Open a curated Hermes command REPL. This is not a raw shell and "
+-            "does not expose the full Hermes CLI."
++            "Open a curated Black Pool command REPL. This is not a raw shell and "
++            "does not expose the full Black Pool CLI."
+         ),
+     )
+     console_parser.set_defaults(func=cmd_console)
 diff --git a/hermes_cli/subcommands/dashboard.py b/hermes_cli/subcommands/dashboard.py
-index 0b695e0..eb135f8 100644
+index 0b695e0..5b2863e 100644
 --- a/hermes_cli/subcommands/dashboard.py
 +++ b/hermes_cli/subcommands/dashboard.py
-@@ -101,7 +101,7 @@ def build_dashboard_parser(
+@@ -75,12 +75,12 @@ def _add_server_runtime_args(parser) -> None:
+     parser.add_argument(
+         "--stop",
+         action="store_true",
+-        help="Stop all running Hermes web server processes and exit",
++        help="Stop all running Black Pool web server processes and exit",
+     )
+     parser.add_argument(
+         "--status",
+         action="store_true",
+-        help="List running Hermes web server processes and exit",
++        help="List running Black Pool web server processes and exit",
+     )
+ 
+ 
+@@ -101,19 +101,19 @@ def build_dashboard_parser(
      dashboard_parser = subparsers.add_parser(
          "dashboard",
          help="Start the web UI dashboard",
@@ -48478,6 +56460,40 @@ index 0b695e0..eb135f8 100644
      )
      _add_server_runtime_args(dashboard_parser)
      dashboard_parser.add_argument(
+         "--no-open", action="store_true", help="Don't open browser automatically"
+     )
+-    # Backward-compat shim: older Hermes desktop app shells (<= 0.15.x) spawn the
++    # Backward-compat shim: older Black Pool desktop app shells (<= 0.15.x) spawn the
+     # backend as `hermes dashboard --no-open --tui --host ... --port ...`. The
+     # `--tui` flag was removed from this subcommand in cae6b5486 (embedded chat is
+     # always on now). When a user's CLI updates past that commit but their desktop
+     # app binary has not, argparse used to hard-error with "unrecognized arguments:
+     # --tui" and exit(2) — the backend died before becoming ready and the GUI just
+-    # showed "Hermes couldn't start" with no actionable cause. Accept and silently
++    # showed "Black Pool couldn't start" with no actionable cause. Accept and silently
+     # ignore the flag so an old app + new CLI degrades gracefully instead of
+     # bricking. Hidden from --help; safe to delete once the floor app version is
+     # well past 0.16.0.
+@@ -128,16 +128,16 @@ def build_dashboard_parser(
+     # serve command — the headless backend server
+     #
+     # `serve` boots the exact same gateway as `dashboard` but never opens a
+-    # browser. It exists so the Hermes Desktop app (and headless remote
++    # browser. It exists so the Black Pool Desktop app (and headless remote
+     # backends) can launch a backend WITHOUT invoking `dashboard`: the desktop
+     # app and the web dashboard are independent surfaces that merely share this
+     # server, and neither should appear to launch the other.
+     # =========================================================================
+     serve_parser = subparsers.add_parser(
+         "serve",
+-        help="Start the Hermes backend server (headless; powers the desktop app and remote backends)",
++        help="Start the Black Pool backend server (headless; powers the desktop app and remote backends)",
+         description=(
+-            "Run the Hermes backend server — the JSON-RPC/WebSocket gateway the "
++            "Run the Black Pool backend server — the JSON-RPC/WebSocket gateway the "
+             "desktop app and remote clients connect to. Headless: it never opens "
+             "a browser UI."
+         ),
 diff --git a/hermes_cli/subcommands/debug.py b/hermes_cli/subcommands/debug.py
 index 65eb842..33728ec 100644
 --- a/hermes_cli/subcommands/debug.py
@@ -48504,10 +56520,215 @@ index 81a2571..56da4ce 100644
      )
      doctor_parser.add_argument(
          "--fix", action="store_true", help="Attempt to fix issues automatically"
+diff --git a/hermes_cli/subcommands/dump.py b/hermes_cli/subcommands/dump.py
+index fdad4e5..3d09b1d 100644
+--- a/hermes_cli/subcommands/dump.py
++++ b/hermes_cli/subcommands/dump.py
+@@ -17,7 +17,7 @@ def build_dump_parser(subparsers, *, cmd_dump: Callable) -> None:
+     dump_parser = subparsers.add_parser(
+         "dump",
+         help="Dump setup summary for support/debugging",
+-        description="Output a compact, plain-text summary of your Hermes setup "
++        description="Output a compact, plain-text summary of your Black Pool setup "
+         "that can be copy-pasted into Discord/GitHub for support context",
+     )
+     dump_parser.add_argument(
+diff --git a/hermes_cli/subcommands/gateway.py b/hermes_cli/subcommands/gateway.py
+index d541b69..b0ce2ce 100644
+--- a/hermes_cli/subcommands/gateway.py
++++ b/hermes_cli/subcommands/gateway.py
+@@ -228,7 +228,7 @@ def build_gateway_parser(
+         "migrate-legacy",
+         help="Remove legacy hermes.service units from pre-rename installs",
+         description=(
+-            "Stop, disable, and remove legacy Hermes gateway unit files "
++            "Stop, disable, and remove legacy Black Pool gateway unit files "
+             "(e.g. hermes.service) left over from older installs. Profile "
+             "units (hermes-gateway-<profile>.service) and unrelated "
+             "third-party services are never touched."
+diff --git a/hermes_cli/subcommands/gui.py b/hermes_cli/subcommands/gui.py
+index b51ff4b..c9853fb 100644
+--- a/hermes_cli/subcommands/gui.py
++++ b/hermes_cli/subcommands/gui.py
+@@ -17,7 +17,7 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
+         aliases=["gui"],
+         help="Build and launch the native desktop app",
+         description=(
+-            "Launch the Hermes Electron desktop app. By default this installs "
++            "Launch the Black Pool Electron desktop app. By default this installs "
+             "workspace Node dependencies, builds the current OS's unpacked "
+             "Electron app, then launches that packaged artifact."
+         ),
+@@ -44,7 +44,7 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
+     )
+     gui_parser.add_argument(
+         "--hermes-root",
+-        help="Override the Hermes source root used by Desktop (sets HERMES_DESKTOP_HERMES_ROOT)",
++        help="Override the Black Pool source root used by Desktop (sets HERMES_DESKTOP_HERMES_ROOT)",
+     )
+     gui_parser.add_argument(
+         "--cwd",
+diff --git a/hermes_cli/subcommands/import_agent.py b/hermes_cli/subcommands/import_agent.py
+index c20d10b..8e80f5a 100644
+--- a/hermes_cli/subcommands/import_agent.py
++++ b/hermes_cli/subcommands/import_agent.py
+@@ -14,11 +14,11 @@ def build_import_agent_parser(subparsers, *, cmd_import_agent: Callable) -> None
+     """Attach the ``import-agent`` subcommand to ``subparsers``."""
+     parser = subparsers.add_parser(
+         "import-agent",
+-        help="Import a Claude Code or Codex CLI setup into Hermes",
++        help="Import a Claude Code or Codex CLI setup into Black Pool",
+         description=(
+-            "One-command import of another coding agent's setup into Hermes. "
++            "One-command import of another coding agent's setup into Black Pool. "
+             "Maps CLAUDE.md/AGENTS.md instructions, permission allowlists, MCP "
+-            "servers, skills, and memories into their Hermes equivalents. "
++            "servers, skills, and memories into their Black Pool equivalents. "
+             "Always shows a preview before making changes. API keys and "
+             "credentials are never imported — run 'hermes setup' for those."
+         ),
+@@ -41,7 +41,7 @@ def build_import_agent_parser(subparsers, *, cmd_import_agent: Callable) -> None
+     parser.add_argument(
+         "--overwrite",
+         action="store_true",
+-        help="Overwrite existing Hermes items on name conflicts (default: skip)",
++        help="Overwrite existing Black Pool items on name conflicts (default: skip)",
+     )
+     parser.add_argument(
+         "--yes", "-y", action="store_true", help="Skip confirmation prompts"
+diff --git a/hermes_cli/subcommands/import_cmd.py b/hermes_cli/subcommands/import_cmd.py
+index 36ed375..22fc646 100644
+--- a/hermes_cli/subcommands/import_cmd.py
++++ b/hermes_cli/subcommands/import_cmd.py
+@@ -16,9 +16,9 @@ def build_import_cmd_parser(subparsers, *, cmd_import: Callable) -> None:
+     # =========================================================================
+     import_parser = subparsers.add_parser(
+         "import",
+-        help="Restore a Hermes backup from a zip file",
+-        description="Extract a previously created Hermes backup into your "
+-        "Hermes home directory, restoring configuration, skills, "
++        help="Restore a Black Pool backup from a zip file",
++        description="Extract a previously created Black Pool backup into your "
++        "Black Pool home directory, restoring configuration, skills, "
+         "sessions, and data",
+     )
+     import_parser.add_argument("zipfile", help="Path to the backup zip file")
+diff --git a/hermes_cli/subcommands/logs.py b/hermes_cli/subcommands/logs.py
+index 53964b0..369a284 100644
+--- a/hermes_cli/subcommands/logs.py
++++ b/hermes_cli/subcommands/logs.py
+@@ -17,7 +17,7 @@ def build_logs_parser(subparsers, *, cmd_logs: Callable) -> None:
+     # =========================================================================
+     logs_parser = subparsers.add_parser(
+         "logs",
+-        help="View and filter Hermes log files",
++        help="View and filter Black Pool log files",
+         description="View, tail, and filter agent.log / errors.log / gateway.log / gui.log / desktop.log",
+         formatter_class=argparse.RawDescriptionHelpFormatter,
+         epilog="""\
+diff --git a/hermes_cli/subcommands/mcp.py b/hermes_cli/subcommands/mcp.py
+index 387a88e..f724a2b 100644
+--- a/hermes_cli/subcommands/mcp.py
++++ b/hermes_cli/subcommands/mcp.py
+@@ -16,19 +16,19 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
+     """Attach the ``mcp`` subcommand to ``subparsers``."""
+     mcp_parser = subparsers.add_parser(
+         "mcp",
+-        help="Manage MCP servers and run Hermes as an MCP server",
++        help="Manage MCP servers and run Black Pool as an MCP server",
+         description=(
+-            "Manage MCP server connections and run Hermes as an MCP server.\n\n"
++            "Manage MCP server connections and run Black Pool as an MCP server.\n\n"
+             "MCP servers provide additional tools via the Model Context Protocol.\n"
+             "Use 'hermes mcp add' to connect to a new server, or\n"
+-            "'hermes mcp serve' to expose Hermes conversations over MCP."
++            "'hermes mcp serve' to expose Black Pool conversations over MCP."
+         ),
+     )
+     mcp_sub = mcp_parser.add_subparsers(dest="mcp_action")
+ 
+     mcp_serve_p = mcp_sub.add_parser(
+         "serve",
+-        help="Run Hermes as an MCP server (expose conversations to other agents)",
++        help="Run Black Pool as an MCP server (expose conversations to other agents)",
+     )
+     mcp_serve_p.add_argument(
+         "-v",
+diff --git a/hermes_cli/subcommands/pause.py b/hermes_cli/subcommands/pause.py
+index 048f783..b06cbeb 100644
+--- a/hermes_cli/subcommands/pause.py
++++ b/hermes_cli/subcommands/pause.py
+@@ -22,7 +22,7 @@ def cmd_pause(args: argparse.Namespace) -> int:
+     already = is_engaged()
+     path = engage(reason=reason)
+     state = get_state() or {}
+-    verb = "Still paused" if already else "Hermes paused"
++    verb = "Still paused" if already else "Black Pool paused"
+     detail = f" — reason: {state['reason']}" if state.get("reason") else ""
+     print(f"⏸️  {verb}{detail}")
+     print(f"    sentinel: {path}")
+@@ -38,9 +38,9 @@ def cmd_resume(args: argparse.Namespace) -> int:
+     from agent.estop import disengage, sentinel_path
+ 
+     if disengage():
+-        print("▶️  Hermes resumed — dispatch picks up on the next tick.")
++        print("▶️  Black Pool resumed — dispatch picks up on the next tick.")
+     else:
+-        print(f"Hermes is not paused (no sentinel at {sentinel_path()}).")
++        print(f"Black Pool is not paused (no sentinel at {sentinel_path()}).")
+     return 0
+ 
+ 
+diff --git a/hermes_cli/subcommands/peer.py b/hermes_cli/subcommands/peer.py
+index 13d1063..3ac9f65 100644
+--- a/hermes_cli/subcommands/peer.py
++++ b/hermes_cli/subcommands/peer.py
+@@ -1,6 +1,6 @@
+ """``hermes peer`` — bot-to-bot DMs across machines/gateways.
+ 
+-A *peer* is another Hermes gateway (any machine: homelab, Spark, Hermes
++A *peer* is another Black Pool gateway (any machine: homelab, Spark, Black Pool
+ Cloud) running the ``api_server`` platform. Registering it here gives every
+ bot on THIS machine a transport to message bots on THAT machine:
+ 
+@@ -270,9 +270,9 @@ def build_peer_parser(subparsers) -> None:
+     """Attach the ``peer`` subcommand to ``subparsers``."""
+     parser = subparsers.add_parser(
+         "peer",
+-        help="Bot-to-bot DMs across machines (peer Hermes gateways)",
++        help="Bot-to-bot DMs across machines (peer Black Pool gateways)",
+         description=(
+-            "Register other Hermes gateways as peers and message their agents. "
++            "Register other Black Pool gateways as peers and message their agents. "
+             "'hermes peer dm <peer>[/<agent>] \"...\"' delivers into the remote "
+             "agent's canonical Bot Chat over the peer's API server and prints "
+             "the reply — the cross-machine twin of 'hermes -p <bot> chat'. "
+diff --git a/hermes_cli/subcommands/plugins.py b/hermes_cli/subcommands/plugins.py
+index 975770c..39da748 100644
+--- a/hermes_cli/subcommands/plugins.py
++++ b/hermes_cli/subcommands/plugins.py
+@@ -15,7 +15,7 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
+         "plugins",
+         help="Manage and validate plugins",
+         description=(
+-            "Install, update, remove, list, or validate native Hermes plugins "
++            "Install, update, remove, list, or validate native Black Pool plugins "
+             "and portable Agent Plugins v1 packages. Portable packages install disabled."
+         ),
+     )
 diff --git a/hermes_cli/subcommands/profile.py b/hermes_cli/subcommands/profile.py
-index abcc53c..330134c 100644
+index abcc53c..4e14e57 100644
 --- a/hermes_cli/subcommands/profile.py
 +++ b/hermes_cli/subcommands/profile.py
+@@ -16,7 +16,7 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
+     # =========================================================================
+     profile_parser = subparsers.add_parser(
+         "profile",
+-        help="Manage profiles — multiple isolated Hermes instances",
++        help="Manage profiles — multiple isolated Black Pool instances",
+     )
+     profile_subparsers = profile_parser.add_subparsers(dest="profile_action")
+ 
 @@ -154,7 +154,7 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
          "install",
          help="Install a profile distribution from a git URL or local directory",
@@ -48517,6 +56738,28 @@ index abcc53c..330134c 100644
              "(github.com/user/repo, https://..., git@...) or a local "
              "directory containing distribution.yaml at its root."
          ),
+diff --git a/hermes_cli/subcommands/security.py b/hermes_cli/subcommands/security.py
+index b763a6e..0855d2d 100644
+--- a/hermes_cli/subcommands/security.py
++++ b/hermes_cli/subcommands/security.py
+@@ -16,7 +16,7 @@ def build_security_parser(subparsers, *, cmd_security: Callable) -> None:
+         "security",
+         help="Supply-chain audit (OSV.dev) for venv, plugins, and MCP servers",
+         description=(
+-            "On-demand vulnerability scan against OSV.dev. Covers the Hermes "
++            "On-demand vulnerability scan against OSV.dev. Covers the Black Pool "
+             "venv (installed PyPI dists), Python deps declared by plugins under "
+             "~/.hermes/plugins/, and pinned npx/uvx MCP servers in config.yaml. "
+             "Does NOT scan globally-installed packages or editor/browser extensions."
+@@ -46,7 +46,7 @@ def build_security_parser(subparsers, *, cmd_security: Callable) -> None:
+     audit_parser.add_argument(
+         "--skip-venv",
+         action="store_true",
+-        help="Skip scanning the Hermes Python venv",
++        help="Skip scanning the Black Pool Python venv",
+     )
+     audit_parser.add_argument(
+         "--skip-plugins",
 diff --git a/hermes_cli/subcommands/setup.py b/hermes_cli/subcommands/setup.py
 index fa0c0dc..53fdd13 100644
 --- a/hermes_cli/subcommands/setup.py
@@ -48530,6 +56773,41 @@ index fa0c0dc..53fdd13 100644
          "Run a specific section: "
          "hermes setup model|tts|terminal|gateway|tools|telemetry|agent",
      )
+diff --git a/hermes_cli/subcommands/skin.py b/hermes_cli/subcommands/skin.py
+index ae49c6b..d60cfe5 100644
+--- a/hermes_cli/subcommands/skin.py
++++ b/hermes_cli/subcommands/skin.py
+@@ -10,7 +10,7 @@ def build_skin_parser(subparsers, *, cmd_skin: Callable) -> None:
+     skin_parser = subparsers.add_parser(
+         "skin",
+         help="List, switch, and tweak skins",
+-        description="Manage Hermes skins. `set` tweaks one color of the active skin in place.",
++        description="Manage Black Pool skins. `set` tweaks one color of the active skin in place.",
+     )
+     skin_subparsers = skin_parser.add_subparsers(dest="skin_command")
+ 
+diff --git a/hermes_cli/subcommands/slack.py b/hermes_cli/subcommands/slack.py
+index 5eb4249..2519f07 100644
+--- a/hermes_cli/subcommands/slack.py
++++ b/hermes_cli/subcommands/slack.py
+@@ -17,7 +17,7 @@ def build_slack_parser(subparsers, *, cmd_slack: Callable) -> None:
+     slack_parser = subparsers.add_parser(
+         "slack",
+         help="Slack integration helpers (manifest generation, etc.)",
+-        description="Slack integration helpers for Hermes.",
++        description="Slack integration helpers for Black Pool.",
+     )
+     slack_sub = slack_parser.add_subparsers(dest="slack_command")
+     slack_manifest = slack_sub.add_parser(
+@@ -44,7 +44,7 @@ def build_slack_parser(subparsers, *, cmd_slack: Callable) -> None:
+     slack_manifest.add_argument(
+         "--name",
+         default=None,
+-        help='Bot display name (default: "Hermes")',
++        help='Bot display name (default: "Black Pool")',
+     )
+     slack_manifest.add_argument(
+         "--description",
 diff --git a/hermes_cli/subcommands/status.py b/hermes_cli/subcommands/status.py
 index ad107a3..63112b8 100644
 --- a/hermes_cli/subcommands/status.py
@@ -48559,7 +56837,7 @@ index f746a89..db23a55 100644
      uninstall_parser.add_argument(
          "--full",
 diff --git a/hermes_cli/subcommands/update.py b/hermes_cli/subcommands/update.py
-index 917cf9f..ad1c2c3 100644
+index 917cf9f..6f31cef 100644
 --- a/hermes_cli/subcommands/update.py
 +++ b/hermes_cli/subcommands/update.py
 @@ -16,7 +16,7 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
@@ -48571,10 +56849,28 @@ index 917cf9f..ad1c2c3 100644
          description="Pull the latest changes from git and reinstall dependencies",
      )
      update_parser.add_argument(
+@@ -37,7 +37,7 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
+         default=False,
+         help=(
+             "Show the update plan and exit without changing anything: install "
+-            "kind (git/docker/nix), every running Hermes service across all "
++            "kind (git/docker/nix), every running Black Pool service across all "
+             "profiles with its supervisor and running code version, and how "
+             "each will be restarted. Read-only; safe on a live fleet."
+         ),
 diff --git a/hermes_cli/telegram_managed_bot.py b/hermes_cli/telegram_managed_bot.py
-index 89395d5..469eae4 100644
+index 89395d5..5cbea91 100644
 --- a/hermes_cli/telegram_managed_bot.py
 +++ b/hermes_cli/telegram_managed_bot.py
+@@ -1,7 +1,7 @@
+ """Telegram Managed Bot onboarding client.
+ 
+ Uses Telegram's Managed Bots feature to create a user-owned child bot without
+-manual BotFather token copy-paste. Hermes talks only to the Nous onboarding
++manual BotFather token copy-paste. Black Pool talks only to the Nous onboarding
+ service; the raw Telegram token is saved locally after one-time retrieval.
+ """
+ 
 @@ -27,7 +27,7 @@ TELEGRAM_ONBOARDING_URL_ENV = "TELEGRAM_ONBOARDING_URL"
  # actual deep link, so this is only used by local helpers/tests.
  DEFAULT_MANAGER_BOT = "HermesSetupBot"
@@ -48584,8 +56880,179 @@ index 89395d5..469eae4 100644
  DEFAULT_POLL_TIMEOUT = 180
  POLL_INTERVAL = 2
  
+@@ -286,11 +286,11 @@ def auto_setup_telegram_bot_result(
+     _ = manager_bot, profile_name
+     resolved_api_url = _api_url(api_url)
+     print()
+-    print(f"  Contacting Hermes Telegram onboarding service: {resolved_api_url}")
++    print(f"  Contacting Black Pool Telegram onboarding service: {resolved_api_url}")
+     sys.stdout.flush()
+     pairing = create_pairing(resolved_api_url)
+     if not pairing:
+-        print("  ✗ Could not reach the Hermes Telegram onboarding service.")
++        print("  ✗ Could not reach the Black Pool Telegram onboarding service.")
+         print("    Try the manual setup instead, or check your network.")
+         return None
+ 
+diff --git a/hermes_cli/tips.py b/hermes_cli/tips.py
+index b2c8a04..24d0944 100644
+--- a/hermes_cli/tips.py
++++ b/hermes_cli/tips.py
+@@ -56,7 +56,7 @@ TIPS = [
+     # --- Keybindings ---
+     "Alt+Enter inserts a newline for multi-line input. (Windows Terminal intercepts Alt+Enter — use Ctrl+Enter instead.)",
+     "Ctrl+C interrupts the agent. Double-press within 2 seconds to force exit.",
+-    "Ctrl+Z suspends Hermes to the background — run fg in your shell to resume.",
++    "Ctrl+Z suspends Black Pool to the background — run fg in your shell to resume.",
+     "Tab accepts auto-suggestion ghost text or autocompletes slash commands.",
+     "Type a new message while the agent is working to interrupt and redirect it.",
+     "Alt+V pastes an image from your clipboard into the conversation.",
+@@ -89,15 +89,15 @@ TIPS = [
+     "hermes skills tap add myorg/skills-repo adds a custom GitHub skill source.",
+     "hermes skills snapshot export setup.json exports your skill configuration for backup or sharing.",
+     "hermes mcp add github --command npx adds MCP servers from the command line.",
+-    "hermes mcp serve runs Hermes itself as an MCP server for other agents.",
++    "hermes mcp serve runs Black Pool itself as an MCP server for other agents.",
+     "hermes auth add lets you add multiple API keys for credential pool rotation.",
+     "hermes completion bash >> ~/.bashrc enables tab completion for all commands and profiles.",
+     "hermes logs -f follows agent.log in real time. --level WARNING --since 1h filters output.",
+-    "hermes backup creates a zip backup of your entire Hermes home directory.",
++    "hermes backup creates a zip backup of your entire Black Pool home directory.",
+     "hermes profile create coder creates an isolated profile that becomes its own command.",
+     "hermes profile create work --clone copies your current config and keys to a new profile.",
+     "hermes update syncs new bundled skills to ALL profiles automatically.",
+-    "hermes gateway install sets up Hermes as a system service (systemd/launchd).",
++    "hermes gateway install sets up Black Pool as a system service (systemd/launchd).",
+     "hermes memory setup lets you configure an external memory provider (Honcho, Mem0, etc.).",
+     "hermes webhook subscribe creates event-driven webhook routes with HMAC validation.",
+     "Save money: hermes tools disables unused tools, hermes skills config trims skills down.",
+@@ -128,7 +128,7 @@ TIPS = [
+     "provider_routing controls OpenRouter provider sorting, whitelisting, and blacklisting.",
+ 
+     # --- Tools & Capabilities ---
+-    "execute_code runs Python scripts that call Hermes tools programmatically — results stay out of context.",
++    "execute_code runs Python scripts that call Black Pool tools programmatically — results stay out of context.",
+     "delegate_task spawns up to 3 concurrent sub-agents by default (delegation.max_concurrent_children) with isolated contexts for parallel work.",
+     "web_extract works on PDF URLs — pass any PDF link and it converts to markdown.",
+     "search_files is ripgrep-backed and faster than grep — use it instead of terminal grep.",
+@@ -158,7 +158,7 @@ TIPS = [
+     # --- Sessions ---
+     "Sessions auto-generate descriptive titles after the first exchange — no manual naming needed.",
+     "Session titles support lineage: \"my project\" → \"my project #2\" → \"my project #3\".",
+-    "When exiting, Hermes prints a resume command with session ID and stats.",
++    "When exiting, Black Pool prints a resume command with session ID and stats.",
+     "hermes sessions export backup.jsonl exports all sessions for backup or analysis.",
+     "hermes -r SESSION_ID resumes any specific past session by its ID.",
+ 
+@@ -192,10 +192,10 @@ TIPS = [
+     "Voice messages on Telegram, Discord, WhatsApp, and Slack are auto-transcribed.",
+ 
+     # --- Gateway & Messaging ---
+-    "Hermes runs on 21 messaging platforms: Telegram, Discord, Slack, WhatsApp, Signal, Matrix, IRC, Microsoft Teams, email, and more.",
++    "Black Pool runs on 21 messaging platforms: Telegram, Discord, Slack, WhatsApp, Signal, Matrix, IRC, Microsoft Teams, email, and more.",
+     "hermes gateway install sets it up as a system service that starts on boot.",
+     "DingTalk uses Stream Mode — no webhooks or public URL needed.",
+-    "BlueBubbles brings iMessage to Hermes via a local macOS server.",
++    "BlueBubbles brings iMessage to Black Pool via a local macOS server.",
+     "Webhook routes support HMAC validation, rate limiting, and event filtering.",
+     "The API server exposes an OpenAI-compatible endpoint compatible with Open WebUI and LibreChat.",
+     "Discord voice channel mode: the bot joins VC, transcribes speech, and talks back.",
+@@ -216,7 +216,7 @@ TIPS = [
+     "Context auto-compresses when it reaches the threshold — memories are flushed and history summarized.",
+     "The status bar turns yellow, then orange, then red as context fills up.",
+     "SOUL.md is the agent's primary identity file — customize it to shape behavior.",
+-    "Hermes loads project context from .hermes.md, AGENTS.md, CLAUDE.md, or .cursorrules (first match).",
++    "Black Pool loads project context from .hermes.md, AGENTS.md, CLAUDE.md, or .cursorrules (first match).",
+     "Subdirectory AGENTS.md files are discovered progressively as the agent navigates into folders.",
+     "Context files are capped at 20,000 characters with smart head/tail truncation.",
+ 
+@@ -259,7 +259,7 @@ TIPS = [
+     "Slash commands support prefix matching: /h resolves to /help, /mod to /model.",
+     "Dragging a file path into the terminal auto-attaches images or sends as context.",
+     ".worktreeinclude in your repo root lists gitignored files to copy into worktrees.",
+-    "hermes acp runs Hermes as an ACP server for VS Code, Zed, and JetBrains integration.",
++    "hermes acp runs Black Pool as an ACP server for VS Code, Zed, and JetBrains integration.",
+     "Custom providers: save named endpoints in config.yaml under custom_providers.",
+     "HERMES_EPHEMERAL_SYSTEM_PROMPT injects a system prompt that's never persisted to history.",
+     "credential_pool_strategies supports fill_first, round_robin, least_used, and random rotation.",
+@@ -272,11 +272,11 @@ TIPS = [
+     "Cron jobs can attach a Python script (--script) whose stdout is injected into the prompt as context.",
+     "Cron scripts live in ~/.hermes/scripts/ and run before the agent — perfect for data collection pipelines.",
+     "prefill_messages_file in config.yaml injects few-shot examples into every API call, never saved to history.",
+-    "SOUL.md completely replaces the agent's default identity — rewrite it to make Hermes your own.",
++    "SOUL.md completely replaces the agent's default identity — rewrite it to make Black Pool your own.",
+     "SOUL.md is auto-seeded with a default personality on first run. Edit it to customize.",
+     "/compress <focus topic> allocates 60-70% of the summary budget to your topic and aggressively trims the rest.",
+     "On second+ compression, the compressor updates the previous summary instead of starting from scratch.",
+-    "Before a gateway session reset, Hermes auto-flushes important facts to memory in the background.",
++    "Before a gateway session reset, Black Pool auto-flushes important facts to memory in the background.",
+     "network.force_ipv4: true in config.yaml fixes hangs on servers with broken IPv6 — monkey-patches socket.",
+     "The terminal tool annotates common exit codes: grep returning 1 = 'No matches found (not an error)'.",
+     "Failed foreground terminal commands auto-retry up to 3 times with exponential backoff (2s, 4s, 8s).",
+@@ -298,7 +298,7 @@ TIPS = [
+     "Any website can expose skills via /.well-known/skills/index.json — the skills hub discovers them automatically.",
+     "The skills audit log at ~/.hermes/skills/.hub/audit.log tracks every install and removal operation.",
+     "Stale git worktrees are auto-cleaned on startup: clean, fully-merged trees get pruned; dirty or unpushed work is always preserved.",
+-    "Profiles scope Hermes state via HERMES_HOME; host tool subprocesses keep your real HOME unless terminal.home_mode is profile.",
++    "Profiles scope Black Pool state via HERMES_HOME; host tool subprocesses keep your real HOME unless terminal.home_mode is profile.",
+     "HERMES_HOME_MODE env var (octal, e.g. 0701) sets custom directory permissions for web server traversal.",
+     "Container mode: place .container-mode in HERMES_HOME and the host CLI auto-execs into the container.",
+     "Ctrl+C has 5 priority tiers: cancel recording → cancel prompts → cancel picker → interrupt agent → exit.",
+@@ -340,13 +340,13 @@ TIPS = [
+ 
+     # --- Advanced Slash Commands ---
+     '/steer <prompt> injects a note after the next tool call — nudge direction mid-task without interrupting.',
+-    '/goal <text> sets a standing Ralph-loop objective — Hermes auto-continues turn after turn until a judge says done.',
+-    '/snapshot create [label] saves a full state snapshot of Hermes config; /snapshot restore <id> reverts later.',
++    '/goal <text> sets a standing Ralph-loop objective — Black Pool auto-continues turn after turn until a judge says done.',
++    '/snapshot create [label] saves a full state snapshot of Black Pool config; /snapshot restore <id> reverts later.',
+     '/copy [N] copies the last assistant response to your clipboard, or the Nth-from-last with a number.',
+     '/redraw forces a full UI repaint, fixing terminal drift after tmux resize or mouse selection artifacts.',
+     '/agents (alias /tasks) shows active agents and running background tasks across the current session.',
+     '/footer toggles the gateway footer on final replies showing model, context %, and cwd.',
+-    '/busy queue|steer|interrupt controls what pressing Enter does while Hermes is working.',
++    '/busy queue|steer|interrupt controls what pressing Enter does while Black Pool is working.',
+     '/topic in Telegram DMs enables user-managed multi-session topic mode — /topic <id> restores past sessions inline.',
+     '/approve session|always runs a pending dangerous command with your chosen trust scope; /deny rejects it.',
+     '/restart gracefully restarts the gateway after draining active runs, then pings the requester when back up.',
+@@ -381,7 +381,7 @@ TIPS = [
+     'Ctrl+G or Ctrl+X Ctrl+E in the TUI opens the input buffer in $EDITOR for long multi-line prompts.',
+     'The TUI renders LaTeX inline — $E=mc^2$ becomes Unicode math instead of raw TeX.',
+     'hermes dashboard launches a local web UI at 127.0.0.1:9119 — zero data leaves localhost.',
+-    'hermes dashboard embeds the full Hermes TUI in your browser via xterm.js and a WebSocket PTY.',
++    'hermes dashboard embeds the full Black Pool TUI in your browser via xterm.js and a WebSocket PTY.',
+     'Drop a YAML in ~/.hermes/dashboard-themes/ with two palette colors to reskin the entire dashboard.',
+     'Dashboard plugins are drop-in: manifest.json + JS bundle in ~/.hermes/dashboard-plugins/ — no npm build required.',
+     'layoutVariant: cockpit in a dashboard theme adds a 260px left rail that plugins can populate via the sidebar slot.',
+@@ -433,7 +433,7 @@ TIPS = [
+     "hermes chat --source tool tags programmatic chats so they don't clutter hermes sessions list.",
+     'hermes dump --show-keys includes redacted API key fingerprints for deeper support debugging.',
+     'hermes sessions rename <ID> "new title" renames any past session; hermes sessions delete <ID> removes one.',
+-    'hermes import restores a full Hermes backup zip; session JSON/JSONL exports import from the dashboard Sessions page.',
++    'hermes import restores a full Black Pool backup zip; session JSON/JSONL exports import from the dashboard Sessions page.',
+     'hermes fallback manages the fallback_model chain interactively — no hand-editing config.yaml.',
+     'hermes pairing rotates the DM pairing token — the first messager after rotation claims access to the bot.',
+     'hermes setup walks first-time users through provider, keys, and platform wiring in one interactive flow.',
+@@ -462,7 +462,7 @@ TIPS = [
+     'AUXILIARY_VISION_BASE_URL + AUXILIARY_VISION_API_KEY point vision analysis at any OpenAI-compatible endpoint.',
+ 
+     # --- Security ---
+-    'security.tirith_fail_open: false makes Hermes block commands when the tirith scanner itself errors out.',
++    'security.tirith_fail_open: false makes Black Pool block commands when the tirith scanner itself errors out.',
+     'TIRITH_FAIL_OPEN env var overrides the tirith_fail_open config — a quick toggle without editing config.yaml.',
+ 
+     # --- Sessions & Source Tags ---
+@@ -489,7 +489,7 @@ def get_random_tip(exclude_recent: int = 0) -> str:
+ # Composer placeholders — short, task-oriented example prompts shown in the
+ # empty input box to nudge new users toward high-value first actions (C-09,
+ # inspired by opencode/codex rotating placeholders). Kept generic so they fit
+-# any project or none — Hermes is not a coding-only agent.
++# any project or none — Black Pool is not a coding-only agent.
+ # ---------------------------------------------------------------------------
+ 
+ COMPOSER_PLACEHOLDERS = [
 diff --git a/hermes_cli/tools_config.py b/hermes_cli/tools_config.py
-index a28fc09..60bcd66 100644
+index a28fc09..4936211 100644
 --- a/hermes_cli/tools_config.py
 +++ b/hermes_cli/tools_config.py
 @@ -1,5 +1,5 @@
@@ -48595,6 +57062,90 @@ index a28fc09..60bcd66 100644
  
  `hermes tools` and `hermes setup tools` both enter this module.
  Select a platform → toggle toolsets on/off → for newly enabled tools
+@@ -574,7 +574,7 @@ TOOL_CATEGORIES = {
+         "name": "X (Twitter) Search",
+         "setup_title": "Select xAI Credential Source",
+         "setup_note": (
+-            "Hermes routes X searches through xAI's built-in x_search "
++            "Black Pool routes X searches through xAI's built-in x_search "
+             "Responses tool for read-only public X discovery. Use the xurl "
+             "skill for authenticated X API reads and account actions. Both "
+             "credential sources hit the same "
+@@ -795,7 +795,7 @@ def _resolved_cua_driver_cmd() -> Optional[str]:
+ 
+ 
+ def _cua_driver_env() -> dict:
+-    """cua-driver child env with the Hermes telemetry policy applied.
++    """cua-driver child env with the Black Pool telemetry policy applied.
+ 
+     Delegates to ``cua_backend.cua_driver_child_env`` (telemetry disabled by
+     default; user opt-in via ``computer_use.cua_telemetry``). Falls back to the
+@@ -814,7 +814,7 @@ _CUA_DRIVER_CONTRACT_CACHE: dict = {}
+ 
+ 
+ def _cua_driver_contract_status(binary: Optional[str] = None) -> dict:
+-    """Inspect whether an installed driver supports Hermes' runtime contract."""
++    """Inspect whether an installed driver supports Black Pool' runtime contract."""
+     import time
+ 
+     from tools.computer_use.cua_backend import cua_driver_runtime_contract_status
+@@ -879,7 +879,7 @@ def _pip_install(
+     uv_env = {**os.environ, "VIRTUAL_ENV": str(venv_root)}
+ 
+     # Managed uv first: $HERMES_HOME/bin is never on PATH, so a bare which()
+-    # misses the uv Hermes installed and prefers a system one when both exist.
++    # misses the uv Black Pool installed and prefers a system one when both exist.
+     # ensure_uv() rather than a pure lookup because this runs during setup,
+     # where installing uv is in scope — and tier 2 is a pip that the Windows
+     # installer's `uv venv` does not seed, so failing to find uv here is the
+@@ -1072,9 +1072,9 @@ def install_cua_driver(
+         # baked in by CD and errors cleanly on missing-arch assets.
+         return _run_cua_driver_installer(label="Installing")
+ 
+-    # An installed driver that fails Hermes' runtime contract (version floor,
++    # An installed driver that fails Black Pool' runtime contract (version floor,
+     # missing manifest verbs) is repaired regardless of the caller's mode.
+-    # Hermes' own minimum requirement IS the confirmation that an upgrade is
++    # Black Pool' own minimum requirement IS the confirmation that an upgrade is
+     # needed, so the ``upgrade=True`` path must not defer to the driver's
+     # ``check-update`` verb here — a cached/indeterminate "no update" answer
+     # would otherwise pin users on an unusable driver forever (observed:
+@@ -1115,7 +1115,7 @@ def install_cua_driver(
+         version = contract.get("version") or "unknown version"
+         reason = contract.get("reason") or "required runtime features are missing"
+         _print_warning(
+-            f"    Found cua-driver {version}, but Hermes cannot use its current "
++            f"    Found cua-driver {version}, but Black Pool cannot use its current "
+             f"runtime contract: {reason}."
+         )
+         if os.environ.get("HERMES_CUA_DRIVER_CMD", "").strip():
+@@ -1731,7 +1731,7 @@ def _run_cua_driver_installer(
+                     _print_info("    IMPORTANT — grant macOS permissions now:")
+                     _print_info("      System Settings > Privacy & Security > Accessibility")
+                     _print_info("      System Settings > Privacy & Security > Screen Recording")
+-                    _print_info("    Both must allow the terminal / Hermes process.")
++                    _print_info("    Both must allow the terminal / Black Pool process.")
+             return True
+         _print_warning(f"    cua-driver {label.lower()} did not complete. Re-run manually:")
+         _print_info(f"      {manual_hint}")
+@@ -1775,7 +1775,7 @@ def _ensure_browser_use_cli(*, verbose_hints: bool = False) -> None:
+     MANAGED-FIRST: a browser-use on the user's PATH does NOT satisfy this
+     check — only the Hermes-managed ``$HERMES_HOME/bin`` copy does.
+     ``install_cli()`` short-circuits on the managed copy and otherwise
+-    provisions it, so resolution always lands on a binary Hermes installs
++    provisions it, so resolution always lands on a binary Black Pool installs
+     and updates rather than a user-level side install.
+     """
+     _print_info("    Ensuring browser-use CLI (managed install)...")
+@@ -2097,7 +2097,7 @@ def _run_post_setup(post_setup_key: str):
+         except Exception as exc:
+             _print_warning(f"    Could not enable plugin automatically: {exc}")
+             _print_info("    Run manually: hermes plugins enable observability/langfuse")
+-        _print_info("    Restart Hermes for tracing to take effect.")
++        _print_info("    Restart Black Pool for tracing to take effect.")
+         _print_info("    Verify: hermes plugins list")
+ 
+     elif post_setup_key == "xai_grok":
 @@ -5381,7 +5381,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                  print(color("    (none enabled)", Colors.DIM))
          print()
@@ -48604,8 +57155,21 @@ index a28fc09..60bcd66 100644
      print(color("  Enable or disable tools per platform.", Colors.DIM))
      print(color("  Tools that need API keys will be configured when enabled.", Colors.DIM))
      print(color("  Guide: https://hermes-agent.nousresearch.com/docs/user-guide/features/tools", Colors.DIM))
+diff --git a/hermes_cli/toolset_validation.py b/hermes_cli/toolset_validation.py
+index 4b72ec6..553202a 100644
+--- a/hermes_cli/toolset_validation.py
++++ b/hermes_cli/toolset_validation.py
+@@ -1,7 +1,7 @@
+ """Validation for the ``platform_toolsets`` config section.
+ 
+ Pure, side-effect-free helpers so the logic is unit-testable without importing
+-the tool registry or launching Hermes (mirrors the decoupled-helper pattern used
++the tool registry or launching Black Pool (mirrors the decoupled-helper pattern used
+ elsewhere in the CLI).
+ 
+ Motivated by #38798: a config migration silently rewrote the valid toolset name
 diff --git a/hermes_cli/uninstall.py b/hermes_cli/uninstall.py
-index efc546d..b3d6018 100644
+index efc546d..ac5c140 100644
 --- a/hermes_cli/uninstall.py
 +++ b/hermes_cli/uninstall.py
 @@ -1,5 +1,5 @@
@@ -48615,6 +57179,15 @@ index efc546d..b3d6018 100644
  
  Provides options for:
  - Full uninstall: Remove everything including configs and data
+@@ -51,7 +51,7 @@ def find_shell_configs() -> list:
+ 
+ 
+ def remove_path_from_shell_configs():
+-    """Remove Hermes PATH entries from shell configuration files."""
++    """Remove Black Pool PATH entries from shell configuration files."""
+     configs = find_shell_configs()
+     removed_from = []
+     
 @@ -65,8 +65,8 @@ def remove_path_from_shell_configs():
              skip_next = False
              
@@ -48626,13 +57199,51 @@ index efc546d..b3d6018 100644
                      skip_next = True
                      continue
                  if skip_next and ('hermes' in line.lower() and 'PATH' in line):
-@@ -529,7 +529,7 @@ def run_gui_uninstall(args):
+@@ -161,7 +161,7 @@ def remove_node_symlinks(hermes_home: Path) -> list:
+     We check all candidate directories so that uninstall works regardless of
+     how the install was done (e.g. a root FHS install that placed links in
+     ``/usr/local/bin``, or an older install that used ``~/.local/bin`` before
+-    the FHS fix).  Only symlinks that resolve into this Hermes home's ``node``
++    the FHS fix).  Only symlinks that resolve into this Black Pool home's ``node``
+     directory are removed — links the user has repointed elsewhere (nvm, fnm,
+     etc.) are left untouched.
+     """
+@@ -529,16 +529,16 @@ def run_gui_uninstall(args):
  
      print()
      print(color("┌─────────────────────────────────────────────────────────┐", Colors.MAGENTA, Colors.BOLD))
 -    print(color("│         ⚕ Hermes Chat GUI Uninstaller                  │", Colors.MAGENTA, Colors.BOLD))
 +    print(color("│         ⚕ Black Pool Chat GUI Uninstaller                  │", Colors.MAGENTA, Colors.BOLD))
      print(color("└─────────────────────────────────────────────────────────┘", Colors.MAGENTA, Colors.BOLD))
+     print()
+ 
+     if not summary["gui_installed"]:
+-        print("No Hermes Chat GUI installation was found.")
++        print("No Black Pool Chat GUI installation was found.")
+         print(f"  Checked: {hermes_home}, and the standard app locations for this OS.")
+         return
+ 
+-    print(color("This removes the Chat GUI only. The Hermes agent stays installed.", Colors.CYAN))
++    print(color("This removes the Chat GUI only. The Black Pool agent stays installed.", Colors.CYAN))
+     print()
+     print(color("Will remove:", Colors.YELLOW, Colors.BOLD))
+     for p in summary["source_built_artifacts"]:
+@@ -550,7 +550,7 @@ def run_gui_uninstall(args):
+     print()
+     if agent_is_installed(hermes_home):
+         print(color("Kept intact:", Colors.GREEN, Colors.BOLD))
+-        print(f"  • The Hermes agent at {hermes_home / 'hermes-agent'}")
++        print(f"  • The Black Pool agent at {hermes_home / 'hermes-agent'}")
+         print(f"  • Your config, sessions, and secrets under {hermes_home}")
+         print()
+ 
+@@ -576,7 +576,7 @@ def run_gui_uninstall(args):
+     print(color("│            ✓ Chat GUI Uninstalled!                      │", Colors.GREEN, Colors.BOLD))
+     print(color("└─────────────────────────────────────────────────────────┘", Colors.GREEN, Colors.BOLD))
+     print()
+-    print("The Hermes agent is still installed. Run 'hermes' to use the CLI,")
++    print("The Black Pool agent is still installed. Run 'hermes' to use the CLI,")
+     print("or 'hermes uninstall' to remove the agent too.")
      print()
  
 @@ -626,7 +626,7 @@ def run_uninstall(args):
@@ -48644,6 +57255,58 @@ index efc546d..b3d6018 100644
      print(color("└─────────────────────────────────────────────────────────┘", Colors.MAGENTA, Colors.BOLD))
      print()
      
+@@ -696,7 +696,7 @@ def run_uninstall(args):
+     # Final confirmation
+     print()
+     if full_uninstall:
+-        print(color("⚠️  WARNING: This will permanently delete ALL Hermes data!", Colors.RED, Colors.BOLD))
++        print(color("⚠️  WARNING: This will permanently delete ALL Black Pool data!", Colors.RED, Colors.BOLD))
+         print(color("   Including: configs, API keys, sessions, scheduled jobs, logs", Colors.RED))
+         if remove_profiles:
+             print(color(
+@@ -705,7 +705,7 @@ def run_uninstall(args):
+                 Colors.RED
+             ))
+     else:
+-        print("This will remove the Hermes code but keep your configuration and data.")
++        print("This will remove the Black Pool code but keep your configuration and data.")
+     
+     print()
+     try:
+@@ -736,12 +736,12 @@ def _print_uninstall_dry_run(*, project_root: Path, hermes_home: Path, full_unin
+     print()
+     print(color("Would inspect/remove:", Colors.YELLOW, Colors.BOLD))
+     print("  • Gateway services and standalone gateway processes")
+-    print("  • Hermes PATH entries from shell configs / Windows User PATH")
+-    print("  • Hermes wrapper scripts and Hermes-managed node/npm/npx symlinks")
++    print("  • Black Pool PATH entries from shell configs / Windows User PATH")
++    print("  • Black Pool wrapper scripts and Hermes-managed node/npm/npx symlinks")
+     print("  • Desktop Chat GUI artifacts")
+     print(f"  • Code checkout: {project_root}")
+     if full_uninstall:
+-        print(f"  • Hermes config/data: {hermes_home}")
++        print(f"  • Black Pool config/data: {hermes_home}")
+         if _is_default_hermes_home(hermes_home):
+             profiles = _discover_named_profiles()
+             if profiles:
+@@ -749,7 +749,7 @@ def _print_uninstall_dry_run(*, project_root: Path, hermes_home: Path, full_unin
+                 for prof in profiles:
+                     print(f"    - {prof.name}: {prof.path}")
+     else:
+-        print(f"  • Keep Hermes config/data: {hermes_home}")
++        print(f"  • Keep Black Pool config/data: {hermes_home}")
+     print()
+ 
+ 
+@@ -819,7 +819,7 @@ def _perform_uninstall(
+         log_info("No wrapper script found")
+ 
+     # 3b. Remove node/npm/npx symlinks the installer left in ~/.local/bin
+-    #     (only when they still point into this Hermes home's node dir, so we
++    #     (only when they still point into this Black Pool home's node dir, so we
+     #     never clobber an existing nvm / user-managed Node).
+     log_info("Removing Hermes-managed node/npm/npx symlinks...")
+     removed_node_links = remove_node_symlinks(hermes_home)
 @@ -928,7 +928,7 @@ def _perform_uninstall(
          print(color("Reload your shell to complete the process:", Colors.YELLOW))
          print("  source ~/.bashrc  # or ~/.zshrc")
@@ -48654,9 +57317,64 @@ index efc546d..b3d6018 100644
  
  
 diff --git a/hermes_cli/update_cmd.py b/hermes_cli/update_cmd.py
-index f41a37f..212e8e6 100644
+index f41a37f..cd765b5 100644
 --- a/hermes_cli/update_cmd.py
 +++ b/hermes_cli/update_cmd.py
+@@ -1,4 +1,4 @@
+-"""Hermes update pipeline — extracted from ``hermes_cli/main.py``.
++"""Black Pool update pipeline — extracted from ``hermes_cli/main.py``.
+ 
+ Mechanical move (main.py decomposition): ``_cmd_update_impl``, ``_cmd_update_check``
+ and every module-level helper used only by the update path, plus the update-only
+@@ -88,7 +88,7 @@ _STALE_PURGE_PROTECTED = frozenset(
+ 
+ 
+ def _purge_stale_hermes_modules() -> None:
+-    """Evict every cached Hermes module after the checkout changed in-place.
++    """Evict every cached Black Pool module after the checkout changed in-place.
+ 
+     ``hermes update`` keeps running in the pre-pull Python process. The
+     gateway auto-restart phase that follows does function-level
+@@ -102,7 +102,7 @@ def _purge_stale_hermes_modules() -> None:
+ 
+     ``_UPDATE_RUNTIME_RELOAD_MODULES`` handled this per-symptom — three
+     hardcoded module names, re-fixed every time a new module grew a new
+-    export. This is the class fix: drop EVERY cached module under the Hermes
++    export. This is the class fix: drop EVERY cached module under the Black Pool
+     package prefixes so subsequent lazy imports rebuild a self-consistent,
+     all-new module graph from the updated checkout. Old module objects
+     referenced by the running updater frames stay alive and functional (a
+@@ -131,10 +131,10 @@ def _purge_stale_hermes_modules() -> None:
+                 purged.append(name)
+         if purged:
+             logger.debug(
+-                "Purged %d stale Hermes module(s) after checkout update", len(purged)
++                "Purged %d stale Black Pool module(s) after checkout update", len(purged)
+             )
+     except Exception as exc:
+-        logger.debug("Could not purge stale Hermes modules: %s", exc)
++        logger.debug("Could not purge stale Black Pool modules: %s", exc)
+ 
+ 
+ def _reload_updated_runtime_modules() -> None:
+@@ -226,7 +226,7 @@ def _run_migrate_config_fresh(*, interactive: bool = False, quiet: bool = False)
+     return migrate_config(interactive=interactive, quiet=quiet)
+ 
+ 
+-# Critical files that Hermes must be able to import immediately after an
++# Critical files that Black Pool must be able to import immediately after an
+ # update/install. Most are imported on every CLI startup; ``web_server.py``
+ # is the desktop/dashboard backend path that a fresh Windows install launches
+ # right away. If any of these fail to parse after a pull, the user can be
+@@ -279,7 +279,7 @@ def _editable_install_is_current(git_cmd, cwd, pre_pull_sha: str | None) -> bool
+     cannot change anything removes that risk outright for the common update,
+     rather than trying to make the rename win more often.
+ 
+-    Skipping is safe because Hermes pins its editable finder to a *static*
++    Skipping is safe because Black Pool pins its editable finder to a *static*
+     module list (``[tool.setuptools] py-modules`` plus
+     ``packages.find.include``). The one source-only change that would stale
+     that finder is a new top-level module or package, and it cannot land
 @@ -1197,7 +1197,7 @@ def _write_gateway_update_exit_code(ok: bool) -> None:
  
  
@@ -48666,15 +57384,98 @@ index f41a37f..212e8e6 100644
  
      Used on Windows when git file I/O is broken (antivirus, NTFS filter
      drivers causing 'Invalid argument' errors on file creation).
-@@ -2740,7 +2740,7 @@ def _update_node_dependencies() -> list[str]:
+@@ -1771,7 +1771,7 @@ def _restore_stashed_changes(
+         print(
+             "  Restoring them may reapply local customizations onto the updated codebase."
+         )
+-        print("  Review the result afterward if Hermes behaves unexpectedly.")
++        print("  Review the result afterward if Black Pool behaves unexpectedly.")
+         print("Restore local changes now? [Y/n]")
+         if input_fn is not None:
+             response = input_fn("Restore local changes now? [Y/n]", "y")
+@@ -1855,7 +1855,7 @@ def _restore_stashed_changes(
+     stash_selector = _resolve_stash_selector(git_cmd, cwd, stash_ref)
+     if stash_selector is None:
+         print(
+-            "⚠ Local changes were restored, but Hermes couldn't find the stash entry to drop."
++            "⚠ Local changes were restored, but Black Pool couldn't find the stash entry to drop."
+         )
+         print(
+             "  The stash was left in place. You can remove it manually after checking the result."
+@@ -1870,7 +1870,7 @@ def _restore_stashed_changes(
+         )
+         if drop.returncode != 0:
+             print(
+-                "⚠ Local changes were restored, but Hermes couldn't drop the saved stash entry."
++                "⚠ Local changes were restored, but Black Pool couldn't drop the saved stash entry."
+             )
+             if drop.stdout.strip():
+                 print(drop.stdout.strip())
+@@ -1882,7 +1882,7 @@ def _restore_stashed_changes(
+             _print_stash_cleanup_guidance(stash_ref, stash_selector)
+ 
+     print("⚠ Local changes were restored on top of the updated codebase.")
+-    print("  Review `git diff` / `git status` if Hermes behaves unexpectedly.")
++    print("  Review `git diff` / `git status` if Black Pool behaves unexpectedly.")
+     return True
+ 
+ def _discard_stashed_changes(
+@@ -1908,7 +1908,7 @@ def _discard_stashed_changes(
+     if stash_selector is None:
+         print(
+             "⚠ Configured to discard local changes on non-interactive update, "
+-            "but Hermes couldn't find the stash entry to drop."
++            "but Black Pool couldn't find the stash entry to drop."
+         )
+         _print_stash_cleanup_guidance(stash_ref)
+         return False
+@@ -1921,7 +1921,7 @@ def _discard_stashed_changes(
+     )
+     if drop.returncode != 0:
+         print(
+-            "⚠ Configured to discard local changes, but Hermes couldn't drop "
++            "⚠ Configured to discard local changes, but Black Pool couldn't drop "
+             "the saved stash entry."
+         )
+         if drop.stderr.strip():
+@@ -2064,7 +2064,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
+ 
+         # Ask user if they want to add upstream
+         print()
+-        print("ℹ Your fork is not tracking the official Hermes repository.")
++        print("ℹ Your fork is not tracking the official Black Pool repository.")
+         print("  This means you may miss updates from NousResearch/hermes-agent.")
+         print()
+         try:
+@@ -2220,7 +2220,7 @@ def _format_concurrent_instances_message(
+     lines.append(f"  Updating now would fail to overwrite {shim} because")
+     lines.append("  Windows blocks REPLACE on a running executable.")
+     lines.append("")
+-    lines.append("  Close Hermes Desktop, exit any open `hermes` REPLs, and")
++    lines.append("  Close Black Pool Desktop, exit any open `hermes` REPLs, and")
+     lines.append("  stop the gateway (`hermes gateway stop`) before retrying.")
+     lines.append("")
+     if matches:
+@@ -2470,7 +2470,7 @@ def _refresh_active_memory_provider_dependencies() -> None:
+ 
+     Memory-provider bridge packages are declared in each provider's
+     ``plugin.yaml`` (plus mode-dependent extras like Hindsight's
+-    ``hindsight-all``), NOT in Hermes' editable-install extras or
++    ``hindsight-all``), NOT in Black Pool' editable-install extras or
+     ``LAZY_DEPS`` alone — so the core dependency reinstall above can strip
+     or downgrade them (#53272 mem0ai, #70636 hindsight-embed). Re-run the
+     provider's declared install for the ACTIVE provider only, after the
+@@ -2740,8 +2740,8 @@ def _update_node_dependencies() -> list[str]:
      from hermes_constants import get_default_hermes_root
  
      # This cache describes PROJECT_ROOT/node_modules, which is shared by every
 -    # Hermes profile using this checkout. Keep one per-checkout cache under the
+-    # shared Hermes root rather than rerunning npm once per named profile.
 +    # Black Pool profile using this checkout. Keep one per-checkout cache under the
-     # shared Hermes root rather than rerunning npm once per named profile.
++    # shared Black Pool root rather than rerunning npm once per named profile.
      shared_hermes_root = get_default_hermes_root()
  
+     # Best-effort: warm npx's cache for agent-browser (#43564). Runs before
 @@ -3148,7 +3148,7 @@ def _ensure_fhs_path_guard() -> None:
  
      path_line = 'export PATH="/usr/local/bin:$PATH"'
@@ -48684,6 +57485,15 @@ index f41a37f..212e8e6 100644
      )
      wrote_any = False
      for candidate in (".bashrc", ".bash_profile"):
+@@ -3188,7 +3188,7 @@ def _ensure_acp_launcher() -> None:
+     (Zed, JetBrains, Buzz Desktop) spawn the agent by resolving the
+     ``hermes-acp`` command name against the login-shell PATH; the console
+     script of that name lives inside the install's venv, which is not on that
+-    PATH, so those hosts report Hermes as not installed even when it is.
++    PATH, so those hosts report Black Pool as not installed even when it is.
+ 
+     The shim simply delegates to the sibling ``hermes`` launcher with the
+     ``acp`` subcommand, which makes it correct for every install layout
 @@ -3218,7 +3218,7 @@ def _ensure_acp_launcher() -> None:
                  continue
              shim = (
@@ -48693,6 +57503,73 @@ index f41a37f..212e8e6 100644
                  "# ACP hosts (Zed, JetBrains, Buzz) resolve the agent by this\n"
                  "# command name on the login-shell PATH.\n"
                  f'exec "{hermes_cmd}" acp "$@"\n'
+@@ -3844,13 +3844,13 @@ def _defer_update_for_self_lock(loaded: list[str]) -> None:
+ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
+     """Explain which venv processes block the update and how to clear them."""
+     lines = [
+-        "✗ Other Hermes processes are running from this install's venv:",
++        "✗ Other Black Pool processes are running from this install's venv:",
+     ]
+     for pid, name, cmdline in matches[:6]:
+         hint = ""
+         low = cmdline.lower()
+         if "serve" in low or "dashboard" in low:
+-            hint = "  ← Hermes Desktop backend (close the desktop app)"
++            hint = "  ← Black Pool Desktop backend (close the desktop app)"
+         elif "gateway" in low:
+             hint = "  ← gateway"
+         lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
+@@ -3864,7 +3864,7 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) ->
+         "  dependency update would fail partway and leave a broken install."
+     )
+     lines.append(
+-        "  Close the Hermes desktop app / other Hermes terminals, then re-run:"
++        "  Close the Black Pool desktop app / other Black Pool terminals, then re-run:"
+     )
+     lines.append("    hermes update")
+     lines.append("  (or use `hermes update --force-venv` to proceed anyway at your own risk)")
+@@ -3997,12 +3997,12 @@ def _orphaned_desktop_backend_pids(
+     ``serve`` backend still holding the venv at that point is a straggler
+     whose supervisor is gone: SIGTERM raced its spawn, or it belongs to a
+     crashed window. Nothing will respawn it, and refusing on it dead-ends
+-    the update with "Hermes is still running" while the user stares at zero
++    the update with "Black Pool is still running" while the user stares at zero
+     open windows (ryanc's 2026-08-09 01:59/02:17 failures).
+ 
+     A holder qualifies only when BOTH hold:
+ 
+-    - its cmdline is a Hermes backend (``hermes_cli.main`` + ``serve`` /
++    - its cmdline is a Black Pool backend (``hermes_cli.main`` + ``serve`` /
+       ``dashboard``), and
+     - its supervising parent is demonstrably gone: the parent PID no longer
+       exists, or the PID was reused (parent created *after* the child).
+@@ -4135,7 +4135,7 @@ def _ledger_reapable_backend_pids(
+ def _handoff_reapable_backend_pids(
+     matches: list[tuple[int, str, str]],
+ ) -> list[int] | None:
+-    """PIDs of Hermes ``serve``/``dashboard`` backends safe to reap during a
++    """PIDs of Black Pool ``serve``/``dashboard`` backends safe to reap during a
+     GUI-updater hand-off, INCLUDING ones with a still-live parent.
+ 
+     Complements ``_orphaned_desktop_backend_pids``, which only reaps backends
+@@ -4161,7 +4161,7 @@ def _handoff_reapable_backend_pids(
+ 
+     Guarded conservatively:
+ 
+-    - Only Hermes backends (``hermes_cli.main`` + ``serve``/``dashboard``)
++    - Only Black Pool backends (``hermes_cli.main`` + ``serve``/``dashboard``)
+       from THIS install's venv qualify; a non-backend holder (operator REPL,
+       stray script) disqualifies the whole set → ``None`` (keep refusing), so
+       we never widen the blast radius during a hand-off.
+@@ -4310,7 +4310,7 @@ def _pause_windows_gateways_for_update() -> dict | None:
+     # update even though the gateway itself is stopped.
+     launcher_pids = _m()._venv_launcher_ancestors(mapped_pids)
+ 
+-    print("→ Stopping Windows gateway process(es) before updating Hermes...")
++    print("→ Stopping Windows gateway process(es) before updating Black Pool...")
+     try:
+         drain_timeout = max(float(_get_restart_drain_timeout()), 1.0)
+     except Exception:
 @@ -5120,7 +5120,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
              logger.debug("Could not read updates.non_interactive_local_changes: %s", exc)
              discard_local_changes = False
@@ -48702,8 +57579,272 @@ index f41a37f..212e8e6 100644
      print()
  
      # Phase 1 (#91277): structured update receipt — record what this run
+@@ -5134,7 +5134,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+         logger.debug("Update receipt unavailable: %s", _receipt_exc)
+ 
+     # Plan phase (#91277 Phase 2): snapshot the pre-update fleet — every
+-    # running Hermes runtime, its supervisor, and its running code version —
++    # running Black Pool runtime, its supervisor, and its running code version —
+     # into the receipt, so a post-mortem can compare what the update SAW
+     # against what it did. Read-only; a probe failure records nothing.
+     try:
+@@ -5229,7 +5229,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+                 _venv_holders = _m()._detect_venv_python_processes()
+         if _venv_holders:
+             # Positive-identity rung (runs FIRST, any update context): holders
+-            # the spawn ledger proves are orphaned Hermes backends — the
++            # the spawn ledger proves are orphaned Black Pool backends — the
+             # process self-registered (pid, create_time, purpose, spawner) at
+             # startup and its recorded spawner is provably dead. No PPID
+             # archaeology, no hand-off contract required.
+@@ -5237,7 +5237,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+             if _ledger_backends:
+                 print(
+                     f"  ⚠ {len(_ledger_backends)} ledger-identified orphaned "
+-                    "Hermes backend process(es) hold the venv; stopping their trees"
++                    "Black Pool backend process(es) hold the venv; stopping their trees"
+                 )
+                 _m()._stop_process_trees(_ledger_backends)
+                 _time.sleep(1.0)
+@@ -5250,7 +5250,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+                 # Electron's teardown lost the SIGTERM race, exited, and left
+                 # its backend (and any .hermes-runtime child) holding the
+                 # venv. Nothing will respawn an orphan, so reap the tree and
+-                # re-check instead of dead-ending with "Hermes is still
++                # re-check instead of dead-ending with "Black Pool is still
+                 # running" while no window is open. Backends whose Desktop
+                 # is still alive never reach here (_orphaned_desktop_
+                 # backend_pids returns None for them) — that path keeps the
+@@ -5271,7 +5271,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+             # live parent — which stranded a whole swarm of per-profile
+             # backends (the tearing-down Electron parent / the venv
+             # launcher→worker chain still mid-exit) and hung the update. In
+-            # the hand-off context those surviving Hermes backends are leaks,
++            # the hand-off context those surviving Black Pool backends are leaks,
+             # live parent or not — reap them by cmdline instead of dead-ending.
+             _handoff = False
+             try:
+@@ -5292,7 +5292,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+                 _handoff_backends = _m()._handoff_reapable_backend_pids(_venv_holders)
+                 if _handoff_backends:
+                     print(
+-                        f"  ⚠ {len(_handoff_backends)} Hermes backend process(es) "
++                        f"  ⚠ {len(_handoff_backends)} Black Pool backend process(es) "
+                         "still hold the venv after the Desktop hand-off; "
+                         "stopping their trees"
+                     )
+@@ -5690,7 +5690,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+                     _print_update_completion("✓ Update complete!")
+                 else:
+                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
+-                    print("  Close all Hermes windows/gateways and re-run: hermes update")
++                    print("  Close all Black Pool windows/gateways and re-run: hermes update")
+             else:
+                 _repair_node_deps_on_current_checkout(_print_update_completion)
+             if runtime_repaired is not None and not _m()._is_windows():
+@@ -5699,7 +5699,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+                     "⚠ Restart required to finish the managed Python runtime repair."
+                 )
+                 print(
+-                    "  Any running Hermes gateways, Desktop backends, or other "
++                    "  Any running Black Pool gateways, Desktop backends, or other "
+                     "long-lived processes still use the previous runtime."
+                 )
+                 print("  Restart each of them to pick up the repaired runtime.")
+@@ -6479,7 +6479,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+             logger.debug("FHS PATH guard check failed: %s", e)
+ 
+         # Self-heal the hermes-acp launcher for installs that predate it, so
+-        # ACP hosts (Zed, JetBrains, Buzz) can resolve Hermes on PATH without
++        # ACP hosts (Zed, JetBrains, Buzz) can resolve Black Pool on PATH without
+         # a reinstall.  No-op on Windows and when already present.
+         try:
+             _ensure_acp_launcher()
+@@ -6574,7 +6574,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+         # The code update (git pull) is shared across all profiles, so every
+         # running gateway needs restarting to pick up the new code.
+         #
+-        # Purge stale cached Hermes modules FIRST: the import below pulls
++        # Purge stale cached Black Pool modules FIRST: the import below pulls
+         # freshly-updated gateway source into this pre-update interpreter,
+         # and any already-cached sibling module (cli_output, status, ...)
+         # that the new source expects a new symbol from would otherwise
+@@ -7340,7 +7340,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+ 
+         _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+ 
+-        # Warn if legacy Hermes gateway unit files are still installed.
++        # Warn if legacy Black Pool gateway unit files are still installed.
+         # When both hermes.service (from a pre-rename install) and the
+         # current hermes-gateway.service are enabled, they SIGTERM-fight
+         # for the same bot token (see PR #11909). Flagging here means
+@@ -7354,7 +7354,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
+ 
+             if supports_systemd_services() and has_legacy_hermes_units():
+                 print()
+-                print("⚠ Legacy Hermes gateway unit(s) detected:")
++                print("⚠ Legacy Black Pool gateway unit(s) detected:")
+                 for name, path, is_sys in _find_legacy_hermes_units():
+                     scope = "system" if is_sys else "user"
+                     print(f"    {path}  ({scope} scope)")
+diff --git a/hermes_cli/update_inventory.py b/hermes_cli/update_inventory.py
+index 51e2faf..e1f0dfa 100644
+--- a/hermes_cli/update_inventory.py
++++ b/hermes_cli/update_inventory.py
+@@ -1,6 +1,6 @@
+ """Runtime inventory + update plan for the fleet-update pipeline (#91277 Phase 2).
+ 
+-One read-only pass that answers, BEFORE any mutation: what Hermes runtimes
++One read-only pass that answers, BEFORE any mutation: what Black Pool runtimes
+ are running on this machine, how is each one deployed, which of them will
+ this update touch, and how will each be restarted?
+ 
+@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
+ 
+ @dataclass
+ class RuntimeRecord:
+-    """One running (or expected) Hermes runtime on this machine."""
++    """One running (or expected) Black Pool runtime on this machine."""
+ 
+     kind: str                     # gateway | dashboard | serve
+     profile: str                  # profile name ("default", ...)
+@@ -251,7 +251,7 @@ def print_update_plan(plan: UpdatePlan) -> None:
+     profiles = ", ".join(plan.profiles) if plan.profiles else "(none found)"
+     print(f"  Profiles: {profiles}")
+     if not plan.runtimes:
+-        print("  Running Hermes services: none detected — code swap only.")
++        print("  Running Black Pool services: none detected — code swap only.")
+         return
+     print(f"  Running services to restart ({len(plan.runtimes)}):")
+     for runtime in plan.runtimes:
+diff --git a/hermes_cli/update_lock.py b/hermes_cli/update_lock.py
+index 964638d..7972715 100644
+--- a/hermes_cli/update_lock.py
++++ b/hermes_cli/update_lock.py
+@@ -1,4 +1,4 @@
+-"""Cross-process mutual exclusion for in-flight Hermes updates.
++"""Cross-process mutual exclusion for in-flight Black Pool updates.
+ 
+ Three different surfaces can start an update of the same install tree:
+ 
+@@ -31,7 +31,7 @@ marker is removed on read by whoever notices it first.
+ One layering wrinkle: the Tauri updater holds this marker for its WHOLE run and
+ then spawns ``hermes update`` as a child stage. Without a handoff the child
+ sees its own parent's live marker and refuses — the GUI update deadlocks
+-against itself on every attempt ("Hermes is still running", retry forever).
++against itself on every attempt ("Black Pool is still running", retry forever).
+ Two mechanisms recognize the orchestrating parent, and either suffices:
+ 
+ * The updater exports :data:`HANDOFF_PID_ENV` naming its own pid, and
+@@ -44,8 +44,8 @@ Two mechanisms recognize the orchestrating parent, and either suffices:
+   installer run (``copy_self_to_hermes_home`` deliberately no-ops during
+   ``--update``), so every desktop whose staged updater predates the
+   HANDOFF_PID_ENV export runs an old parent against a new child. Without the
+-  ancestry check those users get exit 2 ("Hermes is still running") on every
+-  GUI update forever, with no Hermes process actually running.
++  ancestry check those users get exit 2 ("Black Pool is still running") on every
++  GUI update forever, with no Black Pool process actually running.
+ """
+ 
+ from __future__ import annotations
+@@ -77,7 +77,7 @@ HANDOFF_PID_ENV = "HERMES_UPDATE_HANDOFF_PID"
+ # Already the de-facto contract: the Windows shim + venv-holder guards in
+ # _cmd_update_impl exit 2, and the Tauri updater matches on it
+ # (UPDATE_EXIT_CONCURRENT in apps/bootstrap-installer/src-tauri/src/update.rs)
+-# to show "Hermes is still running" instead of a generic failure. Naming it
++# to show "Black Pool is still running" instead of a generic failure. Naming it
+ # here keeps the concurrent-update refusal on that same understood contract.
+ UPDATE_EXIT_CONCURRENT = 2
+ 
+@@ -85,7 +85,7 @@ UPDATE_EXIT_CONCURRENT = 2
+ def update_marker_path() -> Path:
+     """Path of the shared update marker.
+ 
+-    Uses the *process* Hermes home (never the context-local profile override):
++    Uses the *process* Black Pool home (never the context-local profile override):
+     the Rust updater resolves ``$HERMES_HOME`` or the platform default, and the
+     desktop pins that same value into the updater's env. A profile-scoped path
+     here would put the lock somewhere the other two owners never look.
+@@ -208,7 +208,7 @@ def describe_holder(holder: UpdateHolder) -> str:
+     minutes, seconds = divmod(int(max(holder.age_seconds, 0)), 60)
+     elapsed = f"{minutes}m {seconds}s" if minutes else f"{seconds}s"
+     return (
+-        f"✗ Another Hermes update is already running (PID {holder.pid}, "
++        f"✗ Another Black Pool update is already running (PID {holder.pid}, "
+         f"started {elapsed} ago).\n"
+         "\n"
+         "  Two updates mutating the same checkout corrupt it: one rewrites\n"
+diff --git a/hermes_cli/web_git.py b/hermes_cli/web_git.py
+index 3ea3c77..7543dbf 100644
+--- a/hermes_cli/web_git.py
++++ b/hermes_cli/web_git.py
+@@ -664,7 +664,7 @@ def _ensure_repo(cwd: str) -> None:
+                 "-c",
+                 "user.email=hermes@localhost",
+                 "-c",
+-                "user.name=Hermes",
++                "user.name=Black Pool",
+                 "commit",
+                 "--allow-empty",
+                 "-m",
+diff --git a/hermes_cli/web_models.py b/hermes_cli/web_models.py
+index 2a44cfe..9d698ba 100644
+--- a/hermes_cli/web_models.py
++++ b/hermes_cli/web_models.py
+@@ -1,4 +1,4 @@
+-"""Pydantic request/response models for the Hermes dashboard web server.
++"""Pydantic request/response models for the Black Pool dashboard web server.
+ 
+ Extracted verbatim from ``hermes_cli/web_server.py`` (pure schema move).
+ ``web_server`` re-exports every name here, so existing imports like
+diff --git a/hermes_cli/web_routers/mcp.py b/hermes_cli/web_routers/mcp.py
+index 1dd5875..4a5ec80 100644
+--- a/hermes_cli/web_routers/mcp.py
++++ b/hermes_cli/web_routers/mcp.py
+@@ -358,7 +358,7 @@ async def mcp_oauth_callback(
+         None,
+     )
+     if flow is None:
+-        return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
++        return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Black Pool and try again.</p>", status_code=404)
+     try:
+         flow.deliver_callback(code=code, state=state, error=error)
+     except ValueError as exc:
+@@ -370,8 +370,8 @@ async def mcp_oauth_callback(
+             status_code=status_code,
+         )
+     if error:
+-        return HTMLResponse("<h1>Authorization failed</h1><p>Return to Hermes for details.</p>", status_code=400)
+-    return HTMLResponse("<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>")
++        return HTMLResponse("<h1>Authorization failed</h1><p>Return to Black Pool for details.</p>", status_code=400)
++    return HTMLResponse("<h1>Authorization received</h1><p>You can close this tab and return to Black Pool.</p>")
+ 
+ 
+ @router.put("/api/mcp/servers/{name}/enabled")
+diff --git a/hermes_cli/web_routers/sessions.py b/hermes_cli/web_routers/sessions.py
+index 8b37f9f..2790c13 100644
+--- a/hermes_cli/web_routers/sessions.py
++++ b/hermes_cli/web_routers/sessions.py
+@@ -315,7 +315,7 @@ async def search_sessions(
+                 seen[root] = payload
+ 
+             # Direct ID matches first: users often paste a session id from CLI,
+-            # logs, or another Hermes surface. FTS can't find those unless the
++            # logs, or another Black Pool surface. FTS can't find those unless the
+             # id happens to appear in message text. search_sessions_by_id is
+             # SQL-bounded, so this stays cheap even with thousands of sessions.
+             for row in db.search_sessions_by_id(
+@@ -450,7 +450,7 @@ async def import_sessions_endpoint(request: Request):
+     """Import one or more sessions exported from the dashboard or CLI.
+ 
+     This is intentionally separate from ``/api/ops/import``: that endpoint
+-    restores a whole Hermes backup archive, while this endpoint is scoped to
++    restores a whole Black Pool backup archive, while this endpoint is scoped to
+     session rows/messages and is safe to use from the Sessions page.
+     """
+     try:
 diff --git a/hermes_cli/web_server.py b/hermes_cli/web_server.py
-index cc24499..ae3f6da 100644
+index cc24499..68d0375 100644
 --- a/hermes_cli/web_server.py
 +++ b/hermes_cli/web_server.py
 @@ -1,5 +1,5 @@
@@ -48722,6 +57863,349 @@ index cc24499..ae3f6da 100644
  
  
  # Memory-provider OAuth connect routes live in the memory layer, not here.
+@@ -1162,7 +1162,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
+     "updates.non_interactive_local_changes": {
+         "type": "select",
+         "description": (
+-            "When the chat app / gateway updates Hermes (no terminal prompt), "
++            "When the chat app / gateway updates Black Pool (no terminal prompt), "
+             "what to do with uncommitted local source edits. 'stash' keeps them "
+             "and re-applies them after the update; 'discard' throws them away. "
+             "Terminal updates always ask, regardless of this setting."
+@@ -1608,7 +1608,7 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
+ 
+     The Models page has two assignment paths and only one of them was safe:
+ 
+-    - The "Change" picker sends a real Hermes provider slug — fine.
++    - The "Change" picker sends a real Black Pool provider slug — fine.
+     - The per-card "Use as → Main model" menu sends ``entry.provider``
+       from the analytics rows, falling back to the model's VENDOR prefix
+       (``modelVendor("anthropic/claude-opus-4.6") == "anthropic"``) when
+@@ -1622,7 +1622,7 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
+     Two repairs, both at this single chokepoint so every caller inherits:
+ 
+     1. Vendor-name → Hermes-provider mapping: when the provider string is
+-       not a known Hermes provider/alias (e.g. ``moonshotai``, ``x-ai`` is
++       not a known Black Pool provider/alias (e.g. ``moonshotai``, ``x-ai`` is
+        known but ``poolside`` isn't) but the model is a vendor-prefixed
+        aggregator slug, keep the user's CURRENT aggregator if they're on
+        one, else fall back to openrouter.
+@@ -1670,7 +1670,7 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
+ 
+     # A named custom provider that didn't resolve above (typo, config
+     # mismatch, entry missing from custom_providers/providers) must still
+-    # not be treated as a stray vendor prefix -- it isn't a known Hermes
++    # not be treated as a stray vendor prefix -- it isn't a known Black Pool
+     # provider/alias, but it also isn't the analytics-vendor case this
+     # fallback exists for. Match only the durable named-custom syntax
+     # (bare "custom" bucket, or "custom:<name>" per
+@@ -1859,7 +1859,7 @@ def _count_status_active_sessions() -> int:
+     This is best-effort status garnish, not a critical path.  Opens read-only
+     (via the shared stale-schema heal, same as every other dashboard read
+     path) so /api/status never routinely writes to state.db while another
+-    Hermes process is using it.
++    Black Pool process is using it.
+     """
+     from hermes_state import _default_db_path
+ 
+@@ -2000,7 +2000,7 @@ def _is_sensitive_filename(name: str) -> bool:
+     """Return True for a basename the managed-files API must never expose.
+ 
+     Covers ``.env`` / ``.env.<suffix>`` / ``.envrc`` variants plus the
+-    canonical Hermes credential-store basenames (see
++    canonical Black Pool credential-store basenames (see
+     ``_SENSITIVE_MANAGED_FILE_BASENAMES`` above).
+ 
+     Case-insensitive so ``.ENV`` / ``.Env.local`` / ``Auth.JSON`` on
+@@ -2323,7 +2323,7 @@ def _dashboard_local_update_managed_externally() -> bool:
+     still behave like their actual install method in the CLI.
+ 
+     However, when the install method is ``git`` (a bind-mounted checkout inside
+-    a container — e.g. the hermes-webui image sharing the Hermes source tree),
++    a container — e.g. the hermes-webui image sharing the Black Pool source tree),
+     the dashboard's ``hermes update`` button is the correct update path and
+     should not be suppressed. Other containerized install methods remain
+     externally managed unless their apply path is proven safe inside the
+@@ -2361,7 +2361,7 @@ def _managed_files_policy(request: Request, *, create_root: bool = True) -> Mana
+     # Remote/OAuth access does not imply a hosted container. Users can expose a
+     # local dashboard through the auth gate (for example a macOS launchd install)
+     # and still expect the Files page to browse their local home directory. Lock
+-    # to /opt/data only when the installation's Hermes root is actually /opt/data
++    # to /opt/data only when the installation's Black Pool root is actually /opt/data
+     # (the container/hosted layout) or when HERMES_DASHBOARD_FILES_ROOT is set.
+     if _default_hermes_root_is_opt_data():
+         root = _ensure_managed_root(_HOSTED_MANAGED_FILES_ROOT) if create_root else _HOSTED_MANAGED_FILES_ROOT
+@@ -2506,7 +2506,7 @@ def _decode_chat_image_upload(payload: ChatImageUpload) -> tuple[bytes, str, str
+ async def upload_chat_image(payload: ChatImageUpload, profile: Optional[str] = None):
+     """Persist a browser-provided chat image where the embedded TUI can read it.
+ 
+-    The dashboard /chat page runs Hermes inside an xterm.js PTY. Browser
++    The dashboard /chat page runs Black Pool inside an xterm.js PTY. Browser
+     clipboard image bytes are not visible to the server-side clipboard, so the
+     page uploads them here, then drives the TUI's ``/image <path>`` command
+     with the returned gateway-visible path. Files land under
+@@ -3320,7 +3320,7 @@ _TOPOLOGY_CACHE_LOCK = threading.Lock()
+ _TOPOLOGY_CACHE_TTL = 10.0
+ 
+ # Stable install identity for /api/status. One random opaque id per physical
+-# install, minted on first read and persisted under the ROOT Hermes home
++# install, minted on first read and persisted under the ROOT Black Pool home
+ # (get_default_hermes_root()) — NOT the profile-scoped HERMES_HOME — so every
+ # profile served by the same install reports the same id. Clients (the desktop
+ # connection registry) use it to recognize that two registered addresses
+@@ -3336,7 +3336,7 @@ _INSTALL_ID_LOCK = threading.Lock()
+ 
+ 
+ def _read_or_create_install_id() -> Optional[str]:
+-    """Read (or mint + persist) the install id under the root Hermes home.
++    """Read (or mint + persist) the install id under the root Black Pool home.
+ 
+     Returns ``None`` only when the id can neither be read nor persisted (e.g.
+     a read-only filesystem) — an unpersisted id would violate the stability
+@@ -3928,7 +3928,7 @@ async def get_status(profile: Optional[str] = None):
+         # process table, so keep it off the event loop.
+         #
+         # Split by sensitivity: profile NAMES (``profiles``) and the gateway
+-        # ``gateway_mode`` are low-sensitivity PRODUCT surface — Hermes Cloud
++        # ``gateway_mode`` are low-sensitivity PRODUCT surface — Black Pool Cloud
+         # renders the profile list in the Portal, which reads this endpoint over
+         # the network (a gated bind), so they must survive the auth gate. The
+         # per-gateway ``gateways[]`` detail carries host ports (deployment
+@@ -4800,7 +4800,7 @@ async def update_hermes():
+     """Kick off ``hermes update`` in the background."""
+     if _dashboard_local_update_managed_externally():
+         message = (
+-            "Hermes updates are managed outside this dashboard in "
++            "Black Pool updates are managed outside this dashboard in "
+             "containerized environments. The built-in local updater is "
+             "disabled here."
+         )
+@@ -4928,7 +4928,7 @@ def _recent_upstream_commits(n: int = 20) -> List[Dict[str, Any]]:
+ 
+ @app.get("/api/hermes/update/check")
+ async def check_hermes_update(force: bool = False):
+-    """Report whether a Hermes update is available, without applying it.
++    """Report whether a Black Pool update is available, without applying it.
+ 
+     Powers the dashboard's "check before you update" flow: the System page
+     shows the commit-behind count and asks the user to confirm before
+@@ -4936,7 +4936,7 @@ async def check_hermes_update(force: bool = False):
+ 
+     Returns:
+         install_method: 'apt' | 'git' | 'docker' | 'nix' | 'nixos' | 'unknown'
+-        current_version: installed Hermes version string
++        current_version: installed Black Pool version string
+         behind: commits behind upstream (>=1), 0 if up to date,
+                 -1 if behind by an unknown count, or null if the
+                 check could not run (offline, no remote, etc.)
+@@ -4961,7 +4961,7 @@ async def check_hermes_update(force: bool = False):
+             "can_apply": False,
+             "update_command": "managed outside dashboard",
+             "message": (
+-                "Hermes updates are managed outside this dashboard in "
++                "Black Pool updates are managed outside this dashboard in "
+                 "containerized environments."
+             ),
+         }
+@@ -4984,7 +4984,7 @@ async def check_hermes_update(force: bool = False):
+         return payload
+     if install_method == "apt":
+         payload["message"] = (
+-            "Hermes is managed by Termux APT; run `pkg upgrade hermes-agent`."
++            "Black Pool is managed by Termux APT; run `pkg upgrade hermes-agent`."
+         )
+         return payload
+ 
+@@ -5570,7 +5570,7 @@ from hermes_cli.web_routers.sessions import (  # noqa: E402,F401 — legacy re-e
+ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
+     """Normalize config for the web UI.
+ 
+-    Hermes supports ``model`` as either a bare string (``"anthropic/claude-sonnet-4"``)
++    Black Pool supports ``model`` as either a bare string (``"anthropic/claude-sonnet-4"``)
+     or a dict (``{default: ..., provider: ..., base_url: ...}``).  The schema is built
+     from DEFAULT_CONFIG where ``model`` is a string, but user configs often have the
+     dict form.  Normalize to the string form so the frontend schema matches.
+@@ -8459,14 +8459,14 @@ async def reveal_env_var(
+ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     "telegram": {
+         "name": "Telegram",
+-        "description": "Run Hermes from Telegram DMs, groups, and topics.",
++        "description": "Run Black Pool from Telegram DMs, groups, and topics.",
+         "docs_url": "https://core.telegram.org/bots/features#botfather",
+         "env_vars": ("TELEGRAM_BOT_TOKEN", "TELEGRAM_ALLOWED_USERS", "TELEGRAM_PROXY"),
+         "required_env": ("TELEGRAM_BOT_TOKEN",),
+     },
+     "discord": {
+         "name": "Discord",
+-        "description": "Connect Hermes to Discord DMs, channels, and threads.",
++        "description": "Connect Black Pool to Discord DMs, channels, and threads.",
+         "docs_url": "https://discord.com/developers/applications",
+         "env_vars": (
+             "DISCORD_BOT_TOKEN",
+@@ -8476,21 +8476,21 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     },
+     "slack": {
+         "name": "Slack",
+-        "description": "Use Hermes from Slack via Socket Mode. Add allowed Slack member IDs so connected bots can respond.",
++        "description": "Use Black Pool from Slack via Socket Mode. Add allowed Slack member IDs so connected bots can respond.",
+         "docs_url": "https://api.slack.com/apps",
+         "env_vars": ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"),
+         "required_env": ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"),
+     },
+     "mattermost": {
+         "name": "Mattermost",
+-        "description": "Connect Hermes to Mattermost channels and direct messages.",
++        "description": "Connect Black Pool to Mattermost channels and direct messages.",
+         "docs_url": "https://mattermost.com/deploy/",
+         "env_vars": ("MATTERMOST_URL", "MATTERMOST_TOKEN", "MATTERMOST_ALLOWED_USERS"),
+         "required_env": ("MATTERMOST_URL", "MATTERMOST_TOKEN"),
+     },
+     "matrix": {
+         "name": "Matrix",
+-        "description": "Use Hermes in Matrix rooms and direct messages.",
++        "description": "Use Black Pool in Matrix rooms and direct messages.",
+         "docs_url": "https://matrix.org/ecosystem/servers/",
+         "env_vars": (
+             "MATRIX_HOMESERVER",
+@@ -8509,7 +8509,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     },
+     "whatsapp": {
+         "name": "WhatsApp",
+-        "description": "Use Hermes through the bundled WhatsApp bridge with QR-based auth.",
++        "description": "Use Black Pool through the bundled WhatsApp bridge with QR-based auth.",
+         "docs_url": "https://github.com/tulir/whatsmeow",
+         "env_vars": (
+             "WHATSAPP_ENABLED",
+@@ -8521,14 +8521,14 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     },
+     "homeassistant": {
+         "name": "Home Assistant",
+-        "description": "Control your smart home from Hermes via Home Assistant.",
++        "description": "Control your smart home from Black Pool via Home Assistant.",
+         "docs_url": "https://www.home-assistant.io/docs/authentication/",
+         "env_vars": ("HASS_URL", "HASS_TOKEN"),
+         "required_env": ("HASS_URL", "HASS_TOKEN"),
+     },
+     "email": {
+         "name": "Email",
+-        "description": "Talk to Hermes through an IMAP/SMTP mailbox.",
++        "description": "Talk to Black Pool through an IMAP/SMTP mailbox.",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/",
+         "env_vars": (
+             "EMAIL_ADDRESS",
+@@ -8552,14 +8552,14 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     },
+     "dingtalk": {
+         "name": "DingTalk",
+-        "description": "Connect Hermes to DingTalk groups (钉钉).",
++        "description": "Connect Black Pool to DingTalk groups (钉钉).",
+         "docs_url": "https://open.dingtalk.com/document/orgapp/the-robot-development-process",
+         "env_vars": ("DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET"),
+         "required_env": ("DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET"),
+     },
+     "feishu": {
+         "name": "Feishu / Lark",
+-        "description": "Use Hermes inside Feishu / Lark.",
++        "description": "Use Black Pool inside Feishu / Lark.",
+         "docs_url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/intro",
+         "env_vars": (
+             "FEISHU_APP_ID",
+@@ -8571,7 +8571,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     },
+     "google_chat": {
+         "name": "Google Chat",
+-        "description": "Connect Hermes to Google Chat via Cloud Pub/Sub.",
++        "description": "Connect Black Pool to Google Chat via Cloud Pub/Sub.",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/google_chat",
+     },
+     "wecom": {
+@@ -8607,7 +8607,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     },
+     "bluebubbles": {
+         "name": "BlueBubbles (iMessage)",
+-        "description": "Use Hermes through iMessage via a BlueBubbles server.",
++        "description": "Use Black Pool through iMessage via a BlueBubbles server.",
+         "docs_url": "https://bluebubbles.app/",
+         "env_vars": (
+             "BLUEBUBBLES_SERVER_URL",
+@@ -8618,7 +8618,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     },
+     "qqbot": {
+         "name": "QQ Bot",
+-        "description": "Connect Hermes to a QQ Bot from the QQ Open Platform.",
++        "description": "Connect Black Pool to a QQ Bot from the QQ Open Platform.",
+         "docs_url": "https://q.qq.com",
+         "env_vars": ("QQ_APP_ID", "QQ_CLIENT_SECRET", "QQ_ALLOWED_USERS"),
+         "required_env": ("QQ_APP_ID", "QQ_CLIENT_SECRET"),
+@@ -8627,26 +8627,26 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     # plugin registry. Only the docs link needs an override here so the
+     # Channels page can point at the Microsoft Teams setup guide.
+     "teams": {
+-        "description": "Connect Hermes to Microsoft Teams chats via the Bot Framework.",
++        "description": "Connect Black Pool to Microsoft Teams chats via the Bot Framework.",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/teams",
+     },
+     # Bundled platform plugins: name comes from the plugin registry label;
+     # give each a human description (the registry's install_hint is a
+     # dependency note, not a description) and a docs link.
+     "irc": {
+-        "description": "Relay messages between an IRC channel (or DMs) and Hermes.",
++        "description": "Relay messages between an IRC channel (or DMs) and Black Pool.",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/irc",
+     },
+     "line": {
+-        "description": "Use Hermes from LINE via the LINE Messaging API webhook.",
++        "description": "Use Black Pool from LINE via the LINE Messaging API webhook.",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/line",
+     },
+     "ntfy": {
+-        "description": "Chat with Hermes over ntfy push topics (ntfy.sh or self-hosted).",
++        "description": "Chat with Black Pool over ntfy push topics (ntfy.sh or self-hosted).",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/ntfy",
+     },
+     "photon": {
+-        "description": "Use Hermes through iMessage via Photon's managed Spectrum platform.",
++        "description": "Use Black Pool through iMessage via Photon's managed Spectrum platform.",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/photon",
+     },
+     "raft": {
+@@ -8654,18 +8654,18 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/raft",
+     },
+     "simplex": {
+-        "description": "Talk to Hermes over SimpleX Chat via a local simplex-chat daemon.",
++        "description": "Talk to Black Pool over SimpleX Chat via a local simplex-chat daemon.",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/simplex",
+     },
+     "yuanbao": {
+         "name": "Yuanbao (元宝)",
+-        "description": "Connect Hermes to Tencent Yuanbao.",
++        "description": "Connect Black Pool to Tencent Yuanbao.",
+         "docs_url": "",
+         "required_env": (),
+     },
+     "api_server": {
+         "name": "API server",
+-        "description": "Expose Hermes as an OpenAI-compatible HTTP API for tools like Open WebUI.",
++        "description": "Expose Black Pool as an OpenAI-compatible HTTP API for tools like Open WebUI.",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/",
+         "env_vars": (
+             "API_SERVER_ENABLED",
+@@ -8691,12 +8691,12 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
+     },
+     "whatsapp_cloud": {
+         "name": "WhatsApp Cloud API",
+-        "description": "Use Hermes via Meta's hosted WhatsApp Cloud API (no local bridge).",
++        "description": "Use Black Pool via Meta's hosted WhatsApp Cloud API (no local bridge).",
+         "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/whatsapp-cloud",
+     },
+     "relay": {
+         "name": "Relay (experimental)",
+-        "description": "Generic relay adapter fronted by the Hermes Relay connector.",
++        "description": "Generic relay adapter fronted by the Black Pool Relay connector.",
+         "docs_url": "",
+         "required_env": (),
+     },
 @@ -9903,7 +9903,7 @@ async def _telegram_onboarding_request(
  
  @app.post("/api/messaging/telegram/onboarding/start")
@@ -48731,6 +58215,149 @@ index cc24499..ae3f6da 100644
      payload = await _telegram_onboarding_request(
          "POST",
          "/v1/telegram/pairings",
+@@ -10017,7 +10017,7 @@ def _restart_gateway_after_telegram_onboarding(profile: Optional[str] = None) ->
+     """Best-effort gateway restart after saving Telegram QR onboarding.
+ 
+     The QR flow naturally pulls users into Telegram on another device. If the
+-    saved token waits on a separate dashboard restart click, Hermes appears
++    saved token waits on a separate dashboard restart click, Black Pool appears
+     broken from the chat side. Keep the config save authoritative, but report
+     restart failures so the UI can fall back to the existing manual banner.
+     """
+@@ -10413,7 +10413,7 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
+         return {
+             "logged_in": True,
+             "source": "hermes_pkce",
+-            "source_label": f"Hermes PKCE ({_get_hermes_oauth_file() if _get_hermes_oauth_file else None})",
++            "source_label": f"Black Pool PKCE ({_get_hermes_oauth_file() if _get_hermes_oauth_file else None})",
+             "token_preview": _truncate_token(hermes_creds.get("accessToken")),
+             "expires_at": hermes_creds.get("expiresAt"),
+             "has_refresh_token": bool(hermes_creds.get("refreshToken")),
+@@ -10456,7 +10456,7 @@ def _claude_code_only_status() -> Dict[str, Any]:
+     """Surface Claude Code CLI credentials as their own provider entry.
+ 
+     Independent of the Anthropic entry above so users can see whether their
+-    Claude Code subscription tokens are actively flowing into Hermes even
++    Claude Code subscription tokens are actively flowing into Black Pool even
+     when they also have a separate Hermes-managed PKCE login.
+     """
+     try:
+@@ -10481,7 +10481,7 @@ def _copilot_acp_status() -> Dict[str, Any]:
+ 
+     There is no cheap programmatic credential probe for the ACP subprocess, so
+     this is a read-only "managed by the Copilot CLI" card (like claude-code):
+-    Hermes never claims a login state it can't verify.
++    Black Pool never claims a login state it can't verify.
+     """
+     return {
+         "logged_in": False,
+@@ -10684,11 +10684,11 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
+ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str]:
+     """Shell command that clears an external provider's credentials.
+ 
+-    External providers store their credentials outside Hermes, so the disconnect
++    External providers store their credentials outside Black Pool, so the disconnect
+     API deliberately refuses them (we never delete files another CLI owns on the
+     user's behalf via a silent API call). For the ones we know how to clear we
+     instead hand the GUI a command it can *run in the embedded terminal* — the
+-    user sees exactly what executes, and Hermes then stops resolving the token.
++    user sees exactly what executes, and Black Pool then stops resolving the token.
+ 
+     Claude Code has no scriptable logout (only the interactive ``/logout``), so
+     we remove the credential the same way logout does: the macOS Keychain entry
+@@ -10712,7 +10712,7 @@ def _oauth_provider_disconnect_hint(provider: Dict[str, Any], status: Dict[str,
+         if _oauth_provider_disconnect_command(provider):
+             # The GUI offers a one-click "run in terminal" path; this hint is the
+             # fallback wording for surfaces that only show text.
+-            return "Managed outside Hermes — run the disconnect command to remove it."
++            return "Managed outside Black Pool — run the disconnect command to remove it."
+         return "Managed by that provider's CLI; remove it there."
+     if status.get("source") == "env_var":
+         return "Remove the API key from Settings → Keys instead."
+@@ -11000,7 +11000,7 @@ def _oauth_session_profile(
+ 
+ 
+ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_at_ms: int) -> None:
+-    """Persist Anthropic PKCE creds to both Hermes file AND credential pool.
++    """Persist Anthropic PKCE creds to both Black Pool file AND credential pool.
+ 
+     Mirrors what auth_commands.add_command does so the dashboard flow leaves
+     the system in the same state as ``hermes auth add anthropic``.
+@@ -11628,7 +11628,7 @@ def _codex_device_code_start_error(resp: Any) -> str:
+     if "device" in lower and ("authori" in lower or "enable" in lower):
+         message = (
+             "OpenAI rejected the device-code login request. Your OpenAI "
+-            "account may need device-code authorization enabled before Hermes "
++            "account may need device-code authorization enabled before Black Pool "
+             "can start this dashboard login. Enable device-code authorization "
+             "in OpenAI, then return here and click Login again."
+         )
+@@ -15231,7 +15231,7 @@ def _probe_terminal_backend(name: str, terminal_cfg: dict) -> tuple:
+ #
+ # cua-driver runs on macOS, Windows, and Linux. The desktop card reflects
+ # per-OS readiness: on macOS the Accessibility + Screen Recording TCC grants
+-# (which attach to cua-driver's OWN identity, com.trycua.driver — not Hermes,
++# (which attach to cua-driver's OWN identity, com.trycua.driver — not Black Pool,
+ # so no app entitlement is involved); elsewhere, driver health from
+ # `cua-driver doctor`. The grant flow is macOS-only (no TCC toggles to request
+ # on Windows/Linux).
+@@ -16106,7 +16106,7 @@ def _resolve_chat_argv(
+         profile_dir = _resolve_profile_dir(requested)
+ 
+     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
+-    # Hermes TUI child: build via the single spawn-env factory (profile-home
++    # Black Pool TUI child: build via the single spawn-env factory (profile-home
+     # contract applied; secrets kept — the spawned agent needs provider creds).
+     # An explicit profile scope below still overrides HERMES_HOME afterwards.
+     from tools.environments.local import build_subprocess_env
+@@ -16377,9 +16377,9 @@ def _ws_close_reason(text: str) -> str:
+ 
+ 
+ # ---------------------------------------------------------------------------
+-# /api/console — safe Hermes Console command WebSocket.
++# /api/console — safe Black Pool Console command WebSocket.
+ #
+-# Unlike /api/pty, this endpoint never spawns a PTY, shell, or full Hermes CLI
++# Unlike /api/pty, this endpoint never spawns a PTY, shell, or full Black Pool CLI
+ # subprocess. It runs the curated console engine in-process and exchanges
+ # structured JSON frames with the dashboard xterm overlay.
+ # ---------------------------------------------------------------------------
+@@ -16709,7 +16709,7 @@ async def console_ws(ws: WebSocket) -> None:
+                         "type": "error",
+                         "id": command_id,
+                         "message": (
+-                            "Command timed out. Hermes Console returned to the prompt."
++                            "Command timed out. Black Pool Console returned to the prompt."
+                         ),
+                         "command": line,
+                     },
+@@ -16987,7 +16987,7 @@ async def pty_ws(ws: WebSocket) -> None:
+         await ws.send_text(
+             "\r\n\x1b[31mChat unavailable: the embedded terminal requires a "
+             "POSIX PTY, which native Windows Python doesn't provide.\x1b[0m\r\n"
+-            "\x1b[33mInstall Hermes inside WSL2 to use the dashboard's /chat "
++            "\x1b[33mInstall Black Pool inside WSL2 to use the dashboard's /chat "
+             "tab — the rest of the dashboard works here.\x1b[0m\r\n"
+         )
+         await ws.close(code=1011)
+@@ -17430,7 +17430,7 @@ def mount_spa(application: FastAPI):
+     # absolute ``url(/fonts/...)`` and ``url(/ds-assets/...)`` references.
+     # Browsers resolve those against the document origin, which means
+     # under ``/hermes`` they'd hit ``mission-control.tilos.com/fonts/...``
+-    # (the MC Pages app), not the Hermes backend. Intercept CSS asset
++    # (the MC Pages app), not the Black Pool backend. Intercept CSS asset
+     # requests BEFORE the StaticFiles mount and rewrite the absolute paths
+     # when a prefix is in play.
+     @application.get("/assets/{filename}.css")
+@@ -17507,7 +17507,7 @@ def mount_spa(application: FastAPI):
+ # Built-in dashboard themes — label + description only.  The actual color
+ # definitions live in the frontend (web/src/themes/presets.ts).
+ _BUILTIN_DASHBOARD_THEMES = [
+-    {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
++    {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Black Pool look"},
+     {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
+     {"name": "nous-blue",     "label": "Nous Blue",           "description": "Light mode — vivid Nous-blue accents on cream canvas"},
+     {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
 @@ -18916,7 +18916,7 @@ def start_server(
          if not list_providers():
              # Surface the *specific* reason any bundled provider declined
@@ -48740,6 +58367,121 @@ index cc24499..ae3f6da 100644
              # module-level ``LAST_SKIP_REASON`` string for this purpose;
              # without it the operator would only see "no providers" which
              # is misleading when the provider IS installed but unconfigured.
+@@ -19112,9 +19112,9 @@ def start_server(
+                 # block-buffered and can surface MINUTES after the flushed
+                 # READY sentinel above, which reads as a slow boot in
+                 # support bundles when the backend was actually up.
+-                print(f"  Hermes backend listening on {host}:{actual_port}", flush=True)
++                print(f"  Black Pool backend listening on {host}:{actual_port}", flush=True)
+             else:
+-                print(f"  Hermes Web UI → http://{host}:{actual_port}")
++                print(f"  Black Pool Web UI → http://{host}:{actual_port}")
+             _maybe_open_browser(host, actual_port, open_browser, initial_profile)
+ 
+             # Collapse the peer-hangup teardown flood (#50005). When the Desktop
+diff --git a/hermes_cli/windows_ssh_runtime.py b/hermes_cli/windows_ssh_runtime.py
+index e031274..324f5cb 100644
+--- a/hermes_cli/windows_ssh_runtime.py
++++ b/hermes_cli/windows_ssh_runtime.py
+@@ -390,7 +390,7 @@ def spawn_backend(payload: dict[str, Any]) -> dict[str, Any]:
+     spawn_nonce = _nonce(str(payload["spawnNonce"]))
+     configured_path = str(payload["hermesPath"])
+     if not os.path.isabs(configured_path):
+-        raise ValueError("Hermes path must be absolute")
++        raise ValueError("Black Pool path must be absolute")
+     hermes_path = os.path.abspath(configured_path)
+     token_path = str(_token_path(ownership_id, spawn_nonce))
+     log_path = _log_path(ownership_id, spawn_nonce)
+@@ -400,7 +400,7 @@ def spawn_backend(payload: dict[str, Any]) -> dict[str, Any]:
+     venv_dir = os.path.dirname(hermes_path)
+     python_entry = os.path.join(venv_dir, "python.exe")
+     if not os.path.isfile(python_entry):
+-        raise ValueError("Hermes Python runtime was not found")
++        raise ValueError("Black Pool Python runtime was not found")
+     base_python, sys_path = _resolve_direct_interpreter(python_entry)
+     # Seed sys.path IN-PROCESS via a -c bootstrap rather than exporting PYTHONPATH:
+     # PYTHONPATH would be inherited by every subprocess the running backend spawns
+@@ -439,7 +439,7 @@ def spawn_backend(payload: dict[str, Any]) -> dict[str, Any]:
+ def inspect_hermes(hermes_path: str) -> dict[str, Any]:
+     path = os.path.abspath(hermes_path)
+     if not os.path.isabs(hermes_path) or not os.path.isfile(path):
+-        raise ValueError("Hermes path is not an executable file")
++        raise ValueError("Black Pool path is not an executable file")
+     version = subprocess.run([path, "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=20)
+     help_result = subprocess.run([path, "serve", "--help"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=20)
+     help_text = help_result.stdout + help_result.stderr
+diff --git a/hermes_cli/xai_retirement.py b/hermes_cli/xai_retirement.py
+index 965cc1b..5047f34 100644
+--- a/hermes_cli/xai_retirement.py
++++ b/hermes_cli/xai_retirement.py
+@@ -2,7 +2,7 @@
+ 
+ Source: https://docs.x.ai/developers/migration/may-15-retirement
+ 
+-Pure logic: walks a Hermes config dict, returns issues for any reference
++Pure logic: walks a Black Pool config dict, returns issues for any reference
+ to a retired xAI model. No I/O, no CLI dependencies — testable in isolation
+ and reusable from both `hermes doctor` and a future `hermes migrate xai`.
+ """
+@@ -34,7 +34,7 @@ _RETIRED_MODELS: Dict[str, Dict[str, Optional[str]]] = {
+ 
+ @dataclass(frozen=True)
+ class RetirementIssue:
+-    """A reference to a retired xAI model found in a Hermes config."""
++    """A reference to a retired xAI model found in a Black Pool config."""
+ 
+     config_path: str            # e.g. "principal.model" or "auxiliary.vision.model"
+     current_model: str          # exact value found in config (preserves casing/prefix)
+@@ -60,7 +60,7 @@ def _looks_like_xai(model_id: Optional[str]) -> bool:
+ 
+ 
+ def find_retired_xai_refs(config: Dict[str, Any]) -> List[RetirementIssue]:
+-    """Walk all model slots in a Hermes config and return retirement issues.
++    """Walk all model slots in a Black Pool config and return retirement issues.
+ 
+     Slots scanned:
+       - ``principal.model``
+diff --git a/plugins/__init__.py b/plugins/__init__.py
+index c3f3fb3..62d0593 100644
+--- a/plugins/__init__.py
++++ b/plugins/__init__.py
+@@ -1 +1 @@
+-# Hermes plugins package
++# Black Pool plugins package
+diff --git a/plugins/browser/browser_use/provider.py b/plugins/browser/browser_use/provider.py
+index bfc2709..693b944 100644
+--- a/plugins/browser/browser_use/provider.py
++++ b/plugins/browser/browser_use/provider.py
+@@ -7,7 +7,7 @@ is now the canonical implementation.
+ 
+ Browser Use is the only browser backend with dual auth: a direct
+ ``BROWSER_USE_API_KEY`` for self-billed users, or the managed Nous tool
+-gateway (which Hermes uses to bill Browser Use sessions to a Nous
++gateway (which Black Pool uses to bill Browser Use sessions to a Nous
+ subscription). The dispatch order — direct API key first, managed gateway
+ second — preserves the pre-migration behaviour in
+ ``tools.browser_providers.browser_use.BrowserUseProvider._get_config_or_none``.
+@@ -232,7 +232,7 @@ class BrowserUseBrowserProvider(BrowserProvider):
+             headers["X-Idempotency-Key"] = _get_or_create_pending_create_key(task_id)
+ 
+         # Keep gateway-backed sessions short so billing authorization does not
+-        # default to a long Browser-Use timeout when Hermes only needs a task-
++        # default to a long Browser-Use timeout when Black Pool only needs a task-
+         # scoped ephemeral browser.
+         payload = (
+             {
+diff --git a/plugins/cron_providers/chronos/__init__.py b/plugins/cron_providers/chronos/__init__.py
+index a4c8097..321d6d7 100644
+--- a/plugins/cron_providers/chronos/__init__.py
++++ b/plugins/cron_providers/chronos/__init__.py
+@@ -1,6 +1,6 @@
+ """Chronos — NAS-mediated managed cron provider (scale-to-zero).
+ 
+-Chronos (the Greek god of time, alongside Hermes) is the first non-default
++Chronos (the Greek god of time, alongside Black Pool) is the first non-default
+ ``CronScheduler``. It lets a hosted gateway scale to zero while idle and still
+ fire cron jobs: instead of a 60s in-process ticker, it asks NAS to arm exactly
+ one external one-shot per job at that job's real next-fire time. NAS calls the
 diff --git a/plugins/dashboard_auth/nous/__init__.py b/plugins/dashboard_auth/nous/__init__.py
 index 69acd18..252ddfb 100644
 --- a/plugins/dashboard_auth/nous/__init__.py
@@ -48753,8 +58495,38 @@ index 69acd18..252ddfb 100644
              "instance — set it to your provisioned client id (either "
              "as an env var or under dashboard.oauth.client_id in "
              "config.yaml), or pass --insecure to skip the OAuth gate "
+diff --git a/plugins/dashboard_auth/self_hosted/__init__.py b/plugins/dashboard_auth/self_hosted/__init__.py
+index 2672006..9018bdb 100644
+--- a/plugins/dashboard_auth/self_hosted/__init__.py
++++ b/plugins/dashboard_auth/self_hosted/__init__.py
+@@ -672,7 +672,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
+ 
+         The verified ID token is stored in ``Session.access_token`` so the
+         per-request ``verify_session`` re-verifies a real JWT. The opaque
+-        OAuth access token is intentionally NOT stored — Hermes does not call
++        OAuth access token is intentionally NOT stored — Black Pool does not call
+         any resource API with it; the dashboard only needs identity.
+         """
+         user_id = str(claims.get("sub", ""))
+diff --git a/plugins/disk-cleanup/__init__.py b/plugins/disk-cleanup/__init__.py
+index 71d44b1..68e8f0f 100644
+--- a/plugins/disk-cleanup/__init__.py
++++ b/plugins/disk-cleanup/__init__.py
+@@ -1,4 +1,4 @@
+-"""disk-cleanup plugin — auto-cleanup of ephemeral Hermes session files.
++"""disk-cleanup plugin — auto-cleanup of ephemeral Black Pool session files.
+ 
+ Wires three behaviours:
+ 
+@@ -312,5 +312,5 @@ def register(ctx) -> None:
+     ctx.register_command(
+         "disk-cleanup",
+         handler=_handle_slash,
+-        description="Track and clean up ephemeral Hermes session files.",
++        description="Track and clean up ephemeral Black Pool session files.",
+     )
 diff --git a/plugins/disk-cleanup/disk_cleanup.py b/plugins/disk-cleanup/disk_cleanup.py
-index 8432c5a..fca5d93 100755
+index 8432c5a..3c4b93f 100755
 --- a/plugins/disk-cleanup/disk_cleanup.py
 +++ b/plugins/disk-cleanup/disk_cleanup.py
 @@ -1,4 +1,4 @@
@@ -48763,6 +58535,27 @@ index 8432c5a..fca5d93 100755
  
  Library module wrapping the deterministic cleanup rules written by
  @LVT382009 in PR #12212. The plugin ``__init__.py`` wires these
+@@ -383,7 +383,7 @@ def quick() -> Dict[str, Any]:
+             new_tracked.append(item)
+ 
+     # Remove empty dirs under HERMES_HOME, but never recurse into known
+-    # durable state trees.  Some installs place the Hermes checkout, venv,
++    # durable state trees.  Some installs place the Black Pool checkout, venv,
+     # and desktop build under HERMES_HOME; a full rglob over that tree can
+     # stall the gateway event loop for minutes.
+     hermes_home = get_hermes_home()
+diff --git a/plugins/disk-cleanup/plugin.yaml b/plugins/disk-cleanup/plugin.yaml
+index fe005c8..28b52b9 100644
+--- a/plugins/disk-cleanup/plugin.yaml
++++ b/plugins/disk-cleanup/plugin.yaml
+@@ -1,6 +1,6 @@
+ name: disk-cleanup
+ version: 2.0.0
+-description: "Auto-track and clean up ephemeral files (test scripts, temp outputs, cron logs) created during Hermes sessions. Runs via plugin hooks — no agent action required."
++description: "Auto-track and clean up ephemeral files (test scripts, temp outputs, cron logs) created during Black Pool sessions. Runs via plugin hooks — no agent action required."
+ author: "@LVT382009 (original), NousResearch (plugin port)"
+ hooks:
+   - post_tool_call
 diff --git a/plugins/google_meet/cli.py b/plugins/google_meet/cli.py
 index 45fede0..56431a7 100644
 --- a/plugins/google_meet/cli.py
@@ -48776,6 +58569,19 @@ index 45fede0..56431a7 100644
      join_p.add_argument("--duration", default=None, help="e.g. 30m, 2h, 90s")
      join_p.add_argument("--headed", action="store_true", help="show browser")
      join_p.add_argument(
+diff --git a/plugins/google_meet/meet_bot.py b/plugins/google_meet/meet_bot.py
+index 20745eb..6cc84ea 100644
+--- a/plugins/google_meet/meet_bot.py
++++ b/plugins/google_meet/meet_bot.py
+@@ -449,7 +449,7 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
+     out_dir_env = os.environ.get("HERMES_MEET_OUT_DIR", "").strip()
+     headed = os.environ.get("HERMES_MEET_HEADED", "").lower() in {"1", "true", "yes"}
+     auth_state = os.environ.get("HERMES_MEET_AUTH_STATE", "").strip()
+-    guest_name = os.environ.get("HERMES_MEET_GUEST_NAME", "Hermes Agent")
++    guest_name = os.environ.get("HERMES_MEET_GUEST_NAME", "Black Pool Agent")
+     duration_s = _parse_duration(os.environ.get("HERMES_MEET_DURATION", ""))
+     # v2: optional realtime mode. Enabled when HERMES_MEET_MODE=realtime.
+     mode = os.environ.get("HERMES_MEET_MODE", "transcribe").strip().lower()
 diff --git a/plugins/google_meet/node/client.py b/plugins/google_meet/node/client.py
 index 1965333..660a456 100644
 --- a/plugins/google_meet/node/client.py
@@ -48834,7 +58640,7 @@ index 034116b..bab1f28 100644
          mode=mode,
      )
 diff --git a/plugins/hermes-achievements/dashboard/dist/index.js b/plugins/hermes-achievements/dashboard/dist/index.js
-index 5be8a3f..aa8c748 100644
+index 5be8a3f..c6165a5 100644
 --- a/plugins/hermes-achievements/dashboard/dist/index.js
 +++ b/plugins/hermes-achievements/dashboard/dist/index.js
 @@ -257,7 +257,7 @@
@@ -48855,6 +58661,248 @@ index 5be8a3f..aa8c748 100644
          tier_part: tierPart,
          name: achievement.name,
        });
+@@ -443,8 +443,8 @@
+       React.createElement("section", { className: "ha-hero ha-loading-hero" },
+         React.createElement("div", null,
+           React.createElement("div", { className: "ha-kicker" }, tx(t, "hero.kicker", "Agentic Gamerscore")),
+-          React.createElement("h1", null, tx(t, "hero.title", "Hermes Achievements")),
+-          React.createElement("p", null, tx(t, "hero.scan_subtitle", "Scanning Hermes session history. First scan can take 5–10 seconds on large histories."))
++          React.createElement("h1", null, tx(t, "hero.title", "Black Pool Achievements")),
++          React.createElement("p", null, tx(t, "hero.scan_subtitle", "Scanning Black Pool session history. First scan can take 5–10 seconds on large histories."))
+         ),
+         React.createElement("div", { className: "ha-scan-status", role: "status", "aria-live": "polite" },
+           React.createElement("span", { className: "ha-scan-pulse", "aria-hidden": "true" }),
+@@ -475,7 +475,7 @@
+       React.createElement("section", { className: "ha-guide ha-loading-guide" },
+         React.createElement("div", null,
+           React.createElement("strong", null, tx(t, "guide.scan_status_header", "Scan status")),
+-          React.createElement("p", null, tx(t, "guide.scan_status_body", "Hermes is scanning local history once, then cards will appear automatically. Nothing is stuck if this takes a few seconds."))
++          React.createElement("p", null, tx(t, "guide.scan_status_body", "Black Pool is scanning local history once, then cards will appear automatically. Nothing is stuck if this takes a few seconds."))
+         ),
+         React.createElement("div", null,
+           React.createElement("strong", null, tx(t, "guide.what_scanned_header", "What is scanned")),
+@@ -666,8 +666,8 @@
+       React.createElement("section", { className: "ha-hero" },
+         React.createElement("div", null,
+           React.createElement("div", { className: "ha-kicker" }, tx(t, "hero.kicker", "Agentic Gamerscore")),
+-          React.createElement("h1", null, tx(t, "hero.title", "Hermes Achievements")),
+-          React.createElement("p", null, tx(t, "hero.subtitle", "Collectible Hermes badges earned from real session history. Known unfinished achievements are shown as Discovered; Secret achievements stay hidden until the first matching behavior appears."))
++          React.createElement("h1", null, tx(t, "hero.title", "Black Pool Achievements")),
++          React.createElement("p", null, tx(t, "hero.subtitle", "Collectible Black Pool badges earned from real session history. Known unfinished achievements are shown as Discovered; Secret achievements stay hidden until the first matching behavior appears."))
+         ),
+         React.createElement(C.Button, { onClick: load, className: "ha-refresh" }, tx(t, "actions.rescan", "Rescan"))
+       ),
+@@ -678,7 +678,7 @@
+         React.createElement(StatCard, { label: tx(t, "stats.discovered", "Discovered"), value: discovered.length, hint: tx(t, "stats.discovered_hint", "known, not earned yet") }),
+         React.createElement(StatCard, { label: tx(t, "stats.secrets", "Secrets"), value: secret.length, hint: tx(t, "stats.secrets_hint", "hidden until first signal") }),
+         React.createElement(StatCard, { label: tx(t, "stats.highest_tier", "Highest tier"), value: highest, hint: tx(t, "stats.highest_tier_hint", "Copper → Silver → Gold → Diamond → Olympian") }),
+-        React.createElement(StatCard, { label: tx(t, "stats.latest", "Latest"), value: latest[0] ? latest[0].name : tx(t, "stats.none_yet", "None yet"), hint: latest[0] ? latest[0].category : tx(t, "stats.latest_hint_empty", "run Hermes more") })
++        React.createElement(StatCard, { label: tx(t, "stats.latest", "Latest"), value: latest[0] ? latest[0].name : tx(t, "stats.none_yet", "None yet"), hint: latest[0] ? latest[0].category : tx(t, "stats.latest_hint_empty", "run Black Pool more") })
+       ),
+       React.createElement("section", { className: "ha-guide" },
+         React.createElement("div", null,
+@@ -687,7 +687,7 @@
+         ),
+         React.createElement("div", null,
+           React.createElement("strong", null, tx(t, "guide.secret_header", "Secret achievements")),
+-          React.createElement("p", null, tx(t, "guide.secret_body", "Secrets hide their exact trigger. Once Hermes sees a related signal, the card becomes Discovered and shows its requirement."))
++          React.createElement("p", null, tx(t, "guide.secret_body", "Secrets hide their exact trigger. Once Black Pool sees a related signal, the card becomes Discovered and shows its requirement."))
+         )
+       ),
+       React.createElement("div", { className: "ha-toolbar" },
+diff --git a/plugins/hermes-achievements/dashboard/manifest.json b/plugins/hermes-achievements/dashboard/manifest.json
+index 5fcc393..6a79288 100644
+--- a/plugins/hermes-achievements/dashboard/manifest.json
++++ b/plugins/hermes-achievements/dashboard/manifest.json
+@@ -1,7 +1,7 @@
+ {
+   "name": "hermes-achievements",
+   "label": "Achievements",
+-  "description": "Steam-style achievements for vibe coding and agentic Hermes workflows.",
++  "description": "Steam-style achievements for vibe coding and agentic Black Pool workflows.",
+   "icon": "Star",
+   "version": "0.4.0",
+   "tab": { "path": "/achievements", "position": "after:analytics" },
+diff --git a/plugins/hermes-achievements/dashboard/plugin_api.py b/plugins/hermes-achievements/dashboard/plugin_api.py
+index 643c306..451a030 100644
+--- a/plugins/hermes-achievements/dashboard/plugin_api.py
++++ b/plugins/hermes-achievements/dashboard/plugin_api.py
+@@ -1,6 +1,6 @@
+-"""Hermes Achievements dashboard plugin backend.
++"""Black Pool Achievements dashboard plugin backend.
+ 
+-Mounted at /api/plugins/hermes-achievements/ by Hermes dashboard.
++Mounted at /api/plugins/hermes-achievements/ by Black Pool dashboard.
+ """
+ from __future__ import annotations
+ 
+@@ -63,9 +63,9 @@ def req(metric: str, gte: int) -> Dict[str, Any]:
+ 
+ ACHIEVEMENTS: List[Dict[str, Any]] = [
+     # Agent Autonomy — mostly best-session feats
+-    {"id": "let_him_cook", "name": "Let Him Cook", "description": "Let Hermes run a serious autonomous tool chain in one session.", "category": "Agent Autonomy", "kind": "best_session", "icon": "flame", "threshold_metric": "max_tool_calls_in_session", "tiers": tiers([200, 500, 1200, 3000, 8000])},
+-    {"id": "autonomous_avalanche", "name": "Autonomous Avalanche", "description": "Accumulate a lifetime avalanche of Hermes tool calls across sessions.", "category": "Agent Autonomy", "kind": "lifetime", "icon": "avalanche", "threshold_metric": "total_tool_calls", "tiers": tiers([1000, 3000, 8000, 20000, 50000])},
+-    {"id": "toolchain_maxxer", "name": "Toolchain Maxxer", "description": "Use a wide spread of distinct Hermes tools in one session.", "category": "Agent Autonomy", "kind": "best_session", "icon": "nodes", "threshold_metric": "max_distinct_tools_in_session", "tiers": tiers([18, 28, 45, 70, 100])},
++    {"id": "let_him_cook", "name": "Let Him Cook", "description": "Let Black Pool run a serious autonomous tool chain in one session.", "category": "Agent Autonomy", "kind": "best_session", "icon": "flame", "threshold_metric": "max_tool_calls_in_session", "tiers": tiers([200, 500, 1200, 3000, 8000])},
++    {"id": "autonomous_avalanche", "name": "Autonomous Avalanche", "description": "Accumulate a lifetime avalanche of Black Pool tool calls across sessions.", "category": "Agent Autonomy", "kind": "lifetime", "icon": "avalanche", "threshold_metric": "total_tool_calls", "tiers": tiers([1000, 3000, 8000, 20000, 50000])},
++    {"id": "toolchain_maxxer", "name": "Toolchain Maxxer", "description": "Use a wide spread of distinct Black Pool tools in one session.", "category": "Agent Autonomy", "kind": "best_session", "icon": "nodes", "threshold_metric": "max_distinct_tools_in_session", "tiers": tiers([18, 28, 45, 70, 100])},
+     {"id": "full_send", "name": "Full Send", "description": "Terminal, files, and web/browser all get involved in one real run.", "category": "Agent Autonomy", "kind": "multi_condition", "icon": "rocket", "requirements": [req("max_terminal_calls_in_session", 180), req("max_file_tool_calls_in_session", 120), req("max_web_browser_calls_in_session", 60)]},
+     {"id": "subagent_commander", "name": "Subagent Commander", "description": "Coordinate delegated agent work.", "category": "Agent Autonomy", "kind": "lifetime", "icon": "branch", "threshold_metric": "total_delegate_calls", "tiers": tiers([5, 40, 100, 1000, 5000])},
+     {"id": "background_process_enjoyer", "name": "Background Process Enjoyer", "description": "Start or control enough long-running processes to deserve the title.", "category": "Agent Autonomy", "kind": "lifetime", "icon": "daemon", "threshold_metric": "total_process_calls", "tiers": tiers([300, 800, 2000, 6000, 15000])},
+@@ -92,15 +92,15 @@ ACHIEVEMENTS: List[Dict[str, Any]] = [
+     {"id": "css_exorcist", "name": "CSS Exorcist", "description": "Cast repeated styling demons out of the interface.", "category": "Vibe Coding", "kind": "lifetime", "icon": "spark_cursor", "threshold_metric": "css_activity_events", "tiers": tiers([10000, 30000, 80000, 200000, 500000])},
+     {"id": "one_character_fix", "name": "One Character Fix", "description": "A tiny edit after a pile of errors. Painful. Beautiful.", "category": "Vibe Coding", "kind": "multi_condition", "icon": "needle", "secret": True, "requirements": [req("tiny_patch_after_errors_events", 5), req("total_errors", 4000)]},
+ 
+-    # Hermes Native
+-    {"id": "skillsmith", "name": "Skillsmith", "description": "Work with Hermes skills enough to leave fingerprints.", "category": "Hermes Native", "kind": "lifetime", "icon": "hammer_scroll", "threshold_metric": "skill_events", "tiers": tiers([5000, 15000, 40000, 100000, 250000])},
+-    {"id": "skill_issue_skill_created", "name": "Skill Issue? Skill Created.", "description": "Create or patch durable procedures instead of repeating yourself.", "category": "Hermes Native", "kind": "lifetime", "icon": "anvil", "threshold_metric": "skill_manage_events", "tiers": tiers([25, 75, 200, 600, 1500])},
+-    {"id": "memory_keeper", "name": "Memory Keeper", "description": "Persist durable knowledge with memory or Mnemosyne.", "category": "Hermes Native", "kind": "lifetime", "icon": "crystal", "threshold_metric": "memory_events", "tiers": tiers([100, 300, 1000, 3000, 8000])},
+-    {"id": "memory_palace", "name": "Memory Palace", "description": "Build a serious durable-memory trail.", "category": "Hermes Native", "kind": "lifetime", "icon": "palace", "threshold_metric": "memory_write_events", "tiers": tiers([100, 300, 1000, 3000, 8000])},
+-    {"id": "context_dragon", "name": "Context Dragon", "description": "Brush against compression, huge context, or token pressure repeatedly.", "category": "Hermes Native", "kind": "lifetime", "icon": "dragon", "threshold_metric": "context_events", "tiers": tiers([5000, 15000, 40000, 100000, 250000])},
+-    {"id": "gateway_dweller", "name": "Gateway Dweller", "description": "Live through gateway-connected Hermes workflows.", "category": "Hermes Native", "kind": "lifetime", "icon": "antenna", "threshold_metric": "gateway_events", "tiers": tiers([5000, 15000, 40000, 100000, 250000])},
+-    {"id": "plugin_goblin", "name": "Plugin Goblin", "description": "Use or develop plugins enough that the dashboard notices.", "category": "Hermes Native", "kind": "lifetime", "icon": "puzzle", "threshold_metric": "plugin_events", "tiers": tiers([1000, 3000, 8000, 20000, 50000])},
+-    {"id": "rollback_wizard", "name": "Rollback Wizard", "description": "Invoke rollback/checkpoint recovery magic.", "category": "Hermes Native", "kind": "lifetime", "icon": "rewind", "secret": True, "threshold_metric": "rollback_events", "tiers": tiers([500, 1500, 4000, 10000, 25000])},
++    # Black Pool Native
++    {"id": "skillsmith", "name": "Skillsmith", "description": "Work with Black Pool skills enough to leave fingerprints.", "category": "Black Pool Native", "kind": "lifetime", "icon": "hammer_scroll", "threshold_metric": "skill_events", "tiers": tiers([5000, 15000, 40000, 100000, 250000])},
++    {"id": "skill_issue_skill_created", "name": "Skill Issue? Skill Created.", "description": "Create or patch durable procedures instead of repeating yourself.", "category": "Black Pool Native", "kind": "lifetime", "icon": "anvil", "threshold_metric": "skill_manage_events", "tiers": tiers([25, 75, 200, 600, 1500])},
++    {"id": "memory_keeper", "name": "Memory Keeper", "description": "Persist durable knowledge with memory or Mnemosyne.", "category": "Black Pool Native", "kind": "lifetime", "icon": "crystal", "threshold_metric": "memory_events", "tiers": tiers([100, 300, 1000, 3000, 8000])},
++    {"id": "memory_palace", "name": "Memory Palace", "description": "Build a serious durable-memory trail.", "category": "Black Pool Native", "kind": "lifetime", "icon": "palace", "threshold_metric": "memory_write_events", "tiers": tiers([100, 300, 1000, 3000, 8000])},
++    {"id": "context_dragon", "name": "Context Dragon", "description": "Brush against compression, huge context, or token pressure repeatedly.", "category": "Black Pool Native", "kind": "lifetime", "icon": "dragon", "threshold_metric": "context_events", "tiers": tiers([5000, 15000, 40000, 100000, 250000])},
++    {"id": "gateway_dweller", "name": "Gateway Dweller", "description": "Live through gateway-connected Black Pool workflows.", "category": "Black Pool Native", "kind": "lifetime", "icon": "antenna", "threshold_metric": "gateway_events", "tiers": tiers([5000, 15000, 40000, 100000, 250000])},
++    {"id": "plugin_goblin", "name": "Plugin Goblin", "description": "Use or develop plugins enough that the dashboard notices.", "category": "Black Pool Native", "kind": "lifetime", "icon": "puzzle", "threshold_metric": "plugin_events", "tiers": tiers([1000, 3000, 8000, 20000, 50000])},
++    {"id": "rollback_wizard", "name": "Rollback Wizard", "description": "Invoke rollback/checkpoint recovery magic.", "category": "Black Pool Native", "kind": "lifetime", "icon": "rewind", "secret": True, "threshold_metric": "rollback_events", "tiers": tiers([500, 1500, 4000, 10000, 25000])},
+ 
+     # Research/Web
+     {"id": "rabbit_hole_certified", "name": "Rabbit Hole Certified", "description": "Search or extract enough web content to qualify as a research spiral.", "category": "Research/Web", "kind": "lifetime", "icon": "spiral", "threshold_metric": "total_web_calls", "tiers": tiers([400, 1200, 3000, 8000, 20000])},
+@@ -119,24 +119,24 @@ ACHIEVEMENTS: List[Dict[str, Any]] = [
+     {"id": "model_hopper", "name": "Model Hopper", "description": "Switch or inspect providers/models enough to count as a habit.", "category": "Model Lore", "kind": "lifetime", "icon": "swap", "threshold_metric": "model_events", "tiers": tiers([10000, 30000, 80000, 200000, 500000])},
+     {"id": "openrouter_enjoyer", "name": "OpenRouter Enjoyer", "description": "Route model work through OpenRouter repeatedly.", "category": "Model Lore", "kind": "lifetime", "icon": "router", "threshold_metric": "openrouter_events", "tiers": tiers([250, 750, 2000, 6000, 15000])},
+     {"id": "codex_conjurer", "name": "Codex Conjurer", "description": "Summon Codex-flavored assistance often enough for a ritual.", "category": "Model Lore", "kind": "lifetime", "icon": "codex", "threshold_metric": "codex_events", "tiers": tiers([500, 1500, 4000, 10000, 25000])},
+-    {"id": "multi_model_mage", "name": "Multi-Model Mage", "description": "Use a real spread of distinct model names across Hermes history.", "category": "Model Lore", "kind": "lifetime", "icon": "prism", "threshold_metric": "distinct_model_count", "tiers": tiers([10, 20, 40, 80, 160])},
++    {"id": "multi_model_mage", "name": "Multi-Model Mage", "description": "Use a real spread of distinct model names across Black Pool history.", "category": "Model Lore", "kind": "lifetime", "icon": "prism", "threshold_metric": "distinct_model_count", "tiers": tiers([10, 20, 40, 80, 160])},
+     {"id": "five_model_flight", "name": "Five-Model Flight", "description": "Try at least five distinct LLMs instead of marrying the first model that answers.", "category": "Model Lore", "kind": "lifetime", "icon": "prism", "threshold_metric": "distinct_model_count", "tiers": tiers([5, 10, 20, 40, 80])},
+-    {"id": "provider_polyglot", "name": "Provider Polyglot", "description": "Use models from multiple providers across Hermes history.", "category": "Model Lore", "kind": "lifetime", "icon": "swap", "threshold_metric": "distinct_provider_count", "tiers": tiers([2, 3, 5, 8, 12])},
++    {"id": "provider_polyglot", "name": "Provider Polyglot", "description": "Use models from multiple providers across Black Pool history.", "category": "Model Lore", "kind": "lifetime", "icon": "swap", "threshold_metric": "distinct_provider_count", "tiers": tiers([2, 3, 5, 8, 12])},
+     {"id": "model_sommelier", "name": "Model Sommelier", "description": "Taste enough model/provider conversations to develop preferences.", "category": "Model Lore", "kind": "lifetime", "icon": "wine", "threshold_metric": "model_events", "tiers": tiers([250, 750, 2000, 6000, 15000])},
+     {"id": "claude_confidant", "name": "Claude Confidant", "description": "Bring Claude-flavored reasoning into the workflow repeatedly.", "category": "Model Lore", "kind": "lifetime", "icon": "quote", "threshold_metric": "claude_events", "tiers": tiers([50, 150, 500, 1500, 4000])},
+     {"id": "gemini_cartographer", "name": "Gemini Cartographer", "description": "Map enough Gemini-related workflows to know the terrain.", "category": "Model Lore", "kind": "lifetime", "icon": "compass", "threshold_metric": "gemini_events", "tiers": tiers([50, 150, 500, 1500, 4000])},
+-    {"id": "open_weights_pilgrim", "name": "Open Weights Pilgrim", "description": "Actually chat with local/open-weight models through Hermes session metadata.", "category": "Model Lore", "kind": "lifetime", "icon": "terminal", "threshold_metric": "local_model_chat_sessions", "tiers": tiers([1, 3, 10, 30, 100])},
++    {"id": "open_weights_pilgrim", "name": "Open Weights Pilgrim", "description": "Actually chat with local/open-weight models through Black Pool session metadata.", "category": "Model Lore", "kind": "lifetime", "icon": "terminal", "threshold_metric": "local_model_chat_sessions", "tiers": tiers([1, 3, 10, 30, 100])},
+ 
+     # Workflow Intelligence
+-    {"id": "toolset_cartographer", "name": "Toolset Cartographer", "description": "Navigate Hermes toolsets deliberately instead of treating tools as a blur.", "category": "Hermes Native", "kind": "lifetime", "icon": "compass", "threshold_metric": "toolset_events", "tiers": tiers([20, 60, 200, 600, 1500])},
+-    {"id": "config_surgeon", "name": "Config Surgeon", "description": "Operate on real config files, manifests, env files, and dashboard settings without flinching.", "category": "Hermes Native", "kind": "lifetime", "icon": "key", "threshold_metric": "config_events", "tiers": tiers([100, 300, 1000, 3000, 10000])},
++    {"id": "toolset_cartographer", "name": "Toolset Cartographer", "description": "Navigate Black Pool toolsets deliberately instead of treating tools as a blur.", "category": "Black Pool Native", "kind": "lifetime", "icon": "compass", "threshold_metric": "toolset_events", "tiers": tiers([20, 60, 200, 600, 1500])},
++    {"id": "config_surgeon", "name": "Config Surgeon", "description": "Operate on real config files, manifests, env files, and dashboard settings without flinching.", "category": "Black Pool Native", "kind": "lifetime", "icon": "key", "threshold_metric": "config_events", "tiers": tiers([100, 300, 1000, 3000, 10000])},
+     {"id": "rebase_acrobat", "name": "Rebase Acrobat", "description": "Handle real git history surgery: rebase, conflict, merge, fetch, push.", "category": "Vibe Coding", "kind": "lifetime", "icon": "branch", "threshold_metric": "git_history_events", "tiers": tiers([10, 30, 100, 300, 800])},
+     {"id": "test_suite_tamer", "name": "Test Suite Tamer", "description": "Run enough verification commands that green text becomes part of the ritual.", "category": "Tool Mastery", "kind": "lifetime", "icon": "daemon", "threshold_metric": "test_events", "tiers": tiers([100, 300, 800, 2400, 6000])},
+     {"id": "screenshot_hunter", "name": "Screenshot Hunter", "description": "Capture, inspect, and polish visual proof instead of just claiming it works.", "category": "Tool Mastery", "kind": "lifetime", "icon": "eye", "threshold_metric": "screenshot_events", "tiers": tiers([50, 150, 500, 1500, 5000])},
+ 
+     # Lifestyle
+-    {"id": "marathon_operator", "name": "Marathon Operator", "description": "Accumulate a serious number of Hermes sessions.", "category": "Lifestyle", "kind": "lifetime", "icon": "marathon", "threshold_metric": "session_count", "tiers": tiers([75, 200, 500, 1500, 5000])},
+-    {"id": "weekend_warrior", "name": "Weekend Warrior", "description": "Run Hermes on weekends enough times to make it a lifestyle.", "category": "Lifestyle", "kind": "lifetime", "icon": "calendar", "threshold_metric": "weekend_sessions", "tiers": tiers([25, 75, 200, 600, 1500])},
++    {"id": "marathon_operator", "name": "Marathon Operator", "description": "Accumulate a serious number of Black Pool sessions.", "category": "Lifestyle", "kind": "lifetime", "icon": "marathon", "threshold_metric": "session_count", "tiers": tiers([75, 200, 500, 1500, 5000])},
++    {"id": "weekend_warrior", "name": "Weekend Warrior", "description": "Run Black Pool on weekends enough times to make it a lifestyle.", "category": "Lifestyle", "kind": "lifetime", "icon": "calendar", "threshold_metric": "weekend_sessions", "tiers": tiers([25, 75, 200, 600, 1500])},
+     {"id": "night_shift_operator", "name": "Night Shift Operator", "description": "Run sessions during gremlin hours repeatedly.", "category": "Lifestyle", "kind": "lifetime", "icon": "moon", "threshold_metric": "night_sessions", "tiers": tiers([25, 75, 200, 600, 1500])},
+     {"id": "cache_hit_appreciator", "name": "Cache Hit Appreciator", "description": "Notice or benefit from prompt/cache behavior.", "category": "Lifestyle", "kind": "lifetime", "icon": "cache", "secret": True, "threshold_metric": "cache_events", "tiers": tiers([100, 300, 1000, 3000, 8000])},
+ ]
+@@ -494,7 +494,7 @@ def evaluate_boolean(definition: Dict[str, Any], aggregate: Dict[str, Any]) -> D
+ 
+ METRIC_LABELS = {
+     "max_tool_calls_in_session": "tool calls in one session",
+-    "max_distinct_tools_in_session": "distinct Hermes tools used in one session",
++    "max_distinct_tools_in_session": "distinct Black Pool tools used in one session",
+     "max_terminal_calls_in_session": "terminal calls in one session",
+     "max_file_tool_calls_in_session": "file/search/patch calls in one session",
+     "max_web_browser_calls_in_session": "web search/extract or browser calls in one session",
+@@ -518,7 +518,7 @@ METRIC_LABELS = {
+     "css_activity_events": "CSS, styling, Tailwind, or className activity",
+     "git_events": "git workflow commands",
+     "tiny_patch_after_errors_events": "tiny typo-style fixes after error clusters",
+-    "skill_events": "Hermes skill mentions or tool use",
++    "skill_events": "Black Pool skill mentions or tool use",
+     "skill_manage_events": "skill_manage create/patch/delete operations",
+     "memory_events": "memory or Mnemosyne tool events",
+     "memory_write_events": "durable memory writes",
+@@ -534,7 +534,7 @@ METRIC_LABELS = {
+     "total_web_calls": "lifetime web_search/web_extract calls",
+     "total_web_extract_calls": "lifetime web_extract calls",
+     "browser_calls": "lifetime browser automation calls",
+-    "total_tool_calls": "lifetime Hermes tool calls",
++    "total_tool_calls": "lifetime Black Pool tool calls",
+     "total_terminal_calls": "lifetime terminal calls",
+     "total_patch_calls": "lifetime targeted patch edits",
+     "total_file_reads_searches": "lifetime read_file/search_files calls",
+@@ -545,14 +545,14 @@ METRIC_LABELS = {
+     "claude_events": "Claude/Anthropic model mentions",
+     "gemini_events": "Gemini/Google model mentions",
+     "local_model_events": "local/open-weight model mentions",
+-    "local_model_chat_sessions": "Hermes sessions whose model metadata is local/open-weight",
++    "local_model_chat_sessions": "Black Pool sessions whose model metadata is local/open-weight",
+     "toolset_events": "toolset or tool-family mentions",
+     "config_events": "configuration/environment/manifest activity",
+     "git_history_events": "git history operations such as rebase, merge, fetch, push, or tag",
+     "test_events": "test/check/verification command mentions",
+     "screenshot_events": "screenshot, Playwright, PNG, or vision-inspection activity",
+     "release_events": "release, version, publish, or git tag events",
+-    "session_count": "Hermes sessions",
++    "session_count": "Black Pool sessions",
+     "weekend_sessions": "sessions started on weekends",
+     "night_sessions": "sessions started late night or before dawn",
+ }
+@@ -564,12 +564,12 @@ def metric_label(metric: str) -> str:
+ 
+ def criteria_for(definition: Dict[str, Any]) -> str:
+     if definition.get("secret") and definition.get("state") == "secret":
+-        return "Secret: exact requirement hidden until Hermes sees the first matching signal. Keep using Hermes across debugging, tools, memory, skills, plugins, and model workflows to reveal it."
++        return "Secret: exact requirement hidden until Black Pool sees the first matching signal. Keep using Black Pool across debugging, tools, memory, skills, plugins, and model workflows to reveal it."
+     secret_prefix = ""
+     if "threshold_metric" in definition:
+         tiers_list = sorted(definition.get("tiers", []), key=lambda t: t["threshold"])
+         if not tiers_list:
+-            return secret_prefix + "Requirement: use Hermes in the matching workflow."
++            return secret_prefix + "Requirement: use Black Pool in the matching workflow."
+         metric = metric_label(definition["threshold_metric"])
+         ladder = ", ".join(f"{t['name']} {t['threshold']}" for t in tiers_list)
+         return secret_prefix + f"Requirement: {metric}. Tier ladder: {ladder}."
+@@ -577,13 +577,13 @@ def criteria_for(definition: Dict[str, Any]) -> str:
+     if requirements:
+         parts = [f"{metric_label(r['metric'])} ≥ {int(r.get('gte', 1))}" for r in requirements]
+         return secret_prefix + "Requirement: " + "; ".join(parts) + "."
+-    return secret_prefix + "Requirement: complete the matching Hermes behavior."
++    return secret_prefix + "Requirement: complete the matching Black Pool behavior."
+ 
+ 
+ def display_achievement(item: Dict[str, Any]) -> Dict[str, Any]:
+     clean = dict(item)
+     if clean.get("state") == "secret":
+-        return {**clean, "name": "???", "description": "Secret achievement: hidden until Hermes detects the first relevant behavior in your session history.", "criteria": criteria_for(clean), "icon": "secret"}
++        return {**clean, "name": "???", "description": "Secret achievement: hidden until Black Pool detects the first relevant behavior in your session history.", "criteria": criteria_for(clean), "icon": "secret"}
+     clean["criteria"] = criteria_for(clean)
+     return clean
+ 
+@@ -593,7 +593,7 @@ def scan_sessions(
+     progress_callback: Optional[Any] = None,
+     progress_every: int = 250,
+ ) -> Dict[str, Any]:
+-    """Scan Hermes sessions and build per-session achievement stats.
++    """Scan Black Pool sessions and build per-session achievement stats.
+ 
+     ``limit=None`` (the default) scans the ENTIRE session history. Prior
+     versions capped this at 200, which silently reduced achievement totals
+diff --git a/plugins/image_gen/krea/__init__.py b/plugins/image_gen/krea/__init__.py
+index 0027a8f..5ff10ba 100644
+--- a/plugins/image_gen/krea/__init__.py
++++ b/plugins/image_gen/krea/__init__.py
+@@ -83,7 +83,7 @@ _MODELS: Dict[str, Dict[str, Any]] = {
+ 
+ DEFAULT_MODEL = "krea-2-medium"
+ 
+-# Hermes uses 3 abstract aspect ratios. Map to Krea's enum (which is wider).
++# Black Pool uses 3 abstract aspect ratios. Map to Krea's enum (which is wider).
+ # Krea accepts: 1:1, 4:3, 3:2, 16:9, 2.35:1, 4:5, 2:3, 9:16
+ _ASPECT_MAP = {
+     "landscape": "16:9",
 diff --git a/plugins/image_gen/openrouter/__init__.py b/plugins/image_gen/openrouter/__init__.py
 index bb3f23e..91f6cff 100644
 --- a/plugins/image_gen/openrouter/__init__.py
@@ -48869,9 +58917,27 @@ index bb3f23e..91f6cff 100644
          last_error: Optional[Dict[str, Any]] = None
          for i, model_id in enumerate(model_chain):
 diff --git a/plugins/kanban/dashboard/dist/index.js b/plugins/kanban/dashboard/dist/index.js
-index dc582a7..80152cd 100644
+index dc582a7..41ddeff 100644
 --- a/plugins/kanban/dashboard/dist/index.js
 +++ b/plugins/kanban/dashboard/dist/index.js
+@@ -1,5 +1,5 @@
+ /**
+- * Hermes Kanban — Dashboard Plugin
++ * Black Pool Kanban — Dashboard Plugin
+  *
+  * Board view for the multi-agent collaboration board backed by
+  * ~/.hermes/kanban.db. Calls the plugin's backend at /api/plugins/kanban/
+@@ -1779,8 +1779,8 @@
+       target: "_blank",
+       rel: "noopener noreferrer",
+       className: "hermes-kanban-docs-link",
+-      title: "Open Hermes Kanban docs in a new tab",
+-      "aria-label": "Hermes Kanban documentation",
++      title: "Open Black Pool Kanban docs in a new tab",
++      "aria-label": "Black Pool Kanban documentation",
+     }, "?");
+   }
+ 
 @@ -2443,7 +2443,7 @@
          ),
        ),
@@ -48910,8 +58976,19 @@ index dc582a7..80152cd 100644
                  style: { textTransform: "none" },
                  autoCapitalize: "none",
                  autoCorrect: "off",
+diff --git a/plugins/kanban/dashboard/dist/style.css b/plugins/kanban/dashboard/dist/style.css
+index fe0fd72..6886103 100644
+--- a/plugins/kanban/dashboard/dist/style.css
++++ b/plugins/kanban/dashboard/dist/style.css
+@@ -1,5 +1,5 @@
+ /*
+- * Hermes Kanban — dashboard plugin styles.
++ * Black Pool Kanban — dashboard plugin styles.
+  *
+  * All colors reference theme CSS vars so the board reskins with the
+  * active dashboard theme. No hardcoded palette.
 diff --git a/plugins/kanban/dashboard/plugin_api.py b/plugins/kanban/dashboard/plugin_api.py
-index ade9fa1..473a235 100644
+index ade9fa1..ebcf99e 100644
 --- a/plugins/kanban/dashboard/plugin_api.py
 +++ b/plugins/kanban/dashboard/plugin_api.py
 @@ -2086,7 +2086,7 @@ def _configured_home_channels() -> list[dict]:
@@ -48923,19 +59000,66 @@ index ade9fa1..473a235 100644
      try:
          from hermes_cli.profiles import get_active_profile_name
          return get_active_profile_name() or "default"
+@@ -2310,7 +2310,7 @@ def model_options():
+ 
+     Thin wrapper around ``hermes_cli.inventory.build_models_payload`` — the
+     same substrate the dashboard Models page and the TUI picker use, so the
+-    dropdown can never offer a model/provider pair the rest of Hermes
++    dropdown can never offer a model/provider pair the rest of Black Pool
+     wouldn't accept. Deliberately skips pricing/capability enrichment and
+     custom-provider probes: the dropdown needs names fast, not $/Mtok
+     columns (a slow/offline local endpoint must not hang the drawer).
+@@ -2433,7 +2433,7 @@ def _default_workspace_kind(board: dict[str, Any]) -> str:
+ 
+ @router.get("/projects")
+ def list_kanban_projects():
+-    """List first-class Hermes projects for board scoping.
++    """List first-class Black Pool projects for board scoping.
+ 
+     Returns ``{projects: [{id, slug, name, primary_path, icon, color}]}``.
+     Archived projects are excluded — a board can only be scoped to a live one.
 diff --git a/plugins/memory/hindsight/__init__.py b/plugins/memory/hindsight/__init__.py
-index 03632b9..b05518f 100644
+index 03632b9..04d8175 100644
 --- a/plugins/memory/hindsight/__init__.py
 +++ b/plugins/memory/hindsight/__init__.py
-@@ -693,7 +693,7 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
+@@ -155,7 +155,7 @@ def _check_local_runtime() -> tuple[bool, str | None]:
+ 
+     On older CPUs, importing the local Hindsight stack can raise a runtime
+     error from NumPy before the daemon starts. Treat that as "unavailable"
+-    so Hermes can degrade gracefully instead of repeatedly trying to start
++    so Black Pool can degrade gracefully instead of repeatedly trying to start
+     a broken local memory backend.
+ 
+     The embedded daemon computes embeddings via ``sentence_transformers``
+@@ -545,7 +545,7 @@ def _utc_timestamp() -> str:
+ 
+ 
+ def _embedded_profile_name(config: dict[str, Any]) -> str:
+-    """Return the Hindsight embedded profile name for this Hermes config."""
++    """Return the Hindsight embedded profile name for this Black Pool config."""
+     profile = config.get("profile", "hermes")
+     return str(profile or "hermes")
+ 
+@@ -556,7 +556,7 @@ def _load_simple_env(path) -> dict[str, str]:
+         return {}
+ 
+     values: dict[str, str] = {}
+-    # utf-8-sig, not plain utf-8: this is also used on the Hermes .env during
++    # utf-8-sig, not plain utf-8: this is also used on the Black Pool .env during
+     # post_setup, and a Notepad BOM would otherwise stick to the first key.
+     for line in path.read_text(encoding="utf-8-sig", errors="replace").splitlines():
+         if not line or line.startswith("#") or "=" not in line:
+@@ -693,8 +693,8 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
      """Resolve a bank_id template string with the given placeholders.
  
      Supported placeholders (each is sanitized before substitution):
 -      {profile}   — active Hermes profile name (from agent_identity)
+-      {workspace} — Hermes workspace name (from agent_workspace)
 +      {profile}   — active Black Pool profile name (from agent_identity)
-       {workspace} — Hermes workspace name (from agent_workspace)
++      {workspace} — Black Pool workspace name (from agent_workspace)
        {platform}  — "cli", "telegram", "discord", etc.
        {user}      — platform user id (gateway sessions)
+       {session}   — current session id
 @@ -834,7 +834,7 @@ class HindsightMemoryProvider(MemoryProvider):
          # path.
          self._prefetch_waits_for_retain = True
@@ -48945,6 +59069,15 @@ index 03632b9..b05518f 100644
          self._turn_counter = 0
          self._session_turns: list[str] = []  # accumulates ALL turns for the session
          # How many turns the last append-mode retain already shipped. Used to
+@@ -1145,7 +1145,7 @@ class HindsightMemoryProvider(MemoryProvider):
+         print("\n  Start a new session to activate.\n")
+ 
+     def _offer_starter_template(self, mode: str, provider_config: dict, env_writes: dict) -> None:
+-        """Offer to seed the bank with a Hermes starter template (best-effort)."""
++        """Offer to seed the bank with a Black Pool starter template (best-effort)."""
+         from hermes_cli.memory_setup import _CANCELLED, _curses_select
+ 
+         from . import templates as _hs_templates
 @@ -1200,7 +1200,7 @@ class HindsightMemoryProvider(MemoryProvider):
              {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
              {"key": "prefetch_waits_for_retain", "description": "Have the background next-turn prefetch wait for the just-completed retain to become recall-visible on the server (local queue drain + async operation completion) before recalling, so recall includes the just-completed turn (runs off the reply path, adds no response latency)", "default": True},
@@ -48963,8 +59096,89 @@ index 03632b9..b05518f 100644
  
          # Recall controls
          self._auto_recall = self._config.get("auto_recall", True)
+@@ -1715,7 +1715,7 @@ class HindsightMemoryProvider(MemoryProvider):
+             self._recall_types = list(configured_types) or ["observation"]
+         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
+         # On-by-default deterministic indicator: when auto-recall injects memory,
+-        # Hermes emits a "👁️ Hindsight — recalled N memories" status line so the
++        # Black Pool emits a "👁️ Hindsight — recalled N memories" status line so the
+         # user SEES memory working, independent of whether the model mentions it.
+         # Off switch for customer-facing agents that shouldn't surface internals.
+         self._recall_indicator = bool(self._config.get("recall_indicator", True))
+@@ -1761,13 +1761,13 @@ class HindsightMemoryProvider(MemoryProvider):
+                 msg = (
+                     "Hindsight local_embedded mode cannot run as root "
+                     "(PostgreSQL initdb refuses root). Skipping the embedded "
+-                    "memory daemon. Run Hermes as a non-root user, or switch "
++                    "memory daemon. Run Black Pool as a non-root user, or switch "
+                     "to cloud / local_external mode via 'hermes memory setup'."
+                 )
+                 logger.warning(msg)
+                 # Surface to the terminal too — a daemon that never starts
+                 # would otherwise fail silently and the user would only see
+-                # Hermes get sluggish. (issue #13125)
++                # Black Pool get sluggish. (issue #13125)
+                 try:
+                     print(f"  ⚠ {msg}", file=sys.stderr, flush=True)
+                 except Exception:
+@@ -2401,7 +2401,7 @@ class HindsightMemoryProvider(MemoryProvider):
+             try:
+                 if self._mode == "local_embedded":
+                     # HindsightEmbedded.close() delegates to its sync client.close().
+-                    # When Hermes created/used that client on the shared async loop,
++                    # When Black Pool created/used that client on the shared async loop,
+                     # closing it from this thread can raise "attached to a different
+                     # loop" before aiohttp releases the session. Close the embedded
+                     # inner async client on the shared loop first, then let the
+diff --git a/plugins/memory/hindsight/config_schema.py b/plugins/memory/hindsight/config_schema.py
+index a6e7ef9..a7f8be6 100644
+--- a/plugins/memory/hindsight/config_schema.py
++++ b/plugins/memory/hindsight/config_schema.py
+@@ -18,7 +18,7 @@ CONFIG_SCHEMA = ProviderConfigSchema(
+             label="Mode",
+             kind=KIND_SELECT,
+             default="cloud",
+-            description="How Hermes connects to Hindsight.",
++            description="How Black Pool connects to Hindsight.",
+             options=(
+                 ProviderFieldOption(
+                     "cloud",
+diff --git a/plugins/memory/holographic/store.py b/plugins/memory/holographic/store.py
+index 802ffaf..3fdb478 100644
+--- a/plugins/memory/holographic/store.py
++++ b/plugins/memory/holographic/store.py
+@@ -1,6 +1,6 @@
+ """
+ SQLite-backed fact store with entity resolution and trust scoring.
+-Single-user Hermes memory store plugin.
++Single-user Black Pool memory store plugin.
+ """
+ 
+ import os
+diff --git a/plugins/memory/honcho/__init__.py b/plugins/memory/honcho/__init__.py
+index 1347014..8e1a61d 100644
+--- a/plugins/memory/honcho/__init__.py
++++ b/plugins/memory/honcho/__init__.py
+@@ -450,7 +450,7 @@ class HonchoMemoryProvider(MemoryProvider):
+     def _start_session_init_background(self, *, wait_timeout: float = 0.0) -> None:
+         """Start Honcho session initialization in a daemon thread.
+ 
+-        This keeps Hermes CLI/gateway startup responsive when Honcho is down,
++        This keeps Black Pool CLI/gateway startup responsive when Honcho is down,
+         slow, or its database is unhealthy. The thread may still take the SDK
+         timeout path, but it cannot block agent construction or first prompt
+         assembly. ``wait_timeout`` lets fast/mock initializations finish before
+@@ -524,7 +524,7 @@ class HonchoMemoryProvider(MemoryProvider):
+         # not treat that partially initialized state as usable.
+         session = self._manager.get_or_create(self._session_key)
+ 
+-        # Skip under per-session strategy: every Hermes run creates a fresh
++        # Skip under per-session strategy: every Black Pool run creates a fresh
+         # Honcho session by design, so uploading MEMORY.md/USER.md/SOUL.md to
+         # each one would flood the backend with short-lived duplicates instead
+         # of performing a one-time migration.
 diff --git a/plugins/memory/honcho/cli.py b/plugins/memory/honcho/cli.py
-index 74822e3..f3fb801 100644
+index 74822e3..5c7d451 100644
 --- a/plugins/memory/honcho/cli.py
 +++ b/plugins/memory/honcho/cli.py
 @@ -161,7 +161,7 @@ def cmd_disable(args) -> None:
@@ -48985,6 +59199,33 @@ index 74822e3..f3fb801 100644
      if _profile_override:
          if _profile_override in {"default", "custom"}:
              return HOST
+@@ -540,7 +540,7 @@ def cmd_setup(args) -> None:
+     write_path = _local_config_path()
+     read_path = _config_path()
+     print("\nHoncho memory setup\n" + "─" * 40)
+-    print("  Honcho gives Hermes persistent cross-session memory.")
++    print("  Honcho gives Black Pool persistent cross-session memory.")
+     print(f"  Config: {write_path}")
+     if read_path != write_path and read_path.exists():
+         print(f"  (seeding from existing config at {read_path})")
+@@ -771,7 +771,7 @@ def cmd_setup(args) -> None:
+         hermes_host["workspace"] = new_workspace
+ 
+     # --- 3b. Gateway identity mapping ---
+-    # These keys only affect the Hermes GATEWAY (Telegram/Discord/Slack/...),
++    # These keys only affect the Black Pool GATEWAY (Telegram/Discord/Slack/...),
+     # the one entrypoint that supplies a runtime user ID.  CLI/TUI/desktop/ACP
+     # sessions have no runtime ID and fall through to peerName, so the step is
+     # moot off-gateway — gate it behind detection.
+@@ -798,7 +798,7 @@ def cmd_setup(args) -> None:
+     if gw_platforms is None:
+         print("\n  Gateway identity mapping routes platform users to memory peers.")
+         run_mapping = _prompt(
+-            "Running the Hermes gateway (Telegram/Discord/etc.)? (y/N)",
++            "Running the Black Pool gateway (Telegram/Discord/etc.)? (y/N)",
+             default="n",
+         ).strip().lower() in {"y", "yes"}
+     elif not gw_platforms:
 @@ -1078,7 +1078,7 @@ def _apply_grant_to_host(hermes_host: dict, cred) -> None:
  
  
@@ -48994,10 +59235,121 @@ index 74822e3..f3fb801 100644
      if _profile_override:
          return _profile_override
      try:
+@@ -1375,7 +1375,7 @@ def cmd_peer(args) -> None:
+         print(f"  User peer:   {user}")
+         print("    Your identity in Honcho. Messages you send build this peer's card.")
+         print(f"  AI peer:     {ai}")
+-        print("    Hermes' identity in Honcho. Seed with 'hermes honcho identity <file>'.")
++        print("    Black Pool' identity in Honcho. Seed with 'hermes honcho identity <file>'.")
+         print("    Dialectic calls ask this peer questions to warm session context.")
+         print()
+         print(f"  Dialectic reasoning:  {lvl}  ({', '.join(REASONING_LEVELS)})")
+@@ -1497,7 +1497,7 @@ def cmd_tokens(args) -> None:
+         print("    the user and session, injected directly into the system prompt.")
+         print()
+         print(f"  Dialectic   {d_chars} chars, reasoning: {d_level}")
+-        print("    AI-to-AI inference. Hermes asks Honcho's AI peer a question")
++        print("    AI-to-AI inference. Black Pool asks Honcho's AI peer a question")
+         print("    (e.g. \"what were we working on?\") and Honcho runs its own model")
+         print("    to synthesize an answer. Used for first-turn session continuity.")
+         print("    Level controls how much reasoning Honcho spends on the answer.")
+@@ -1602,7 +1602,7 @@ def cmd_identity(args) -> None:
+ 
+ 
+ def cmd_migrate(args) -> None:
+-    """Step-by-step migration guide: OpenClaw native memory → Hermes + Honcho."""
++    """Step-by-step migration guide: OpenClaw native memory → Black Pool + Honcho."""
+     from pathlib import Path
+ 
+     # ── Detect OpenClaw native memory files ──────────────────────────────────
+@@ -1630,7 +1630,7 @@ def cmd_migrate(args) -> None:
+     cfg = _read_config()
+     has_key = bool(_resolve_api_key(cfg))
+ 
+-    print("\nHoncho migration: OpenClaw native memory → Hermes\n" + "─" * 50)
++    print("\nHoncho migration: OpenClaw native memory → Black Pool\n" + "─" * 50)
+     print()
+     print("  OpenClaw's native memory stores context in local markdown files")
+     print("  (USER.md, MEMORY.md, SOUL.md, ...) and injects them via QMD search.")
+@@ -1647,7 +1647,7 @@ def cmd_migrate(args) -> None:
+         print(f"  Honcho API key already configured: {masked}")
+         print("  Skip to Step 2.")
+     else:
+-        print("  Honcho is a cloud memory service that gives Hermes persistent memory")
++        print("  Honcho is a cloud memory service that gives Black Pool persistent memory")
+         print("  across sessions. You need an API key to use it.")
+         print()
+         print("  1. Get your API key at https://app.honcho.dev")
+@@ -1694,7 +1694,7 @@ def cmd_migrate(args) -> None:
+         print()
+         print("  These are picked up automatically the first time you run 'hermes'")
+         print("  with Honcho configured and no prior session history.")
+-        print("  (Hermes calls migrate_memory_files() on first session init.)")
++        print("  (Black Pool calls migrate_memory_files() on first session init.)")
+         print()
+         print("  If you want to migrate them now without starting a session:")
+         for f in user_files:
+@@ -1741,7 +1741,7 @@ def cmd_migrate(args) -> None:
+     print("  agent's character, capabilities, and behavioral rules. In OpenClaw")
+     print("  these are injected via file search at prompt-build time.")
+     print()
+-    print("  In Hermes, they are seeded once into Honcho's AI peer through the")
++    print("  In Black Pool, they are seeded once into Honcho's AI peer through the")
+     print("  observation pipeline. Honcho builds a representation from them and")
+     print("  from every subsequent assistant message (observe_me=True). Over time")
+     print("  the representation reflects actual behavior, not just declaration.")
+@@ -1788,17 +1788,17 @@ def cmd_migrate(args) -> None:
+     print()
+     print("  Storage")
+     print("    OpenClaw: markdown files on disk, searched via QMD at prompt-build time.")
+-    print("    Hermes:   cloud-backed Honcho peers. Files can stay on disk as source")
++    print("    Black Pool:   cloud-backed Honcho peers. Files can stay on disk as source")
+     print("              of truth; Honcho holds the live representation.")
+     print()
+     print("  Context injection")
+     print("    OpenClaw: file excerpts injected synchronously before each LLM call.")
+-    print("    Hermes:   Honcho context fetched async at turn end, injected next turn.")
++    print("    Black Pool:   Honcho context fetched async at turn end, injected next turn.")
+     print("              First turn has no Honcho context; subsequent turns are loaded.")
+     print()
+     print("  Memory growth")
+     print("    OpenClaw: you edit files manually to update memory.")
+-    print("    Hermes:   Honcho observes every message and updates representations")
++    print("    Black Pool:   Honcho observes every message and updates representations")
+     print("              automatically. Files become the seed, not the live store.")
+     print()
+     print("  Honcho tools (available to the agent during conversation)")
+@@ -1810,7 +1810,7 @@ def cmd_migrate(args) -> None:
+     print()
+     print("  Session naming")
+     print("    OpenClaw: no persistent session concept — files are global.")
+-    print("    Hermes:   per-session by default — each run gets its own session")
++    print("    Black Pool:   per-session by default — each run gets its own session")
+     print("              Map a custom name:  hermes honcho map <session-name>")
+ 
+     # ── Step 6: Next steps ────────────────────────────────────────────────────
+@@ -1967,7 +1967,7 @@ def register_cli(subparser) -> None:
+ 
+     subs.add_parser(
+         "migrate",
+-        help="Step-by-step migration guide from openclaw-honcho to Hermes Honcho",
++        help="Step-by-step migration guide from openclaw-honcho to Black Pool Honcho",
+     )
+     subs.add_parser("enable", help="Enable Honcho for the active profile")
+     subs.add_parser("disable", help="Disable Honcho for the active profile")
 diff --git a/plugins/memory/honcho/client.py b/plugins/memory/honcho/client.py
-index 8a2d019..ab7e7de 100644
+index 8a2d019..d49e5ab 100644
 --- a/plugins/memory/honcho/client.py
 +++ b/plugins/memory/honcho/client.py
+@@ -1,7 +1,7 @@
+ """Honcho client initialization and configuration.
+ 
+ Resolution order for config file:
+-  1. $HERMES_HOME/honcho.json  (instance-local, enables isolated Hermes instances)
++  1. $HERMES_HOME/honcho.json  (instance-local, enables isolated Black Pool instances)
+   2. ~/.honcho/config.json     (global, shared across all Honcho-enabled apps)
+   3. Environment variables     (HONCHO_API_KEY, HONCHO_ENVIRONMENT)
+ 
 @@ -57,7 +57,7 @@ HOST = "hermes"
  
  
@@ -49016,9 +59368,12 @@ index 8a2d019..ab7e7de 100644
  
      Resolution order:
        1. HERMES_HONCHO_HOST env var (explicit override)
-@@ -97,7 +97,7 @@ def resolve_active_host() -> str:
+@@ -95,9 +95,9 @@ def resolve_active_host() -> str:
+         profile_host = HOST
+ 
      # Honcho's generic config can carry a defaultHost (for example "local"),
-     # but applying it before profile resolution makes every named Hermes
+-    # but applying it before profile resolution makes every named Hermes
++    # but applying it before profile resolution makes every named Black Pool
      # profile share that same host.  Keep named profiles isolated; only the
 -    # default Hermes profile may opt into the config's default host.
 +    # default Black Pool profile may opt into the config's default host.
@@ -49034,6 +59389,19 @@ index 8a2d019..ab7e7de 100644
          """
          resolved_host = host or resolve_active_host()
          path = config_path or resolve_config_path()
+@@ -879,10 +879,10 @@ class HonchoClientConfig:
+ 
+         Resolution order:
+           1. Gateway session key (stable per-chat identifier from gateway platforms)
+-          2. per-session strategy — Hermes session_id ({timestamp}_{hex}); authoritative,
++          2. per-session strategy — Black Pool session_id ({timestamp}_{hex}); authoritative,
+              so a generated title never remaps a live conversation
+           3. Manual directory override from sessions map
+-          4. Hermes session title (from /title command; non-per-session)
++          4. Black Pool session title (from /title command; non-per-session)
+           5. per-repo strategy — git repo root directory name
+           6. per-directory strategy — directory basename
+           7. global strategy — workspace name
 diff --git a/plugins/memory/honcho/oauth.py b/plugins/memory/honcho/oauth.py
 index a51f03c..621c573 100644
 --- a/plugins/memory/honcho/oauth.py
@@ -49047,10 +59415,270 @@ index a51f03c..621c573 100644
      the single-use refresh token and tripping reuse-detection — which revokes
      the whole grant. An OS file lock on ``<config>.lock`` serializes rotation
      across processes; best-effort, so a platform without flock degrades to
+diff --git a/plugins/memory/honcho/oauth_flow.py b/plugins/memory/honcho/oauth_flow.py
+index b1268c0..d174514 100644
+--- a/plugins/memory/honcho/oauth_flow.py
++++ b/plugins/memory/honcho/oauth_flow.py
+@@ -27,7 +27,7 @@ from plugins.memory.honcho.client import resolve_active_host, resolve_config_pat
+ 
+ logger = logging.getLogger(__name__)
+ 
+-# The loopback redirect registered for the Hermes OAuth client. IP-literal so
++# The loopback redirect registered for the Black Pool OAuth client. IP-literal so
+ # the browser can't resolve the advertised host to ::1 and miss the IPv4 bind.
+ LOOPBACK_HOST = "127.0.0.1"
+ LOOPBACK_PORT = 8765
+@@ -242,7 +242,7 @@ _CALLBACK_HTML = (
+     b"<title>Honcho connected</title>"
+     b"<body style='font:14px ui-monospace,monospace;background:#0b0e14;color:#c9d1d9;"
+     b"display:flex;align-items:center;justify-content:center;height:100vh;margin:0'>"
+-    b"<div>Connected to Honcho. You can close this tab and return to Hermes.</div>"
++    b"<div>Connected to Honcho. You can close this tab and return to Black Pool.</div>"
+ )
+ 
+ _CALLBACK_ERROR_HTML = (
+diff --git a/plugins/memory/honcho/session.py b/plugins/memory/honcho/session.py
+index 1ee7dc4..31c4c3d 100644
+--- a/plugins/memory/honcho/session.py
++++ b/plugins/memory/honcho/session.py
+@@ -1036,7 +1036,7 @@ class HonchoSessionManager:
+         except Exception as e:
+             logger.warning("Failed to fetch user context from Honcho: %s", e)
+ 
+-        # Also fetch AI peer's own representation so Hermes knows itself.
++        # Also fetch AI peer's own representation so Black Pool knows itself.
+         try:
+             ai_ctx = self._fetch_peer_context(session.assistant_peer_id, target=session.assistant_peer_id)
+             result["ai_representation"] = ai_ctx["representation"]
+diff --git a/plugins/memory/mem0/_setup.py b/plugins/memory/mem0/_setup.py
+index 368aec3..e1267d6 100644
+--- a/plugins/memory/mem0/_setup.py
++++ b/plugins/memory/mem0/_setup.py
+@@ -319,7 +319,7 @@ def _setup_platform(hermes_home: str, config: dict, flags: dict[str, str]) -> No
+         print(
+             "\n  ⚠ MEM0_HOST is set in your environment "
+             f"({os.environ['MEM0_HOST']}). It overrides platform mode — "
+-            "remove it from ~/.hermes/.env (or unset it) or Hermes will keep "
++            "remove it from ~/.hermes/.env (or unset it) or Black Pool will keep "
+             "routing to the self-hosted server."
+         )
+ 
+diff --git a/plugins/memory/openviking/__init__.py b/plugins/memory/openviking/__init__.py
+index 74a5a8d..560bbea 100644
+--- a/plugins/memory/openviking/__init__.py
++++ b/plugins/memory/openviking/__init__.py
+@@ -13,7 +13,7 @@ or a linked OpenViking CLI config:
+   OPENVIKING_API_KEY   — API key (required for authenticated servers)
+   OPENVIKING_ACCOUNT   — Tenant account for local/trusted mode (default: default)
+   OPENVIKING_USER      — Tenant user for local/trusted mode (default: default)
+-  OPENVIKING_AGENT     — Hermes peer ID in OpenViking (default: hermes)
++  OPENVIKING_AGENT     — Black Pool peer ID in OpenViking (default: hermes)
+ 
+ Capabilities:
+   - Automatic memory extraction on session commit (6 categories)
+@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
+ _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
+ _OPENVIKING_SERVICE_ENDPOINT = "https://api.vikingdb.cn-beijing.volces.com/openviking"
+ _DEFAULT_AGENT = "hermes"
+-_AGENT_PROMPT_LABEL = "Hermes peer ID in OpenViking"
++_AGENT_PROMPT_LABEL = "Black Pool peer ID in OpenViking"
+ _OVCLI_CONFIG_ENV = "OPENVIKING_CLI_CONFIG_FILE"
+ _OVCLI_DEFAULT_RELATIVE_PATH = ".openviking/ovcli.conf"
+ _OVCLI_SAVED_PREFIX = "ovcli.conf."
+@@ -218,7 +218,7 @@ def _format_openviking_exception(error: Exception) -> str:
+ 
+ 
+ def _derive_openviking_user_text(content: Any) -> str:
+-    """Strip Hermes slash-skill scaffolding before sending content to OpenViking.
++    """Strip Black Pool slash-skill scaffolding before sending content to OpenViking.
+ 
+     Defense-in-depth: MemoryManager already strips skill scaffolding for the
+     whole provider fan-out (see ``MemoryManager._strip_skill_scaffolding``), so
+@@ -927,7 +927,7 @@ def _normalize_openviking_url(url: str) -> str:
+     # Local / LAN self-host remains allowed; reject cloud-metadata and other
+     # always-blocked floors so a poisoned endpoint cannot SSRF via memory sync.
+     # Never silently replace an explicitly unsafe endpoint with localhost: that
+-    # could attach Hermes to an unrelated deployment and forward credentials to
++    # could attach Black Pool to an unrelated deployment and forward credentials to
+     # a destination the user did not configure.
+     try:
+         check_url = candidate
+@@ -941,7 +941,7 @@ def _normalize_openviking_url(url: str) -> str:
+     except Exception as exc:
+         logger.debug("OpenViking endpoint safety validation failed", exc_info=True)
+         raise _OpenVikingEndpointError(
+-            "OpenViking endpoint safety validation failed; Hermes refused the connection."
++            "OpenViking endpoint safety validation failed; Black Pool refused the connection."
+         ) from exc
+ 
+     return candidate
+@@ -1536,7 +1536,7 @@ def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
+         listener = _describe_local_port_listener(host, port)
+         return (
+             _LOCAL_SERVER_OCCUPIED,
+-            f"Port {host}:{port} is occupied by {listener}. Hermes did not start "
++            f"Port {host}:{port} is occupied by {listener}. Black Pool did not start "
+             "openviking-server because the listener has not passed OpenViking's /health check.",
+         )
+     server_cmd = shutil.which("openviking-server")
+@@ -1549,12 +1549,12 @@ def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
+     try:
+         log_path.parent.mkdir(parents=True, exist_ok=True)
+         # Do not let the server child inherit this process's PYTHONPATH.
+-        # The Hermes Desktop backend can include the Hermes venv's
++        # The Black Pool Desktop backend can include the Black Pool venv's
+         # site-packages in PYTHONPATH. If inherited, openviking-server would
+-        # import aiohttp and friends from the Hermes venv instead of its own
++        # import aiohttp and friends from the Black Pool venv instead of its own
+         # (its venv's site-packages are shadowed because PYTHONPATH precedes
+         # them) —
+-        # and on Windows the loaded DLLs then lock the Hermes venv,
++        # and on Windows the loaded DLLs then lock the Black Pool venv,
+         # aborting `hermes update` with access-denied on .pyd files.
+         # Strip PYTHONPATH so the server resolves packages from its own
+         # venv. (#78153)
+@@ -1671,7 +1671,7 @@ def _runtime_openviking_timeout_message(endpoint: str) -> str:
+         f"Local OpenViking server at {endpoint} is not reachable. "
+         "Tried to start openviking-server, but it did not become reachable "
+         f"within {_LOCAL_OPENVIKING_AUTOSTART_TIMEOUT:.0f} seconds. "
+-        "OpenViking memory is temporarily unavailable; Hermes will retry on a later access or when "
++        "OpenViking memory is temporarily unavailable; Black Pool will retry on a later access or when "
+         "the config changes."
+     )
+ 
+@@ -2053,7 +2053,7 @@ def _print_openviking_ready(message: str, path: Optional[Path] = None) -> None:
+     print(f"  {message}")
+     if path is not None:
+         print(f"  Config file: {path}")
+-    print("  Start a new Hermes session to activate.\n")
++    print("  Start a new Black Pool session to activate.\n")
+ 
+ 
+ def _run_existing_profile_setup(
+@@ -2171,7 +2171,7 @@ def _run_create_profile_setup(
+     save_choice = select(
+         "  Save OpenViking config",
+         [
+-            ("Keep in Hermes only", "write values only to Hermes .env"),
++            ("Keep in Black Pool only", "write values only to Black Pool .env"),
+             ("Mirror to OpenViking store", "write ~/.openviking/ovcli.conf.<name> and link it"),
+         ],
+         default=1,
+@@ -2204,7 +2204,7 @@ def _run_create_profile_setup(
+         env_path=env_path,
+         values=values,
+     )
+-    _print_openviking_ready("Connection saved to Hermes .env.")
++    _print_openviking_ready("Connection saved to Black Pool .env.")
+     return True
+ 
+ 
+@@ -2339,7 +2339,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
+             {
+                 "key": "agent",
+                 "description": (
+-                    "Hermes peer ID in OpenViking, sent as the actor peer and "
++                    "Black Pool peer ID in OpenViking, sent as the actor peer and "
+                     "used for peer-scoped memories"
+                 ),
+                 "default": "hermes",
+@@ -2611,7 +2611,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
+                 if not healthy:
+                     warning_message = (
+                         f"OpenViking server at {endpoint} is still not reachable after auto-start. "
+-                        "OpenViking memory is temporarily unavailable; Hermes will retry on a later access or when "
++                        "OpenViking memory is temporarily unavailable; Black Pool will retry on a later access or when "
+                         "the config changes."
+                     )
+                 else:
+@@ -2630,7 +2630,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
+             except Exception as e:
+                 warning_message = (
+                     f"OpenViking server at {endpoint} could not be attached after auto-start: {e}. "
+-                    "OpenViking memory is temporarily unavailable; Hermes will retry on a later access or when "
++                    "OpenViking memory is temporarily unavailable; Black Pool will retry on a later access or when "
+                     "the config changes."
+                 )
+ 
+@@ -2656,7 +2656,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
+         if not _is_local_openviking_url(endpoint):
+             _emit_runtime_warning(
+                 f"Remote OpenViking server at {endpoint} is not reachable. "
+-                "OpenViking memory is temporarily unavailable; Hermes will retry on a later access or when "
++                "OpenViking memory is temporarily unavailable; Black Pool will retry on a later access or when "
+                 "the config changes. "
+                 "Check the configured endpoint and network connectivity.",
+                 warning_callback,
+@@ -2682,7 +2682,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
+                 self._runtime_start_pending = False
+                 warning_message = (
+                     f"Local OpenViking server at {endpoint} is not reachable. {start_message} "
+-                    "OpenViking memory is temporarily unavailable; Hermes will retry on a later access or when "
++                    "OpenViking memory is temporarily unavailable; Black Pool will retry on a later access or when "
+                     "the config changes."
+                 )
+                 self._client = None
+@@ -2787,7 +2787,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
+                 elif health_state != "healthy":
+                     _emit_runtime_warning(
+                         f"{health_message} OpenViking memory is temporarily unavailable; "
+-                        "Hermes will retry on a later access or when the config changes.",
++                        "Black Pool will retry on a later access or when the config changes.",
+                         warning_callback,
+                     )
+                     self._client = None
+@@ -2911,7 +2911,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
+         self._failed_refresh = (settings_key, time.monotonic())
+         if health_state == "responded":
+             logger.warning(
+-                "%s OpenViking memory is temporarily unavailable; Hermes will retry on a "
++                "%s OpenViking memory is temporarily unavailable; Black Pool will retry on a "
+                 "later access (after cooldown) or when the config changes.",
+                 health_message,
+             )
+@@ -4267,7 +4267,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
+         user_content: str,
+         assistant_content: str,
+     ) -> List[Dict[str, Any]]:
+-        """Slice the completed turn out of Hermes' full canonical transcript."""
++        """Slice the completed turn out of Black Pool' full canonical transcript."""
+         if not messages:
+             return []
+ 
+@@ -4386,7 +4386,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
+         *,
+         assistant_peer_id: str = "",
+     ) -> List[Dict[str, Any]]:
+-        """Convert Hermes canonical messages into OpenViking batch payloads."""
++        """Convert Black Pool canonical messages into OpenViking batch payloads."""
+         assistant_peer_id = str(assistant_peer_id or "").strip()
+         tool_calls_by_id: Dict[str, Dict[str, Any]] = {}
+         completed_tool_ids: set[str] = set()
+diff --git a/plugins/memory/supermemory/__init__.py b/plugins/memory/supermemory/__init__.py
+index 7d737fd..5ad1bc4 100644
+--- a/plugins/memory/supermemory/__init__.py
++++ b/plugins/memory/supermemory/__init__.py
+@@ -308,7 +308,7 @@ class _SupermemoryClient:
+         )
+ 
+     def _merge_metadata(self, metadata: Optional[dict]) -> dict:
+-        # sm_source routes Hermes writes into the "Hermes" Space in the Supermemory
++        # sm_source routes Black Pool writes into the "Black Pool" Space in the Supermemory
+         # app so the user can filter / bulk-manage them per source agent. This is a
+         # functional routing key for the user, not vendor telemetry.
+         merged = {"sm_source": "hermes", **(metadata or {})}
 diff --git a/plugins/model-providers/ai-gateway/__init__.py b/plugins/model-providers/ai-gateway/__init__.py
-index 9d01ab9..b85ca4e 100644
+index 9d01ab9..57fc8c0 100644
 --- a/plugins/model-providers/ai-gateway/__init__.py
 +++ b/plugins/model-providers/ai-gateway/__init__.py
+@@ -1,6 +1,6 @@
+ """Vercel AI Gateway provider profile.
+ 
+-AI Gateway routes to multiple backends. Hermes sends attribution
++AI Gateway routes to multiple backends. Black Pool sends attribution
+ headers and full reasoning config passthrough.
+ """
+ 
 @@ -35,7 +35,7 @@ vercel = VercelAIGatewayProfile(
      base_url="https://ai-gateway.vercel.sh/v1",
      default_headers={
@@ -49060,11 +59688,48 @@ index 9d01ab9..b85ca4e 100644
      },
      default_aux_model="google/gemini-3-flash",
  )
+diff --git a/plugins/model-providers/deepseek/__init__.py b/plugins/model-providers/deepseek/__init__.py
+index 1273f51..4755b0e 100644
+--- a/plugins/model-providers/deepseek/__init__.py
++++ b/plugins/model-providers/deepseek/__init__.py
+@@ -2,7 +2,7 @@
+ 
+ DeepSeek's V4 family defaults to thinking-mode ON when ``extra_body.thinking``
+ is unset.  The API then returns ``reasoning_content`` and starts enforcing
+-the contract that subsequent turns echo it back; combined with how Hermes
++the contract that subsequent turns echo it back; combined with how Black Pool
+ replays history this lands on the notorious HTTP 400
+ ``reasoning_content must be passed back`` error after the first tool call
+ (#15700, #17212, #17825).
+@@ -17,7 +17,7 @@ Non-thinking models (``deepseek-v3-*`` variants) are left as no-ops so we
+ don't perturb the V3 wire format.
+ 
+ The legacy aliases ``deepseek-chat`` / ``deepseek-reasoner`` were retired on
+-2026-07-24.  Use ``deepseek-v4-flash`` or ``deepseek-v4-pro``; Hermes remaps
++2026-07-24.  Use ``deepseek-v4-flash`` or ``deepseek-v4-pro``; Black Pool remaps
+ the retired IDs in ``hermes_cli.model_normalize``.
+ """
+ 
+@@ -34,7 +34,7 @@ def _model_supports_thinking(model: str | None) -> bool:
+ 
+     Currently covers the V4 family (``deepseek-v4-pro``, ``deepseek-v4-flash``,
+     and any future ``deepseek-v4-*`` variants).  Retired aliases are remapped
+-    before requests leave Hermes, so they are not listed here.
++    before requests leave Black Pool, so they are not listed here.
+     """
+     m = (model or "").strip().lower()
+     if not m:
 diff --git a/plugins/model-providers/fireworks/__init__.py b/plugins/model-providers/fireworks/__init__.py
-index 338058e..e5b3a50 100644
+index 338058e..31dd86a 100644
 --- a/plugins/model-providers/fireworks/__init__.py
 +++ b/plugins/model-providers/fireworks/__init__.py
-@@ -29,7 +29,7 @@ fireworks = ProviderProfile(
+@@ -24,12 +24,12 @@ fireworks = ProviderProfile(
+     base_url="https://api.fireworks.ai/inference/v1",
+     auth_type="api_key",
+     # Attribution headers sent on every Fireworks request. Values match the
+-    # canonical Hermes set in agent/auxiliary_client.py. Applied through the
++    # canonical Black Pool set in agent/auxiliary_client.py. Applied through the
+     # generic profile.default_headers path, so they survive switch_model and
      # credential rotation.
      default_headers={
          "HTTP-Referer": "https://hermes-agent.nousresearch.com",
@@ -49109,15 +59774,69 @@ index 23b3341..5213314 100644
      },
      default_aux_model="kimi-k2-turbo-preview",
 diff --git a/plugins/model-providers/meta-ai/__init__.py b/plugins/model-providers/meta-ai/__init__.py
-index de2a384..baa96f1 100644
+index de2a384..b171021 100644
 --- a/plugins/model-providers/meta-ai/__init__.py
 +++ b/plugins/model-providers/meta-ai/__init__.py
-@@ -1,4 +1,4 @@
+@@ -1,9 +1,9 @@
 -"""Meta Model API (Muse Spark) provider plugin for Hermes Agent.
 +"""Meta Model API (Muse Spark) provider plugin for Black Pool Agent.
  
  Provider profile for Meta Superintelligence Labs' Muse Spark family, served
  via the OpenAI-compatible Meta Model API at ``https://api.meta.ai/v1``.
+ 
+-Bundled from https://github.com/albertodepaola/hermes-meta-provider. Hermes'
++Bundled from https://github.com/albertodepaola/hermes-meta-provider. Black Pool'
+ provider discovery (``providers/__init__.py``) imports it on first
+ ``get_provider_profile()`` / ``list_providers()`` call, and the module-level
+ ``register_provider()`` below wires it into the registry.
+@@ -36,7 +36,7 @@ from providers.base import ProviderProfile
+ 
+ 
+ def _resolve_effort(reasoning_config: dict | None) -> str:
+-    """Map Hermes' reasoning_config to a Meta-safe ``reasoning_effort`` value.
++    """Map Black Pool' reasoning_config to a Meta-safe ``reasoning_effort`` value.
+ 
+     Meta's vocabulary (minimal..xhigh; rejects ``none``) is declared in
+     agent.reasoning_effort. Disabled/"none" maps to ``minimal`` (the closest
+diff --git a/plugins/model-providers/minimax/__init__.py b/plugins/model-providers/minimax/__init__.py
+index 7dbaf40..a628a67 100644
+--- a/plugins/model-providers/minimax/__init__.py
++++ b/plugins/model-providers/minimax/__init__.py
+@@ -41,7 +41,7 @@ class MiniMaxProfile(ProviderProfile):
+ 
+         MiniMax-M3's OpenAI-compatible endpoint keeps thinking inline unless
+         ``reasoning_split`` is sent, so always request the split format on that
+-        route. ``thinking`` controls the M3 mode; Hermes' effort levels are not
++        route. ``thinking`` controls the M3 mode; Black Pool' effort levels are not
+         a MiniMax depth knob here, so they only select adaptive vs disabled.
+         """
+         if not _is_minimax_global_openai_base_url(base_url) or not _is_minimax_m3(model):
+diff --git a/plugins/model-providers/nous/__init__.py b/plugins/model-providers/nous/__init__.py
+index e564704..e153dc7 100644
+--- a/plugins/model-providers/nous/__init__.py
++++ b/plugins/model-providers/nous/__init__.py
+@@ -129,7 +129,7 @@ nous = NousProfile(
+     aliases=("nous-portal", "nousresearch"),
+     env_vars=("NOUS_API_KEY",),
+     display_name="Nous Research",
+-    description="Nous Research — Hermes model family",
++    description="Nous Research — Black Pool model family",
+     signup_url="https://nousresearch.com/",
+     fallback_models=(
+         "hermes-3-405b",
+diff --git a/plugins/model-providers/ollama-cloud/__init__.py b/plugins/model-providers/ollama-cloud/__init__.py
+index ccc1eb1..51d65e0 100644
+--- a/plugins/model-providers/ollama-cloud/__init__.py
++++ b/plugins/model-providers/ollama-cloud/__init__.py
+@@ -6,7 +6,7 @@ supports top-level ``reasoning_effort`` with values ``none``, ``low``,
+ empirically confirmed for DeepSeek V4 — ``max`` produces ~2.5× more
+ thinking tokens than ``high``).
+ 
+-This profile maps Hermes's ``xhigh`` → ``max`` to unlock DeepSeek V4's
++This profile maps Black Pool's ``xhigh`` → ``max`` to unlock DeepSeek V4's
+ "Max thinking" tier through Ollama Cloud.  ``low`` / ``medium`` / ``high``
+ pass through unchanged.
+ 
 diff --git a/plugins/model-providers/opencode-free/__init__.py b/plugins/model-providers/opencode-free/__init__.py
 index 96d1970..06d4def 100644
 --- a/plugins/model-providers/opencode-free/__init__.py
@@ -49148,21 +59867,242 @@ index 2d55cae..77564c4 100644
      "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
  }
  
+diff --git a/plugins/model-providers/upstage/__init__.py b/plugins/model-providers/upstage/__init__.py
+index 1d6f574..8180c9a 100644
+--- a/plugins/model-providers/upstage/__init__.py
++++ b/plugins/model-providers/upstage/__init__.py
+@@ -13,10 +13,10 @@ from providers.base import ProviderProfile
+ # ``solar-mini-250127`` are covered too.
+ _NON_REASONING_MODEL_MARKERS = ("solar-mini", "syn-pro")
+ 
+-# When the user hasn't picked a reasoning effort, Hermes passes
++# When the user hasn't picked a reasoning effort, Black Pool passes
+ # reasoning_config=None. Solar's own server default is "minimal" (reasoning
+ # off), which is the wrong default for an agentic workload. We default reasoning
+-# ON at this effort — matching the "medium (default)" that Hermes' /reasoning
++# ON at this effort — matching the "medium (default)" that Black Pool' /reasoning
+ # panel shows for an unset config, so the displayed default and the real wire
+ # value agree. An explicit saved setting or a `/reasoning <level>` change is
+ # always honored over this default; `/reasoning none` disables it.
+@@ -75,7 +75,7 @@ class UpstageProfile(ProviderProfile):
+         if reasoning_config.get("enabled") is False:
+             return {}, top_level
+ 
+-        # Map Hermes' effort vocabulary onto Solar's accepted set via the
++        # Map Black Pool' effort vocabulary onto Solar's accepted set via the
+         # shared clamp (agent.reasoning_effort). minimal → omit (Solar's
+         # minimal means off); unknown-but-enabled bespoke levels collapse to
+         # high rather than silently downgrading (#62650 precedent).
+diff --git a/plugins/model-providers/zai/__init__.py b/plugins/model-providers/zai/__init__.py
+index 3220686..a1133d3 100644
+--- a/plugins/model-providers/zai/__init__.py
++++ b/plugins/model-providers/zai/__init__.py
+@@ -1,13 +1,13 @@
+ """ZAI / GLM provider profile.
+ 
+ Z.AI's GLM-4.5-and-later chat models default to thinking-mode ON when the
+-request omits ``thinking``.  Hermes' ``reasoning_config = {"enabled": False}``
++request omits ``thinking``.  Black Pool' ``reasoning_config = {"enabled": False}``
+ was previously a silent no-op on this route — the base profile emits nothing,
+ so users who turned thinking off (desktop toggle, ``/reasoning none``,
+ ``reasoning_effort: none``/``false`` in config.yaml) kept burning thinking
+ tokens on every turn.
+ 
+-:meth:`ZaiProfile.build_api_kwargs_extras` translates the Hermes reasoning
++:meth:`ZaiProfile.build_api_kwargs_extras` translates the Black Pool reasoning
+ config into the wire shape Z.AI's OpenAI-compat endpoint expects:
+ 
+     {"extra_body": {"thinking": {"type": "enabled" | "disabled"}}}
+@@ -19,7 +19,7 @@ untouched.
+ 
+ GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with exactly
+ two enabled levels — ``high`` and ``max`` — on the OpenAI-compatible endpoint
+-(per Z.AI / BigModel docs).  Hermes' richer effort scale is collapsed onto
++(per Z.AI / BigModel docs).  Black Pool' richer effort scale is collapsed onto
+ those two so the user's effort preference actually reaches the model instead
+ of being silently dropped.
+ """
+@@ -60,7 +60,7 @@ def _is_glm_5_2(model: str | None) -> bool:
+ 
+ 
+ def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
+-    """Map Hermes reasoning effort onto GLM-5.2's native ``high``/``max``.
++    """Map Black Pool reasoning effort onto GLM-5.2's native ``high``/``max``.
+ 
+     GLM-5.2 only supports two enabled effort levels. ``xhigh``/``max``/``ultra``
+     request the top tier; everything else that is enabled requests ``high``
+diff --git a/plugins/observability/langfuse/__init__.py b/plugins/observability/langfuse/__init__.py
+index 4454fd5..abe6f23 100644
+--- a/plugins/observability/langfuse/__init__.py
++++ b/plugins/observability/langfuse/__init__.py
+@@ -1,8 +1,8 @@
+-"""langfuse — Hermes plugin for Langfuse observability.
++"""langfuse — Black Pool plugin for Langfuse observability.
+ 
+-Traces Hermes conversations, LLM calls, and tool usage to Langfuse.
++Traces Black Pool conversations, LLM calls, and tool usage to Langfuse.
+ 
+-Activation is handled by the Hermes plugin system — standalone plugins only
++Activation is handled by the Black Pool plugin system — standalone plugins only
+ load when listed in ``plugins.enabled`` (via ``hermes plugins enable
+ observability/langfuse`` or ``hermes tools → Langfuse Observability``). At
+ runtime the plugin also requires the ``langfuse`` SDK and credentials; if
+@@ -252,7 +252,7 @@ def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
+ def _get_langfuse() -> Optional[Langfuse]:
+     """Return a cached Langfuse client, or ``None`` if unavailable.
+ 
+-    Activation of this plugin is controlled by the Hermes plugin system —
++    Activation of this plugin is controlled by the Black Pool plugin system —
+     this function only handles the runtime-availability gate (SDK installed
+     + credentials present). The result is cached: on the first call we try
+     to construct a client, and every subsequent call returns that client
+@@ -382,7 +382,7 @@ def _trace_key(
+ ) -> str:
+     """Build a stable in-process trace scope key for one agent turn.
+ 
+-    Older Hermes paths only expose ``task_id``/``session_id``. Newer paths
++    Older Black Pool paths only expose ``task_id``/``session_id``. Newer paths
+     pass ``turn_id`` and ``api_request_id`` in LLM/tool hooks; when present,
+     they must scope trace state so concurrent requests sharing one task/session
+     never collide. ``turn_id`` is preferred over ``api_request_id`` so the
+@@ -767,7 +767,7 @@ def _canonical_usage_and_cost(
+     model: str,
+     base_url: str,
+ ) -> tuple[dict[str, int], dict[str, float]]:
+-    """Translate canonical Hermes usage into Langfuse usage and cost maps."""
++    """Translate canonical Black Pool usage into Langfuse usage and cost maps."""
+     usage_details: Dict[str, int] = {
+         "input": canonical.input_tokens,
+         "output": canonical.output_tokens,
+@@ -811,7 +811,7 @@ def _canonical_usage_and_cost(
+ 
+     # Langfuse only derives a total for the built-in input/output cost keys.
+     # Cache/custom keys therefore need an explicit canonical total.  Use the
+-    # Hermes estimate rather than summing components because it also includes
++    # Black Pool estimate rather than summing components because it also includes
+     # request-level pricing.  Preserve the existing component-only payload for
+     # subscription-included routes; their export policy is handled separately.
+     # A zero estimate is not exported either: a priced model that billed no
+@@ -906,12 +906,12 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
+         try:
+             with propagate_attributes(
+                 session_id=session_id or task_key,
+-                trace_name="Hermes turn",
++                trace_name="Black Pool turn",
+                 tags=["hermes", "langfuse"],
+             ):
+                 root_ctx = client.start_as_current_observation(
+                     trace_context=trace_ctx,
+-                    name="Hermes turn",
++                    name="Black Pool turn",
+                     as_type="chain",
+                     input=trace_input,
+                     metadata=metadata,
+@@ -921,7 +921,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
+         except Exception:
+             root_ctx = client.start_as_current_observation(
+                 trace_context=trace_ctx,
+-                name="Hermes turn",
++                name="Black Pool turn",
+                 as_type="chain",
+                 input=trace_input,
+                 metadata=metadata,
+@@ -931,7 +931,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
+     else:
+         root_ctx = client.start_as_current_observation(
+             trace_context=trace_ctx,
+-            name="Hermes turn",
++            name="Black Pool turn",
+             as_type="chain",
+             input=trace_input,
+             metadata=metadata,
+@@ -1148,8 +1148,8 @@ def on_pre_llm_call(*, task_id: str = "", session_id: str = "", platform: str =
+                     api_call_count: int = 0, messages: Any = None, turn_type: str = "user",
+                     conversation_history: Any = None, user_message: Any = None,
+                     turn_id: str = "", api_request_id: str = "", **_: Any) -> None:
+-    # Older Hermes branches used pre_llm_call for request-scoped tracing and
+-    # passed the actual API messages. Current Hermes also has a turn-scoped
++    # Older Black Pool branches used pre_llm_call for request-scoped tracing and
++    # passed the actual API messages. Current Black Pool also has a turn-scoped
+     # pre_llm_call used for context injection; tracing that hook creates an
+     # extra orphan/root trace before the real request trace. Only trace the
+     # legacy request-shaped call here.
+@@ -1160,8 +1160,8 @@ def on_pre_llm_call(*, task_id: str = "", session_id: str = "", platform: str =
+     if client is None:
+         return
+ 
+-    # messages is a list only for legacy Hermes branches that fired
+-    # pre_llm_call with API messages directly. Current Hermes fires
++    # messages is a list only for legacy Black Pool branches that fired
++    # pre_llm_call with API messages directly. Current Black Pool fires
+     # pre_llm_call for context injection (conversation_history/user_message,
+     # no messages list) — tracing that would create orphan traces.
+     task_key = _trace_key(
+@@ -1786,7 +1786,7 @@ def on_subagent_stop(*, parent_session_id: Any = None, parent_turn_id: str = "",
+ 
+ def register(ctx) -> None:
+     # Register for both hook name variants so the plugin works across
+-    # Hermes versions.  pre_api_request / post_api_request fire per API
++    # Black Pool versions.  pre_api_request / post_api_request fire per API
+     # call (preferred); pre_llm_call / post_llm_call fire once per turn.
+     ctx.register_hook("pre_api_request", on_pre_llm_request)
+     ctx.register_hook("post_api_request", on_post_llm_call)
+diff --git a/plugins/observability/langfuse/plugin.yaml b/plugins/observability/langfuse/plugin.yaml
+index e1244e6..b6b96d7 100644
+--- a/plugins/observability/langfuse/plugin.yaml
++++ b/plugins/observability/langfuse/plugin.yaml
+@@ -1,6 +1,6 @@
+ name: langfuse
+ version: "1.0.0"
+-description: "Optional Langfuse observability for Hermes — traces conversations, LLM calls, and tool usage. Opt-in via `hermes plugins enable observability/langfuse` or `hermes tools → Langfuse Observability`."
++description: "Optional Langfuse observability for Black Pool — traces conversations, LLM calls, and tool usage. Opt-in via `hermes plugins enable observability/langfuse` or `hermes tools → Langfuse Observability`."
+ author: NousResearch
+ requires_env:
+   - HERMES_LANGFUSE_PUBLIC_KEY
 diff --git a/plugins/platforms/a2a/__init__.py b/plugins/platforms/a2a/__init__.py
-index 840f381..1588778 100644
+index 840f381..dda7434 100644
 --- a/plugins/platforms/a2a/__init__.py
 +++ b/plugins/platforms/a2a/__init__.py
-@@ -1,5 +1,5 @@
+@@ -1,8 +1,8 @@
  """
 -A2A (Agent-to-Agent) plugin for Hermes Agent.
 +A2A (Agent-to-Agent) plugin for Black Pool Agent.
  
  Registers:
-   - The ``a2a`` platform adapter (inbound: exposes Hermes as an A2A agent,
+-  - The ``a2a`` platform adapter (inbound: exposes Hermes as an A2A agent,
++  - The ``a2a`` platform adapter (inbound: exposes Black Pool as an A2A agent,
+     protocol v1.0).
+   - Five client tools in the ``a2a`` toolset (outbound: call other agents).
+ 
+@@ -57,7 +57,7 @@ def interactive_setup() -> None:
+     )
+ 
+     print_header("A2A (Agent-to-Agent)")
+-    print_info("Expose Hermes as an A2A-discoverable agent and call other A2A agents.")
++    print_info("Expose Black Pool as an A2A-discoverable agent and call other A2A agents.")
+     print_info("Uses Python stdlib — no extra packages needed.")
+     print()
+ 
+@@ -95,7 +95,7 @@ def interactive_setup() -> None:
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     # 1) Client tools (outbound). Registering these even when the inbound
+     #    platform is disabled lets the agent call peers without exposing itself.
+     try:
 diff --git a/plugins/platforms/a2a/adapter.py b/plugins/platforms/a2a/adapter.py
-index e54fa65..091be12 100644
+index e54fa65..c1124e3 100644
 --- a/plugins/platforms/a2a/adapter.py
 +++ b/plugins/platforms/a2a/adapter.py
+@@ -1,5 +1,5 @@
+ """
+-A2A inbound platform adapter — exposes Hermes as an A2A-discoverable agent.
++A2A inbound platform adapter — exposes Black Pool as an A2A-discoverable agent.
+ 
+ Design (the #11025 insight, done as a plugin with zero core edits):
+   - Runs a stdlib http.server in a daemon thread (no a2a-sdk, no asyncio loop
 @@ -502,7 +502,7 @@ class A2AAdapter(BasePlatformAdapter):
          agents: dict[str, dict] = {}
          default_desc = os.getenv(
@@ -49172,11 +60112,13 @@ index e54fa65..091be12 100644
          )
          agents[""] = {
              "slug": "",
-@@ -550,7 +550,7 @@ class A2AAdapter(BasePlatformAdapter):
+@@ -549,8 +549,8 @@ class A2AAdapter(BasePlatformAdapter):
+                 "tenant": tenant,
                  "profile": profile or slug,
                  "local": local,
-                 "name": str(val.get("name") or f"Hermes {slug}"),
+-                "name": str(val.get("name") or f"Hermes {slug}"),
 -                "description": str(val.get("description") or f"Hermes profile '{profile or slug}' exposed over A2A."),
++                "name": str(val.get("name") or f"Black Pool {slug}"),
 +                "description": str(val.get("description") or f"Black Pool profile '{profile or slug}' exposed over A2A."),
                  "advertised_toolsets": list(toolsets or []),
                  "timeout": int(val.get("timeout") or _reply_timeout()),
@@ -49200,10 +60142,10 @@ index e54fa65..091be12 100644
          First contact creates a normal ``source=a2a`` CLI session, records its
          session id, and titles it deterministically. Later turns resume by the
 diff --git a/plugins/platforms/a2a/plugin.yaml b/plugins/platforms/a2a/plugin.yaml
-index 110267d..d9a4b4d 100644
+index 110267d..bdd9abf 100644
 --- a/plugins/platforms/a2a/plugin.yaml
 +++ b/plugins/platforms/a2a/plugin.yaml
-@@ -3,7 +3,7 @@ label: A2A
+@@ -3,15 +3,15 @@ label: A2A
  kind: platform
  version: 1.0.0
  description: >
@@ -49212,8 +60154,18 @@ index 110267d..d9a4b4d 100644
    of the open Linux Foundation standard for inter-agent communication.
  
    OUTBOUND (client tools): a2a_discover, a2a_call, a2a_list, a2a_history, and
+   a2a_orchestrate let the agent fetch another agent's Agent Card and send it
+-  tasks over JSON-RPC — works with any A2A-compliant peer (Hermes, LangChain,
++  tasks over JSON-RPC — works with any A2A-compliant peer (Black Pool, LangChain,
+   CrewAI, Google ADK, OpenClaw, ...).
+ 
+-  INBOUND (platform adapter): exposes Hermes as an A2A-discoverable agent. An
++  INBOUND (platform adapter): exposes Black Pool as an A2A-discoverable agent. An
+   Agent Card is served at /.well-known/agent-card.json (v1.0 canonical path;
+   legacy agent.json also answers) and incoming tasks are routed
+   into the agent's live gateway session like any other platform — so the agent
 diff --git a/plugins/platforms/a2a/protocol.py b/plugins/platforms/a2a/protocol.py
-index f1522fc..f1a28dc 100644
+index f1522fc..9f15937 100644
 --- a/plugins/platforms/a2a/protocol.py
 +++ b/plugins/platforms/a2a/protocol.py
 @@ -122,7 +122,7 @@ def build_agent_card(
@@ -49225,22 +60177,74 @@ index f1522fc..f1a28dc 100644
              "url": os.getenv("A2A_PROVIDER_URL", "") or url,
          },
          "supportedInterfaces": [iface],
+@@ -158,7 +158,7 @@ def skills_from_toolsets(toolsets: "list[str] | dict[str, list[str]] | None") ->
+             skills.append({
+                 "id": f"toolset.{ts_name}",
+                 "name": ts_name,
+-                "description": f"Hermes '{ts_name}' capabilities",
++                "description": f"Black Pool '{ts_name}' capabilities",
+                 "tags": [ts_name] + tool_names[:10],
+             })
+     else:
+@@ -166,7 +166,7 @@ def skills_from_toolsets(toolsets: "list[str] | dict[str, list[str]] | None") ->
+             skills.append({
+                 "id": f"toolset.{ts}",
+                 "name": ts,
+-                "description": f"Hermes '{ts}' capabilities",
++                "description": f"Black Pool '{ts}' capabilities",
+                 "tags": [ts],
+             })
+     if not skills:
+diff --git a/plugins/platforms/a2a/tools.py b/plugins/platforms/a2a/tools.py
+index c599ee9..2ef4a23 100644
+--- a/plugins/platforms/a2a/tools.py
++++ b/plugins/platforms/a2a/tools.py
+@@ -1,5 +1,5 @@
+ """
+-A2A client tools — let the Hermes agent talk to *other* agents as a peer.
++A2A client tools — let the Black Pool agent talk to *other* agents as a peer.
+ 
+ Tools (registered in the ``a2a`` toolset):
+   - a2a_discover(url)         -> fetch + summarize a peer's Agent Card
 diff --git a/plugins/platforms/buzz/adapter.py b/plugins/platforms/buzz/adapter.py
-index 8b77ae3..c150f55 100644
+index 8b77ae3..843d571 100644
 --- a/plugins/platforms/buzz/adapter.py
 +++ b/plugins/platforms/buzz/adapter.py
-@@ -1,5 +1,5 @@
+@@ -1,9 +1,9 @@
  """
 -Buzz Platform Adapter for Hermes Agent.
 +Buzz Platform Adapter for Black Pool Agent.
  
  A plugin-based gateway adapter that connects to a Buzz community relay
  (Block's open-source human+agent collaboration platform, built on the
+-Nostr protocol) and relays messages to/from the Hermes agent.
++Nostr protocol) and relays messages to/from the Black Pool agent.
+ 
+ The adapter does not speak Nostr itself — it shells out to the ``buzz``
+ CLI binary ("JSON in, JSON out") via ``asyncio.create_subprocess_exec``.
+@@ -1431,7 +1431,7 @@ def interactive_setup() -> None:
+         if not prompt_yes_no("Reconfigure Buzz?", False):
+             return
+ 
+-    print_info("Connect Hermes to a Buzz community (Block's Nostr-based human+agent platform).")
++    print_info("Connect Black Pool to a Buzz community (Block's Nostr-based human+agent platform).")
+     print_info("   Requires the buzz CLI binary and a Nostr key that is a community member.")
+     print()
+ 
+@@ -1485,7 +1485,7 @@ def interactive_setup() -> None:
+ 
+ 
+ def register(ctx):
+-    """Plugin entry point: called by the Hermes plugin system."""
++    """Plugin entry point: called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="buzz",
+         label="Buzz",
 diff --git a/plugins/platforms/buzz/plugin.yaml b/plugins/platforms/buzz/plugin.yaml
-index 5bc8bed..9716efa 100644
+index 5bc8bed..37e7d15 100644
 --- a/plugins/platforms/buzz/plugin.yaml
 +++ b/plugins/platforms/buzz/plugin.yaml
-@@ -3,7 +3,7 @@ label: Buzz
+@@ -3,10 +3,10 @@ label: Buzz
  kind: platform
  version: 1.0.0
  description: >
@@ -49248,25 +60252,171 @@ index 5bc8bed..9716efa 100644
 +  Buzz gateway adapter for Black Pool Agent.
    Connects to a Buzz community relay (Block's open-source human+agent
    collaboration platform built on Nostr) and relays messages between
-   channels/DMs and the Hermes agent.  Pure stdlib — shells out to the
+-  channels/DMs and the Hermes agent.  Pure stdlib — shells out to the
++  channels/DMs and the Black Pool agent.  Pure stdlib — shells out to the
+   buzz CLI binary (JSON in/out); no Python packages required.
+ author: Nous Research
+ # ``requires_env`` entries are surfaced in ``hermes config`` UI via the
+diff --git a/plugins/platforms/dingtalk/adapter.py b/plugins/platforms/dingtalk/adapter.py
+index d59db86..a1d6503 100644
+--- a/plugins/platforms/dingtalk/adapter.py
++++ b/plugins/platforms/dingtalk/adapter.py
+@@ -1094,7 +1094,7 @@ class DingTalkAdapter(BasePlatformAdapter):
+ 
+         payload = {
+             "msgtype": "markdown",
+-            "markdown": {"title": "Hermes", "text": normalized},
++            "markdown": {"title": "Black Pool", "text": normalized},
+         }
+ 
+         try:
+@@ -1908,7 +1908,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="dingtalk",
+         label="DingTalk",
 diff --git a/plugins/platforms/dingtalk/plugin.yaml b/plugins/platforms/dingtalk/plugin.yaml
-index ab22803..c1d8ba8 100644
+index ab22803..7b2e283 100644
 --- a/plugins/platforms/dingtalk/plugin.yaml
 +++ b/plugins/platforms/dingtalk/plugin.yaml
-@@ -3,7 +3,7 @@ label: DingTalk
+@@ -3,9 +3,9 @@ label: DingTalk
  kind: platform
  version: 1.0.0
  description: >
 -  DingTalk gateway adapter for Hermes Agent.
 +  DingTalk gateway adapter for Black Pool Agent.
    Connects to DingTalk via the dingtalk-stream SDK (Stream Mode) and relays
-   messages between DingTalk chats and the Hermes agent. Supports text, images,
+-  messages between DingTalk chats and the Hermes agent. Supports text, images,
++  messages between DingTalk chats and the Black Pool agent. Supports text, images,
    audio, video, rich text, files, group @mention gating, free-response chats,
+   and per-user allowlists.
+ author: NousResearch
 diff --git a/plugins/platforms/discord/adapter.py b/plugins/platforms/discord/adapter.py
-index ad1a6ab..d9cc7aa 100644
+index ad1a6ab..de8af95 100644
 --- a/plugins/platforms/discord/adapter.py
 +++ b/plugins/platforms/discord/adapter.py
-@@ -5959,7 +5959,7 @@ class DiscordAdapter(BasePlatformAdapter):
+@@ -113,7 +113,7 @@ _DISCORD_NONCONVERSATIONAL_HISTORY_MESSAGE_PATTERNS = (
+         re.IGNORECASE,
+     ),
+     re.compile(
+-        r"^\s*(?:✅|❌)\s+Hermes update\s+"
++        r"^\s*(?:✅|❌)\s+Black Pool update\s+"
+         r"(?:finished|failed|timed out)[\s\S]*$",
+         re.IGNORECASE,
+     ),
+@@ -270,7 +270,7 @@ def _needs_server_members_intent(
+     allowed_user_ids: set[str] | list[str] | None,
+     allowed_role_ids: set[str] | list[str] | None,
+ ) -> bool:
+-    """Return True when Hermes must request Discord's Server Members intent.
++    """Return True when Black Pool must request Discord's Server Members intent.
+ 
+     Message Content is always requested. Server Members is only needed when the
+     allowlist contains usernames (not pure numeric IDs / ``*``) or when role
+@@ -287,7 +287,7 @@ def _format_privileged_intents_guidance(*, needs_members: bool) -> str:
+     lines = [
+         "Discord rejected the connection because privileged Gateway Intents "
+         "are not enabled for this bot in the Developer Portal.",
+-        "Hermes is requesting:",
++        "Black Pool is requesting:",
+         "  - Message Content Intent (required to read message text)",
+     ]
+     if needs_members:
+@@ -1210,7 +1210,7 @@ class DiscordAdapter(BasePlatformAdapter):
+ 
+         discord.py reconnects normal gateway interruptions internally. When its
+         top-level ``Bot.start()`` task actually exits after the adapter has been
+-        marked running, the Discord websocket is dead while the Hermes gateway
++        marked running, the Discord websocket is dead while the Black Pool gateway
+         process can remain alive. Treat that split-brain state as a retryable
+         fatal adapter error so ``GatewayRunner._handle_adapter_fatal_error`` can
+         remove this adapter and queue Discord for the existing reconnect watcher.
+@@ -1535,7 +1535,7 @@ class DiscordAdapter(BasePlatformAdapter):
+                 False,
+             )
+         if _is("PrivilegedIntentsRequired"):
+-            # Name the exact intents Hermes requested (#79430): Message
++            # Name the exact intents Black Pool requested (#79430): Message
+             # Content always; Server Members only when username/role
+             # allowlists actually need member lookups.
+             guidance = _format_privileged_intents_guidance(
+@@ -2567,7 +2567,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         is offline. Normal startup resume only handles sessions already marked
+         resume_pending; this pass scans recent channel/thread history, records
+         what it saw durably, and reuses the normal message handler for messages
+-        that lack a substantive non-outage Hermes response. Emoji-only acks are
++        that lack a substantive non-outage Black Pool response. Emoji-only acks are
+         deliberately not sufficient completion evidence.
+         """
+         if not self._client:
+@@ -2835,7 +2835,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         self._with_discord_recovery_db(_op)
+ 
+     async def _should_backfill_discord_message(self, message: Any) -> bool:
+-        """Return True when a recent Discord message still needs Hermes work."""
++        """Return True when a recent Discord message still needs Black Pool work."""
+         if not self._client or not getattr(self._client, "user", None):
+             return False
+         if getattr(getattr(message, "author", None), "id", None) == getattr(self._client.user, "id", None):
+@@ -2851,7 +2851,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         return True
+ 
+     def _is_down_notice_content(self, content: str) -> bool:
+-        """Recognize only explicit Hermes/gateway outage notices."""
++        """Recognize only explicit Black Pool/gateway outage notices."""
+         text = (content or "").lower()
+         subject = r"(?:hermes|the agent|agent|the gateway|gateway|bmo)"
+         state = r"(?:is|was|appears to be|is currently|was currently)"
+@@ -3136,7 +3136,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         return "safe"
+ 
+     def _canonicalize_app_command_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+-        """Reduce command payloads to the semantic fields Hermes manages."""
++        """Reduce command payloads to the semantic fields Black Pool manages."""
+         contexts = payload.get("contexts")
+         integration_types = payload.get("integration_types")
+         return {
+@@ -4984,7 +4984,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         return bool(channel_ids & allowed)
+ 
+     def _is_pairing_approved_user(self, user_id: str) -> bool:
+-        """True when the Discord user has an explicit Hermes pairing grant."""
++        """True when the Discord user has an explicit Black Pool pairing grant."""
+         user_id = str(user_id or "").strip()
+         if not user_id:
+             return False
+@@ -5843,7 +5843,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         async def slash_new(interaction: discord.Interaction):
+             await self._run_simple_slash(interaction, "/reset", "New conversation started~")
+ 
+-        @tree.command(name="reset", description="Reset your Hermes session")
++        @tree.command(name="reset", description="Reset your Black Pool session")
+         async def slash_reset(interaction: discord.Interaction):
+             await self._run_simple_slash(interaction, "/reset", "Session reset~")
+ 
+@@ -5889,7 +5889,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         async def slash_undo(interaction: discord.Interaction):
+             await self._run_simple_slash(interaction, "/undo")
+ 
+-        @tree.command(name="status", description="Show Hermes session status")
++        @tree.command(name="status", description="Show Black Pool session status")
+         async def slash_status(interaction: discord.Interaction):
+             await self._run_simple_slash(interaction, "/status", "Status sent~")
+ 
+@@ -5897,7 +5897,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         async def slash_sethome(interaction: discord.Interaction):
+             await self._run_simple_slash(interaction, "/sethome")
+ 
+-        @tree.command(name="stop", description="Stop the running Hermes agent")
++        @tree.command(name="stop", description="Stop the running Black Pool agent")
+         async def slash_stop(interaction: discord.Interaction):
+             await self._run_simple_slash(interaction, "/stop", "Stop requested~")
+ 
+@@ -5959,11 +5959,11 @@ class DiscordAdapter(BasePlatformAdapter):
          async def slash_voice(interaction: discord.Interaction, mode: str = ""):
              await self._run_simple_slash(interaction, f"/voice {mode}".strip())
  
@@ -49275,23 +60425,189 @@ index ad1a6ab..d9cc7aa 100644
          async def slash_update(interaction: discord.Interaction):
              await self._run_simple_slash(interaction, "/update", "Update initiated~")
  
+-        @tree.command(name="restart", description="Gracefully restart the Hermes gateway")
++        @tree.command(name="restart", description="Gracefully restart the Black Pool gateway")
+         async def slash_restart(interaction: discord.Interaction):
+             await self._run_simple_slash(interaction, "/restart", "Restart requested~")
+ 
+@@ -5977,10 +5977,10 @@ class DiscordAdapter(BasePlatformAdapter):
+         async def slash_deny(interaction: discord.Interaction, scope: str = ""):
+             await self._run_simple_slash(interaction, f"/deny {scope}".strip())
+ 
+-        @tree.command(name="thread", description="Create a new thread and start a Hermes session in it")
++        @tree.command(name="thread", description="Create a new thread and start a Black Pool session in it")
+         @discord.app_commands.describe(
+             name="Thread name",
+-            message="Optional first message to send to Hermes in the thread",
++            message="Optional first message to send to Black Pool in the thread",
+             auto_archive_duration="Auto-archive in minutes (60, 1440, 4320, 10080)",
+         )
+         async def slash_thread(
+@@ -6304,7 +6304,7 @@ class DiscordAdapter(BasePlatformAdapter):
+ 
+             cmd = discord.app_commands.Command(
+                 name="skill",
+-                description="Run a Hermes skill",
++                description="Run a Black Pool skill",
+                 callback=_skill_handler,
+             )
+             tree.add_command(cmd)
+@@ -6474,7 +6474,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         if thread_id:
+             self._threads.mark(thread_id)
+ 
+-        # If a message was provided, kick off a new Hermes session in the thread
++        # If a message was provided, kick off a new Black Pool session in the thread
+         starter = (message or "").strip()
+         if starter and thread_id:
+             await self._dispatch_thread_session(interaction, thread_id, thread_name, starter)
+@@ -7170,7 +7170,7 @@ class DiscordAdapter(BasePlatformAdapter):
+             }
+         except Exception as direct_error:
+             try:
+-                seed_content = starter_message or f"\U0001f9f5 Thread created by Hermes: **{name}**"
++                seed_content = starter_message or f"\U0001f9f5 Thread created by Black Pool: **{name}**"
+                 seed_msg = await parent_channel.send(seed_content)
+                 thread = await seed_msg.create_thread(
+                     name=name,
+@@ -7201,7 +7201,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         titles don't show raw <@id>, <@&id>, or <#id> markers — the ID
+         isn't meaningful to humans glancing at the thread list (#6336).
+         Real semantic naming is done after the first agent turn, when
+-        Hermes has an LLM-generated session title and can safely rename
++        Black Pool has an LLM-generated session title and can safely rename
+         only this newly-created thread.
+         """
+         content = (content or "").strip()
+@@ -7209,7 +7209,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         content = re.sub(r"<@[!&]?\d+>", "", content)
+         content = re.sub(r"<#\d+>", "", content)
+         content = re.sub(r"\s+", " ", content).strip()
+-        thread_name = content[:80] if content else "Hermes"
++        thread_name = content[:80] if content else "Black Pool"
+         if len(content) > 80:
+             thread_name = thread_name[:77] + "..."
+         return thread_name
+@@ -7242,7 +7242,7 @@ class DiscordAdapter(BasePlatformAdapter):
+                 last_direct_error = direct_error
+                 try:
+                     seed_msg = await message.channel.send(
+-                        f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
++                        f"\U0001f9f5 Thread created by Black Pool: **{thread_name}**"
+                     )
+                     thread = await seed_msg.create_thread(
+                         name=thread_name,
+@@ -7322,7 +7322,7 @@ class DiscordAdapter(BasePlatformAdapter):
+         if edit is None:
+             return False
+         try:
+-            await edit(name=cleaned, reason="Hermes semantic session title")
++            await edit(name=cleaned, reason="Black Pool semantic session title")
+             logger.info(
+                 "[%s] Renamed Discord thread %s from %r to %r",
+                 self.name, thread_id, current_name, cleaned,
+@@ -7373,7 +7373,7 @@ class DiscordAdapter(BasePlatformAdapter):
+             return None
+ 
+         thread_name = (name or "handoff").strip()[:80] or "handoff"
+-        reason = "Hermes session handoff"
++        reason = "Black Pool session handoff"
+ 
+         # First try: create a thread directly on the channel.
+         try:
+@@ -7396,7 +7396,7 @@ class DiscordAdapter(BasePlatformAdapter):
+             send = getattr(parent, "send", None)
+             if send is None:
+                 return None
+-            seed_msg = await send(f"\U0001f9f5 Hermes handoff: **{thread_name}**")
++            seed_msg = await send(f"\U0001f9f5 Black Pool handoff: **{thread_name}**")
+             thread = await seed_msg.create_thread(
+                 name=thread_name,
+                 auto_archive_duration=1440,
+@@ -7486,7 +7486,7 @@ class DiscordAdapter(BasePlatformAdapter):
+ 
+             prompt_prefix = (
+                 "⚠️ **Command Approval Required**\n\n"
+-                "Do you want Hermes to run this command?\n\n"
++                "Do you want Black Pool to run this command?\n\n"
+                 "**Requested command:**\n```bash\n"
+             )
+             if smart_denied:
+@@ -7640,7 +7640,7 @@ class DiscordAdapter(BasePlatformAdapter):
+                 body = body[: max_desc - 3] + "..."
+ 
+             embed = discord.Embed(
+-                title="❓ Hermes needs your input",
++                title="❓ Black Pool needs your input",
+                 description=body,
+                 color=discord.Color.orange(),
+             )
+@@ -7709,7 +7709,7 @@ class DiscordAdapter(BasePlatformAdapter):
+                 else "\n\nReply in this channel with your answer."
+             )
+             content = self._self_contained_prompt_content(
+-                "❓ **Hermes needs your input**", str(question or "").strip(),
++                "❓ **Black Pool needs your input**", str(question or "").strip(),
+                 tail=clarify_tail,
+             )
+             msg = await channel.send(content=content, embed=embed, view=view) if view else await channel.send(content=content, embed=embed)
+@@ -8190,7 +8190,7 @@ class DiscordAdapter(BasePlatformAdapter):
+                     # invocation for this message.
+                     try:
+                         await message.channel.send(
+-                            "⚠️ Hermes could not create a Discord thread for "
++                            "⚠️ Black Pool could not create a Discord thread for "
+                             "this message, so the request was not processed. Please retry."
+                         )
+                     except Exception as notify_error:
+@@ -10298,7 +10298,7 @@ def interactive_setup() -> None:
+         )
+ 
+     print()
+-    print_info("📬 Home Channel: where Hermes delivers cron job results,")
++    print_info("📬 Home Channel: where Black Pool delivers cron job results,")
+     print_info("   cross-platform messages, and notifications.")
+     print_info("   To get a channel ID: right-click a channel → Copy Channel ID")
+     print_info("   (requires Developer Mode in Discord settings)")
+@@ -10519,7 +10519,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="discord",
+         label="Discord",
 diff --git a/plugins/platforms/discord/plugin.yaml b/plugins/platforms/discord/plugin.yaml
-index 3e09fc9..1f4e37f 100644
+index 3e09fc9..7995f01 100644
 --- a/plugins/platforms/discord/plugin.yaml
 +++ b/plugins/platforms/discord/plugin.yaml
-@@ -3,7 +3,7 @@ label: Discord
+@@ -3,9 +3,9 @@ label: Discord
  kind: platform
  version: 1.0.0
  description: >
 -  Discord gateway adapter for Hermes Agent.
 +  Discord gateway adapter for Black Pool Agent.
    Connects to Discord via the discord.py library and relays messages
-   between Discord guilds/DMs and the Hermes agent. Supports voice mode,
+-  between Discord guilds/DMs and the Hermes agent. Supports voice mode,
++  between Discord guilds/DMs and the Black Pool agent. Supports voice mode,
    slash commands, free-response channels, role-based DM auth, threads,
+   reactions, and channel skill bindings.
+ author: NousResearch
 diff --git a/plugins/platforms/email/adapter.py b/plugins/platforms/email/adapter.py
-index 704524e..cedd356 100644
+index 704524e..23fcaae 100644
 --- a/plugins/platforms/email/adapter.py
 +++ b/plugins/platforms/email/adapter.py
+@@ -1,7 +1,7 @@
+ """
+-Email platform adapter for the Hermes gateway.
++Email platform adapter for the Black Pool gateway.
+ 
+-Allows users to interact with Hermes by sending emails.
++Allows users to interact with Black Pool by sending emails.
+ Uses IMAP to receive and SMTP to send messages.
+ 
+ Environment variables:
 @@ -1168,7 +1168,7 @@ class EmailAdapter(BasePlatformAdapter):
  
          # Thread context for reply
@@ -49328,24 +60644,107 @@ index 704524e..cedd356 100644
          msg["Date"] = formatdate(localtime=True)
  
          server = smtplib.SMTP(smtp_host, smtp_port)
+@@ -1490,7 +1490,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="email",
+         label="Email",
 diff --git a/plugins/platforms/email/plugin.yaml b/plugins/platforms/email/plugin.yaml
-index 8e9ca3d..7f44bde 100644
+index 8e9ca3d..f75941e 100644
 --- a/plugins/platforms/email/plugin.yaml
 +++ b/plugins/platforms/email/plugin.yaml
-@@ -3,7 +3,7 @@ label: Email
+@@ -3,9 +3,9 @@ label: Email
  kind: platform
  version: 1.0.0
  description: >
 -  Email gateway adapter for Hermes Agent. Polls an IMAP mailbox for inbound
 +  Email gateway adapter for Black Pool Agent. Polls an IMAP mailbox for inbound
    messages and replies over SMTP, relaying email threads to and from the
-   Hermes agent.
+-  Hermes agent.
++  Black Pool agent.
  author: NousResearch
+ requires_env:
+   - name: EMAIL_ADDRESS
+diff --git a/plugins/platforms/feishu/adapter.py b/plugins/platforms/feishu/adapter.py
+index d2f3352..dbfe965 100644
+--- a/plugins/platforms/feishu/adapter.py
++++ b/plugins/platforms/feishu/adapter.py
+@@ -37,7 +37,7 @@ For bots specifically:
+                         puts in ``mentions[].id.open_id`` when someone
+                         @-mentions the bot.  Used for mention gating only.
+ 
+-In single-bot mode (what Hermes currently supports), open_id works as a
++In single-bot mode (what Black Pool currently supports), open_id works as a
+ de-facto unique user identifier since there is only one app context.
+ 
+ Session-key participant isolation prefers ``union_id`` (via user_id_alt)
+@@ -1804,7 +1804,7 @@ class FeishuAdapter(BasePlatformAdapter):
+             if not acquired:
+                 owner_pid = existing.get("pid") if isinstance(existing, dict) else None
+                 message = (
+-                    "Another local Hermes gateway is already using this Feishu app_id"
++                    "Another local Black Pool gateway is already using this Feishu app_id"
+                     + (f" (PID {owner_pid})." if owner_pid else ".")
+                     + " Stop the other gateway before starting a second Feishu websocket client."
+                 )
+@@ -2630,7 +2630,7 @@ class FeishuAdapter(BasePlatformAdapter):
+         )
+ 
+     def _on_message_read_event(self, data: P2ImMessageMessageReadV1) -> None:
+-        """Ignore read-receipt events that Hermes does not act on."""
++        """Ignore read-receipt events that Black Pool does not act on."""
+         event = getattr(data, "event", None)
+         message = getattr(event, "message", None)
+         message_id = getattr(message, "message_id", None) or ""
+@@ -3633,7 +3633,7 @@ class FeishuAdapter(BasePlatformAdapter):
+             return web.Response(status=401, text="Invalid signature")
+ 
+         if payload.get("encrypt"):
+-            logger.error("[Feishu] Encrypted webhook payloads are not supported by Hermes webhook mode")
++            logger.error("[Feishu] Encrypted webhook payloads are not supported by Black Pool webhook mode")
+             self._record_webhook_anomaly(remote_ip, "400-encrypted")
+             return web.json_response({"code": 400, "msg": "encrypted webhook payloads are not supported"}, status=400)
+ 
+@@ -4152,7 +4152,7 @@ class FeishuAdapter(BasePlatformAdapter):
+         *,
+         is_bot: bool = False,
+     ) -> Dict[str, Optional[str]]:
+-        """Map Feishu's three-tier user IDs onto Hermes' SessionSource fields.
++        """Map Feishu's three-tier user IDs onto Black Pool' SessionSource fields.
+ 
+         Preference order for the primary ``user_id`` field:
+           1. user_id  (tenant-scoped, most stable — requires permission scope)
+@@ -5873,7 +5873,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="feishu",
+         label="Feishu / Lark",
+diff --git a/plugins/platforms/feishu/feishu_meeting_invite.py b/plugins/platforms/feishu/feishu_meeting_invite.py
+index 69a487c..c1013c5 100644
+--- a/plugins/platforms/feishu/feishu_meeting_invite.py
++++ b/plugins/platforms/feishu/feishu_meeting_invite.py
+@@ -3,7 +3,7 @@ Feishu/Lark meeting-invitation event handling.
+ 
+ Processes ``vc.bot.meeting_invited_v1`` events by converting them into a
+ synthetic gateway ``MessageEvent``.  Unlike document comments, the response
+-should go back to the inviter through the normal Hermes gateway pipeline, so
++should go back to the inviter through the normal Black Pool gateway pipeline, so
+ this module does not instantiate an agent directly.
+ """
+ 
 diff --git a/plugins/platforms/feishu/plugin.yaml b/plugins/platforms/feishu/plugin.yaml
-index 0eabd94..ad1d894 100644
+index 0eabd94..e42a09e 100644
 --- a/plugins/platforms/feishu/plugin.yaml
 +++ b/plugins/platforms/feishu/plugin.yaml
-@@ -3,7 +3,7 @@ label: Feishu / Lark
+@@ -3,10 +3,10 @@ label: Feishu / Lark
  kind: platform
  version: 1.0.0
  description: >
@@ -49353,7 +60752,127 @@ index 0eabd94..ad1d894 100644
 +  Feishu / Lark gateway adapter for Black Pool Agent.
    Connects to Feishu (China) or Lark (International) via the official
    lark-oapi SDK over WebSocket or webhook and relays messages between
-   Feishu/Lark chats and the Hermes agent. Supports text, images, video,
+-  Feishu/Lark chats and the Hermes agent. Supports text, images, video,
++  Feishu/Lark chats and the Black Pool agent. Supports text, images, video,
+   voice, documents, threads, DM pairing, group @mention gating, drive
+   comment events, and meeting invites.
+ author: NousResearch
+diff --git a/plugins/platforms/google_chat/adapter.py b/plugins/platforms/google_chat/adapter.py
+index ba11710..a84c925 100644
+--- a/plugins/platforms/google_chat/adapter.py
++++ b/plugins/platforms/google_chat/adapter.py
+@@ -286,7 +286,7 @@ def _is_retryable_error(exc: BaseException) -> bool:
+ # marker into the agent's real response. Two purposes:
+ #   * ``send_typing`` checks for any value before posting — sentinel keeps
+ #     ``_keep_typing`` (running on the base-class timer) from creating a
+-#     fresh "Hermes is thinking…" card during the small window between
++#     fresh "Black Pool is thinking…" card during the small window between
+ #     ``send()`` finishing and the base-class cancelling its typing_task.
+ #   * ``stop_typing`` checks for the sentinel and skips the API delete —
+ #     otherwise the safety-net cleanup at base.py:_process_message_background
+@@ -734,7 +734,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
+         # Orphaned typing cards (created by background tasks that lost a
+         # race with send() / another concurrent create). Cleaned up at
+         # end-of-turn by on_processing_complete via patch-to-empty so
+-        # they don't sit in the chat forever as "Hermes is thinking…".
++        # they don't sit in the chat forever as "Black Pool is thinking…".
+         self._orphan_typing_messages: Dict[str, List[str]] = {}
+         # FlowControl knobs (env-configurable).
+         try:
+@@ -2634,7 +2634,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
+         return SendResult(success=True, message_id=resp.get("name"))
+ 
+     async def send_typing(self, chat_id: str, metadata: Any = None) -> None:
+-        """Post a visible 'Hermes is thinking…' marker message.
++        """Post a visible 'Black Pool is thinking…' marker message.
+ 
+         NOT ephemeral (Google Chat has no ephemeral text messages outside
+         slash command responses). ``send()`` PATCHes this marker in-place
+@@ -2658,7 +2658,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
+         keeps running and creates a card in Chat that we have NO way to
+         track (the storage line never runs). Next ``_keep_typing`` tick
+         sees an empty slot and creates a SECOND card. Result: one orphan
+-        "Hermes is thinking…" stuck in chat forever, plus one card that
++        "Black Pool is thinking…" stuck in chat forever, plus one card that
+         gets patched into the reply.
+ 
+         Fix: reserve the slot with an in-flight ``Event``, run the
+@@ -2689,7 +2689,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
+         )
+         body: Dict[str, Any] = {
+             "text": getattr(self.config, "typing_status_text", None)
+-            or "Hermes is thinking…"
++            or "Black Pool is thinking…"
+         }
+         if thread_id:
+             body["thread"] = {"name": thread_id}
+@@ -2738,7 +2738,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
+     async def stop_typing(self, chat_id: str) -> None:
+         """Stop the typing indicator — NO-OP when a live card is tracked.
+ 
+-        Google Chat has no separate typing API: the "Hermes is thinking…"
++        Google Chat has no separate typing API: the "Black Pool is thinking…"
+         marker is a real message that ``send()`` patches in-place with the
+         agent's reply. Deleting the marker creates a "Message deleted by
+         its author" tombstone, which is visual noise.
+@@ -2790,7 +2790,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
+         when the API call takes longer than _keep_typing's wait_for
+         timeout), the orphan id is stashed in ``self._orphan_typing_messages``.
+         Patch each orphan with an empty-ish marker so the user doesn't
+-        see "Hermes is thinking…" stuck forever.
++        see "Black Pool is thinking…" stuck forever.
+         """
+         if event.source is None:
+             return
+@@ -2845,7 +2845,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
+         Leaves the SENTINEL in place when present: a previous ``send()``
+         already consumed the typing card, and the SENTINEL must stay in
+         the slot to keep the base class's ``_keep_typing`` loop from
+-        creating a fresh "Hermes is thinking…" card during any subsequent
++        creating a fresh "Black Pool is thinking…" card during any subsequent
+         attachment send (which would later be reaped as "(no reply)").
+         """
+         current = self._typing_messages.get(chat_id)
+@@ -3681,7 +3681,7 @@ async def _standalone_send(
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system at startup.
++    """Plugin entry point — called by the Black Pool plugin system at startup.
+ 
+     Registers the Google Chat adapter under the ``google_chat`` name.
+     The gateway's ``_create_adapter`` consults the platform registry
+@@ -3719,7 +3719,7 @@ def register(ctx) -> None:
+         allowed_users_env="GOOGLE_CHAT_ALLOWED_USERS",
+         allow_all_env="GOOGLE_CHAT_ALLOW_ALL_USERS",
+         # Chat caps text messages at 4096 chars; we leave margin to fit
+-        # the "Hermes is thinking..." marker patches and edit overhead.
++        # the "Black Pool is thinking..." marker patches and edit overhead.
+         max_message_length=4000,
+         emoji="💬",
+         allow_update_command=True,
+@@ -3736,7 +3736,7 @@ def register(ctx) -> None:
+             "to a text notice with the host path. Do NOT generate interactive "
+             "Card v2 buttons — Google Chat interactivity is not yet supported "
+             "by this gateway; ask for typed confirmations instead. While you "
+-            "are generating a response, a 'Hermes is thinking…' marker message "
++            "are generating a response, a 'Black Pool is thinking…' marker message "
+             "appears in the space and is deleted once your response is ready. "
+             "You do NOT have access to Google Chat-specific APIs — you cannot "
+             "search space history, list space members, or manage spaces. Do "
+diff --git a/plugins/platforms/google_chat/oauth.py b/plugins/platforms/google_chat/oauth.py
+index 65744d2..2aa7f07 100644
+--- a/plugins/platforms/google_chat/oauth.py
++++ b/plugins/platforms/google_chat/oauth.py
+@@ -656,7 +656,7 @@ def revoke(email: Optional[str] = None) -> None:
+ 
+ def main() -> None:
+     parser = argparse.ArgumentParser(
+-        description="Google Chat user-OAuth setup for Hermes (native attachment delivery)"
++        description="Google Chat user-OAuth setup for Black Pool (native attachment delivery)"
+     )
+     group = parser.add_mutually_exclusive_group(required=True)
+     group.add_argument("--check", action="store_true",
 diff --git a/plugins/platforms/google_chat/plugin.yaml b/plugins/platforms/google_chat/plugin.yaml
 index d178a53..6c7ae5d 100644
 --- a/plugins/platforms/google_chat/plugin.yaml
@@ -49368,7 +60887,7 @@ index d178a53..6c7ae5d 100644
    pull subscription for inbound events, and uses the Google Chat REST API for
    outbound messages. Native file attachments are delivered via per-user OAuth
 diff --git a/plugins/platforms/homeassistant/adapter.py b/plugins/platforms/homeassistant/adapter.py
-index 6564460..2864d4f 100644
+index 6564460..1abec63 100644
 --- a/plugins/platforms/homeassistant/adapter.py
 +++ b/plugins/platforms/homeassistant/adapter.py
 @@ -427,7 +427,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
@@ -49380,6 +60899,15 @@ index 6564460..2864d4f 100644
              "message": content[:self.MAX_MESSAGE_LENGTH],
          }
  
+@@ -580,7 +580,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="homeassistant",
+         label="Home Assistant",
 diff --git a/plugins/platforms/homeassistant/plugin.yaml b/plugins/platforms/homeassistant/plugin.yaml
 index b772d86..febdc4a 100644
 --- a/plugins/platforms/homeassistant/plugin.yaml
@@ -49394,16 +60922,20 @@ index b772d86..febdc4a 100644
    (with per-entity cooldowns and domain/entity filtering) to the agent.
    Outbound messages are delivered as HA persistent notifications via the
 diff --git a/plugins/platforms/irc/adapter.py b/plugins/platforms/irc/adapter.py
-index 030300b..c2e961d 100644
+index 030300b..6ed1887 100644
 --- a/plugins/platforms/irc/adapter.py
 +++ b/plugins/platforms/irc/adapter.py
-@@ -1,5 +1,5 @@
+@@ -1,8 +1,8 @@
  """
 -IRC Platform Adapter for Hermes Agent.
 +IRC Platform Adapter for Black Pool Agent.
  
  A plugin-based gateway adapter that connects to an IRC server and relays
- messages to/from the Hermes agent.  Zero external dependencies — uses
+-messages to/from the Hermes agent.  Zero external dependencies — uses
++messages to/from the Black Pool agent.  Zero external dependencies — uses
+ Python's stdlib asyncio for the IRC protocol.
+ 
+ Configuration in config.yaml::
 @@ -217,7 +217,7 @@ class IRCAdapter(BasePlatformAdapter):
          if self.server_password:
              await self._send_raw(f"PASS {self.server_password}")
@@ -49422,6 +60954,15 @@ index 030300b..c2e961d 100644
                  await asyncio.sleep(0.5)
              except Exception:
                  pass
+@@ -583,7 +583,7 @@ def interactive_setup() -> None:
+         if not prompt_yes_no("Reconfigure IRC?", False):
+             return
+ 
+-    print_info("Connect Hermes to an IRC network. Uses Python stdlib — no extra packages needed.")
++    print_info("Connect Black Pool to an IRC network. Uses Python stdlib — no extra packages needed.")
+     print_info("   Works with Libera.Chat, OFTC, your own ZNC/InspIRCd, etc.")
+     print()
+ 
 @@ -824,7 +824,7 @@ async def _standalone_send(
          if server_password:
              await _raw(f"PASS {_strip_irc_control_chars(server_password)}")
@@ -49431,21 +60972,33 @@ index 030300b..c2e961d 100644
  
          loop = asyncio.get_running_loop()
          deadline = loop.time() + 15.0
+@@ -951,7 +951,7 @@ async def _standalone_send(
+ 
+ 
+ def register(ctx):
+-    """Plugin entry point: called by the Hermes plugin system."""
++    """Plugin entry point: called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="irc",
+         label="IRC",
 diff --git a/plugins/platforms/irc/plugin.yaml b/plugins/platforms/irc/plugin.yaml
-index ccf83c4..9dbf6e3 100644
+index ccf83c4..c1c8925 100644
 --- a/plugins/platforms/irc/plugin.yaml
 +++ b/plugins/platforms/irc/plugin.yaml
-@@ -3,7 +3,7 @@ label: IRC
+@@ -3,9 +3,9 @@ label: IRC
  kind: platform
  version: 1.0.0
  description: >
 -  IRC gateway adapter for Hermes Agent.
 +  IRC gateway adapter for Black Pool Agent.
    Connects to an IRC server and relays messages between an IRC channel
-   (or DMs) and the Hermes agent.  No external dependencies — uses
+-  (or DMs) and the Hermes agent.  No external dependencies — uses
++  (or DMs) and the Black Pool agent.  No external dependencies — uses
    Python's stdlib asyncio for the IRC protocol.
+ author: Nous Research
+ # ``requires_env`` entries are surfaced in ``hermes config`` UI via the
 diff --git a/plugins/platforms/line/adapter.py b/plugins/platforms/line/adapter.py
-index b31c1a2..82ac1d0 100644
+index b31c1a2..9e3d25c 100644
 --- a/plugins/platforms/line/adapter.py
 +++ b/plugins/platforms/line/adapter.py
 @@ -1,5 +1,5 @@
@@ -49464,11 +61017,20 @@ index b31c1a2..82ac1d0 100644
  a single plugin-form module that requires zero core edits:
  
  * PR #18153 (leepoweii)   — Template Buttons postback cache state machine,
+@@ -1724,7 +1724,7 @@ def interactive_setup() -> None:
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system at startup."""
++    """Plugin entry point — called by the Black Pool plugin system at startup."""
+     ctx.register_platform(
+         name="line",
+         label="LINE",
 diff --git a/plugins/platforms/line/plugin.yaml b/plugins/platforms/line/plugin.yaml
-index 2f06b3e..14a0c83 100644
+index 2f06b3e..0356f47 100644
 --- a/plugins/platforms/line/plugin.yaml
 +++ b/plugins/platforms/line/plugin.yaml
-@@ -3,7 +3,7 @@ label: LINE
+@@ -3,10 +3,10 @@ label: LINE
  kind: platform
  version: 1.0.0
  description: >
@@ -49476,11 +61038,46 @@ index 2f06b3e..14a0c83 100644
 +  LINE Messaging API gateway adapter for Black Pool Agent.
    Runs an aiohttp webhook server that receives LINE webhook events
    (with HMAC-SHA256 signature verification) and relays messages between
-   LINE chats (1:1, groups, rooms) and the Hermes agent. Outbound replies
+-  LINE chats (1:1, groups, rooms) and the Hermes agent. Outbound replies
++  LINE chats (1:1, groups, rooms) and the Black Pool agent. Outbound replies
+   prefer the free reply token and fall back to the metered Push API
+   when the token has expired or is absent. Slow LLM responses surface a
+   Template Buttons postback bubble so the user can fetch the answer with
 diff --git a/plugins/platforms/matrix/adapter.py b/plugins/platforms/matrix/adapter.py
-index 0da6f37..b0ad89d 100644
+index 0da6f37..208b77a 100644
 --- a/plugins/platforms/matrix/adapter.py
 +++ b/plugins/platforms/matrix/adapter.py
+@@ -282,10 +282,10 @@ _MATRIX_BANG_COMMAND_RE = re.compile(
+ 
+ 
+ def _resolve_matrix_bang_command(name: str) -> str | None:
+-    """Resolve a ``!command`` token to a dispatchable Hermes command token.
++    """Resolve a ``!command`` token to a dispatchable Black Pool command token.
+ 
+     Matrix clients often reserve leading ``/`` for local client commands.
+-    Hermes accepts ``!command`` as a Matrix-friendly alias, but only for
++    Black Pool accepts ``!command`` as a Matrix-friendly alias, but only for
+     commands that the gateway can actually dispatch so ordinary exclamations
+     remain normal chat text.
+ 
+@@ -333,7 +333,7 @@ def _resolve_matrix_bang_command(name: str) -> str | None:
+ 
+ 
+ def _normalize_matrix_bang_command(text: str) -> str:
+-    """Convert Matrix ``!command`` aliases to normal Hermes ``/command`` text."""
++    """Convert Matrix ``!command`` aliases to normal Black Pool ``/command`` text."""
+     if not text or not text.startswith("!"):
+         return text
+     match = _MATRIX_BANG_COMMAND_RE.match(text)
+@@ -1177,7 +1177,7 @@ class MatrixAdapter(BasePlatformAdapter):
+     splits_long_messages = True  # send() chunks via truncate_message(max_message_length)
+ 
+     # Matrix clients commonly reserve typed "/" for client-local commands;
+-    # the adapter accepts "!command" as the alias that always reaches Hermes
++    # the adapter accepts "!command" as the alias that always reaches Black Pool
+     # (see _normalize_matrix_bang_command), so instruction text shows "!".
+     typed_command_prefix = "!"
+ 
 @@ -1843,7 +1843,7 @@ class MatrixAdapter(BasePlatformAdapter):
                  resp = await client.login(
                      identifier=self._user_id,
@@ -49499,24 +61096,76 @@ index 0da6f37..b0ad89d 100644
          """
          if not body:
              return ""
+@@ -5359,7 +5359,7 @@ def interactive_setup() -> None:
+         else:
+             print_info("⚠️  No allowlist set - anyone who can message the bot can use it!")
+ 
+-        print_info("📬 Home Room: where Hermes delivers cron job results and notifications.")
++        print_info("📬 Home Room: where Black Pool delivers cron job results and notifications.")
+         print_info("   Room IDs look like !abc123:server (shown in Element room settings)")
+         print_info("   You can also set this later by typing /set-home in a Matrix room.")
+         print_info("Leave blank to clear a previously saved home room (cron / notifications).")
+@@ -5440,7 +5440,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="matrix",
+         label="Matrix",
 diff --git a/plugins/platforms/matrix/plugin.yaml b/plugins/platforms/matrix/plugin.yaml
-index 77d65d9..554b62f 100644
+index 77d65d9..c94ba61 100644
 --- a/plugins/platforms/matrix/plugin.yaml
 +++ b/plugins/platforms/matrix/plugin.yaml
-@@ -3,7 +3,7 @@ label: Matrix
+@@ -3,9 +3,9 @@ label: Matrix
  kind: platform
  version: 1.0.0
  description: >
 -  Matrix gateway adapter for Hermes Agent.
 +  Matrix gateway adapter for Black Pool Agent.
    Connects to a Matrix homeserver via mautrix (with optional E2EE) and relays
-   messages between Matrix rooms/DMs and the Hermes agent. Supports threads,
+-  messages between Matrix rooms/DMs and the Hermes agent. Supports threads,
++  messages between Matrix rooms/DMs and the Black Pool agent. Supports threads,
    HTML/markdown rendering, native media uploads, mention gating, free-response
+   rooms, and per-room allowlists.
+ author: NousResearch
+diff --git a/plugins/platforms/mattermost/adapter.py b/plugins/platforms/mattermost/adapter.py
+index 4e80958..7fb9ee2 100644
+--- a/plugins/platforms/mattermost/adapter.py
++++ b/plugins/platforms/mattermost/adapter.py
+@@ -2,7 +2,7 @@
+ 
+ Connects to a self-hosted (or cloud) Mattermost instance via its REST API
+ (v4) and WebSocket for real-time events.  No external Mattermost library
+-required — uses aiohttp which is already a Hermes dependency.
++required — uses aiohttp which is already a Black Pool dependency.
+ 
+ Environment variables:
+     MATTERMOST_URL              Server URL (e.g. https://mm.example.com)
+@@ -1213,7 +1213,7 @@ def interactive_setup() -> None:
+         print_info("⚠️  No allowlist set - anyone who can message the bot can use it!")
+ 
+     print()
+-    print_info("📬 Home Channel: where Hermes delivers cron job results and notifications.")
++    print_info("📬 Home Channel: where Black Pool delivers cron job results and notifications.")
+     print_info("   To get a channel ID: click channel name → View Info → copy the ID")
+     print_info("   You can also set this later by typing /set-home in a Mattermost channel.")
+     home_channel = prompt("Home channel ID (leave empty to set later with /set-home)").strip()
+@@ -1298,7 +1298,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="mattermost",
+         label="Mattermost",
 diff --git a/plugins/platforms/mattermost/plugin.yaml b/plugins/platforms/mattermost/plugin.yaml
-index 3ee5814..bf6afa3 100644
+index 3ee5814..cd3846d 100644
 --- a/plugins/platforms/mattermost/plugin.yaml
 +++ b/plugins/platforms/mattermost/plugin.yaml
-@@ -3,7 +3,7 @@ label: Mattermost
+@@ -3,10 +3,10 @@ label: Mattermost
  kind: platform
  version: 1.0.0
  description: >
@@ -49524,12 +61173,55 @@ index 3ee5814..bf6afa3 100644
 +  Mattermost gateway adapter for Black Pool Agent.
    Connects to a self-hosted or cloud Mattermost instance via the v4 REST
    API + WebSocket event stream and relays messages between Mattermost
-   channels/DMs and the Hermes agent. Supports thread-mode replies, native
+-  channels/DMs and the Hermes agent. Supports thread-mode replies, native
++  channels/DMs and the Black Pool agent. Supports thread-mode replies, native
+   file uploads, channel-scoped allowlists, and home-channel cron delivery.
+ author: NousResearch
+ requires_env:
+diff --git a/plugins/platforms/ntfy/adapter.py b/plugins/platforms/ntfy/adapter.py
+index 935610c..65e15e4 100644
+--- a/plugins/platforms/ntfy/adapter.py
++++ b/plugins/platforms/ntfy/adapter.py
+@@ -1,12 +1,12 @@
+-"""ntfy platform adapter (Hermes plugin).
++"""ntfy platform adapter (Black Pool plugin).
+ 
+ Subscribes to a topic on ntfy.sh or any self-hosted ntfy server via
+ HTTP streaming (``/json`` endpoint with ``poll=false``) and publishes
+ replies via HTTP POST. No external SDK — only httpx, which is already
+-a Hermes dependency.
++a Black Pool dependency.
+ 
+-This adapter ships as a Hermes platform plugin under
+-``plugins/platforms/ntfy/``. The Hermes plugin loader scans the
++This adapter ships as a Black Pool platform plugin under
++``plugins/platforms/ntfy/``. The Black Pool plugin loader scans the
+ directory at startup, calls :func:`register`, and the platform becomes
+ available to ``gateway/run.py`` and ``tools/send_message_tool`` through
+ the registry — no edits to core files required.
+@@ -577,7 +577,7 @@ async def _standalone_send(
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system at startup."""
++    """Plugin entry point — called by the Black Pool plugin system at startup."""
+     ctx.register_platform(
+         name="ntfy",
+         label="ntfy",
+@@ -586,7 +586,7 @@ def register(ctx) -> None:
+         validate_config=validate_config,
+         is_connected=is_connected,
+         required_env=["NTFY_TOPIC"],
+-        install_hint="pip install httpx   # already a Hermes dependency",
++        install_hint="pip install httpx   # already a Black Pool dependency",
+         # Env-driven auto-configuration: seeds PlatformConfig.extra so
+         # env-only setups show up in `hermes gateway status` without
+         # instantiating the HTTP client.
 diff --git a/plugins/platforms/ntfy/plugin.yaml b/plugins/platforms/ntfy/plugin.yaml
-index e476a36..a9ba7fa 100644
+index e476a36..a4e5788 100644
 --- a/plugins/platforms/ntfy/plugin.yaml
 +++ b/plugins/platforms/ntfy/plugin.yaml
-@@ -3,7 +3,7 @@ label: ntfy
+@@ -3,10 +3,10 @@ label: ntfy
  kind: platform
  version: 1.0.0
  description: >
@@ -49537,9 +61229,13 @@ index e476a36..a9ba7fa 100644
 +  ntfy push-notification gateway adapter for Black Pool Agent.
    Subscribes to a topic on ntfy.sh or any self-hosted ntfy server via
    HTTP streaming, and publishes replies via HTTP POST. Lightweight —
-   no external SDK, only httpx (already a Hermes dependency).
+-  no external SDK, only httpx (already a Hermes dependency).
++  no external SDK, only httpx (already a Black Pool dependency).
+ 
+   ntfy has no native user-identity primitive; the adapter treats each
+   topic as a single trusted channel and never derives user identity
 diff --git a/plugins/platforms/photon/adapter.py b/plugins/platforms/photon/adapter.py
-index b0bc3e3..d2133ba 100644
+index b0bc3e3..873fa72 100644
 --- a/plugins/platforms/photon/adapter.py
 +++ b/plugins/platforms/photon/adapter.py
 @@ -1,5 +1,5 @@
@@ -49549,15 +61245,106 @@ index b0bc3e3..d2133ba 100644
  
  Both directions of traffic flow through a small supervised Node sidecar
  (see ``sidecar/index.mjs``) that runs the ``spectrum-ts`` SDK — the SDK is
+@@ -51,7 +51,7 @@ else:
+     try:
+         import httpx
+         HTTPX_AVAILABLE = True
+-    except ImportError:  # pragma: no cover - httpx is already a Hermes dep
++    except ImportError:  # pragma: no cover - httpx is already a Black Pool dep
+         HTTPX_AVAILABLE = False
+         httpx = None
+ 
+@@ -261,7 +261,7 @@ _PHOTON_RETRYABLE_PATTERNS = (
+ 
+ # iMessage may emit the Open Graph preview art for a rich link as one or more
+ # image attachments immediately after the URL/richlink message. Suppress those
+-# artifacts so Hermes sees the link once, not a follow-up "(attachment)" prompt.
++# artifacts so Black Pool sees the link once, not a follow-up "(attachment)" prompt.
+ _RICHLINK_PREVIEW_SUPPRESS_SECONDS = 30.0
+ _RICHLINK_PREVIEW_ATTACHMENT_SUFFIX = ".pluginpayloadattachment"
+ 
+@@ -614,7 +614,7 @@ def _richlink_candidate(text: str) -> Optional[str]:
+ 
+     Keep this intentionally narrow: only exact http(s) URL messages become
+     rich links. Prose containing URLs and Markdown links stay on the normal
+-    markdown/text path so Hermes does not drop labels or rewrite intent.
++    markdown/text path so Black Pool does not drop labels or rewrite intent.
+     """
+     if not _markdown_enabled():
+         return None
+@@ -860,7 +860,7 @@ class PhotonAdapter(BasePlatformAdapter):
+         """Compile group-mention wake words from config/env.
+ 
+         ``raw`` is a list (config or env JSON), a string (env var: JSON
+-        list, or comma/newline-separated), or None (use Hermes defaults).
++        list, or comma/newline-separated), or None (use Black Pool defaults).
+         Mirrors the BlueBubbles implementation so both iMessage channels
+         accept the same configuration shapes.
+         """
+@@ -1506,7 +1506,7 @@ class PhotonAdapter(BasePlatformAdapter):
+             )
+         except (OSError, subprocess.TimeoutExpired):
+             return False
+-        # Checkout-agnostic: any Hermes checkout's sidecar entry point.
++        # Checkout-agnostic: any Black Pool checkout's sidecar entry point.
+         return "photon/sidecar/index.mjs" in out.stdout
+ 
+     @staticmethod
+@@ -2594,7 +2594,7 @@ class PhotonAdapter(BasePlatformAdapter):
+         to a plain audio attachment on platforms without voice notes),
+         otherwise ``"attachment"``. spectrum-ts infers ``name`` and
+         ``mimeType`` from the file extension; we only pass overrides when
+-        Hermes supplied them.
++        Black Pool supplied them.
+         """
+         # Defense-in-depth: re-validate the path before handing it to the
+         # Node sidecar. The gateway already filters MEDIA paths, but
+@@ -2819,7 +2819,7 @@ async def _standalone_send(
+             return {
+                 "error": (
+                     "Photon standalone send requires a running sidecar. "
+-                    "Start the Hermes gateway (which spawns the sidecar and "
++                    "Start the Black Pool gateway (which spawns the sidecar and "
+                     "records its address under <hermes-home>/runtime/"
+                     f"{_RUNTIME_RECORD_NAME}), or set PHOTON_SIDECAR_TOKEN "
+                     "in this process's environment." + stale_hint
+@@ -2901,7 +2901,7 @@ async def _standalone_send(
+ # Plugin entry point
+ 
+ def register(ctx) -> None:
+-    """Called by the Hermes plugin loader at startup."""
++    """Called by the Black Pool plugin loader at startup."""
+     # Local import to avoid argparse work at module load; reused for both the
+     # gateway-setup hook and the `hermes photon` CLI command below.
+     from . import cli as _cli
 diff --git a/plugins/platforms/photon/auth.py b/plugins/platforms/photon/auth.py
-index 34b573a..868f76b 100644
+index 34b573a..a505128 100644
 --- a/plugins/platforms/photon/auth.py
 +++ b/plugins/platforms/photon/auth.py
-@@ -98,7 +98,7 @@ DEFAULT_DASHBOARD_HOST = "https://app.photon.codes"
+@@ -22,7 +22,7 @@ The ``spectrum-ts`` SDK (run by the Node sidecar) authenticates to Spectrum
+ Cloud with ``(id, projectSecret)`` — the same ``id`` used in Dashboard API
+ paths — which we persist as ``PHOTON_PROJECT_ID`` for the runtime.
+ 
+-Credential storage mirrors every other Hermes channel:
++Credential storage mirrors every other Black Pool channel:
+ 
+     * runtime SDK creds  -> ``~/.hermes/.env``  (``PHOTON_PROJECT_ID`` =
+       project id, ``PHOTON_PROJECT_SECRET``) via ``save_env_value``
+@@ -90,15 +90,15 @@ class PhotonDashboardAuthError(RuntimeError):
+ # endpoint — an unregistered client_id is rejected with
+ # `400 {"error":"invalid_client"}`.  Use Photon's published CLI device
+ # client (matches `CLI_CLIENT_ID` in photon-hq/cli) until the dashboard API
+-# registers Hermes as its own client_id.
++# registers Black Pool as its own client_id.
+ DEFAULT_CLIENT_ID = "photon-cli"
+ DEFAULT_SCOPE = "openid profile email"
+ 
+ DEFAULT_DASHBOARD_HOST = "https://app.photon.codes"
  DEFAULT_SPECTRUM_HOST = "https://spectrum.photon.codes"
  
- # Default name of the project Hermes provisions for the operator.
+-# Default name of the project Hermes provisions for the operator.
 -DEFAULT_PROJECT_NAME = "Hermes Agent"
++# Default name of the project Black Pool provisions for the operator.
 +DEFAULT_PROJECT_NAME = "Black Pool Agent"
  
  # Polling defaults per RFC 8628.  Photon overrides via `interval` /
@@ -49572,9 +61359,18 @@ index 34b573a..868f76b 100644
          from hermes_constants import get_hermes_home
          return Path(get_hermes_home()) / "auth.json"
 diff --git a/plugins/platforms/photon/cli.py b/plugins/platforms/photon/cli.py
-index 1cc19f6..730d373 100644
+index 1cc19f6..845f847 100644
 --- a/plugins/platforms/photon/cli.py
 +++ b/plugins/platforms/photon/cli.py
+@@ -10,7 +10,7 @@ Subcommands:
+     telemetry          show or toggle Spectrum SDK telemetry (on/off)
+ 
+ The device-code login runs automatically as the first step of ``setup``;
+-there is no standalone ``login`` verb (matching how every other Hermes
++there is no standalone ``login`` verb (matching how every other Black Pool
+ gateway channel onboards through a single setup surface).
+ 
+ Photon uses the spectrum-ts gRPC stream for inbound — there is no webhook
 @@ -72,7 +72,7 @@ def register_cli(parser: argparse.ArgumentParser) -> None:
          help="First-time setup (device login + project + user + sidecar)",
      )
@@ -49594,7 +61390,7 @@ index 1cc19f6..730d373 100644
      dashboard_id = photon_auth.load_dashboard_project_id()
      try:
 diff --git a/plugins/platforms/photon/plugin.yaml b/plugins/platforms/photon/plugin.yaml
-index a39193a..5081059 100644
+index a39193a..9fb4696 100644
 --- a/plugins/platforms/photon/plugin.yaml
 +++ b/plugins/platforms/photon/plugin.yaml
 @@ -3,7 +3,7 @@ label: iMessage via Photon
@@ -49606,16 +61402,85 @@ index a39193a..5081059 100644
    Connects to iMessage (and other Spectrum interfaces) through Photon's
    managed Spectrum platform. Both directions run over the `spectrum-ts`
    SDK's long-lived gRPC stream via a small supervised Node sidecar —
+@@ -63,7 +63,7 @@ optional_env:
+     prompt: "Require a mention in group chats?"
+     password: false
+   - name: PHOTON_MENTION_PATTERNS
+-    description: "Mention wake-word regexes for group chats (JSON list or comma/newline-separated; defaults to Hermes wake words)"
++    description: "Mention wake-word regexes for group chats (JSON list or comma/newline-separated; defaults to Black Pool wake words)"
+     prompt: "Group mention patterns"
+     password: false
+   - name: PHOTON_HOME_CHANNEL
 diff --git a/plugins/platforms/photon/sidecar/index.mjs b/plugins/platforms/photon/sidecar/index.mjs
-index 5c8611f..d2f684a 100644
+index 5c8611f..4e8f68b 100644
 --- a/plugins/platforms/photon/sidecar/index.mjs
 +++ b/plugins/platforms/photon/sidecar/index.mjs
-@@ -1,4 +1,4 @@
+@@ -1,17 +1,17 @@
 -// Hermes Agent — Photon Spectrum sidecar
 +// Black Pool Agent — Photon Spectrum sidecar
  //
  // Spawned by `plugins/platforms/photon/adapter.py` to bridge BOTH directions
  // of messaging to Photon's Spectrum platform via the `spectrum-ts` SDK (the
+ // SDK is TypeScript-only, so a Node sidecar is unavoidable — there is no
+ // Python SDK and no public HTTP message API).
+ //
+-// Inbound  (gRPC -> Hermes): the SDK's `app.messages` async iterator is a
++// Inbound  (gRPC -> Black Pool): the SDK's `app.messages` async iterator is a
+ //   long-lived gRPC stream. We serialize each `[space, message]` to a
+ //   normalized JSON event and stream it to the Python adapter over a
+ //   loopback `GET /inbound` (NDJSON). We pause pulling from the stream while
+ //   no consumer is attached so a backlog isn't pulled-and-lost before the
+ //   gateway connects.
+-// Outbound (Hermes -> gRPC): `/send` drives `space.send(...)`; `/typing`
++// Outbound (Black Pool -> gRPC): `/send` drives `space.send(...)`; `/typing`
+ //   sends the documented `typing("start" | "stop")` content builder.
+ //
+ // Protocol (all requests require `X-Hermes-Sidecar-Token: ${TOKEN}`):
+@@ -194,7 +194,7 @@ function scheduleStreamRestart() {
+     }
+     console.error(
+       `photon-sidecar: upstream stream degraded for ${degradedForMs}ms; ` +
+-        "exiting so Hermes can restart the Photon adapter"
++        "exiting so Black Pool can restart the Photon adapter"
+     );
+     process.exit(75);
+   }, STREAM_DEGRADED_RESTART_MS + 1000);
+@@ -278,7 +278,7 @@ if (!projectId || !projectSecret || !sharedToken) {
+ }
+ 
+ // Lazy-load spectrum-ts so a missing install fails with a clear message
+-// instead of a cryptic module-resolution error during import. Apply Hermes'
++// instead of a cryptic module-resolution error during import. Apply Black Pool'
+ // pinned-sdk compatibility patch first so existing installs self-heal at
+ // runtime, not only during npm postinstall.
+ try {
+@@ -617,7 +617,7 @@ function inboundStreamErrorMessage(e) {
+   let out = "photon-sidecar: inbound stream errored — restarting: " + msg;
+ 
+   // The Spectrum SDK surfaces Photon cloud CatchUpEvents failures as an
+-  // iMessage internal error. Local Hermes allowlists cannot cause or fix this:
++  // iMessage internal error. Local Black Pool allowlists cannot cause or fix this:
+   // inbound messages stop before they reach the gateway. Add an explicit hint
+   // so operators know to retry/restart or escalate to Photon support instead
+   // of chasing PHOTON_ALLOWED_USERS / pairing configuration.
+@@ -631,7 +631,7 @@ function inboundStreamErrorMessage(e) {
+   ) {
+     out +=
+       " | Photon Spectrum CatchUpEvents returned an internal server error; " +
+-      "this is upstream of Hermes, so inbound iMessages may not be delivered " +
++      "this is upstream of Black Pool, so inbound iMessages may not be delivered " +
+       "until Photon recovers or the stream is re-established.";
+   }
+   return out;
+@@ -1053,7 +1053,7 @@ const server = http.createServer(async (req, res) => {
+       const space = await resolveSpace(spaceId);
+ 
+       // spectrum-ts infers name + MIME from the file extension; pass
+-      // overrides only when Hermes supplied them so a known-good
++      // overrides only when Black Pool supplied them so a known-good
+       // inference isn't clobbered with an empty string.
+       const opts = {};
+       if (name) opts.name = name;
 diff --git a/plugins/platforms/photon/sidecar/package.json b/plugins/platforms/photon/sidecar/package.json
 index b7e0f82..75285be 100644
 --- a/plugins/platforms/photon/sidecar/package.json
@@ -49629,11 +61494,91 @@ index b7e0f82..75285be 100644
    "type": "module",
    "main": "index.mjs",
    "scripts": {
+diff --git a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+index 151043b..b425c00 100644
+--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
++++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+@@ -2,7 +2,7 @@
+ // Patch spectrum-ts' iMessage inbound mapper until upstream preserves mixed
+ // text + attachment Apple events. The mapper returns only
+ // buildAttachmentMessage(...) whenever attachments are present, which drops
+-// `message.content.text` before Hermes can see it. We rewrite the two inbound
++// `message.content.text` before Black Pool can see it. We rewrite the two inbound
+ // mappers — `rebuildFromAppleMessage` (used by `space.getMessage`) and
+ // `toInboundMessages` (used by the live stream) — so a bubble carrying both
+ // text and attachment(s) surfaces as a group whose first child is the typed
+@@ -18,7 +18,7 @@ import fs from "node:fs";
+ import path from "node:path";
+ import { fileURLToPath, pathToFileURL } from "node:url";
+ 
+-const MARKER = "Hermes patch: Preserve mixed text + attachment iMessage payloads";
++const MARKER = "Black Pool patch: Preserve mixed text + attachment iMessage payloads";
+ 
+ function scriptDir() {
+   return path.dirname(fileURLToPath(import.meta.url));
+diff --git a/plugins/platforms/raft/adapter.py b/plugins/platforms/raft/adapter.py
+index 7ad661f..6123a20 100644
+--- a/plugins/platforms/raft/adapter.py
++++ b/plugins/platforms/raft/adapter.py
+@@ -1,7 +1,7 @@
+ """Raft channel platform adapter.
+ 
+ Starts a local wake endpoint, spawns ``raft agent bridge`` as a child process,
+-and injects content-free wake hints into Hermes' normal gateway session pipeline.
++and injects content-free wake hints into Black Pool' normal gateway session pipeline.
+ Token and port are auto-generated when not provided via env/config.
+ The bridge remains responsible for Raft message cursors and body materialization;
+ the agent uses the Raft CLI according to the Raft manual.
+@@ -626,7 +626,7 @@ class RaftAdapter(BasePlatformAdapter):
+             payload = parsed
+ 
+         # Do not gate on payload["schema"]: the bridge owns schema evolution;
+-        # Hermes only verifies that wake hints are content-free.
++        # Black Pool only verifies that wake hints are content-free.
+         if _has_content_field(payload):
+             return web.json_response({"ok": False, "error": "content_not_allowed"}, status=400)
+ 
+@@ -733,7 +733,7 @@ class RaftAdapter(BasePlatformAdapter):
+         return True
+ 
+     async def handle_message(self, event: MessageEvent) -> None:
+-        """Accept Raft wake hints without interrupting an active Hermes turn."""
++        """Accept Raft wake hints without interrupting an active Black Pool turn."""
+         if not self._message_handler:
+             return
+ 
+@@ -786,7 +786,7 @@ def interactive_setup() -> None:
+     """Interactive ``hermes gateway setup`` flow for the Raft platform.
+ 
+     Lazy-imports CLI helpers so the plugin stays importable in gateway runtime
+-    and test contexts. The flow persists ``RAFT_PROFILE`` to the Hermes env
++    and test contexts. The flow persists ``RAFT_PROFILE`` to the Black Pool env
+     file so the Raft adapter auto-enables after a gateway restart.
+     """
+     from hermes_cli.cli_output import (
+@@ -807,7 +807,7 @@ def interactive_setup() -> None:
+             print_info(f"Keeping RAFT_PROFILE={existing_profile}.")
+             return
+ 
+-    print_info("Connect Hermes to Raft as an external agent.")
++    print_info("Connect Black Pool to Raft as an external agent.")
+     print_info("Create the External Agent in Raft first, then run:")
+     print_info("  raft agent login --server <server-url> --agent <agent-id> --profile-slug <slug>")
+     print()
+@@ -825,7 +825,7 @@ def interactive_setup() -> None:
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="raft",
+         label="Raft",
 diff --git a/plugins/platforms/raft/plugin.yaml b/plugins/platforms/raft/plugin.yaml
-index 81b772e..44fabab 100644
+index 81b772e..e3667cf 100644
 --- a/plugins/platforms/raft/plugin.yaml
 +++ b/plugins/platforms/raft/plugin.yaml
-@@ -3,7 +3,7 @@ label: Raft
+@@ -3,11 +3,11 @@ label: Raft
  kind: platform
  version: 1.0.0
  description: >
@@ -49642,47 +61587,237 @@ index 81b772e..44fabab 100644
    Connects to a Raft workspace as an external agent via a local
    wake-channel bridge. The adapter starts a loopback HTTP endpoint
    that receives content-free wake hints from the bridge, then
+-  injects them into the Hermes gateway session pipeline. The agent
++  injects them into the Black Pool gateway session pipeline. The agent
+   reads and sends messages through the Raft CLI — the adapter never
+   touches message bodies or delivery cursors.
+ author: botiverse
+diff --git a/plugins/platforms/simplex/adapter.py b/plugins/platforms/simplex/adapter.py
+index 9eaa4d8..1d5f322 100644
+--- a/plugins/platforms/simplex/adapter.py
++++ b/plugins/platforms/simplex/adapter.py
+@@ -1,11 +1,11 @@
+-"""SimpleX Chat platform adapter (Hermes plugin).
++"""SimpleX Chat platform adapter (Black Pool plugin).
+ 
+ Connects to a simplex-chat daemon running in WebSocket mode.
+ Inbound messages arrive via a persistent WebSocket connection.
+ Outbound messages use the same WebSocket with JSON commands.
+ 
+-This adapter ships as a Hermes platform plugin under
+-``plugins/platforms/simplex/``. The Hermes plugin loader scans the
++This adapter ships as a Black Pool platform plugin under
++``plugins/platforms/simplex/``. The Black Pool plugin loader scans the
+ directory at startup, calls ``register(ctx)``, and the platform
+ becomes available to ``gateway/run.py`` and ``tools/send_message_tool``
+ through the registry — no edits to core files are required.
+@@ -57,7 +57,7 @@ from pathlib import Path
+ from typing import Any, Dict, List, Optional
+ 
+ # Lazy import: BasePlatformAdapter and friends live in the main repo.
+-# Imported at module top because they're stdlib-only inside Hermes — no
++# Imported at module top because they're stdlib-only inside Black Pool — no
+ # external dependency that would block the plugin from loading.
+ from gateway.config import Platform, PlatformConfig
+ from gateway.platforms.base import (
+@@ -1345,7 +1345,7 @@ def interactive_setup() -> None:
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system at startup."""
++    """Plugin entry point — called by the Black Pool plugin system at startup."""
+     ctx.register_platform(
+         name="simplex",
+         label="SimpleX Chat",
 diff --git a/plugins/platforms/simplex/plugin.yaml b/plugins/platforms/simplex/plugin.yaml
-index 84ef401..f6c5406 100644
+index 84ef401..16efba9 100644
 --- a/plugins/platforms/simplex/plugin.yaml
 +++ b/plugins/platforms/simplex/plugin.yaml
-@@ -3,7 +3,7 @@ label: SimpleX Chat
+@@ -3,9 +3,9 @@ label: SimpleX Chat
  kind: platform
  version: 1.1.0
  description: >
 -  SimpleX Chat gateway adapter for Hermes Agent.
 +  SimpleX Chat gateway adapter for Black Pool Agent.
    Connects to a local simplex-chat daemon via WebSocket and relays
-   messages between SimpleX contacts/groups and the Hermes agent.
+-  messages between SimpleX contacts/groups and the Hermes agent.
++  messages between SimpleX contacts/groups and the Black Pool agent.
    SimpleX is decentralised and assigns no persistent user IDs —
+   every contact is an opaque internal ID generated at connection
+   time, making it one of the most private messengers available.
+diff --git a/plugins/platforms/slack/adapter.py b/plugins/platforms/slack/adapter.py
+index e017838..acf67b1 100644
+--- a/plugins/platforms/slack/adapter.py
++++ b/plugins/platforms/slack/adapter.py
+@@ -68,7 +68,7 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
+ logger = logging.getLogger(__name__)
+ 
+ # User-Agent prefix for outbound Slack API calls so platform partners can
+-# identify HermesAgent traffic — matching other Hermes outbound surfaces
++# identify HermesAgent traffic — matching other Black Pool outbound surfaces
+ # that already set ``HermesAgent/<version>`` for platform-partner attribution.
+ try:
+     from hermes_cli import __version__ as _HERMES_VERSION
+@@ -2056,7 +2056,7 @@ class SlackAdapter(BasePlatformAdapter):
+                 await self._handle_assistant_thread_lifecycle_event(event, body)
+ 
+             # Catch-all no-op ack for any other subscribed event type that
+-            # Hermes has no listener for (e.g. user_change,
++            # Black Pool has no listener for (e.g. user_change,
+             # user_huddle_changed, member_joined_channel, channel_archive,
+             # pin_added, etc.).
+             #
+@@ -2086,7 +2086,7 @@ class SlackAdapter(BasePlatformAdapter):
+             async def handle_unhandled_event(event, body, logger):
+                 logger.debug(
+                     "[Slack] Ignoring unhandled event type=%s (no listener "
+-                    "registered; subscribed events not handled by Hermes can "
++                    "registered; subscribed events not handled by Black Pool can "
+                     "be removed from the Slack app manifest via "
+                     "`hermes slack manifest`)",
+                     (event or {}).get(
+@@ -2296,7 +2296,7 @@ class SlackAdapter(BasePlatformAdapter):
+             if client is None:
+                 return None
+             seed_text = (
+-                f":thread: Hermes handoff — *{(name or 'session').strip()[:80]}*"
++                f":thread: Black Pool handoff — *{(name or 'session').strip()[:80]}*"
+             )
+             result = await client.chat_postMessage(
+                 channel=parent_chat_id,
+@@ -2559,7 +2559,7 @@ class SlackAdapter(BasePlatformAdapter):
+         chat_id: str,
+         tasks: List[Dict[str, str]],
+         *,
+-        title: str = "Hermes is working",
++        title: str = "Black Pool is working",
+         reply_to: Optional[str] = None,
+         metadata: Optional[Dict[str, Any]] = None,
+         fallback_text: Optional[str] = None,
+@@ -3532,7 +3532,7 @@ class SlackAdapter(BasePlatformAdapter):
+         """Whether top-level Slack DMs get per-message session threads.
+ 
+         Defaults to ``True`` so each visible DM reply thread is isolated as its
+-        own Hermes session — matching the per-thread behavior channels already
++        own Black Pool session — matching the per-thread behavior channels already
+         have.  Set ``platforms.slack.extra.dm_top_level_threads_as_sessions``
+         to ``false`` in config.yaml to revert to the legacy behavior where all
+         top-level DMs share one continuous session.
+@@ -5216,7 +5216,7 @@ class SlackAdapter(BasePlatformAdapter):
+         user_id = event.get("user") or event.get("user_id") or ""
+         team_id = self._event_team_id(event, body)
+         # ``context_channel_id`` is a channel the user is viewing, not the DM
+-        # Hermes owns. Do not write it into _channel_team: channel IDs can be
++        # Black Pool owns. Do not write it into _channel_team: channel IDs can be
+         # shared across Slack Connect workspaces, so doing so can misroute a
+         # later unrelated send. Workspace ownership is recorded from actual
+         # inbound DM/channel events below.
+@@ -6136,7 +6136,7 @@ class SlackAdapter(BasePlatformAdapter):
+ 
+         # Some Slack bot posts arrive as ordinary-looking message events with a
+         # bot *user* id but without ``bot_id``/``subtype=bot_message``.  This is
+-        # the shape produced by peer Hermes agents in Socket Mode on some
++        # the shape produced by peer Black Pool agents in Socket Mode on some
+         # workspaces.  If we let those fall through as human users, an old
+         # thread mention or active session will re-trigger the target agent on
+         # every peer status/error/ack message, causing agent-agent loops.  Apply
+@@ -9394,8 +9394,8 @@ def interactive_setup() -> None:
+             import json as _json
+ 
+             manifest = _build_full_manifest(
+-                bot_name="Hermes",
+-                bot_description="Your Hermes agent on Slack",
++                bot_name="Black Pool",
++                bot_description="Your Black Pool agent on Slack",
+             )
+             target = Path(get_hermes_home()) / "slack-manifest.json"
+             target.parent.mkdir(parents=True, exist_ok=True)
+@@ -9411,7 +9411,7 @@ def interactive_setup() -> None:
+             )
+             print_info(
+                 "   Re-run `hermes slack manifest --write` anytime to refresh after "
+-                "Hermes adds new commands."
++                "Black Pool adds new commands."
+             )
+         except Exception as e:
+             print_warning(f"Could not write Slack manifest: {e}")
+@@ -9472,7 +9472,7 @@ def interactive_setup() -> None:
+         print_info("   Set SLACK_ALLOW_ALL_USERS=true or GATEWAY_ALLOW_ALL_USERS=true only if you intentionally want open workspace access.")
+ 
+     print()
+-    print_info("📬 Home Channel: where Hermes delivers cron job results,")
++    print_info("📬 Home Channel: where Black Pool delivers cron job results,")
+     print_info("   cross-platform messages, and notifications.")
+     print_info("   To get a channel ID: open the channel in Slack, then right-click")
+     print_info("   the channel name → Copy link — the ID starts with C (e.g. C01ABC2DE3F).")
+@@ -9573,7 +9573,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="slack",
+         label="Slack",
 diff --git a/plugins/platforms/slack/plugin.yaml b/plugins/platforms/slack/plugin.yaml
-index b04ac8b..a6e221c 100644
+index b04ac8b..da8bf60 100644
 --- a/plugins/platforms/slack/plugin.yaml
 +++ b/plugins/platforms/slack/plugin.yaml
-@@ -3,7 +3,7 @@ label: Slack
+@@ -3,9 +3,9 @@ label: Slack
  kind: platform
  version: 1.0.0
  description: >
 -  Slack gateway adapter for Hermes Agent.
 +  Slack gateway adapter for Black Pool Agent.
    Connects to Slack via slack-bolt in Socket Mode and relays messages
-   between Slack channels/DMs and the Hermes agent. Supports slash
+-  between Slack channels/DMs and the Hermes agent. Supports slash
++  between Slack channels/DMs and the Black Pool agent. Supports slash
    commands, threads, mrkdwn rendering, approval blocks, free-response
+   channels, mention gating, and channel skill bindings.
+ author: NousResearch
+diff --git a/plugins/platforms/sms/adapter.py b/plugins/platforms/sms/adapter.py
+index 0c08124..f4809a3 100644
+--- a/plugins/platforms/sms/adapter.py
++++ b/plugins/platforms/sms/adapter.py
+@@ -80,9 +80,9 @@ def check_sms_requirements() -> bool:
+ 
+ class SmsAdapter(BasePlatformAdapter):
+     """
+-    Twilio SMS <-> Hermes gateway adapter.
++    Twilio SMS <-> Black Pool gateway adapter.
+ 
+-    Each inbound phone number gets its own Hermes session (multi-tenant).
++    Each inbound phone number gets its own Black Pool session (multi-tenant).
+     Replies are always sent from the configured TWILIO_PHONE_NUMBER.
+     """
+ 
+@@ -516,7 +516,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="sms",
+         label="SMS (Twilio)",
 diff --git a/plugins/platforms/sms/plugin.yaml b/plugins/platforms/sms/plugin.yaml
-index 222106b..e0ad0ad 100644
+index 222106b..9a21e43 100644
 --- a/plugins/platforms/sms/plugin.yaml
 +++ b/plugins/platforms/sms/plugin.yaml
-@@ -3,7 +3,7 @@ label: SMS (Twilio)
+@@ -3,9 +3,9 @@ label: SMS (Twilio)
  kind: platform
  version: 1.0.0
  description: >
 -  SMS gateway adapter for Hermes Agent via Twilio. Sends and receives SMS
 +  SMS gateway adapter for Black Pool Agent via Twilio. Sends and receives SMS
    through the Twilio REST API + inbound webhook, relaying texts between phone
-   numbers and the Hermes agent. Markdown is stripped to plain text.
+-  numbers and the Hermes agent. Markdown is stripped to plain text.
++  numbers and the Black Pool agent. Markdown is stripped to plain text.
  author: NousResearch
+ requires_env:
+   - name: TWILIO_ACCOUNT_SID
 diff --git a/plugins/platforms/teams/adapter.py b/plugins/platforms/teams/adapter.py
-index 578d250..a108693 100644
+index 578d250..ebe5538 100644
 --- a/plugins/platforms/teams/adapter.py
 +++ b/plugins/platforms/teams/adapter.py
 @@ -1,5 +1,5 @@
@@ -49692,11 +61827,56 @@ index 578d250..a108693 100644
  
  Uses the microsoft-teams-apps SDK for authentication and activity processing.
  Runs an aiohttp webhook server to receive messages from Teams.
+@@ -662,7 +662,7 @@ def _suppress_third_party_dotenv() -> Iterator[None]:
+     ``microsoft_teams.apps.app`` calls ``load_dotenv(find_dotenv(usecwd=True))``
+     at module import time. That mutates process-global ``os.environ`` from
+     whatever ``.env`` sits above cwd — typically a root profile's secrets.
+-    Hermes owns dotenv loading; third-party import side effects must not.
++    Black Pool owns dotenv loading; third-party import side effects must not.
+     """
+     try:
+         import dotenv as _dotenv
+@@ -819,7 +819,7 @@ class TeamsAdapter(BasePlatformAdapter):
+                 client_secret=self._client_secret,
+                 tenant_id=self._tenant_id,
+                 http_server_adapter=_AiohttpBridgeAdapter(aiohttp_app),
+-                client=ClientOptions(headers={"User-Agent": "Hermes"}),
++                client=ClientOptions(headers={"User-Agent": "Black Pool"}),
+             )
+ 
+             # Register message handler before initialize()
+@@ -1424,7 +1424,7 @@ def interactive_setup() -> None:
+     print()
+     print_info("Then expose port 3978 publicly (devtunnel / ngrok / cloudflared),")
+     print_info("and create your bot:")
+-    print_info("  teams app create --name \"Hermes\" --endpoint \"https://<tunnel>/api/messages\"")
++    print_info("  teams app create --name \"Black Pool\" --endpoint \"https://<tunnel>/api/messages\"")
+     print()
+     print_info("The CLI will print CLIENT_ID, CLIENT_SECRET, and TENANT_ID. Paste them below.")
+     print()
+@@ -1476,7 +1476,7 @@ def _install_hint() -> str:
+ 
+     Derived (not hardcoded) so a pin bump in ``tools/lazy_deps.py`` — aiohttp
+     is CVE-pinned, so bumps happen — never leaves this string stale.
+-    ``feature_install_command(venv_pip=True)`` targets the actual Hermes
++    ``feature_install_command(venv_pip=True)`` targets the actual Black Pool
+     venv in every layout and sidesteps Ubuntu 24.04's PEP 668 failure that
+     a bare ``pip install`` hint invites.
+     """
+@@ -1491,7 +1491,7 @@ def _install_hint() -> str:
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="teams",
+         label="Microsoft Teams",
 diff --git a/plugins/platforms/teams/plugin.yaml b/plugins/platforms/teams/plugin.yaml
-index 6d6e301..b614dca 100644
+index 6d6e301..c9c6a38 100644
 --- a/plugins/platforms/teams/plugin.yaml
 +++ b/plugins/platforms/teams/plugin.yaml
-@@ -3,7 +3,7 @@ label: Microsoft Teams
+@@ -3,10 +3,10 @@ label: Microsoft Teams
  kind: platform
  version: 1.0.0
  description: >
@@ -49704,25 +61884,152 @@ index 6d6e301..b614dca 100644
 +  Microsoft Teams gateway adapter for Black Pool Agent.
    Connects to Microsoft Teams via the Bot Framework and relays messages
    between Teams chats (personal DMs, group chats, channel posts) and
-   the Hermes agent. Supports Adaptive Card approval prompts.
+-  the Hermes agent. Supports Adaptive Card approval prompts.
++  the Black Pool agent. Supports Adaptive Card approval prompts.
+ author: Aamir Jawaid
+ # ``requires_env`` entries are surfaced in ``hermes config`` UI via the
+ # platform-plugin env var injector in ``hermes_cli/config.py``.
+diff --git a/plugins/platforms/telegram/adapter.py b/plugins/platforms/telegram/adapter.py
+index 7fb1469..8dd31b6 100644
+--- a/plugins/platforms/telegram/adapter.py
++++ b/plugins/platforms/telegram/adapter.py
+@@ -1569,10 +1569,10 @@ class TelegramAdapter(BasePlatformAdapter):
+         ``telegram_dm_topic_reply_fallback``. Live replies send the private
+         topic thread id together with a reply anchor. Synthetic/resumed sends
+         without an anchor (loop wakeups, background-process notifications,
+-        queued follow-ups after a gateway restart) prefer the Hermes topic's
++        queued follow-ups after a gateway restart) prefer the Black Pool topic's
+         ``message_thread_id`` so they stay in the active topic lane (#87051);
+         ``direct_messages_topic_id`` is only used when no topic thread
+-        resolves, since the native DM-topic id does not match the Hermes
++        resolves, since the native DM-topic id does not match the Black Pool
+         topic lane and can render the message in a different chat lane.
+ 
+         When ``reply_to_mode`` is ``"off"``, the reply anchor is suppressed for
+@@ -1587,7 +1587,7 @@ class TelegramAdapter(BasePlatformAdapter):
+             if reply_to_message_id is None:
+                 # Anchor-less synthetic sends (loop wakeups, watch
+                 # notifications, restart-resumed follow-ups) must stay in the
+-                # active topic lane: prefer the Hermes topic thread id when it
++                # active topic lane: prefer the Black Pool topic thread id when it
+                 # resolves (#87051). Routing via direct_messages_topic_id here
+                 # sent these to a different lane than the topic the session
+                 # runs in.
+@@ -1935,7 +1935,7 @@ class TelegramAdapter(BasePlatformAdapter):
+     # the RAW agent markdown so richer constructs (tables, task lists,
+     # collapsible details, math, ...) render natively. The legacy MarkdownV2
+     # send() path stays as the fallback for unsupported/oversized content and
+-    # older PTB/clients. Streaming edits stay on Hermes' existing MarkdownV2
++    # older PTB/clients. Streaming edits stay on Black Pool' existing MarkdownV2
+     # edit path for now; finalization can re-send as rich and delete the stale
+     # preview until rich_message edit support is wired directly.
+     # ------------------------------------------------------------------
+@@ -1988,7 +1988,7 @@ class TelegramAdapter(BasePlatformAdapter):
+         Telegram Desktop 6.9.1 can crash while rendering Bot API 10.1 rich
+         messages containing math inside a collapsible details block
+         (telegramdesktop/tdesktop#30808). The Bot API accepts the payload, so
+-        Hermes must skip rich delivery up front and use the legacy MarkdownV2
++        Black Pool must skip rich delivery up front and use the legacy MarkdownV2
+         path until affected Desktop clients age out.
+         """
+         if not content:
+@@ -3562,7 +3562,7 @@ class TelegramAdapter(BasePlatformAdapter):
+             "Telegram polling could not recover after %d retries (%ds total wait). "
+             "The previous gateway session is still held open on Telegram's servers, "
+             "or another process is using the same bot token. "
+-            "To recover: ensure no other Hermes or OpenClaw instance is running "
++            "To recover: ensure no other Black Pool or OpenClaw instance is running "
+             "with this token, then restart the gateway with 'hermes gateway restart'."
+             % (MAX_CONFLICT_RETRIES, sum(10 + i * 10 for i in range(1, MAX_CONFLICT_RETRIES + 1)))
+         )
+@@ -3974,7 +3974,7 @@ class TelegramAdapter(BasePlatformAdapter):
+                 if not self._bot:
+                     return
+                 # Telegram allows up to 100 commands but has an undocumented
+-                # payload size limit (~4KB total).  Hermes defaults to 60 to
++                # payload size limit (~4KB total).  Black Pool defaults to 60 to
+                 # keep built-ins plus common skill commands visible while
+                 # staying under the threshold; users can tune the cap via
+                 # platforms.telegram.extra.command_menu.
+@@ -4308,7 +4308,7 @@ class TelegramAdapter(BasePlatformAdapter):
+             # server's filesystem rather than a relative HTTP path. PTB needs
+             # local_mode=True so download_*() reads from disk instead of issuing
+             # an HTTP GET that would 404. Requires that the same path is
+-            # readable by the Hermes process (shared mount, same machine, etc.).
++            # readable by the Black Pool process (shared mount, same machine, etc.).
+             if self.config.extra.get("local_mode"):
+                 builder = builder.local_mode(True)
+                 logger.info("[%s] Using Telegram local_mode (read files from disk)", self.name)
+@@ -8986,7 +8986,7 @@ class TelegramAdapter(BasePlatformAdapter):
+     def _explicit_bot_mentions_exclude_self(self, message: Message) -> bool:
+         """Return True when explicit bot handles target other bots, not this one.
+ 
+-        Telegram groups can contain several Hermes bot profiles. A message like
++        Telegram groups can contain several Black Pool bot profiles. A message like
+         ``@bot3 hi @bot4`` must not wake ``@bot1`` through reply/wake-word
+         fallbacks. Treat explicit bot-handle mentions as an exclusive routing
+         hint: if at least one @...bot username is present and none matches this
+@@ -9374,7 +9374,7 @@ class TelegramAdapter(BasePlatformAdapter):
+         In some Telegram environments (groups, supergroups where the bot can
+         see its own messages), getUpdates returns the bot's own outgoing
+         messages as updates.  These must be filtered out so they are not
+-        counted as incoming unread messages in the Hermes inbox.
++        counted as incoming unread messages in the Black Pool inbox.
+         """
+         if not self._bot:
+             return False
+@@ -9410,7 +9410,7 @@ class TelegramAdapter(BasePlatformAdapter):
+         # Filter out the bot's own messages (returned by getUpdates in some
+         # environments like groups/supergroups where the bot can see its own
+         # messages).  Without this, outbound messages are counted as incoming
+-        # unread in the Hermes inbox (#52363).
++        # unread in the Black Pool inbox (#52363).
+         #
+         # Telegram stamps our CURRENT @username on those own-messages and on
+         # reply_to_message, so learn the live handle here — before any mention
+@@ -10883,7 +10883,7 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="telegram",
+         label="Telegram",
 diff --git a/plugins/platforms/telegram/plugin.yaml b/plugins/platforms/telegram/plugin.yaml
-index 468081d..97edc03 100644
+index 468081d..1b7997a 100644
 --- a/plugins/platforms/telegram/plugin.yaml
 +++ b/plugins/platforms/telegram/plugin.yaml
-@@ -3,7 +3,7 @@ label: Telegram
+@@ -3,9 +3,9 @@ label: Telegram
  kind: platform
  version: 1.0.0
  description: >
 -  Telegram gateway adapter for Hermes Agent.
 +  Telegram gateway adapter for Black Pool Agent.
    Connects to Telegram via python-telegram-bot and relays messages between
-   Telegram chats/groups/topics and the Hermes agent. Supports threads/topics,
+-  Telegram chats/groups/topics and the Hermes agent. Supports threads/topics,
++  Telegram chats/groups/topics and the Black Pool agent. Supports threads/topics,
    streaming edits, native media, inline keyboards, slash commands, fallback
+   network transport (direct-IP failover), notification modes, mention gating,
+   and per-user/chat allowlists.
+diff --git a/plugins/platforms/telegram/telegram_ids.py b/plugins/platforms/telegram/telegram_ids.py
+index 8553c87..57a1ad1 100644
+--- a/plugins/platforms/telegram/telegram_ids.py
++++ b/plugins/platforms/telegram/telegram_ids.py
+@@ -2,7 +2,7 @@
+ 
+ Telegram's Bot API accepts a ``chat_id`` in two forms: a numeric ID (an int,
+ e.g. ``123456789`` for a DM or ``-1001234567890`` for a channel/supergroup) or
+-an ``@username`` string for public channels and groups. Hermes historically
++an ``@username`` string for public channels and groups. Black Pool historically
+ coerced every ``chat_id`` with ``int()``, which crashes on the username form
+ (``ValueError: invalid literal for int()``). Normalizing here lets numeric IDs
+ pass through as ints while usernames pass through unchanged — both are valid
 diff --git a/plugins/platforms/wecom/plugin.yaml b/plugins/platforms/wecom/plugin.yaml
-index ea213be..ef95b67 100644
+index ea213be..85600c7 100644
 --- a/plugins/platforms/wecom/plugin.yaml
 +++ b/plugins/platforms/wecom/plugin.yaml
-@@ -3,7 +3,7 @@ label: WeCom (Enterprise WeChat)
+@@ -3,10 +3,10 @@ label: WeCom (Enterprise WeChat)
  kind: platform
  version: 1.0.0
  description: >
@@ -49730,20 +62037,62 @@ index ea213be..ef95b67 100644
 +  WeCom / Enterprise WeChat gateway adapter for Black Pool Agent. Registers two
    platforms: ``wecom`` (Smart Robot over WebSocket) and ``wecom_callback``
    (self-built apps over an HTTP callback endpoint with AES message crypto).
-   Relays messages between WeCom chats and the Hermes agent.
+-  Relays messages between WeCom chats and the Hermes agent.
++  Relays messages between WeCom chats and the Black Pool agent.
+ author: NousResearch
+ requires_env:
+   - name: WECOM_BOT_ID
+diff --git a/plugins/platforms/whatsapp/adapter.py b/plugins/platforms/whatsapp/adapter.py
+index fd21387..1df06ac 100644
+--- a/plugins/platforms/whatsapp/adapter.py
++++ b/plugins/platforms/whatsapp/adapter.py
+@@ -300,7 +300,7 @@ from utils import env_int
+ 
+ def _is_allowed_bridge_path(url: str) -> bool:
+     """Return True only when an absolute path from the bridge resolves inside a
+-    known Hermes media cache directory.
++    known Black Pool media cache directory.
+ 
+     The Baileys bridge is a local subprocess that downloads inbound media and
+     hands back absolute file paths. A compromised or buggy bridge could hand
+@@ -1907,7 +1907,7 @@ def _build_adapter(config):
+ 
+ 
+ def register(ctx) -> None:
+-    """Plugin entry point — called by the Hermes plugin system."""
++    """Plugin entry point — called by the Black Pool plugin system."""
+     ctx.register_platform(
+         name="whatsapp",
+         label="WhatsApp",
 diff --git a/plugins/platforms/whatsapp/plugin.yaml b/plugins/platforms/whatsapp/plugin.yaml
-index 7446f52..1ee2aed 100644
+index 7446f52..faff0d9 100644
 --- a/plugins/platforms/whatsapp/plugin.yaml
 +++ b/plugins/platforms/whatsapp/plugin.yaml
-@@ -3,7 +3,7 @@ label: WhatsApp
+@@ -3,9 +3,9 @@ label: WhatsApp
  kind: platform
  version: 1.0.0
  description: >
 -  WhatsApp gateway adapter for Hermes Agent.
 +  WhatsApp gateway adapter for Black Pool Agent.
    Connects to WhatsApp via a local Node.js bridge (WhatsApp Web client) over
-   an HTTP API and relays messages between WhatsApp chats and the Hermes agent.
+-  an HTTP API and relays messages between WhatsApp chats and the Hermes agent.
++  an HTTP API and relays messages between WhatsApp chats and the Black Pool agent.
    Supports DM/group policies, mention gating, free-response chats, and
+   per-user allowlists.
+ author: NousResearch
+diff --git a/plugins/plugin_storage.py b/plugins/plugin_storage.py
+index ee32013..115b5d8 100644
+--- a/plugins/plugin_storage.py
++++ b/plugins/plugin_storage.py
+@@ -13,7 +13,7 @@ inventing a storage story, and every plugin's data is inspectable in one
+ predictable place.
+ 
+ Secrets are deliberately NOT part of this convention — credential reads go
+-through ``agent.secret_scope`` / ``.env`` like everywhere else in Hermes.
++through ``agent.secret_scope`` / ``.env`` like everywhere else in Black Pool.
+ 
+ Usage::
+ 
 diff --git a/plugins/security-guidance/patterns.py b/plugins/security-guidance/patterns.py
 index 6980888..d47f018 100644
 --- a/plugins/security-guidance/patterns.py
@@ -49757,6 +62106,568 @@ index 6980888..d47f018 100644
    - none to the pattern data itself; this file is byte-for-byte the upstream
      patterns.py at commit 0bde168 (2026-05-26). Hermes-side wiring lives in
      __init__.py.
+diff --git a/plugins/spotify/client.py b/plugins/spotify/client.py
+index 2195cc2..1761cde 100644
+--- a/plugins/spotify/client.py
++++ b/plugins/spotify/client.py
+@@ -1,4 +1,4 @@
+-"""Thin Spotify Web API helper used by Hermes native tools."""
++"""Thin Spotify Web API helper used by Black Pool native tools."""
+ 
+ from __future__ import annotations
+ 
+diff --git a/plugins/spotify/tools.py b/plugins/spotify/tools.py
+index 4bd18a0..e3149f4 100644
+--- a/plugins/spotify/tools.py
++++ b/plugins/spotify/tools.py
+@@ -1,4 +1,4 @@
+-"""Native Spotify tools for Hermes (registered via plugins/spotify)."""
++"""Native Spotify tools for Black Pool (registered via plugins/spotify)."""
+ 
+ from __future__ import annotations
+ 
+diff --git a/plugins/video_gen/xai/__init__.py b/plugins/video_gen/xai/__init__.py
+index 90dfa57..6f3e6fa 100644
+--- a/plugins/video_gen/xai/__init__.py
++++ b/plugins/video_gen/xai/__init__.py
+@@ -128,7 +128,7 @@ def _xai_headers(api_key: str) -> Dict[str, str]:
+ 
+ 
+ def _raise_if_blocked_local_input(ref: str) -> None:
+-    """Refuse to read a local media path that Hermes' read deny-list blocks.
++    """Refuse to read a local media path that Black Pool' read deny-list blocks.
+ 
+     Thin wrapper over the shared ``agent.file_safety.raise_if_read_blocked``
+     chokepoint so xAI video inputs enforce the same credential-store guard as
+diff --git a/plugins/web/ddgs/provider.py b/plugins/web/ddgs/provider.py
+index 824f3ed..568b5f4 100644
+--- a/plugins/web/ddgs/provider.py
++++ b/plugins/web/ddgs/provider.py
+@@ -12,7 +12,7 @@ whether the package is importable; the plugin still registers either way so
+ Isolation note (#68096): ``ddgs``/``primp`` can block inside native code while
+ holding the Python GIL. A ``ThreadPoolExecutor`` + ``future.result(timeout=…)``
+ cap (see #52118) cannot fire in that state — the waiter never reacquires the
+-GIL — so the whole Hermes process freezes through Ctrl+C/SIGTERM. Each search
++GIL — so the whole Black Pool process freezes through Ctrl+C/SIGTERM. Each search
+ therefore runs in a disposable child process the parent can terminate/kill.
+ """
+ 
+@@ -305,7 +305,7 @@ class DDGSWebSearchProvider(WebSearchProvider):
+ 
+         The synchronous ``ddgs`` call runs in a disposable child process with
+         a hard wall-clock timeout (``_SEARCH_TIMEOUT_SECS``) so a hung native
+-        ``primp`` call cannot freeze the Hermes process (#36776, #68096).
++        ``primp`` call cannot freeze the Black Pool process (#36776, #68096).
+         """
+         try:
+             import ddgs  # type: ignore  # noqa: F401 — availability probe
+diff --git a/plugins/web/keyless_mcp.py b/plugins/web/keyless_mcp.py
+index c3c1947..d0bb04e 100644
+--- a/plugins/web/keyless_mcp.py
++++ b/plugins/web/keyless_mcp.py
+@@ -8,7 +8,7 @@ path):
+ - Parallel: https://search.parallel.ai/mcp   (tools: web_search, web_fetch)
+ 
+ This module implements a minimal JSON-RPC ``tools/call`` client for those
+-two endpoints so a fresh Hermes install with **zero web credentials** still
++two endpoints so a fresh Black Pool install with **zero web credentials** still
+ gets working ``web_search`` / ``web_extract`` tools. The keyless tier is
+ resolved strictly LAST — after every keyed backend, the managed tool
+ gateway, ddgs, and custom plugin providers — so it never pre-empts a
+diff --git a/plugins/web/searxng/provider.py b/plugins/web/searxng/provider.py
+index 6f747fc..628d4db 100644
+--- a/plugins/web/searxng/provider.py
++++ b/plugins/web/searxng/provider.py
+@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
+ 
+ 
+ def _searxng_url() -> str:
+-    """Return SEARXNG_URL from Hermes config-aware env, falling back to process env."""
++    """Return SEARXNG_URL from Black Pool config-aware env, falling back to process env."""
+     try:
+         from hermes_cli.config import get_env_value
+ 
+diff --git a/plugins/web/xai/provider.py b/plugins/web/xai/provider.py
+index 77d80a4..1d09bbe 100644
+--- a/plugins/web/xai/provider.py
++++ b/plugins/web/xai/provider.py
+@@ -4,7 +4,7 @@ Routes ``web_search`` tool calls through xAI's agentic Web Search tool
+ (server-side ``web_search`` on the Responses API). Grok runs the actual
+ searching and page-browsing server-side; we ask it to return the top
+ results as structured JSON so we can hand back the same
+-``{title, url, description, position}`` rows every other Hermes web
++``{title, url, description, position}`` rows every other Black Pool web
+ provider produces.
+ 
+ Reference: https://docs.x.ai/developers/tools/web-search
+diff --git a/skills/autonomous-ai-agents/hermes-agent/templates/plugin.js b/skills/autonomous-ai-agents/hermes-agent/templates/plugin.js
+index e3e75ed..a26039a 100644
+--- a/skills/autonomous-ai-agents/hermes-agent/templates/plugin.js
++++ b/skills/autonomous-ai-agents/hermes-agent/templates/plugin.js
+@@ -1,5 +1,5 @@
+ /**
+- * Hermes desktop plugin template. Save as:
++ * Black Pool desktop plugin template. Save as:
+  *   <hermes home>/desktop-plugins/<id>/plugin.js   (folder name == id)
+  * where <hermes home> is ~/.hermes by default, or ~/.hermes/profiles/<name>
+  * when running a named profile (`hermes -p <name>`). Run `hermes doctor` (or
+diff --git a/skills/autonomous-ai-agents/hermes-agent/templates/skin.yaml b/skills/autonomous-ai-agents/hermes-agent/templates/skin.yaml
+index 1316511..d28afbd 100644
+--- a/skills/autonomous-ai-agents/hermes-agent/templates/skin.yaml
++++ b/skills/autonomous-ai-agents/hermes-agent/templates/skin.yaml
+@@ -1,4 +1,4 @@
+-# Hermes skin template — themes the CLI, TUI, and desktop GUI from one file.
++# Black Pool skin template — themes the CLI, TUI, and desktop GUI from one file.
+ # Copy to <hermes-home>/skins/<name>.yaml, edit the palette, then set
+ # `display.skin: <name>` in config.yaml. Missing keys inherit the default skin.
+ 
+@@ -42,7 +42,7 @@ colors:
+ 
+ # Optional flavor — safe to delete.
+ branding:
+-  agent_name: Hermes Agent
++  agent_name: Black Pool Agent
+   prompt_symbol: "❯"
+   help_header: "(^_^)? Commands"
+ 
+diff --git a/skills/creative/touchdesigner-mcp/scripts/setup.sh b/skills/creative/touchdesigner-mcp/scripts/setup.sh
+index 15dc662..67771bf 100644
+--- a/skills/creative/touchdesigner-mcp/scripts/setup.sh
++++ b/skills/creative/touchdesigner-mcp/scripts/setup.sh
+@@ -43,14 +43,14 @@ else
+     fi
+ fi
+ 
+-# ── 3. Ensure Hermes config has twozero_td MCP entry ──
++# ── 3. Ensure Black Pool config has twozero_td MCP entry ──
+ if [[ ! -f "$HERMES_CFG" ]]; then
+-    echo -e " ${FAIL} Hermes config not found at ${HERMES_CFG}"
++    echo -e " ${FAIL} Black Pool config not found at ${HERMES_CFG}"
+     manual_steps+=("Create ${HERMES_CFG} with twozero_td MCP server entry")
+ elif grep -q 'twozero_td' "$HERMES_CFG" 2>/dev/null; then
+-    echo -e " ${OK} twozero_td MCP entry exists in Hermes config"
++    echo -e " ${OK} twozero_td MCP entry exists in Black Pool config"
+ else
+-    echo -e " ${WARN} Adding twozero_td MCP entry to Hermes config..."
++    echo -e " ${WARN} Adding twozero_td MCP entry to Black Pool config..."
+     python3 -c "
+ import yaml, sys, copy
+ 
+@@ -72,7 +72,7 @@ if 'twozero_td' not in cfg['mcp_servers']:
+ " 2>/dev/null && echo -e " ${OK} twozero_td MCP entry added to config" \
+               || { echo -e " ${FAIL} Could not update config (is PyYAML installed?)"; \
+                    manual_steps+=("Add twozero_td MCP entry to ${HERMES_CFG} manually"); }
+-    manual_steps+=("Restart Hermes session to pick up config change")
++    manual_steps+=("Restart Black Pool session to pick up config change")
+ fi
+ 
+ # ── 4. Test if MCP port is responding ──
+diff --git a/skills/github/github-auth/scripts/gh-env.sh b/skills/github/github-auth/scripts/gh-env.sh
+index 5017aa7..b186889 100755
+--- a/skills/github/github-auth/scripts/gh-env.sh
++++ b/skills/github/github-auth/scripts/gh-env.sh
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env bash
+-# GitHub environment detection helper for Hermes Agent skills.
++# GitHub environment detection helper for Black Pool Agent skills.
+ #
+ # Usage (via terminal tool):
+ #   source skills/github/github-auth/scripts/gh-env.sh
+diff --git a/skills/productivity/docx/scripts/docx_comments.py b/skills/productivity/docx/scripts/docx_comments.py
+index 958b337..097ecf3 100644
+--- a/skills/productivity/docx/scripts/docx_comments.py
++++ b/skills/productivity/docx/scripts/docx_comments.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-# MIT License. Part of the Hermes docx skill.
++# MIT License. Part of the Black Pool docx skill.
+ """List, add, and delete comments in a .docx.
+ 
+ Subcommands:
+@@ -238,7 +238,7 @@ def main() -> int:
+     p.add_argument("--target", required=True,
+                    help="anchor: first occurrence of this text")
+     p.add_argument("--text", required=True, help="comment body")
+-    p.add_argument("--author", default="Hermes")
++    p.add_argument("--author", default="Black Pool")
+     p.add_argument("--initials", default="")
+     p.add_argument("--xml", action="store_true",
+                    help="force the XML fallback (skip native API)")
+diff --git a/skills/productivity/docx/scripts/docx_create.py b/skills/productivity/docx/scripts/docx_create.py
+index ea507b9..a7db41f 100644
+--- a/skills/productivity/docx/scripts/docx_create.py
++++ b/skills/productivity/docx/scripts/docx_create.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-# MIT License. Part of the Hermes docx skill.
++# MIT License. Part of the Black Pool docx skill.
+ """Create a .docx document from a JSON spec.
+ 
+ Usage: docx_create.py spec.json output.docx
+diff --git a/skills/productivity/docx/scripts/docx_edit.py b/skills/productivity/docx/scripts/docx_edit.py
+index 7b7804a..e329d62 100644
+--- a/skills/productivity/docx/scripts/docx_edit.py
++++ b/skills/productivity/docx/scripts/docx_edit.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-# MIT License. Part of the Hermes docx skill.
++# MIT License. Part of the Black Pool docx skill.
+ """Edit an existing .docx in place (or to a new file).
+ 
+ Subcommands:
+diff --git a/skills/productivity/docx/scripts/docx_read.py b/skills/productivity/docx/scripts/docx_read.py
+index 4465f99..636813f 100644
+--- a/skills/productivity/docx/scripts/docx_read.py
++++ b/skills/productivity/docx/scripts/docx_read.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-# MIT License. Part of the Hermes docx skill.
++# MIT License. Part of the Black Pool docx skill.
+ """Read a .docx: text, structure outline, styles, images, revision detection.
+ 
+ Usage:
+diff --git a/skills/productivity/docx/scripts/docx_revisions.py b/skills/productivity/docx/scripts/docx_revisions.py
+index 70aff30..650293e 100644
+--- a/skills/productivity/docx/scripts/docx_revisions.py
++++ b/skills/productivity/docx/scripts/docx_revisions.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-# MIT License. Part of the Hermes docx skill.
++# MIT License. Part of the Black Pool docx skill.
+ """Inspect and resolve tracked changes (w:ins / w:del) in a .docx.
+ 
+ Subcommands:
+diff --git a/skills/productivity/docx/scripts/docx_template.py b/skills/productivity/docx/scripts/docx_template.py
+index 2b2db54..2c4c618 100644
+--- a/skills/productivity/docx/scripts/docx_template.py
++++ b/skills/productivity/docx/scripts/docx_template.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-# MIT License. Part of the Hermes docx skill.
++# MIT License. Part of the Black Pool docx skill.
+ """Fill {{placeholder}} tokens in a .docx from a JSON mapping.
+ 
+ Tokens are replaced everywhere: body paragraphs, tables (including nested
+diff --git a/skills/productivity/docx/scripts/docx_validate.py b/skills/productivity/docx/scripts/docx_validate.py
+index 91350a4..580c30f 100644
+--- a/skills/productivity/docx/scripts/docx_validate.py
++++ b/skills/productivity/docx/scripts/docx_validate.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-# MIT License. Part of the Hermes docx skill.
++# MIT License. Part of the Black Pool docx skill.
+ """Health-check a .docx package and report issues as JSON.
+ 
+ Usage: docx_validate.py file.docx
+diff --git a/skills/productivity/google-workspace/scripts/_hermes_home.py b/skills/productivity/google-workspace/scripts/_hermes_home.py
+index 456eaa9..1833f9c 100644
+--- a/skills/productivity/google-workspace/scripts/_hermes_home.py
++++ b/skills/productivity/google-workspace/scripts/_hermes_home.py
+@@ -1,6 +1,6 @@
+ """Resolve HERMES_HOME for standalone skill scripts.
+ 
+-Skill scripts may run outside the Hermes process (e.g. system Python,
++Skill scripts may run outside the Black Pool process (e.g. system Python,
+ nix env, CI) where ``hermes_constants`` is not importable.  This module
+ provides the same ``get_hermes_home()`` and ``display_hermes_home()``
+ contracts as ``hermes_constants`` without requiring it on ``sys.path``.
+@@ -25,7 +25,7 @@ try:
+ except (ModuleNotFoundError, ImportError):
+ 
+     def get_hermes_home() -> Path:
+-        """Return the Hermes home directory (default: ~/.hermes).
++        """Return the Black Pool home directory (default: ~/.hermes).
+ 
+         Mirrors ``hermes_constants.get_hermes_home()``."""
+         val = os.environ.get("HERMES_HOME", "").strip()
+diff --git a/skills/productivity/google-workspace/scripts/google_api.py b/skills/productivity/google-workspace/scripts/google_api.py
+index 5c2e823..3a52a2d 100644
+--- a/skills/productivity/google-workspace/scripts/google_api.py
++++ b/skills/productivity/google-workspace/scripts/google_api.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Google Workspace API CLI for Hermes Agent.
++"""Google Workspace API CLI for Black Pool Agent.
+ 
+ Uses the Google Workspace CLI (`gws`) when available, but preserves the
+ existing Hermes-facing JSON contract and falls back to the Python client
+@@ -1052,7 +1052,7 @@ def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
+ 
+ 
+ def main():
+-    parser = argparse.ArgumentParser(description="Google Workspace API for Hermes Agent")
++    parser = argparse.ArgumentParser(description="Google Workspace API for Black Pool Agent")
+     sub = parser.add_subparsers(dest="service", required=True)
+ 
+     # --- Gmail ---
+diff --git a/skills/productivity/google-workspace/scripts/gws_bridge.py b/skills/productivity/google-workspace/scripts/gws_bridge.py
+index 5fa7a9d..35dd567 100755
+--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
++++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Bridge between Hermes OAuth token and gws CLI.
++"""Bridge between Black Pool OAuth token and gws CLI.
+ 
+ Refreshes the token if expired, then executes gws with the valid access token.
+ """
+diff --git a/skills/productivity/google-workspace/scripts/setup.py b/skills/productivity/google-workspace/scripts/setup.py
+index 375fcd9..62a0df8 100644
+--- a/skills/productivity/google-workspace/scripts/setup.py
++++ b/skills/productivity/google-workspace/scripts/setup.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Google Workspace OAuth2 setup for Hermes Agent.
++"""Google Workspace OAuth2 setup for Black Pool Agent.
+ 
+ Fully non-interactive — designed to be driven by the agent via terminal commands.
+ The agent mediates between this script and the user (works on CLI, Telegram, Discord, etc.)
+@@ -103,7 +103,7 @@ def _format_missing_scopes(missing_scopes: list[str]) -> str:
+     return (
+         "Token is valid but missing required Google Workspace scopes:\n"
+         f"{bullets}\n"
+-        "Run the Google Workspace setup again from this same Hermes profile to refresh consent."
++        "Run the Google Workspace setup again from this same Black Pool profile to refresh consent."
+     )
+ 
+ 
+@@ -149,7 +149,7 @@ def install_deps():
+     except subprocess.CalledProcessError as e:
+         pip_error = e
+ 
+-    # Fallback: the interpreter has no pip (the Hermes Docker image's venv is
++    # Fallback: the interpreter has no pip (the Black Pool Docker image's venv is
+     # built with `uv sync`, which does not bootstrap pip). `uv pip install
+     # --python <interpreter>` installs into that exact interpreter without
+     # needing pip present. Targeting sys.executable keeps us on the venv the
+@@ -175,7 +175,7 @@ def install_deps():
+ 
+     print(f"ERROR: Failed to install dependencies: {pip_error}")
+     print(
+-        "On environments without pip (e.g. Nix, or the Hermes Docker image's "
++        "On environments without pip (e.g. Nix, or the Black Pool Docker image's "
+         "uv-managed venv), install the optional extra instead:"
+     )
+     print("  hermes setup")
+@@ -286,7 +286,7 @@ def check_auth(quiet: bool = False):
+ 
+ 
+ def store_client_secret(path: str):
+-    """Copy and validate client_secret.json to Hermes home."""
++    """Copy and validate client_secret.json to Black Pool home."""
+     src = Path(path).expanduser().resolve()
+     if not src.exists():
+         print(f"ERROR: File not found: {src}")
+@@ -483,7 +483,7 @@ def revoke():
+ 
+ 
+ def main():
+-    parser = argparse.ArgumentParser(description="Google Workspace OAuth setup for Hermes")
++    parser = argparse.ArgumentParser(description="Google Workspace OAuth setup for Black Pool")
+     group = parser.add_mutually_exclusive_group(required=True)
+     group.add_argument("--check", action="store_true", help="Check if auth is valid (exit 0=yes, 1=no)")
+     group.add_argument("--check-live", action="store_true", help="Check auth with a real API call (detects disabled_client)")
+diff --git a/skills/research/grounded-citations/scripts/_hermes_home.py b/skills/research/grounded-citations/scripts/_hermes_home.py
+index 45ed49d..db5553a 100644
+--- a/skills/research/grounded-citations/scripts/_hermes_home.py
++++ b/skills/research/grounded-citations/scripts/_hermes_home.py
+@@ -1,6 +1,6 @@
+ """Resolve HERMES_HOME for standalone skill scripts.
+ 
+-Skill scripts may run outside the Hermes process (system Python, nix env,
++Skill scripts may run outside the Black Pool process (system Python, nix env,
+ CI) where ``hermes_constants`` is not importable.  This module provides the
+ same ``get_hermes_home()`` contract without requiring it on ``sys.path``.
+ 
+@@ -18,6 +18,6 @@ try:
+ except (ModuleNotFoundError, ImportError):
+ 
+     def get_hermes_home() -> Path:
+-        """Return the Hermes home directory (default: ``~/.hermes``)."""
++        """Return the Black Pool home directory (default: ``~/.hermes``)."""
+         val = os.environ.get("HERMES_HOME", "").strip()
+         return Path(val) if val else Path.home() / ".hermes"
+diff --git a/tools/annotate_preview_tool.py b/tools/annotate_preview_tool.py
+index 7174779..55e7181 100644
+--- a/tools/annotate_preview_tool.py
++++ b/tools/annotate_preview_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Leave a mark on the page in the Hermes desktop GUI's in-app browser.
++"""Leave a mark on the page in the Black Pool desktop GUI's in-app browser.
+ 
+ ``drive_preview`` already draws every move it makes — the field it can reach,
+ a box round its target, the cursor going there — but those are transients:
+@@ -46,7 +46,7 @@ def annotate_preview_tool(
+ ) -> str:
+     """Put one annotation up, take one down, or clear them all."""
+     if callback is None:
+-        return tool_error("annotate_preview is only available in the Hermes desktop app.")
++        return tool_error("annotate_preview is only available in the Black Pool desktop app.")
+ 
+     verb = (action or "add").strip().lower()
+     if verb not in ACTIONS:
+@@ -90,7 +90,7 @@ ANNOTATE_PREVIEW_SCHEMA = {
+     "name": "annotate_preview",
+     "description": (
+         "Draw a lasting mark on the page open in the in-app browser / preview "
+-        "pane of the Hermes desktop GUI. Everything drive_preview draws as it "
++        "pane of the Black Pool desktop GUI. Everything drive_preview draws as it "
+         "works fades on its own; an annotation STAYS until you remove it, so "
+         "this is how you point at something. Use it to show the user what you "
+         "found ('here are the three cheapest'), flag what you are about to "
+diff --git a/tools/apply_layout_tool.py b/tools/apply_layout_tool.py
+index b1eb4ab..11975b9 100644
+--- a/tools/apply_layout_tool.py
++++ b/tools/apply_layout_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Apply a layout preset in the Hermes desktop GUI.
++"""Apply a layout preset in the Black Pool desktop GUI.
+ 
+ Lives in the ``desktop_ui`` toolset (like ``focus_pane``), which the GUI
+ gateway enables only for desktop-sourced sessions. Emits ``layout.apply``
+@@ -22,7 +22,7 @@ from tools.registry import registry, tool_error
+ 
+ # Renderer answer arrives via the blocking-prompt bridge with this timeout;
+ # applying a layout is synchronous in the renderer, so this is generous.
+-_TIMEOUT_NOTE = "Layout apply is only available in the Hermes desktop app."
++_TIMEOUT_NOTE = "Layout apply is only available in the Black Pool desktop app."
+ 
+ 
+ def apply_layout_tool(preset: str) -> str:
+@@ -44,7 +44,7 @@ def apply_layout_tool(preset: str) -> str:
+ APPLY_LAYOUT_SCHEMA = {
+     "name": "apply_layout",
+     "description": (
+-        "Apply a saved layout preset to the Hermes desktop app when the user asks to "
++        "Apply a saved layout preset to the Black Pool desktop app when the user asks to "
+         "rearrange the workspace — e.g. \"set up my layout for coding\", \"give me a "
+         "focused view\", \"put the terminal front and center\". Built-in presets: "
+         "default (chat + sidebars), focus (chat only), terminal-deck (terminal "
+diff --git a/tools/approval.py b/tools/approval.py
+index 1ecda55..3258f42 100644
+--- a/tools/approval.py
++++ b/tools/approval.py
+@@ -52,7 +52,7 @@ _approval_tool_call_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+     "approval_tool_call_id",
+     default="",
+ )
+-# Hermes session id (observability identity, distinct from the gateway
++# Black Pool session id (observability identity, distinct from the gateway
+ # routing session_key above). Approval hooks forward it so observer
+ # plugins can attach approval marks to the REAL session scope — without
+ # it they fall back to a synthetic "default" session whose scope never
+@@ -124,7 +124,7 @@ def _fire_approval_hook(hook_name: str, **kwargs) -> None:
+     try:
+         kwargs.setdefault("turn_id", _approval_turn_id.get())
+         kwargs.setdefault("tool_call_id", _approval_tool_call_id.get())
+-        # Forward the Hermes session id so observer plugins parent approval
++        # Forward the Black Pool session id so observer plugins parent approval
+         # marks to the real session scope instead of a synthetic "default"
+         # session (whose scope never closes → marks never export).
+         _session_id = _approval_session_id.get()
+@@ -699,7 +699,7 @@ def _save_blocked_payload(command: str) -> Optional[str]:
+         path = script_dir / f"blocked-{int(_time.time())}-{_uuid.uuid4().hex[:8]}.sh"
+         path.write_text(
+             "#!/bin/bash\n"
+-            "# Auto-saved by Hermes: this command exceeded the inline command\n"
++            "# Auto-saved by Black Pool: this command exceeded the inline command\n"
+             "# parser limit and was blocked from direct execution. Review it,\n"
+             "# then run it via: bash " + str(path) + "\n"
+             + command
+@@ -806,7 +806,7 @@ DANGEROUS_PATTERNS = [
+     (r'\b(?:powershell|pwsh)(?:\.exe)?\b(?:\s+-\S+)*\s+(?:-(?:command|c)\s+)?["\']?(?:remove-item|rmdir|erase|del|rd|ri|rm)\b', "Windows PowerShell destructive delete"),
+     (r'\b(?:powershell|pwsh)(?:\.exe)?\b.*\s-(?:encodedcommand|enc|e)\b', "PowerShell encoded command execution"),
+     # ── Windows destructive tier (#69472) ────────────────────────────────
+-    # These are native Windows EXEs / cmdlets reachable from ANY Hermes
++    # These are native Windows EXEs / cmdlets reachable from ANY Black Pool
+     # terminal backend on a Windows host — including the default git-bash
+     # backend (taskkill.exe, icacls.exe, reg.exe, vssadmin.exe, bcdedit.exe,
+     # cipher.exe are ordinary PATH executables there). Detection input is
+@@ -852,7 +852,7 @@ DANGEROUS_PATTERNS = [
+     # Credential/key paths in Windows form — the POSIX ~/.ssh patterns never
+     # match drive-letter or backslash spellings. Match both separators.
+     (r'\busers[\\/][^\\/\s]+[\\/]\.ssh\b', "access to SSH keys (Windows path)"),
+-    (r'\bappdata[\\/](?:local|roaming)[\\/]hermes[^\n]*\.env\b', "access to Hermes secrets (Windows path)"),
++    (r'\bappdata[\\/](?:local|roaming)[\\/]hermes[^\n]*\.env\b', "access to Black Pool secrets (Windows path)"),
+     # ─────────────────────────────────────────────────────────────────────
+     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),
+     (r'\bchmod\s+--recursive\b.*(777|666|o\+[rwx]*w|a\+[rwx]*w)', "recursive world/other-writable (long flag)"),
+@@ -981,7 +981,7 @@ DANGEROUS_PATTERNS = [
+     # /private/etc/ mirror).
+     (rf'\b(cp|mv|install)\b.*\s{_SYSTEM_CONFIG_PATH}', "copy/move file into system config path"),
+     (rf'\b(cp|mv|install)\b.*\s["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config file"),
+-    # cp/mv/install OVERWRITING a sensitive credential/SSH/shell-rc/Hermes file.
++    # cp/mv/install OVERWRITING a sensitive credential/SSH/shell-rc/Black Pool file.
+     # The tee/redirection patterns above already gate _SENSITIVE_WRITE_TARGET
+     # (~/.ssh/*, ~/.netrc/.pgpass/.npmrc/.pypirc, shell rc files,
+     # ~/.hermes/config.yaml/.env), but cp/mv/install was only paired for /etc and
+@@ -1008,8 +1008,8 @@ DANGEROUS_PATTERNS = [
+     # .env). sed -i bypasses the redirection/tee patterns above because it
+     # mutates the file directly. Pairs the file_tools write_file/patch deny so
+     # the terminal side is not an open door. See #14639.
+-    (rf'\bsed\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env"),
+-    (rf'\bsed\s+--in-place\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (long flag)"),
++    (rf'\bsed\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Black Pool config/env"),
++    (rf'\bsed\s+--in-place\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Black Pool config/env (long flag)"),
+     # perl -i and ruby -i perform the same in-place mutation as sed -i but are
+     # not caught by the -e/-c script-execution pattern above (which targets code
+     # evaluation, not file mutation). Pairs the sed -i coverage from #14639.
+@@ -1018,7 +1018,7 @@ DANGEROUS_PATTERNS = [
+     # backup suffix (`perl -i.bak`). Match any flag token containing `i`
+     # anywhere in the args, not just the first token — `perl -e '...'` (code
+     # eval, no -i) does not trip because it has no `-...i` flag token.
+-    (rf'\b(?:perl|ruby)\b.*(?:^|\s)-[^\s]*i\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl/ruby)"),
++    (rf'\b(?:perl|ruby)\b.*(?:^|\s)-[^\s]*i\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Black Pool config/env (perl/ruby)"),
+     # Interpreter heredocs are handled by _execution_flag_findings() alongside
+     # inline-exec flags; keep only shell heredocs regex-based here.
+     # Shell execution via heredoc — `bash <<'EOF' ... EOF` runs arbitrary
+@@ -1167,7 +1167,7 @@ def _normalize_command_for_detection(command: str) -> str:
+     # would otherwise dissolve (-> C:Usersalice) and make the fold impossible.
+     # The fold matches either separator, so POSIX paths are unaffected by order.
+     #
+-    # Fold the (more specific) Hermes home first: on Windows it nests under the
++    # Fold the (more specific) Black Pool home first: on Windows it nests under the
+     # user home (C:\Users\alice\AppData\...\hermes), so folding the user home
+     # first would eat the prefix the Hermes-home fold needs.
+     command = _rewrite_resolved_hermes_home(command)
+@@ -1276,7 +1276,7 @@ def _rewrite_resolved_user_home(command: str) -> str:
+ 
+ 
+ def _rewrite_resolved_hermes_home(command: str) -> str:
+-    """Rewrite the resolved absolute Hermes home prefix to ``~/.hermes/``.
++    """Rewrite the resolved absolute Black Pool home prefix to ``~/.hermes/``.
+ 
+     Resolves the active ``HERMES_HOME`` at call time (and its symlink-resolved
+     form) and folds an occurrence of ``<home>/`` in *command* into
+@@ -2298,7 +2298,7 @@ def _command_detection_variants(command: str):
+ 
+ 
+ def _is_verification_artifact_cleanup(command: str) -> bool:
+-    """Return whether *command* only removes one Hermes ad-hoc temp script."""
++    """Return whether *command* only removes one Black Pool ad-hoc temp script."""
+     try:
+         argv = shlex.split(command, posix=True)
+     except ValueError:
+@@ -2724,7 +2724,7 @@ def approve_session(session_key: str, pattern_key: str):
+ 
+ 
+ def _release_permission_mode_dependents(session_key: str) -> None:
+-    """Drop resources whose immutable mode is derived from Hermes YOLO.
++    """Drop resources whose immutable mode is derived from Black Pool YOLO.
+ 
+     The import stays lazy so approval-only sessions do not load computer-use.
+     Releasing on both edges makes enabling YOLO replace an existing standard
+@@ -3191,7 +3191,7 @@ def _get_approval_mode() -> str:
+ 
+ 
+ def is_approval_bypass_active_for_session(session_key: str) -> bool:
+-    """Return whether one exact session bypasses Hermes approval prompts.
++    """Return whether one exact session bypasses Black Pool approval prompts.
+ 
+     Collapses the canonical three-source bypass check used across the codebase
+     into one place:
 diff --git a/tools/bot_mode_probe.py b/tools/bot_mode_probe.py
 index b8a588d..12a63dc 100644
 --- a/tools/bot_mode_probe.py
@@ -49771,9 +62682,45 @@ index b8a588d..12a63dc 100644
          "message to a temp file with the file tool FIRST (never inline it into the "
          "command — quotes truncate it and $( ) would execute), then run on the "
 diff --git a/tools/browser_camofox.py b/tools/browser_camofox.py
-index 432ca85..d2def56 100644
+index 432ca85..91f525c 100644
 --- a/tools/browser_camofox.py
 +++ b/tools/browser_camofox.py
+@@ -207,7 +207,7 @@ def _camofox_identity_override(task_id: Optional[str], camofox_cfg: Dict[str, An
+     """Return an externally configured Camofox identity, if one is set.
+ 
+     Integrations that own the visible Camofox browser can set a shared user ID
+-    so Hermes operates in the same browser profile instead of creating a
++    so Black Pool operates in the same browser profile instead of creating a
+     separate private session.
+     """
+     user_id = (
+@@ -238,7 +238,7 @@ def _env_flag(name: str) -> Optional[bool]:
+ 
+ 
+ def _adopt_existing_tab_enabled(camofox_cfg: Dict[str, Any]) -> bool:
+-    """Return whether Hermes should recover an existing Camofox tab ID."""
++    """Return whether Black Pool should recover an existing Camofox tab ID."""
+     env_value = _env_flag("CAMOFOX_ADOPT_EXISTING_TAB")
+     if env_value is not None:
+         return env_value
+@@ -249,7 +249,7 @@ def _loopback_rewrite_enabled(camofox_cfg: Dict[str, Any]) -> bool:
+     """Return whether loopback navigation URLs should be rewritten for Docker.
+ 
+     ``CAMOFOX_URL`` itself often points at a host-published Docker port such as
+-    ``http://127.0.0.1:9377``.  That is correct for Hermes talking to the
++    ``http://127.0.0.1:9377``.  That is correct for Black Pool talking to the
+     Camofox control API, but a page URL like ``http://127.0.0.1:3000`` is opened
+     by the browser *inside* the Docker container.  In that context loopback
+     points at the container, not the host running the web app.
+@@ -339,7 +339,7 @@ _sessions_lock = threading.Lock()
+ def _adopt_existing_tab(session: Dict[str, Any]) -> Dict[str, Any]:
+     """Attach process-local state to an already-open managed Camofox tab.
+ 
+-    Some integrations own the visible Camofox tab outside Hermes. Gateway
++    Some integrations own the visible Camofox tab outside Black Pool. Gateway
+     restarts can leave this module's in-memory session cache empty even though
+     Camofox still has that tab, so rehydrate tab_id before creating a new tab.
+     """
 @@ -378,7 +378,7 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
      """Get or create a camofox session for the given task.
  
@@ -49784,9 +62731,18 @@ index 432ca85..d2def56 100644
      """
      task_id = task_id or "default"
 diff --git a/tools/browser_camofox_state.py b/tools/browser_camofox_state.py
-index 3a2bde0..34ae3f1 100644
+index 3a2bde0..333a696 100644
 --- a/tools/browser_camofox_state.py
 +++ b/tools/browser_camofox_state.py
+@@ -1,7 +1,7 @@
+ """Hermes-managed Camofox state helpers.
+ 
+ Provides profile-scoped identity and state directory paths for Camofox
+-persistent browser profiles.  When managed persistence is enabled, Hermes
++persistent browser profiles.  When managed persistence is enabled, Black Pool
+ sends a deterministic userId derived from the active profile so that
+ Camofox can map it to the same persistent browser profile directory
+ across restarts.
 @@ -27,7 +27,7 @@ def get_camofox_state_dir() -> Path:
  def get_camofox_identity(task_id: Optional[str] = None) -> Dict[str, str]:
      """Return the stable Hermes-managed Camofox identity for this profile.
@@ -49796,10 +62752,40 @@ index 3a2bde0..34ae3f1 100644
      The session key is scoped to the logical browser task so newly created
      tabs within the same profile reuse the same identity contract.
      """
+diff --git a/tools/browser_supervisor.py b/tools/browser_supervisor.py
+index d17806f..e902f29 100644
+--- a/tools/browser_supervisor.py
++++ b/tools/browser_supervisor.py
+@@ -1,6 +1,6 @@
+ """Persistent CDP supervisor for browser dialog + frame detection.
+ 
+-One ``CDPSupervisor`` runs per Hermes ``task_id`` that has a reachable CDP
++One ``CDPSupervisor`` runs per Black Pool ``task_id`` that has a reachable CDP
+ endpoint. It holds a single persistent WebSocket to the backend, subscribes
+ to ``Page`` / ``Runtime`` / ``Target`` events on every attached session
+ (top-level page and every OOPIF / worker target that auto-attaches), and
+@@ -46,7 +46,7 @@ def _redact_cdp_error_text(exc: object) -> str:
+     ``self.cdp_url`` — including a ``?token=`` query credential or
+     ``user:pass@`` userinfo). Every supervisor egress point that turns such an
+     exception into log text or a re-raised message MUST route through here so
+-    those credentials never reach Hermes logs or tracebacks. Falls back to a
++    those credentials never reach Black Pool logs or tracebacks. Falls back to a
+     fixed sentinel if redaction itself raises, erring toward masking.
+     """
+     try:
 diff --git a/tools/browser_tool.py b/tools/browser_tool.py
-index 34f38ba..ed91ed6 100644
+index 34f38ba..e89a0db 100644
 --- a/tools/browser_tool.py
 +++ b/tools/browser_tool.py
+@@ -112,7 +112,7 @@ def _lazy_call_llm(*args, **kwargs):
+ # Browser-specific tool keys passed through to the agent-browser subprocess
+ # AFTER credential stripping.  agent-browser is a Node process loading npm
+ # deps; handing it the full operator keyring (#29157 / GHSA-m4m8-xjp4-5rmm)
+-# means a compromised transitive dependency could read every Hermes secret
++# means a compromised transitive dependency could read every Black Pool secret
+ # straight out of process.env.  Strip by default, then re-add only the
+ # browser-backend keys the worker legitimately needs.
+ _BROWSER_PASSTHROUGH_KEYS: tuple[str, ...] = (
 @@ -756,7 +756,7 @@ def _ensure_browser_plugins_loaded() -> None:
  
  
@@ -49809,6 +62795,751 @@ index 34f38ba..ed91ed6 100644
      global _cached_cloud_provider, _cloud_provider_resolved
      global _cached_cloud_provider_scope
  
+@@ -1100,7 +1100,7 @@ def _lightpanda_fallback_reason(engine: str, command: str, result: Dict[str, Any
+     """Return the user-visible reason a Lightpanda result needs Chrome fallback.
+ 
+     ``None`` means no fallback should run.  The returned string is copied into
+-    the fallback result so CLI/TUI/gateway users can see when Hermes silently
++    the fallback result so CLI/TUI/gateway users can see when Black Pool silently
+     switched from Lightpanda to Chrome for completeness.
+     """
+     if engine != "lightpanda":
+@@ -1289,7 +1289,7 @@ def _run_chrome_fallback_command(
+             #   and that grandchild's CreateProcess dies silently
+             #   ("Daemon process exited during startup with no error output")
+             #   when inherited parent handles are in a weird state. Observed
+-            #   in the Hermes CLI where sys.stdout and sys.stderr both report
++            #   in the Black Pool CLI where sys.stdout and sys.stderr both report
+             #   fileno=1 (stderr dup'd onto stdout at the OS level).
+             # * close_fds=True → block inheritance of every other handle.
+             #   (Default on POSIX; must be explicit on Windows for stdio.)
+@@ -2268,7 +2268,7 @@ BROWSER_TOOL_SCHEMAS = [
+     },
+     {
+         "name": "browser_vision",
+-        "description": "Take a screenshot of the current page so you can inspect it visually. Use this when you need to understand what the page looks like - especially for CAPTCHAs, visual verification challenges, complex layouts, or cases where the text snapshot misses important visual information. When your active model has native vision, the screenshot is attached to your context directly and you inspect it on the next turn; otherwise Hermes falls back to an auxiliary vision model and returns a text analysis. Includes a screenshot_path that you can share with the user by including MEDIA:<screenshot_path> in your response. Requires browser_navigate to be called first.",
++        "description": "Take a screenshot of the current page so you can inspect it visually. Use this when you need to understand what the page looks like - especially for CAPTCHAs, visual verification challenges, complex layouts, or cases where the text snapshot misses important visual information. When your active model has native vision, the screenshot is attached to your context directly and you inspect it on the next turn; otherwise Black Pool falls back to an auxiliary vision model and returns a text analysis. Includes a screenshot_path that you can share with the user by including MEDIA:<screenshot_path> in your response. Requires browser_navigate to be called first.",
+         "parameters": {
+             "type": "object",
+             "properties": {
+@@ -2690,7 +2690,7 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
+     Runs a credential-scrubbed, PATH-propagated environment matching every
+     other agent-browser subprocess spawn (see ``_build_browser_env``) —
+     this used to inherit the full parent environment, including every
+-    provider/gateway credential Hermes holds, while running registry-fetched
++    provider/gateway credential Black Pool holds, while running registry-fetched
+     npm code on every ``hermes update`` (the GHSA-m4m8-xjp4-5rmm class of
+     risk ``_build_browser_env`` exists specifically to prevent). Runs in its
+     own process group and kills the *whole* group — not just the top-level
+@@ -4545,7 +4545,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
+ 
+     Captures what's visually displayed in the browser. When the active model
+     supports native vision, the screenshot is attached directly to the
+-    conversation so the model can inspect it on the next turn; otherwise Hermes
++    conversation so the model can inspect it on the next turn; otherwise Black Pool
+     falls back to the auxiliary vision model and returns a text analysis. Useful
+     for visual content the text-based snapshot may not capture (CAPTCHAs,
+     verification challenges, images, complex layouts, etc.).
+diff --git a/tools/browser_use_cli.py b/tools/browser_use_cli.py
+index 0c99f42..95ffa96 100644
+--- a/tools/browser_use_cli.py
++++ b/tools/browser_use_cli.py
+@@ -109,13 +109,13 @@ def _base_subprocess_env() -> dict:
+ 
+     env = _build_browser_env()
+     # The browser-use CLI runs under its own Python (uv tool / uvx), which
+-    # may differ from Hermes's venv Python. PYTHONPATH/PYTHONHOME inherited
+-    # from the agent process point at Hermes's venv site-packages, and a
++    # may differ from Black Pool's venv Python. PYTHONPATH/PYTHONHOME inherited
++    # from the agent process point at Black Pool's venv site-packages, and a
+     # child interpreter honors them ahead of its own site-packages — so the
+     # CLI imports compiled C-extensions (e.g. pydantic_core) built for the
+     # wrong interpreter and crashes on ABI mismatch (#83427, #84841, #86006,
+     # #86104). Strip both — the CLI manages its own environment and never
+-    # needs Hermes's import path.
++    # needs Black Pool's import path.
+     env.pop("PYTHONPATH", None)
+     env.pop("PYTHONHOME", None)
+     env.setdefault("ANONYMIZED_TELEMETRY", "false")
+@@ -250,7 +250,7 @@ def default_downgrade_notice() -> Optional[str]:
+ 
+ 
+ def _managed_bin_dir() -> Optional[str]:
+-    """Hermes' own bin dir ($HERMES_HOME/bin) — where install.sh puts uv/uvx
++    """Black Pool' own bin dir ($HERMES_HOME/bin) — where install.sh puts uv/uvx
+     and where install_cli() links the browser-use binary."""
+     try:
+         from hermes_constants import get_hermes_home
+@@ -281,7 +281,7 @@ def _user_local_bin_dir() -> Optional[str]:
+ def _find_cli() -> Optional[List[str]]:
+     """Locate the browser-use CLI, or None when it can't be run.
+ 
+-    MANAGED-FIRST resolution: Hermes' own ``$HERMES_HOME/bin`` copy — the
++    MANAGED-FIRST resolution: Black Pool' own ``$HERMES_HOME/bin`` copy — the
+     one every browser backend selection installs and updates via
+     ``install_cli()`` — always wins, so all sessions drive one canonical,
+     Hermes-controlled binary. PATH and the user-level tool dir
+@@ -307,7 +307,7 @@ def _find_cli() -> Optional[List[str]]:
+ def install_cli(timeout_s: int = 600) -> Tuple[bool, str]:
+     """Install the browser-use CLI persistently via ``uv tool install``.
+ 
+-    Resolution order for uv: Hermes' managed uv (bootstrapped on demand via
++    Resolution order for uv: Black Pool' managed uv (bootstrapped on demand via
+     ``hermes_cli.managed_uv.ensure_uv``) → uv on PATH. The binary is linked
+     into ``$HERMES_HOME/bin`` (``UV_TOOL_BIN_DIR``) so ``_find_cli()``
+     resolves it for every profile without touching the user's PATH.
+diff --git a/tools/checkpoint_manager.py b/tools/checkpoint_manager.py
+index 7149eeb..7abafcc 100644
+--- a/tools/checkpoint_manager.py
++++ b/tools/checkpoint_manager.py
+@@ -109,7 +109,7 @@ DEFAULT_EXCLUDES = [
+     ".git/",
+     ".hg/",
+     ".svn/",
+-    # Worktrees (Hermes convention — don't recursively snapshot siblings)
++    # Worktrees (Black Pool convention — don't recursively snapshot siblings)
+     ".worktrees/",
+     # Native / compiled binaries
+     "*.so",
+@@ -248,7 +248,7 @@ def _load_ledger(store: Path, dir_hash: str) -> Dict[str, Dict]:
+     """Load the agent-write ledger: {relpath: {"sha256": ..., "ts": ...}}.
+ 
+     The ledger records the content hash of every file the last successful
+-    ``write_file`` / ``patch`` produced, so restores can tell "Hermes wrote
++    ``write_file`` / ``patch`` produced, so restores can tell "Black Pool wrote
+     this" apart from "the user hand-edited this afterwards".
+     """
+     try:
+@@ -297,7 +297,7 @@ def _git_env(
+ ) -> dict:
+     """Build env dict that redirects git to the shared store.
+ 
+-    The shared store is internal Hermes infrastructure — it must NOT inherit
++    The shared store is internal Black Pool infrastructure — it must NOT inherit
+     the user's global or system git config.  User-level settings like
+     ``commit.gpgsign = true``, signing hooks, or credential helpers would
+     either break background snapshots or, worse, spawn interactive prompts
+@@ -526,7 +526,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
+     # exists since we just created the store inside it.
+     cfg_wd = str(base)
+     _run_git(["config", "user.email", "hermes@local"], store, cfg_wd)
+-    _run_git(["config", "user.name", "Hermes Checkpoint"], store, cfg_wd)
++    _run_git(["config", "user.name", "Black Pool Checkpoint"], store, cfg_wd)
+     _run_git(["config", "commit.gpgsign", "false"], store, cfg_wd)
+     _run_git(["config", "tag.gpgSign", "false"], store, cfg_wd)
+     _run_git(["config", "gc.auto", "0"], store, cfg_wd)
+@@ -801,11 +801,11 @@ class CheckpointManager:
+     # ------------------------------------------------------------------
+ 
+     def record_agent_write(self, file_path: str) -> None:
+-        """Record the content hash of a file Hermes just successfully wrote.
++        """Record the content hash of a file Black Pool just successfully wrote.
+ 
+         Feeds the agent-write ledger used by :meth:`restore` in safe mode:
+         at restore time, a file whose current content no longer matches the
+-        recorded hash was hand-edited by the user after Hermes last touched
++        recorded hash was hand-edited by the user after Black Pool last touched
+         it, and is skipped instead of clobbered.
+ 
+         Never raises — the ledger is best-effort bookkeeping.
+@@ -831,9 +831,9 @@ class CheckpointManager:
+ 
+         Returns ``{"success", "restore": [rel...], "skipped": [rel...],
+         "error"?}`` where ``restore`` lists files whose current content
+-        still matches what Hermes last wrote (per the agent-write ledger)
+-        and ``skipped`` lists files the user hand-edited after Hermes'
+-        last write or that Hermes never wrote at all.
++        still matches what Black Pool last wrote (per the agent-write ledger)
++        and ``skipped`` lists files the user hand-edited after Black Pool'
++        last write or that Black Pool never wrote at all.
+         """
+         hash_err = _validate_commit_hash(commit_hash)
+         if hash_err:
+@@ -862,7 +862,7 @@ class CheckpointManager:
+ 
+         ledger = _load_ledger(store, dir_hash)
+         if not ledger:
+-            # No agent-write ledger yet (pre-existing store, or Hermes has
++            # No agent-write ledger yet (pre-existing store, or Black Pool has
+             # not written any files here since the ledger was introduced).
+             # Signal callers to fall back to a full restore rather than
+             # skipping every file.
+@@ -878,13 +878,13 @@ class CheckpointManager:
+             entry = ledger.get(str(abs_path))
+             recorded = entry.get("sha256") if isinstance(entry, dict) else None
+             if recorded is None:
+-                # Hermes never wrote this file (or the ledger predates it) —
++                # Black Pool never wrote this file (or the ledger predates it) —
+                 # do not touch it in safe mode.
+                 skipped.append(rel)
+                 continue
+             current = _hash_file(abs_path)
+             if current is None:
+-                # File deleted since Hermes wrote it: restoring it back is
++                # File deleted since Black Pool wrote it: restoring it back is
+                 # safe — its last content was Hermes-authored.
+                 restore.append(rel)
+             elif current == recorded:
+@@ -1057,7 +1057,7 @@ class CheckpointManager:
+     def session_diff(self, working_dir: str) -> Dict:
+         """Show the cumulative diff of everything changed in this directory.
+ 
+-        This powers ``/diff session``.  It answers "what has Hermes changed
++        This powers ``/diff session``.  It answers "what has Black Pool changed
+         here?" by diffing the *earliest retained checkpoint* — the snapshot
+         taken before the first recorded edit — against the current working
+         tree.  Because checkpoints are captured just before each file-mutating
+@@ -1067,7 +1067,7 @@ class CheckpointManager:
+         Note: checkpoints are a persistent per-project ref, so the earliest
+         *retained* checkpoint may predate the current session (or, after
+         pruning, postdate its true start).  It is an approximation of "what
+-        Hermes changed", not an exact per-session ledger.
++        Black Pool changed", not an exact per-session ledger.
+ 
+         Returns the same shape as :meth:`diff` (``{"success", "stat",
+         "diff"}``).  When no checkpoints exist yet — nothing has been edited —
+@@ -1096,7 +1096,7 @@ class CheckpointManager:
+         """Restore files to a checkpoint state.
+ 
+         With ``safe=True`` (full-directory restores only), files the user
+-        hand-edited after Hermes' last write — per the agent-write ledger —
++        hand-edited after Black Pool' last write — per the agent-write ledger —
+         are left untouched, and only Hermes-authored changes are reverted.
+         The result gains ``skipped_user_edits`` listing the preserved paths.
+         """
+diff --git a/tools/close_preview_tool.py b/tools/close_preview_tool.py
+index 3fa15b2..1006eb6 100644
+--- a/tools/close_preview_tool.py
++++ b/tools/close_preview_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Close the Hermes desktop GUI's preview pane, or one of its tabs.
++"""Close the Black Pool desktop GUI's preview pane, or one of its tabs.
+ 
+ Lives in the ``desktop_ui`` toolset (same as ``open_preview``), which the GUI
+ gateway enables only for a session whose source is the desktop app. Emits
+@@ -24,7 +24,7 @@ def close_preview_tool(url: str = "") -> str:
+     except Exception as exc:
+         return tool_error(f"Failed to close the preview pane: {exc}")
+     if not ok:
+-        return tool_error("The preview pane is only available in the Hermes desktop app.")
++        return tool_error("The preview pane is only available in the Black Pool desktop app.")
+ 
+     return json.dumps({"success": True, "url": target}, ensure_ascii=False)
+ 
+@@ -32,7 +32,7 @@ def close_preview_tool(url: str = "") -> str:
+ CLOSE_PREVIEW_SCHEMA = {
+     "name": "close_preview",
+     "description": (
+-        "Close the preview pane beside the chat in the Hermes desktop app, or one "
++        "Close the preview pane beside the chat in the Black Pool desktop app, or one "
+         "tab inside it. Use this when the user asks to close, hide, or dismiss the "
+         "preview — e.g. \"close the preview pane\", \"close cnn.com\", \"hide the "
+         "preview\". Omit url to close the whole pane (every tab). Pass a web URL, "
+diff --git a/tools/close_terminal_tool.py b/tools/close_terminal_tool.py
+index 24277f4..3e502de 100644
+--- a/tools/close_terminal_tool.py
++++ b/tools/close_terminal_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Close a read-only agent terminal tab in the Hermes desktop GUI.
++"""Close a read-only agent terminal tab in the Black Pool desktop GUI.
+ 
+ Each ``terminal(background=true)`` process is mirrored as a read-only tab in the
+ desktop's terminal pane. This tool lets the agent drop a tab it no longer needs
+@@ -31,7 +31,7 @@ CLOSE_TERMINAL_SCHEMA = {
+     "name": "close_terminal",
+     "description": (
+         "Close the read-only terminal tab for one of your background processes in "
+-        "the Hermes desktop GUI (the tabs mirroring terminal(background=true) runs). "
++        "the Black Pool desktop GUI (the tabs mirroring terminal(background=true) runs). "
+         "This does NOT kill the process — it only drops the tab/view; the output "
+         "keeps buffering and the user can reopen it from the status stack. Use it "
+         "to tidy up when a background process's live terminal is no longer worth "
+diff --git a/tools/code_execution_tool.py b/tools/code_execution_tool.py
+index 4c6ec73..a3c91c9 100644
+--- a/tools/code_execution_tool.py
++++ b/tools/code_execution_tool.py
+@@ -2,7 +2,7 @@
+ """
+ Code Execution Tool -- Programmatic Tool Calling (PTC)
+ 
+-Lets the LLM write a Python script that calls Hermes tools via RPC,
++Lets the LLM write a Python script that calls Black Pool tools via RPC,
+ collapsing multi-step tool chains into a single inference turn.
+ 
+ Architecture (two transports):
+@@ -53,7 +53,7 @@ from agent.thread_scoped_output import thread_scoped_silence
+ # Availability gate.  On Windows we fall back to loopback TCP for the
+ # sandbox RPC transport (AF_UNIX is unreliable on Windows Python) — see
+ # ``_use_tcp_rpc`` in ``_execute_local`` below.  That makes execute_code
+-# available on every platform Hermes itself runs on.
++# available on every platform Black Pool itself runs on.
+ logger = logging.getLogger(__name__)
+ 
+ SANDBOX_AVAILABLE = True
+@@ -137,7 +137,7 @@ def _truncate_stdout_text(stdout_text: str) -> Tuple[str, Dict[str, Any]]:
+ # backends).  Secret-substring block is applied first; anything left must
+ # match a safe prefix, the operational HERMES_ allowlist, or (on Windows) an
+ # OS-essential name.  Delegate-task child context is also an exact-name
+-# operational marker: without it, a sandbox script that spawns/imports Hermes
++# operational marker: without it, a sandbox script that spawns/imports Black Pool
+ # code can lose the DB-layer Kanban mutation guard while still inheriting
+ # HERMES_HOME.
+ #
+@@ -509,7 +509,7 @@ def retry(fn, max_attempts=3, delay=2):
+ # ---- UDS transport (local backend) ---------------------------------------
+ 
+ _UDS_TRANSPORT_HEADER = '''\
+-"""Auto-generated Hermes tools RPC stubs."""
++"""Auto-generated Black Pool tools RPC stubs."""
+ import json, os, socket, shlex, threading, time
+ 
+ _sock = None
+@@ -577,7 +577,7 @@ def _call(tool_name, args):
+ # ---- File-based transport (remote backends) -------------------------------
+ 
+ _FILE_TRANSPORT_HEADER = '''\
+-"""Auto-generated Hermes tools RPC stubs (file-based transport)."""
++"""Auto-generated Black Pool tools RPC stubs (file-based transport)."""
+ import json, os, shlex, tempfile, threading, time
+ 
+ _RPC_DIR = os.environ.get("HERMES_RPC_DIR") or os.path.join(tempfile.gettempdir(), "hermes_rpc")
+@@ -1259,7 +1259,7 @@ def execute_code(
+ ) -> str:
+     """
+     Run a Python script in a sandboxed child process with RPC access
+-    to a subset of Hermes tools.
++    to a subset of Black Pool tools.
+ 
+     Dispatches to the local (UDS) or remote (file-based RPC) path
+     depending on the configured terminal backend.
+@@ -1456,7 +1456,7 @@ def execute_code(
+         child_env["PYTHONUTF8"] = "1"
+         # Inject user's configured timezone so datetime.now() in sandboxed
+         # code reflects the correct wall-clock time.  Only TZ is set —
+-        # HERMES_TIMEZONE is an internal Hermes setting and must not leak
++        # HERMES_TIMEZONE is an internal Black Pool setting and must not leak
+         # into child processes.
+         _tz_name = os.getenv("HERMES_TIMEZONE", "").strip()
+         if _tz_name:
+@@ -1478,9 +1478,9 @@ def execute_code(
+ 
+         # ``hermes_tools.py`` always lives in the staging directory, so that
+         # directory must be importable even when project mode changes CWD.
+-        # Hermes's own package root is useful too, but only when the child
++        # Black Pool's own package root is useful too, but only when the child
+         # uses the same Python environment. Project mode can select an
+-        # external venv; exposing Hermes's site-packages to that interpreter
++        # external venv; exposing Black Pool's site-packages to that interpreter
+         # can mix incompatible compiled extensions (for example, Python 3.12
+         # NumPy with a Python 3.9 project interpreter).
+         #
+@@ -1503,7 +1503,7 @@ def execute_code(
+             # fails" reports are diagnosable without log spam.
+             _external_env_logged.add(_child_python)
+             logger.info(
+-                "execute_code: child interpreter %s is outside the Hermes "
++                "execute_code: child interpreter %s is outside the Black Pool "
+                 "environment; hermes root omitted from PYTHONPATH",
+                 _child_python,
+             )
+@@ -1858,7 +1858,7 @@ _PROBE_CACHE_MAX = 32
+ _usable_python_cache: dict = {}
+ _python_prefix_cache: dict = {}
+ 
+-# Interpreter paths already reported as outside the Hermes environment —
++# Interpreter paths already reported as outside the Black Pool environment —
+ # dedupes the exclusion log to once per path per process.
+ _external_env_logged: set = set()
+ 
+@@ -1934,7 +1934,7 @@ def _python_environment_prefix(python_path: str) -> str:
+ 
+ 
+ def _uses_hermes_python_environment(python_path: str) -> bool:
+-    """Whether *python_path* belongs to Hermes's active Python environment.
++    """Whether *python_path* belongs to Black Pool's active Python environment.
+ 
+     Short-circuits when *python_path* IS the running interpreter (by path or
+     realpath) — no subprocess probe on the default strict-mode path, and no
+@@ -2121,7 +2121,7 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
+         )
+ 
+     description = (
+-        "Run a Python script that calls Hermes tools programmatically. "
++        "Run a Python script that calls Black Pool tools programmatically. "
+         "Use when you need 3+ tool calls with logic between them: "
+         "filtering/reducing large outputs before they enter context, "
+         "conditional branching, or loops (N pages/files, retry on failure). "
+diff --git a/tools/computer_use/browser_route.py b/tools/computer_use/browser_route.py
+index ef45cec..d29f844 100644
+--- a/tools/computer_use/browser_route.py
++++ b/tools/computer_use/browser_route.py
+@@ -9,13 +9,13 @@ The adapter is deliberately stricter than the transport:
+ * native binding must be exact before mutation;
+ * the driver session id is injected by the adapter, never accepted from the
+   model;
+-* refs are usable only from the latest snapshot in this Hermes session;
++* refs are usable only from the latest snapshot in this Black Pool session;
+ * every mutation invalidates refs and requires a fresh state read; and
+ * changing from trusted input to ``dom_event`` is always explicit.
+ 
+ Browser preparation remains a separate approved action. Existing-profile
+ attachment is delegated to cua-driver's daemon authorization coordinator;
+-ordinary Hermes tool approval never substitutes for protected consent.
++ordinary Black Pool tool approval never substitutes for protected consent.
+ """
+ 
+ from __future__ import annotations
+@@ -428,7 +428,7 @@ class CuaTypedBrowserRoute:
+                     "browser_existing_profile_not_granted",
+                     "Attaching to an existing browser profile requires the "
+                     "one-time opt-in `computer_use.grant_existing_profile: "
+-                    "true` in config.yaml. Hermes cannot grant this at "
++                    "true` in config.yaml. Black Pool cannot grant this at "
+                     "runtime, and an approval bypass does not substitute for "
+                     "it. Use profile_mode=isolated_new to browse without it.",
+                 )
+diff --git a/tools/computer_use/cua_backend.py b/tools/computer_use/cua_backend.py
+index bd93ea2..d5b5599 100644
+--- a/tools/computer_use/cua_backend.py
++++ b/tools/computer_use/cua_backend.py
+@@ -224,7 +224,7 @@ def _computer_use_cfg() -> Dict[str, Any]:
+ 
+ 
+ def _cua_no_overlay() -> bool:
+-    """True when Hermes should pass ``--no-overlay`` to cua-driver.
++    """True when Black Pool should pass ``--no-overlay`` to cua-driver.
+ 
+     Reads ``computer_use.no_overlay``. Default ``None`` (auto-detect):
+     disable the overlay where idle CPU burn is a known failure mode —
+@@ -254,7 +254,7 @@ def _cua_no_overlay() -> bool:
+ 
+ 
+ def _cua_telemetry_disabled() -> bool:
+-    """True when Hermes should disable cua-driver telemetry for this user.
++    """True when Black Pool should disable cua-driver telemetry for this user.
+ 
+     Reads ``computer_use.cua_telemetry`` (default False → telemetry off).
+     Unreadable config falls SAFE toward disabling telemetry.
+@@ -269,7 +269,7 @@ def _cua_configured_permission_mode() -> str:
+     Reads ``computer_use.permission_mode`` (default ``standard``).  Only
+     ``standard`` and ``bounded`` are honored here — ``unrestricted`` is
+     deliberately NOT a config value: it stays tied to the explicit
+-    per-session Hermes YOLO toggle so a stale config line can never
++    per-session Black Pool YOLO toggle so a stale config line can never
+     silently bypass approvals. Unknown values fall closed to ``standard``.
+     """
+     raw = str(_computer_use_cfg().get("permission_mode", "standard") or "").strip().lower()
+@@ -293,7 +293,7 @@ def _cua_grant_existing_profile() -> bool:
+     """True when the user pre-authorized existing-profile browser attachment.
+ 
+     Reads ``computer_use.grant_existing_profile`` (default False). This is
+-    cua-driver's trusted-launcher grant. Hermes passes
++    cua-driver's trusted-launcher grant. Black Pool passes
+     ``--grant existing-profile`` when it launches the standard-mode runtime.
+     On macOS it also selects a private socket so the newly configured
+     CuaDriver.app runtime cannot collide with an already-running default
+@@ -548,10 +548,10 @@ def _select_capture_target(
+ 
+ 
+ def _wsl_windows_path_to_posix(path: str) -> str:
+-    """Translate a Windows absolute manifest command when Hermes runs in WSL.
++    """Translate a Windows absolute manifest command when Black Pool runs in WSL.
+ 
+     Windows cua-driver manifests can report ``C:\\Users\\...\\cua-driver.exe``
+-    even though the Hermes process uses POSIX subprocess spawning inside WSL.
++    even though the Black Pool process uses POSIX subprocess spawning inside WSL.
+     The same file is reachable through DrvFS as ``/mnt/c/Users/...``.
+     Non-Windows paths and non-WSL hosts are returned unchanged.
+     """
+@@ -575,11 +575,11 @@ class _EmbeddedCuaDaemon:
+     """Private host-owned daemon for a non-standard permission mode.
+ 
+     Cua Driver permission mode is immutable after daemon startup.  Reusing the
+-    machine-wide daemon would therefore let one Hermes session's YOLO choice
++    machine-wide daemon would therefore let one Black Pool session's YOLO choice
+     affect another session.  A private embedded daemon gives the requesting
+     session its own socket, process, and launch-time authorization:
+ 
+-    * ``unrestricted`` — explicit Hermes YOLO; launch-time risk
++    * ``unrestricted`` — explicit Black Pool YOLO; launch-time risk
+       acknowledgement via ``--dangerously-bypass-approvals``.
+     * ``bounded`` — a user-reviewed capability manifest
+       (``computer_use.capability_manifest`` in config.yaml) approved at
+@@ -804,7 +804,7 @@ def _resolve_mcp_invocation(
+     (trycua/cua#1961). The manifest carries a stable ``mcp_invocation``
+     pointer with both ``command`` and ``args``, so a future cua-driver
+     that renames or relocates the subcommand keeps working without a
+-    Hermes patch.
++    Black Pool patch.
+ 
+     Falls back to ``(driver_cmd, ["mcp"])`` for older drivers that don't
+     expose ``manifest``, or any indeterminate failure — the wrapper must
+@@ -851,7 +851,7 @@ def _resolve_mcp_invocation(
+         # The driver knows the subcommand but didn't surface its own path.
+         # Keep our resolved driver_cmd; the args are still authoritative.
+         return driver_cmd, _mcp_args_with_overlay_flag(args, driver_cmd=driver_cmd)
+-    # A Windows-installed cua-driver can hand a WSL-hosted Hermes an absolute
++    # A Windows-installed cua-driver can hand a WSL-hosted Black Pool an absolute
+     # ``C:\...`` command; translate it to its DrvFS ``/mnt/<drive>/...`` form
+     # BEFORE the path-separator check (backslash is not a separator on POSIX,
+     # so the raw Windows string would otherwise be discarded here).
+@@ -956,7 +956,7 @@ def _candidate_cua_driver_commands(override: Optional[str] = None) -> List[str]:
+     Desktop apps launched from Finder/Dock often inherit a narrow PATH that
+     omits user-local install directories. The upstream cua-driver installer
+     commonly places the binary under ``~/.local/bin`` on POSIX systems, so a
+-    Hermes Desktop/TUI session can otherwise filter out the `computer_use`
++    Black Pool Desktop/TUI session can otherwise filter out the `computer_use`
+     tool even though `hermes computer-use doctor` succeeds from a login shell.
+     """
+     configured = (override if override is not None else os.environ.get(_CUA_DRIVER_CMD_ENV, "")).strip()
+@@ -974,7 +974,7 @@ def _candidate_cua_driver_commands(override: Optional[str] = None) -> List[str]:
+         candidates.extend([
+             # Official cua-driver installer location on Windows. Freshly
+             # installed sessions inherit a stale PATH, so PATH lookup alone
+-            # misses it until every Hermes process is restarted.
++            # misses it until every Black Pool process is restarted.
+             os.path.join(
+                 local_app_data, "Programs", "Cua", "cua-driver", "bin", "cua-driver.exe"
+             ),
+@@ -1030,7 +1030,7 @@ _CUA_DRIVER_RUNTIME_CONTRACT_ARGS = {
+ 
+ 
+ def cua_driver_runtime_contract_status(binary: Optional[str] = None) -> Dict[str, Any]:
+-    """Report whether a local driver can host Hermes' 0.20 integration."""
++    """Report whether a local driver can host Black Pool' 0.20 integration."""
+     resolved = binary or resolve_cua_driver_cmd()
+     if not resolved:
+         return {
+@@ -1098,7 +1098,7 @@ def cua_driver_runtime_contract_status(binary: Optional[str] = None) -> Dict[str
+             "ready": False,
+             "binary": resolved,
+             "version": raw_version,
+-            "reason": "Hermes computer use requires cua-driver 0.20.0 or newer",
++            "reason": "Black Pool computer use requires cua-driver 0.20.0 or newer",
+         }
+ 
+     invocation = manifest.get("mcp_invocation")
+@@ -2112,7 +2112,7 @@ class _CuaDriverSession:
+                 # "daemon is not running" is a PERMANENT condition for this
+                 # invocation (`cua-driver call` requires the machine-wide
+                 # daemon socket, which Linux installs typically never start —
+-                # Hermes talks to the direct `cua-driver mcp` runtime
++                # Black Pool talks to the direct `cua-driver mcp` runtime
+                 # instead). Retrying with backoff burns ~3.5s of sleeps per
+                 # fallback for an outcome that cannot change; fail fast so
+                 # callers surface a diagnosable error immediately.
+@@ -2215,7 +2215,7 @@ class _CuaDriverSession:
+     def _unknown_transport_outcome(name: str, exc: Exception) -> Dict[str, Any]:
+         message = (
+             f"cua-driver transport failed during {name}; the action outcome is "
+-            "unknown, so Hermes did not replay it. Take fresh state before "
++            "unknown, so Black Pool did not replay it. Take fresh state before "
+             "deciding whether to act again."
+         )
+         return {
+@@ -2557,13 +2557,13 @@ class CuaDriverBackend(ComputerUseBackend):
+         # the private lifecycle and releases it when the connection closes.
+         # start_session/end_session attach this stable label to cursor,
+         # recording, and config state within that lifecycle. Doing so:
+-        #   - Gets a distinct agent-cursor color per Hermes run, with
++        #   - Gets a distinct agent-cursor color per Black Pool run, with
+         #     overlay rendering visualising where actions land
+         #     (without moving the real OS cursor).
+         #   - Gives config and recording state a stable owner label inside the
+         #     transport-private lifecycle.
+         # We mint a UUID4-based id once per CuaDriverBackend instance —
+-        # one Hermes run = one backend = one label — and pass it as
++        # one Black Pool run = one backend = one label — and pass it as
+         # `session` on every cua-driver tool call. Labels are an
+         # part of the required Cua Driver 0.20 runtime contract checked at
+         # backend startup.
+@@ -2598,7 +2598,7 @@ class CuaDriverBackend(ComputerUseBackend):
+     def start(self) -> None:
+         contract = cua_driver_runtime_contract_status()
+         if not contract.get("ready"):
+-            # An installed-but-incompatible driver (e.g. predating a Hermes
++            # An installed-but-incompatible driver (e.g. predating a Black Pool
+             # version-floor bump) is a state we created — repair it once
+             # automatically instead of failing every computer_use call.
+             contract = _maybe_repair_runtime_contract(contract)
+@@ -2614,7 +2614,7 @@ class CuaDriverBackend(ComputerUseBackend):
+             raise RuntimeError(f"cua-driver is not ready: {reason}. {repair}")
+         _maybe_nudge_update()
+         # The MCP client SDK (`mcp`) is an optional dependency (the
+-        # `computer-use` / `mcp` extras), not part of Hermes' minimal core.
++        # `computer-use` / `mcp` extras), not part of Black Pool' minimal core.
+         # Lazy-install it on first use — the same pattern every other optional
+         # backend uses — so users never hit an opaque `No module named 'mcp'`
+         # at invoke time. Auto-install is gated by `security.allow_lazy_installs`
+@@ -3529,7 +3529,7 @@ class CuaDriverBackend(ComputerUseBackend):
+         process.
+ 
+         The default remains non-disruptive. ``raise_window=True`` is explicit,
+-        separately approved by the Hermes adapter, and uses cua-driver's
++        separately approved by the Black Pool adapter, and uses cua-driver's
+         standalone ``bring_to_front`` tool rather than an action property.
+         """
+         try:
+diff --git a/tools/computer_use/doctor.py b/tools/computer_use/doctor.py
+index 1379c8d..4b9d539 100644
+--- a/tools/computer_use/doctor.py
++++ b/tools/computer_use/doctor.py
+@@ -4,7 +4,7 @@
+ cua-driver owns the health model (#1908 / be761fac on `main`). This module
+ just drives the stdio JSON-RPC handshake, calls `health_report`, and
+ renders the structured response. When the driver gets new checks, they
+-flow through here without code changes on the Hermes side — the only
++flow through here without code changes on the Black Pool side — the only
+ contract is the stable `schema_version="1"` payload shape.
+ 
+ cua-driver 0.10.x marks `health_report` with risk.class='unclassified', so
+@@ -55,7 +55,7 @@ class HealthReportUnavailable(RuntimeError):
+ 
+ 
+ def _cua_child_env() -> Dict[str, str]:
+-    """cua-driver child env with the Hermes telemetry policy applied.
++    """cua-driver child env with the Black Pool telemetry policy applied.
+ 
+     Delegates to ``cua_backend.cua_driver_child_env`` (telemetry disabled by
+     default unless the user opts in). Falls back to the current environment
+@@ -70,7 +70,7 @@ def _cua_child_env() -> Dict[str, str]:
+ 
+ 
+ def _sanitized_cua_env() -> Dict[str, str]:
+-    """Telemetry-policy env with Hermes provider secrets stripped.
++    """Telemetry-policy env with Black Pool provider secrets stripped.
+ 
+     cua-driver is a third-party binary — it must never inherit provider
+     API keys (#53503/#55709/#58889 lineage). Falls back to the unsanitized
+@@ -884,7 +884,7 @@ def run_doctor(
+ 
+     if json_output:
+         # Additive envelope: preserve the upstream health_report keys and
+-        # attach Hermes identity under hermes_identity so existing parsers
++        # attach Black Pool identity under hermes_identity so existing parsers
+         # that only read overall/checks keep working.
+         payload = dict(report)
+         payload["hermes_identity"] = identity
+diff --git a/tools/computer_use/permissions.py b/tools/computer_use/permissions.py
+index 65eac78..a804a68 100644
+--- a/tools/computer_use/permissions.py
++++ b/tools/computer_use/permissions.py
+@@ -7,7 +7,7 @@ something different on each:
+   * macOS — explicit TCC grants (Accessibility + Screen Recording). cua-driver
+     reports/requests them via ``permissions status`` / ``permissions grant``.
+     The grants attach to cua-driver's OWN identity (``com.trycua.driver`` /
+-    the installed ``CuaDriver.app``), NOT Hermes — so no Hermes entitlement is
++    the installed ``CuaDriver.app``), NOT Black Pool — so no Black Pool entitlement is
+     involved, and ``grant`` launches CuaDriver via LaunchServices so the macOS
+     dialog is attributed correctly.
+   * Windows — no TCC toggles; the UIAccess worker (``cua-driver-uia.exe``) may
+diff --git a/tools/computer_use/schema.py b/tools/computer_use/schema.py
+index 1c0d322..8c5f4f4 100644
+--- a/tools/computer_use/schema.py
++++ b/tools/computer_use/schema.py
+@@ -310,7 +310,7 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
+                     "computer_use.grant_existing_profile: true (if refused, "
+                     "report that key to the user — you cannot grant it); "
+                     "bounded mode authorizes via the reviewed capability "
+-                    "manifest; explicit Hermes YOLO uses a private "
++                    "manifest; explicit Black Pool YOLO uses a private "
+                     "unrestricted daemon."
+                 ),
+             },
+diff --git a/tools/computer_use/tool.py b/tools/computer_use/tool.py
+index ab2824b..a2eac1d 100644
+--- a/tools/computer_use/tool.py
++++ b/tools/computer_use/tool.py
+@@ -92,7 +92,7 @@ _DESTRUCTIVE_ACTIONS = frozenset({
+ })
+ 
+ # Hard-blocked key combinations. Mirrored from #4562 — these are destructive
+-# regardless of approval level (e.g. logout kills the session Hermes runs in).
++# regardless of approval level (e.g. logout kills the session Black Pool runs in).
+ _BLOCKED_KEY_COMBOS = {
+     frozenset({"cmd", "shift", "backspace"}),   # empty trash
+     frozenset({"cmd", "option", "backspace"}),   # force delete
+@@ -238,9 +238,9 @@ def _warn_bypass_escalation(session_id: str) -> None:
+ 
+ 
+ def _cua_permission_mode(session_id: str) -> str:
+-    """Map Hermes's explicit approval bypass onto Cua's immutable mode.
++    """Map Black Pool's explicit approval bypass onto Cua's immutable mode.
+ 
+-    Hermes has TWO session-identity namespaces: the tool-dispatch path passes
++    Black Pool has TWO session-identity namespaces: the tool-dispatch path passes
+     the DB ``session_id`` (``agent.session_id``), while gateway ``/yolo``
+     keys approval state off the gateway ``session_key`` (set per turn via the
+     ``set_current_session_key`` contextvar in tools/approval.py). CLI and TUI
+@@ -377,7 +377,7 @@ def release_computer_use_session(session_id: str) -> bool:
+     removes the exact session backend, its call lock, and its recorded
+     permission mode before stopping the backend, so new lookups cannot retain
+     the stale target/ref namespace — and stops a private embedded daemon when
+-    Hermes YOLO selected unrestricted mode. Approval state is cleared even
++    Black Pool YOLO selected unrestricted mode. Approval state is cleared even
+     when no backend was started.
+ 
+     Returns ``True`` when a backend was found and released, ``False`` when the
+@@ -405,7 +405,7 @@ def release_computer_use_session(session_id: str) -> bool:
+     try:
+         # Let an in-flight action finish before ending the driver session and
+         # dropping its target/ref state. Do not hold the global cache lock
+-        # while waiting: unrelated Hermes sessions remain independent.
++        # while waiting: unrelated Black Pool sessions remain independent.
+         if call_lock is not None:
+             with call_lock:
+                 backend.stop()
+@@ -424,7 +424,7 @@ def _shutdown_backend_atexit() -> None:
+     """Stop all cached backends so cua-driver children don't outlive us.
+ 
+     Each session backend holds a long-lived ``cua-driver`` subprocess, so
+-    without this a driver can survive the Hermes process that spawned it
++    without this a driver can survive the Black Pool process that spawned it
+     (#28152 item 3). #69903 kept the orphan from burning a core by disabling
+     the cursor overlay; the process itself still lingered.
+ 
+@@ -733,7 +733,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
+     # cua-driver's typed browser surface is namespaced inside the existing
+     # computer_use tool so it cannot collide with native browser/MCP tools.
+     # The backend owns the opaque driver session, target, tab and ref state;
+-    # none of those capabilities can be supplied across Hermes sessions.
++    # none of those capabilities can be supplied across Black Pool sessions.
+     if action == "cua_browser_state":
+         state_args: Dict[str, Any] = {}
+         for public, internal in (
+@@ -1034,7 +1034,7 @@ def _text_response(res: ActionResult) -> str:
+ # Window classes of browsers whose page content the typed cua_browser_* route
+ # can drive with trusted input and ZERO focus steal. When background text
+ # delivery is refused for one of these surfaces, the driver's only hint is
+-# "foreground" (it doesn't know Hermes has a typed page route), so the model
++# "foreground" (it doesn't know Black Pool has a typed page route), so the model
+ # flashes the user's window to front for every keystroke batch. The hint below
+ # offers the no-flash rung first; foreground remains valid for browser chrome,
+ # native dialogs, and anything the typed route can't bind exactly.
+@@ -1671,7 +1671,7 @@ _MAX_CAPTURE_FILES = 20
+ 
+ 
+ def _persist_capture_image(cap: CaptureResult) -> Optional[str]:
+-    """Save a capture in Hermes' media cache and return its absolute path.
++    """Save a capture in Black Pool' media cache and return its absolute path.
+ 
+     Captures are normally embedded only in the model's tool context. Persisting
+     a bounded copy gives attachment-capable surfaces a real file to deliver
+diff --git a/tools/credential_files.py b/tools/credential_files.py
+index b429d4e..0cfe96b 100644
+--- a/tools/credential_files.py
++++ b/tools/credential_files.py
+@@ -530,7 +530,7 @@ def to_agent_visible_cache_path(
+ 
+     Per-backend base (mirrors ``_agent_cache_base_for_env`` in
+     tools/image_generation_tool.py, the proven heuristics for where each
+-    backend's Hermes cache lands):
++    backend's Black Pool cache lands):
+ 
+     * docker / modal — bind-mounted (docker) or per-file-synced (modal) at
+       ``/root/.hermes`` (the *container_base* default).
 diff --git a/tools/cronjob_tools.py b/tools/cronjob_tools.py
 index ae507b7..bbcd51f 100644
 --- a/tools/cronjob_tools.py
@@ -49820,8 +63551,208 @@ index ae507b7..bbcd51f 100644
  
  Expose a single compressed action-oriented tool to avoid schema/context bloat.
  Compatibility wrappers remain for direct Python callers and legacy tests.
+diff --git a/tools/debug_helpers.py b/tools/debug_helpers.py
+index bb124b4..853dd3b 100644
+--- a/tools/debug_helpers.py
++++ b/tools/debug_helpers.py
+@@ -1,4 +1,4 @@
+-"""Shared debug session infrastructure for Hermes tools.
++"""Shared debug session infrastructure for Black Pool tools.
+ 
+ Replaces the identical DEBUG_MODE / _log_debug_call / _save_debug_log /
+ get_debug_session_info boilerplate previously duplicated across web_tools,
+diff --git a/tools/delegate_tool.py b/tools/delegate_tool.py
+index 8699edb..29ec4ca 100644
+--- a/tools/delegate_tool.py
++++ b/tools/delegate_tool.py
+@@ -1766,7 +1766,7 @@ def _build_child_agent(
+     #
+     # Nous Portal is dual-wire within a single provider: anthropic/* → Messages,
+     # everything else → chat_completions. Same-provider inheritance would pin a
+-    # child Hermes/Qwen subagent onto the parent's Claude Messages wire (or the
++    # child Black Pool/Qwen subagent onto the parent's Claude Messages wire (or the
+     # reverse). agent_init honors an explicit api_mode above its nous branch, so
+     # re-derive here before construction.
+     _parent_provider = getattr(parent_agent, "provider", None) or ""
+@@ -4557,7 +4557,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
+ 
+ 
+ def _load_config() -> dict:
+-    """Load delegation config from the active Hermes config.
++    """Load delegation config from the active Black Pool config.
+ 
+     Prefer the shared persistent loader because it follows the active
+     HERMES_HOME/profile. ``cli.CLI_CONFIG`` is a legacy fallback for entry
+diff --git a/tools/delegation_live_log.py b/tools/delegation_live_log.py
+index d355740..debc6e7 100644
+--- a/tools/delegation_live_log.py
++++ b/tools/delegation_live_log.py
+@@ -130,7 +130,7 @@ class LiveTranscriptWriter:
+             d.mkdir(parents=True, exist_ok=True)
+             self.path: Optional[Path] = d / f"task-{task_index}.log"
+             header = [
+-                "=== Hermes subagent live transcript ===",
++                "=== Black Pool subagent live transcript ===",
+                 f"delegation: {delegation_id}   task: {task_index}",
+                 # Header bypasses event(), so redact here too — a goal string
+                 # can carry a key the caller pasted into the task.
+diff --git a/tools/drive_preview_tool.py b/tools/drive_preview_tool.py
+index a90b0e8..fab7a0e 100644
+--- a/tools/drive_preview_tool.py
++++ b/tools/drive_preview_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Interact with the in-app browser / preview pane in the Hermes desktop GUI.
++"""Interact with the in-app browser / preview pane in the Black Pool desktop GUI.
+ 
+ ``open_preview`` shows a page and ``read_preview`` reads it; this tool is the
+ third leg — clicking, typing, scrolling, and history — so the agent can drive
+@@ -66,7 +66,7 @@ def drive_preview_tool(
+ ) -> str:
+     """Dispatch one interaction to the desktop renderer and return its outcome."""
+     if callback is None:
+-        return tool_error("drive_preview is only available in the Hermes desktop app.")
++        return tool_error("drive_preview is only available in the Black Pool desktop app.")
+ 
+     verb = (action or "").strip().lower()
+     if verb not in ACTIONS:
+@@ -128,7 +128,7 @@ ACT_PREVIEW_SCHEMA = {
+     "name": "drive_preview",
+     "description": (
+         "Interact with the page open in the in-app browser / preview pane of "
+-        "the Hermes desktop GUI — the pane open_preview opens beside this "
++        "the Black Pool desktop GUI — the pane open_preview opens beside this "
+         "chat. This is how you USE a web app the user is looking at: log in, "
+         "fill a form, click through a flow, page a long document. ALWAYS call "
+         "action='elements' first to get the current inventory of clickable and "
+diff --git a/tools/env_passthrough.py b/tools/env_passthrough.py
+index 5c7a4c1..8d6d6bd 100644
+--- a/tools/env_passthrough.py
++++ b/tools/env_passthrough.py
+@@ -65,7 +65,7 @@ def _is_hermes_provider_credential(name: str) -> bool:
+     Fail closed: if the authoritative blocklist cannot be imported (partial
+     install, import-time error, etc.) we treat the name as a protected
+     provider credential and refuse passthrough, rather than fall open and
+-    let a skill tunnel a Hermes credential into the execute_code child.
++    let a skill tunnel a Black Pool credential into the execute_code child.
+     """
+     try:
+         from tools.environments.local import (
+@@ -112,7 +112,7 @@ def register_env_passthrough(var_names: Iterable[str]) -> None:
+             continue
+         if _is_hermes_provider_credential(name):
+             logger.warning(
+-                "env passthrough: refusing to register Hermes provider "
++                "env passthrough: refusing to register Black Pool provider "
+                 "credential %r (blocked by _HERMES_PROVIDER_ENV_BLOCKLIST). "
+                 "Skills must not override the execute_code sandbox's "
+                 "credential scrubbing; see GHSA-rhgp-j443-p4rf.",
+@@ -146,7 +146,7 @@ def _load_config_passthrough() -> frozenset[str]:
+                 # See GHSA-rhgp-j443-p4rf.
+                 if _is_hermes_provider_credential(name):
+                     logger.warning(
+-                        "env passthrough: refusing to register Hermes "
++                        "env passthrough: refusing to register Black Pool "
+                         "provider credential %r from config.yaml (blocked "
+                         "by _HERMES_PROVIDER_ENV_BLOCKLIST). Operator "
+                         "configuration must not override the execute_code "
+diff --git a/tools/env_probe.py b/tools/env_probe.py
+index f656af3..341fef8 100644
+--- a/tools/env_probe.py
++++ b/tools/env_probe.py
+@@ -1,11 +1,11 @@
+ """Local-environment toolchain probe for the system prompt.
+ 
+ When the terminal backend is local (the agent's tools run on the same
+-machine as Hermes itself), we surface a single deterministic line about
++machine as Black Pool itself), we surface a single deterministic line about
+ Python tooling state so models don't have to discover it by hitting
+ walls.  Common failure modes this addresses:
+ 
+-* Hermes ships under one Python (e.g. 3.11 in a bundled venv) while the
++* Black Pool ships under one Python (e.g. 3.11 in a bundled venv) while the
+   user's login shell has a different one (e.g. 3.12 system).  ``pip``
+   resolved from PATH may not match ``python3 -m pip``.
+ * The bundled-venv Python has no pip module installed → ``python3 -m
+@@ -203,7 +203,7 @@ def _build_probe_line() -> str:
+     py3_has_pip = _has_pip_module("python3") if py3_ver else False
+     pip_bound_to = _pip_python_version()
+     py3_pep668 = _detect_pep668("python3") if py3_ver else False
+-    # Bare which() is correct here, unlike Hermes's own uv call sites: this
++    # Bare which() is correct here, unlike Black Pool's own uv call sites: this
+     # reports the environment *the model will see* in the terminal tool, and
+     # what the model can type is exactly what is on that subshell's PATH.
+     # local.py puts the Hermes-managed $HERMES_HOME/bin there, so a managed-only
+diff --git a/tools/environments/__init__.py b/tools/environments/__init__.py
+index 0134dc1..e2b8547 100644
+--- a/tools/environments/__init__.py
++++ b/tools/environments/__init__.py
+@@ -1,4 +1,4 @@
+-"""Hermes execution environment backends.
++"""Black Pool execution environment backends.
+ 
+ Each backend provides the same interface (BaseEnvironment ABC) for running
+ shell commands in a specific execution context: local, Docker, SSH,
+diff --git a/tools/environments/base.py b/tools/environments/base.py
+index dbdb874..683f26c 100644
+--- a/tools/environments/base.py
++++ b/tools/environments/base.py
+@@ -1,4 +1,4 @@
+-"""Base class for all Hermes execution environment backends.
++"""Base class for all Black Pool execution environment backends.
+ 
+ Unified spawn-per-call model: every command spawns a fresh ``bash -c`` process.
+ A session snapshot (env vars, functions, aliases) is captured once at init and
+@@ -522,7 +522,7 @@ def _cwd_marker(session_id: str) -> str:
+ # HERMES_SESSION_ID leak via the shared snapshot). Stripping them from the
+ # snapshot is safe because they are re-injected on every command; a snapshot
+ # should only carry the user's own shell state (PATH, functions, exports they
+-# set), not Hermes' per-turn session identity.
++# set), not Black Pool' per-turn session identity.
+ #
+ # Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
+ # with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
+@@ -593,7 +593,7 @@ def _export_dump_excluding_session_vars(
+ 
+ 
+ class BaseEnvironment(ABC):
+-    """Common interface and unified execution flow for all Hermes backends.
++    """Common interface and unified execution flow for all Black Pool backends.
+ 
+     Subclasses implement ``_run_bash()`` and ``cleanup()``.  The base class
+     provides ``execute()`` with session snapshot sourcing, CWD tracking,
+@@ -901,7 +901,7 @@ class BaseEnvironment(ABC):
+             parts.append(f"unset {present} {value}")
+ 
+         # Harness attribution: every tool subprocess advertises that it runs
+-        # under Hermes via the cross-agent ``AI_AGENT`` standard (read by e.g.
++        # under Black Pool via the cross-agent ``AI_AGENT`` standard (read by e.g.
+         # huggingface_hub's agent detection) plus the Hermes-specific
+         # ``HERMES_AGENT`` marker.  The value MUST equal our id in the public
+         # agent-harness registry (``hermes-agent`` — see huggingface.js
+@@ -909,9 +909,9 @@ class BaseEnvironment(ABC):
+         # value is reported as "unknown".  Setting it here (rather than only in
+         # the host process env) is what carries the marker into REMOTE backends
+         # (Docker/SSH/Modal/Daytona/Singularity/Vercel), whose exec env is not
+-        # inherited from the Hermes process.  ``${VAR:-default}`` semantics:
++        # inherited from the Black Pool process.  ``${VAR:-default}`` semantics:
+         # never clobber an outer harness value that arrived via the inherited
+-        # process env (Hermes running inside another agent's terminal).
++        # process env (Black Pool running inside another agent's terminal).
+         parts.append(
+             'export AI_AGENT="${AI_AGENT:-hermes-agent}" '
+             'HERMES_AGENT="${HERMES_AGENT:-true}"'
+@@ -926,7 +926,7 @@ class BaseEnvironment(ABC):
+         # Run the actual command
+         parts.append(f"eval '{escaped}'")
+         parts.append("__hermes_ec=$?")
+-        # Restrict Hermes metadata files without changing the user's command
++        # Restrict Black Pool metadata files without changing the user's command
+         # umask. Snapshot files may contain env-carried secrets.
+         parts.append("umask 077")
+ 
 diff --git a/tools/environments/docker.py b/tools/environments/docker.py
-index a9bca99..6fa4c57 100644
+index a9bca99..eba3d2e 100644
 --- a/tools/environments/docker.py
 +++ b/tools/environments/docker.py
 @@ -131,7 +131,7 @@ def _sanitize_label_value(value: str) -> str:
@@ -49833,6 +63764,27 @@ index a9bca99..6fa4c57 100644
  
      Resolved at container-create time so a single container is permanently
      tagged with the profile that created it. Profile switches inside the
+@@ -157,7 +157,7 @@ def reap_orphan_containers(
+ 
+     * ``label=hermes-agent=1`` (created by this codebase)
+     * ``status=exited`` (running containers are NEVER reaped — they may
+-      belong to a sibling Hermes process whose reuse path will pick them
++      belong to a sibling Black Pool process whose reuse path will pick them
+       up; killing them would crash the sibling mid-command)
+     * (optional) ``label=hermes-profile=<profile_filter>`` (sweep only the
+       caller's profile by default; a hermes process in profile A must not
+@@ -173,9 +173,9 @@ def reap_orphan_containers(
+ 
+     Issue #20561 — this is the safety net for SIGKILL / OOM / crashed
+     terminal exits that bypass the ``atexit`` cleanup hook. Without it,
+-    even with the cleanup-fix in the prior commit, a hard-killed Hermes
++    even with the cleanup-fix in the prior commit, a hard-killed Black Pool
+     process leaves its container behind permanently because there's no
+-    subsequent Hermes process scheduled to reuse that exact (task, profile)
++    subsequent Black Pool process scheduled to reuse that exact (task, profile)
+     pair.
+     """
+     docker = docker_exe or find_docker() or "docker"
 @@ -1366,7 +1366,7 @@ class DockerEnvironment(BaseEnvironment):
          #   * future cross-process reuse (`hermes-task-id`, `hermes-profile`)
          #   * operators running `docker ps --filter label=hermes-agent=1`
@@ -49842,10 +63794,179 @@ index a9bca99..6fa4c57 100644
          # container-start time and never changes for the container's lifetime.
          profile_name = _sanitize_label_value(_get_active_profile_name())
          task_label = _sanitize_label_value(task_id)
+@@ -1390,7 +1390,7 @@ class DockerEnvironment(BaseEnvironment):
+         }
+ 
+         # Cross-process container reuse (issue #20561 — docs claim "ONE long-lived
+-        # container shared across sessions").  If a prior Hermes process
++        # container shared across sessions").  If a prior Black Pool process
+         # already started a container for this (task_id, profile) and it
+         # still exists, attach to it instead of starting a fresh one.  This
+         # restores the documented contract; opt out via
+@@ -1565,7 +1565,7 @@ class DockerEnvironment(BaseEnvironment):
+         except Exception:
+             pass
+         # Explicit docker_forward_env entries are an intentional opt-in and must
+-        # win over the generic Hermes secret blocklist. Only implicit passthrough
++        # win over the generic Black Pool secret blocklist. Only implicit passthrough
+         # keys are filtered. Also strip Hermes-internal dynamic secrets
+         # (AUXILIARY_*_API_KEY / _BASE_URL, GATEWAY_RELAY_* auth) that the
+         # name-based blocklist doesn't cover — see _is_hermes_internal_secret.
+@@ -1884,7 +1884,7 @@ class DockerEnvironment(BaseEnvironment):
+         if not lines:
+             return None
+         # Multiple matches are unusual (one (task, profile) should produce one
+-        # container) but can happen if a previous Hermes process crashed
++        # container) but can happen if a previous Black Pool process crashed
+         # mid-cleanup. Prefer a running one if present; otherwise pick the
+         # first listed. Stale duplicates get reaped by the orphan-reaper in a
+         # follow-up commit; we don't try to be heroic about them here.
+@@ -1920,7 +1920,7 @@ class DockerEnvironment(BaseEnvironment):
+ 
+         Persist-mode (``persist_across_processes=True``, the default) leaves the
+         container **running** untouched. The docs promise "ONE long-lived
+-        container shared across sessions" and stopping it on every Hermes exit
++        container shared across sessions" and stopping it on every Black Pool exit
+         breaks that promise:
+ 
+         * Background processes inside the container (``npm run dev``, watchers,
+@@ -1933,8 +1933,8 @@ class DockerEnvironment(BaseEnvironment):
+ 
+         Resource reclamation for the persist-mode case lives in the
+         ``reap_orphan_containers()`` path (see issue #20561 commit 3): if no
+-        Hermes process touches a labeled container for ``2 × lifetime_seconds``
+-        it gets ``docker rm -f``'d at the next Hermes startup. That covers the
++        Black Pool process touches a labeled container for ``2 × lifetime_seconds``
++        it gets ``docker rm -f``'d at the next Black Pool startup. That covers the
+         SIGKILL / OOM / abandoned-laptop cases without us needing to stop the
+         container on every graceful exit.
+ 
+@@ -1974,7 +1974,7 @@ class DockerEnvironment(BaseEnvironment):
+         #   persist_across_processes=False → stop + rm (per-process isolation)
+         #
+         # The persist-mode no-op is the issue-#20561 contract: the container
+-        # outlives Hermes processes, processes inside it stay alive, and
++        # outlives Black Pool processes, processes inside it stay alive, and
+         # reuse on next startup is instant.
+         if force_remove:
+             should_stop = True
 diff --git a/tools/environments/local.py b/tools/environments/local.py
-index 8b7a479..626a10b 100644
+index 8b7a479..74874d5 100644
 --- a/tools/environments/local.py
 +++ b/tools/environments/local.py
+@@ -56,7 +56,7 @@ def _resolve_local_initial_cwd(cwd: str) -> str:
+ 
+     ``TERMINAL_CWD`` can be populated from config.yaml before the terminal
+     backend is created.  If that value is relative and happens to match the
+-    directory Hermes was already launched from (for example ``hermes-agent``
++    directory Black Pool was already launched from (for example ``hermes-agent``
+     while the process cwd is ``~/.hermes/hermes-agent``), passing it through
+     unchanged makes the wrapper run ``cd hermes-agent`` *inside* the project
+     and fail with a confusing nested-path error.  Anchor relative local cwd
+@@ -78,7 +78,7 @@ def _resolve_local_initial_cwd(cwd: str) -> str:
+     candidate = os.path.abspath(expanded)
+     current = os.getcwd()
+ 
+-    # Common recovery for config values like ``hermes-agent`` when Hermes was
++    # Common recovery for config values like ``hermes-agent`` when Black Pool was
+     # launched from that directory already.  ``os.path.abspath`` would point at
+     # a nonexistent nested ``./hermes-agent``; use the current directory instead.
+     if not os.path.isdir(candidate):
+@@ -203,7 +203,7 @@ _HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
+ 
+ # Hermes-managed AWS *inference* credentials for ``auth_type="aws_sdk"``
+ # providers (Bedrock).  Scoped DELIBERATELY NARROW: this lists only the
+-# Bedrock-specific bearer token, which is a Hermes inference secret exactly
++# Bedrock-specific bearer token, which is a Black Pool inference secret exactly
+ # analogous to ``OPENAI_API_KEY`` — nobody drives the ``aws``/``terraform``/
+ # ``boto3`` toolchain off it, so stripping it from terminal/execute_code
+ # subprocesses costs no user capability.
+@@ -325,7 +325,7 @@ def _build_provider_env_blocklist() -> frozenset:
+     # CLAUDE_CODE_OAUTH_TOKEN is deliberately NOT stripped.  It is set and
+     # owned by the user's Claude Code install (subscription OAuth), not a
+     # Hermes-managed inference credential — Claude subscription auth is not a
+-    # working Hermes provider path.  Stripping it broke agent-spawned
++    # working Black Pool provider path.  Stripping it broke agent-spawned
+     # ``claude`` CLIs: the child fell through to the shared macOS Keychain /
+     # ``~/.claude/.credentials.json`` store and, on auth failure, cleared it,
+     # logging the user out of their interactive Claude sessions (#55878).
+@@ -342,17 +342,17 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
+ # VIRTUAL_ENV (and possibly CONDA_PREFIX). If those leak into commands the
+ # agent runs against OTHER Python projects, tools like ``uv``/``poetry`` treat
+ # the inherited value as the active environment and build/sync that other
+-# project's dependencies into the Hermes venv path instead of the project's own
+-# ``.venv`` — silently clobbering the Hermes environment (e.g. a project pinned
++# project's dependencies into the Black Pool venv path instead of the project's own
++# ``.venv`` — silently clobbering the Black Pool environment (e.g. a project pinned
+ # to a different Python version overwrites it and breaks the gateway). The
+-# Hermes venv stays reachable via PATH (its bin dir is first), so stripping
++# Black Pool venv stays reachable via PATH (its bin dir is first), so stripping
+ # these markers is safe and only prevents the cross-project clobber (#23473).
+ #
+ # PYTHONHOME is included because a gateway-inherited value redirects the
+ # standard-library search of ANY child interpreter — including unrelated
+-# system/venv Pythons — to the Hermes venv's stdlib, which crashes with
++# system/venv Pythons — to the Black Pool venv's stdlib, which crashes with
+ # version-mismatch errors before a child script even imports a package
+-# (#75018). Hermes itself treats PYTHONHOME as contamination in its own
++# (#75018). Black Pool itself treats PYTHONHOME as contamination in its own
+ # child processes (managed_uv.py, sqlite_runtime.py), so stripping it from
+ # subprocess envs is consistent. Users who need PYTHONHOME for a specific
+ # child can set it explicitly in the command.
+@@ -409,7 +409,7 @@ def _is_hermes_internal_secret(key: str) -> bool:
+ 
+ 
+ def _inject_context_hermes_home(env: dict) -> None:
+-    """Bridge the context-local Hermes home override into subprocess env."""
++    """Bridge the context-local Black Pool home override into subprocess env."""
+     try:
+         from hermes_constants import get_hermes_home_override
+ 
+@@ -519,7 +519,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
+ 
+     # Filter PYTHONPATH before removing VIRTUAL_ENV: legacy Windows launchers
+     # can run the gateway under a base interpreter while VIRTUAL_ENV identifies
+-    # the separate Hermes runtime venv.  The filter validates that relationship
++    # the separate Black Pool runtime venv.  The filter validates that relationship
+     # against the repo layout before trusting it.
+     _strip_hermes_owned_pythonpath_and_runtime_markers(sanitized)
+ 
+@@ -548,7 +548,7 @@ def _scrub_delegated_child_kanban_env(env: dict[str, str]) -> dict[str, str]:
+ # Tier-1 secrets: stripped from EVERY spawned subprocess unconditionally —
+ # even when the caller opts into credential inheritance for a model-driving
+ # CLI (claude / codex / gemini).  These are not LLM provider credentials; no
+-# legitimate child Hermes spawns needs them, and they are the highest-value
++# legitimate child Black Pool spawns needs them, and they are the highest-value
+ # secrets to keep out of a compromised dependency's reach (gateway bot tokens,
+ # GitHub auth, remote-compute tokens, dashboard session secret).  The set is a
+ # narrow subset of _HERMES_PROVIDER_ENV_BLOCKLIST; provider keys are handled by
+@@ -604,7 +604,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
+ 
+     * **Tier 1 (always):** ``_ALWAYS_STRIP_KEYS`` — gateway bot tokens, GitHub
+       auth, and remote-compute secrets are removed regardless of
+-      ``inherit_credentials``.  No child Hermes spawns legitimately needs them.
++      ``inherit_credentials``.  No child Black Pool spawns legitimately needs them.
+     * **Tier 2 (conditional):** the rest of ``_HERMES_PROVIDER_ENV_BLOCKLIST``
+       (LLM provider API keys, tool secrets) is removed unless the caller passes
+       ``inherit_credentials=True``.
+@@ -684,7 +684,7 @@ def build_subprocess_env(
+     function (or :func:`hermes_subprocess_env` for the model-driving-CLI
+     surface) instead of copying ``os.environ`` directly, so profile-home
+     propagation (``HERMES_HOME`` / subprocess ``HOME`` contract) and the
+-    Hermes secret-scrub policy have a single owner.  History: ~11 separate
++    Black Pool secret-scrub policy have a single owner.  History: ~11 separate
+     commits each fixed one more spawn site that missed profile-HOME or
+     secret-scrub propagation; this factory is the fix for the class.
+ 
+@@ -706,7 +706,7 @@ def build_subprocess_env(
+       scrubbing could change behavior.  The site is still a win: it becomes
+       grep-able and future-fixable.
+     * ``inherit_profile_home`` — on the non-scrub path, when True, bridge the
+-      context-local Hermes home override into ``HERMES_HOME`` and apply the
++      context-local Black Pool home override into ``HERMES_HOME`` and apply the
+       subprocess HOME contract (``hermes_constants.apply_subprocess_home_env``).
+       Pass False to keep the inherited env untouched (exact legacy
+       ``os.environ.copy()`` behavior).
 @@ -816,7 +816,7 @@ def _find_bash() -> str:
          return candidates[0]
  
@@ -49855,10 +63976,282 @@ index 8b7a479..626a10b 100644
          "Install it from: https://git-scm.com/download/win\n"
          "Or set HERMES_GIT_BASH_PATH to your bash.exe location."
      )
+@@ -904,7 +904,7 @@ def _git_bash_aslr_help(bash: str, details: str = "") -> str:
+         'Get-Item "$gitRoot\\bin\\bash.exe", "$gitRoot\\usr\\bin\\*.exe" '
+         "-ErrorAction SilentlyContinue | ForEach-Object { "
+         "Set-ProcessMitigation -Name $_.FullName -Disable ForceRelocateImages }\n"
+-        "Then restart Hermes. If the override is blocked or later re-applied, "
++        "Then restart Black Pool. If the override is blocked or later re-applied, "
+         "ask your Windows administrator to allow this per-program exception."
+     )
+ 
+@@ -1159,8 +1159,8 @@ def _managed_runtime_path_entries() -> list[str]:
+     """Return existing Hermes-managed runtime dirs for the terminal subshell PATH.
+ 
+     The terminal tool spawns a subshell whose PATH is the agent process's PATH
+-    plus ``_SANE_PATH``. Neither carries the runtimes Hermes installs for
+-    itself, so on a machine where Hermes provisioned its own toolchain a
++    plus ``_SANE_PATH``. Neither carries the runtimes Black Pool installs for
++    itself, so on a machine where Black Pool provisioned its own toolchain a
+     command the agent runs resolves a system copy instead — or nothing at all:
+ 
+     - ``$HERMES_HOME/node`` (+ ``/bin``) — installed to satisfy the desktop and
+@@ -1244,7 +1244,7 @@ def _apply_windows_msys_bash_env_defaults(env: dict) -> None:
+ 
+     Git Bash rewrites arguments that look like Unix paths (``/FO``, ``/TN``,
+     ``/Create``) into ``C:/.../git/FO``-style paths, which breaks native
+-    Windows commands such as ``tasklist``, ``schtasks``, and ``wmic``.  Hermes
++    Windows commands such as ``tasklist``, ``schtasks``, and ``wmic``.  Black Pool
+     runs terminal commands through bash on Windows, so set the standard MSYS
+     opt-out by default.  Users who need conversion can override in their env.
+     Refs #56700.
+@@ -1354,7 +1354,7 @@ def _build_hermes_repo_root_aliases(
+     lexical_root: Path,
+     configured_home: Path,
+ ) -> tuple[Path, ...]:
+-    """Return exact repo-root spellings emitted by Hermes launchers.
++    """Return exact repo-root spellings emitted by Black Pool launchers.
+ 
+     ``gateway_windows._preserve_hermes_home_path`` maps a physical path under
+     the resolved HERMES_HOME back onto the configured HERMES_HOME spelling.
+@@ -1418,17 +1418,17 @@ def _build_hermes_repo_root_aliases(
+     return tuple(aliases)
+ 
+ 
+-# --- Hermes venv / repo-root detection (module-level, computed once) ---
++# --- Black Pool venv / repo-root detection (module-level, computed once) ---
+ 
+-#: The Hermes repository root - three levels up from this file
++#: The Black Pool repository root - three levels up from this file
+ #: (``tools/environments/local.py`` -> ``tools/environments`` -> ``tools``
+ #: -> repo root).  This is the directory the Electron app prepends to
+ #: PYTHONPATH so the backend can do ``import tools``, ``import hermes_cli``,
+-#: etc.  Subprocesses that are NOT the Hermes backend don't need it and it
++#: etc.  Subprocesses that are NOT the Black Pool backend don't need it and it
+ #: can shadow local packages.
+ _hermes_repo_root: Path = Path(__file__).resolve().parents[2]
+ 
+-#: Alternate spellings of the repo root that Hermes launchers may emit.
++#: Alternate spellings of the repo root that Black Pool launchers may emit.
+ #: ``Path(__file__).resolve()`` canonicalizes symlinks/junctions, but the
+ #: Windows gateway launcher deliberately renders Hermes-owned paths under
+ #: the configured HERMES_HOME spelling (which may be a junction to another
+@@ -1462,7 +1462,7 @@ def _validated_runtime_venv(env: dict) -> Path | None:
+ 
+     A user may carry an unrelated VIRTUAL_ENV, so the variable alone is not
+     provenance.  The legacy Windows base-Python gateway producer uses the exact
+-    ``<Hermes repo>/venv`` layout and a real venv marker; require both before
++    ``<Black Pool repo>/venv`` layout and a real venv marker; require both before
+     accepting its separate runtime venv.
+     """
+     value = env.get("VIRTUAL_ENV")
+@@ -1483,7 +1483,7 @@ def _validated_runtime_venv(env: dict) -> Path | None:
+ 
+ 
+ def _get_hermes_site_packages(env: dict) -> list[Path]:
+-    """Return exact site-packages dirs owned by the Hermes runtime.
++    """Return exact site-packages dirs owned by the Black Pool runtime.
+ 
+     Uses ``site.getsitepackages()`` when available for robustness (it respects
+     ``.pth`` rewrites and platform conventions), with a manual fallback that
+@@ -1541,7 +1541,7 @@ def _strip_hermes_owned_pythonpath_and_runtime_markers(env: dict) -> None:
+ def _strip_hermes_owned_pythonpath(env: dict) -> None:
+     """Remove Hermes-owned PYTHONPATH entries from subprocess environments.
+ 
+-    Launchers prepend the Hermes repo root and the Hermes venv's
++    Launchers prepend the Black Pool repo root and the Black Pool venv's
+     site-packages so the backend can ``import tools``; leaking those into a
+     child Python of a DIFFERENT version makes it load the backend's C
+     extensions and crash (``numpy._core._multiarray_umath``, ``PIL._imaging``,
+@@ -1579,7 +1579,7 @@ def _strip_hermes_owned_pythonpath(env: dict) -> None:
+         entry_path = Path(entry)
+         should_strip = False
+ 
+-        # --- Check 1: Hermes venv site-packages ---
++        # --- Check 1: Black Pool venv site-packages ---
+         # Producers inject the exact directory, never a descendant.  Exact
+         # matching avoids deleting a user path nested below site-packages.
+         for sp in hermes_site_packages:
+@@ -1590,7 +1590,7 @@ def _strip_hermes_owned_pythonpath(env: dict) -> None:
+             stripped.append(entry)
+             continue
+ 
+-        # --- Check 2: Hermes repo root ---
++        # --- Check 2: Black Pool repo root ---
+         # The Electron app prepends the repo root so ``import tools`` works
+         # in the backend.  Subprocesses don't need it and it can shadow
+         # local packages of the same name.  Only the EXACT root is stripped:
+@@ -1648,7 +1648,7 @@ def _resolve_shell_init_files() -> list[str]:
+     Expands ``~`` and ``${VAR}`` references and drops anything that doesn't
+     exist on disk, so a missing ``~/.bashrc`` never breaks the snapshot.
+     The ``auto_source_bashrc`` path runs only when the user hasn't supplied
+-    an explicit list — once they have, Hermes trusts them.
++    an explicit list — once they have, Black Pool trusts them.
+     """
+     explicit, auto_bashrc = _read_terminal_shell_init_config()
+ 
+diff --git a/tools/environments/modal.py b/tools/environments/modal.py
+index 3137b32..68abb86 100644
+--- a/tools/environments/modal.py
++++ b/tools/environments/modal.py
+@@ -1,7 +1,7 @@
+ """Modal cloud execution environment using the native Modal SDK directly.
+ 
+ Uses ``Sandbox.create()`` + ``Sandbox.exec()`` instead of the older runtime
+-wrapper, while preserving Hermes' persistent snapshot behavior across sessions.
++wrapper, while preserving Black Pool' persistent snapshot behavior across sessions.
+ """
+ 
+ import asyncio
+diff --git a/tools/environments/modal_utils.py b/tools/environments/modal_utils.py
+index 167ac38..f31d4d5 100644
+--- a/tools/environments/modal_utils.py
++++ b/tools/environments/modal_utils.py
+@@ -1,6 +1,6 @@
+ """Shared Hermes-side execution flow for Modal transports.
+ 
+-This module deliberately stops at the Hermes boundary:
++This module deliberately stops at the Black Pool boundary:
+ - command preparation
+ - cwd/timeout normalization
+ - stdin/sudo shell wrapping
+diff --git a/tools/environments/vercel_sandbox.py b/tools/environments/vercel_sandbox.py
+index 4b6e4ea..b881ebb 100644
+--- a/tools/environments/vercel_sandbox.py
++++ b/tools/environments/vercel_sandbox.py
+@@ -1,6 +1,6 @@
+ """Vercel Sandbox execution environment.
+ 
+-Uses the Vercel Python SDK to run commands in cloud sandboxes through Hermes'
++Uses the Vercel Python SDK to run commands in cloud sandboxes through Black Pool'
+ shared ``BaseEnvironment`` shell contract. When persistence is enabled, the
+ backend stores task-scoped snapshot metadata under ``HERMES_HOME`` and restores
+ new sandboxes from those snapshots on later task reuse.
+@@ -47,7 +47,7 @@ _DEFAULT_CONTAINER_DISK_MB = 51200
+ def _ensure_vercel_sdk() -> None:
+     """Lazy-install vercel SDK on demand. Idempotent."""
+     # The vercel SDK (>=0.7) ships default-on usage telemetry
+-    # (vercel-internal-telemetry posts to telemetry.vercel.com). Hermes
++    # (vercel-internal-telemetry posts to telemetry.vercel.com). Black Pool
+     # policy is no outbound telemetry without explicit user opt-in, so
+     # disable it before the SDK is ever imported. Users who genuinely want
+     # it can re-enable by exporting VERCEL_TELEMETRY_DISABLED=0 after this
+diff --git a/tools/file_operations.py b/tools/file_operations.py
+index aab5c4e..a7df293 100644
+--- a/tools/file_operations.py
++++ b/tools/file_operations.py
+@@ -1152,7 +1152,7 @@ class ShellFileOperations(FileOperations):
+         form (``/c/Users/x``) so bash builtins resolve them. But native
+         Windows binaries invoked from that bash (ripgrep installed via
+         winget/cargo/choco, native git, etc.) do not understand ``/c/...``
+-        paths — and Hermes disables MSYS argument conversion for its bash
++        paths — and Black Pool disables MSYS argument conversion for its bash
+         subprocesses (``MSYS_NO_PATHCONV=1`` / ``MSYS2_ARG_CONV_EXCL=*``,
+         see ``_apply_windows_msys_bash_env_defaults``), so nothing ever
+         translates the MSYS form back. The native tool then fails with
+@@ -3160,7 +3160,7 @@ class ShellFileOperations(FileOperations):
+         cmd_parts.append(self._escape_shell_arg(pattern))
+         # rg is a native Windows binary when installed via winget/cargo/choco:
+         # it needs the C:/... path form, not the MSYS /c/... form (which
+-        # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
++        # nothing converts back — Black Pool sets MSYS_NO_PATHCONV for its bash).
+         cmd_parts.append(self._escape_native_tool_arg(path))
+         
+         # Fetch extra rows so we can report the true total before slicing.
 diff --git a/tools/file_tools.py b/tools/file_tools.py
-index 2270fb5..758c468 100644
+index 2270fb5..4860a3d 100644
 --- a/tools/file_tools.py
 +++ b/tools/file_tools.py
+@@ -445,7 +445,7 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
+ 
+ 
+ def _file_ops_uses_host_paths(file_ops) -> bool:
+-    """Return True when *file_ops* targets the same host filesystem as Hermes.
++    """Return True when *file_ops* targets the same host filesystem as Black Pool.
+ 
+     Only then may we rewrite V4A header paths to resolved host-absolute
+     paths: a container/remote backend has its own filesystem namespace where
+@@ -661,7 +661,7 @@ _hermes_config_resolved_loaded = False
+ 
+ 
+ def _get_hermes_config_resolved() -> str | None:
+-    """Return the resolved absolute path of the Hermes config file (cached)."""
++    """Return the resolved absolute path of the Black Pool config file (cached)."""
+     global _hermes_config_resolved, _hermes_config_resolved_loaded
+     if _hermes_config_resolved_loaded:
+         return _hermes_config_resolved
+@@ -693,14 +693,14 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
+             return _err
+     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+         return _err
+-    # Prevent agents from modifying the Hermes config file directly.
++    # Prevent agents from modifying the Black Pool config file directly.
+     # approvals.mode and other security settings live here; a malicious or
+     # prompt-injected agent could silently disable exec approval by writing to
+     # this file.
+     hermes_config = _get_hermes_config_resolved()
+     if hermes_config and (resolved == hermes_config or normalized == hermes_config):
+         return (
+-            f"Refusing to write to Hermes config file: {filepath}\n"
++            f"Refusing to write to Black Pool config file: {filepath}\n"
+             "Agent cannot modify security-sensitive configuration. "
+             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
+         )
+@@ -738,7 +738,7 @@ _real_hermes_home_loaded = False
+ 
+ 
+ def _get_real_hermes_home() -> str | None:
+-    """Return the realpath of the authoritative Hermes home (cached)."""
++    """Return the realpath of the authoritative Black Pool home (cached)."""
+     global _real_hermes_home_cached, _real_hermes_home_loaded
+     if _real_hermes_home_loaded:
+         return _real_hermes_home_cached
+@@ -1020,7 +1020,7 @@ def _check_approval_required_write(paths: list[str],
+ 
+ 
+ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | None:
+-    """Return the container-side Hermes mirror prefix for Docker file tools."""
++    """Return the container-side Black Pool mirror prefix for Docker file tools."""
+     try:
+         from tools.terminal_tool import (
+             _active_environments,
+@@ -1054,9 +1054,9 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
+ 
+ 
+ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | None:
+-    """Return a soft-guard warning when ``filepath`` lands in another Hermes
++    """Return a soft-guard warning when ``filepath`` lands in another Black Pool
+     profile's scoped area, a host-side sandbox-mirror of authoritative profile
+-    state, or the Docker container's sandbox mirror of Hermes state.
++    state, or the Docker container's sandbox mirror of Black Pool state.
+ 
+     Three detectors run in order:
+ 
+@@ -1065,13 +1065,13 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str |
+     * sandbox-mirror (#32049) — writes that hit the
+       ``…/sandboxes/<backend>/<task>/home/.hermes/…`` mirror created by a
+       non-local terminal backend (Docker, Daytona, etc.), where the host
+-      Hermes process never reads the mirror and the authoritative file is
++      Black Pool process never reads the mirror and the authoritative file is
+       left untouched.
+     * container-mirror (#32049 follow-up) — writes from inside a Docker
+       container whose bind-mounted home strips the ``sandboxes/`` prefix, so
+       the agent sees a plain ``/root/.hermes/…`` path.
+ 
+-    Returns ``None`` when the write is in-scope or outside Hermes scope.
++    Returns ``None`` when the write is in-scope or outside Black Pool scope.
+     All detectors are soft guards — the agent can override any by
+     passing ``cross_profile=True`` to its write tool after explicit user
+     direction. Defense-in-depth, NOT a security boundary — the terminal
+@@ -1766,7 +1766,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
+                 "Use vision_analyze for images, or terminal to inspect binary files."
+             )
+ 
+-        # ── Hermes internal path guard ────────────────────────────────
++        # ── Black Pool internal path guard ────────────────────────────────
+         # Prevent prompt injection via catalog or hub metadata files,
+         # and block credential stores under HERMES_HOME.  Pass the
+         # already-resolved path so a relative-path read against
 @@ -2673,7 +2673,7 @@ WRITE_FILE_SCHEMA = {
              "content": {"type": "string", "description": "Complete content to write to the file"},
              "cross_profile": {
@@ -49877,21 +64270,185 @@ index 2270fb5..758c468 100644
                  "default": False,
              },
          },
+diff --git a/tools/focus_pane_tool.py b/tools/focus_pane_tool.py
+index e154312..589dff2 100644
+--- a/tools/focus_pane_tool.py
++++ b/tools/focus_pane_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Reveal/focus a pane in the Hermes desktop GUI.
++"""Reveal/focus a pane in the Black Pool desktop GUI.
+ 
+ Lives in the ``desktop_ui`` toolset (like the other GUI affordances), which the
+ GUI gateway enables only for desktop-sourced sessions. Emits ``pane.reveal``
+@@ -28,7 +28,7 @@ def focus_pane_tool(pane: str) -> str:
+     except Exception as exc:
+         return tool_error(f"Failed to focus the {name} pane: {exc}")
+     if not ok:
+-        return tool_error("Pane focus is only available in the Hermes desktop app.")
++        return tool_error("Pane focus is only available in the Black Pool desktop app.")
+ 
+     return json.dumps({"success": True, "pane": name}, ensure_ascii=False)
+ 
+@@ -36,7 +36,7 @@ def focus_pane_tool(pane: str) -> str:
+ FOCUS_PANE_SCHEMA = {
+     "name": "focus_pane",
+     "description": (
+-        "Reveal and focus a pane in the Hermes desktop app when the user asks to "
++        "Reveal and focus a pane in the Black Pool desktop app when the user asks to "
+         "see it — e.g. \"show me the terminal\", \"open the file browser\", \"show "
+         "the diff\". Panes: chat (the conversation), files (project file browser), "
+         "terminal (embedded shell), review (git diff), sessions (the session list). "
+diff --git a/tools/image_generation_tool.py b/tools/image_generation_tool.py
+index 5f1d0e1..e64231d 100644
+--- a/tools/image_generation_tool.py
++++ b/tools/image_generation_tool.py
+@@ -1127,7 +1127,7 @@ def _agent_cache_base_for_env(env: Any) -> str | None:
+             return "/root/.hermes"
+ 
+     # If no environment has been created yet, only backends with deterministic
+-    # Hermes cache roots can be translated without side effects. SSH can still
++    # Black Pool cache roots can be translated without side effects. SSH can still
+     # use a shell-visible tilde path; its first environment sync will upload
+     # the cache file before the first command runs.
+     backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+diff --git a/tools/kanban_tools.py b/tools/kanban_tools.py
+index d49b53a..b93f43e 100644
+--- a/tools/kanban_tools.py
++++ b/tools/kanban_tools.py
+@@ -221,7 +221,7 @@ def _connect(board: Optional[str] = None):
+     default) preserves the legacy resolution chain
+     (``HERMES_KANBAN_DB`` → ``HERMES_KANBAN_BOARD`` env → current symlink
+     → ``default``). Per-tool ``board`` lets a Telegram-side agent override
+-    the env-pinned active board without restarting Hermes.
++    the env-pinned active board without restarting Black Pool.
+     """
+     from hermes_cli import kanban_db as kb
+     return kb, kb.connect(board=board)
+@@ -1241,7 +1241,7 @@ def _download_url_with_cap(url: str, max_bytes: int) -> tuple[bytes, Optional[st
+ def _handle_attach_url(args: dict, **kw) -> str:
+     """Attach a file fetched server-side from a URL.
+ 
+-    The agent passes a URL; Hermes downloads it (with the shared size cap)
++    The agent passes a URL; Black Pool downloads it (with the shared size cap)
+     and stores it as a real attachment. Useful when the agent has a link
+     rather than the bytes. Only http/https URLs are accepted.
+     """
+@@ -2074,7 +2074,7 @@ KANBAN_ATTACH_SCHEMA = {
+ KANBAN_ATTACH_URL_SCHEMA = {
+     "name": "kanban_attach_url",
+     "description": (
+-        "Attach a file to a task by URL — Hermes downloads it server-side "
++        "Attach a file to a task by URL — Black Pool downloads it server-side "
+         "and stores it as a real attachment (capped at 25 MB). Use when "
+         "you have a link rather than the bytes. Only http/https URLs are "
+         "accepted."
 diff --git a/tools/lazy_deps.py b/tools/lazy_deps.py
-index 3887d3a..58f7a48 100644
+index 3887d3a..50529ff 100644
 --- a/tools/lazy_deps.py
 +++ b/tools/lazy_deps.py
-@@ -1,5 +1,5 @@
+@@ -1,7 +1,7 @@
  """
 -Lazy dependency installer for opt-in Hermes Agent backends.
 +Lazy dependency installer for opt-in Black Pool Agent backends.
  
- Many Hermes features (Mistral TTS, ElevenLabs TTS, Honcho memory, Bedrock,
+-Many Hermes features (Mistral TTS, ElevenLabs TTS, Honcho memory, Bedrock,
++Many Black Pool features (Mistral TTS, ElevenLabs TTS, Honcho memory, Bedrock,
  Slack, Matrix, etc.) require Python packages that not every user needs. The
+ historical approach was to bundle them all under ``pyproject.toml`` extras
+ (``hermes-agent[all]``) and install them eagerly at setup time. That has
+@@ -38,7 +38,7 @@ Security model:
+   a module the core already ships. The worst a bad/incompatible backend
+   package can do is fail to import and report itself unavailable — the agent
+   core stays healthy. This is the structural guarantee that a lazily
+-  installed package cannot brick Hermes, which is what made it safe to seal
++  installed package cannot brick Black Pool, which is what made it safe to seal
+   the venv in the first place. Compiled-wheel safety across image rebuilds
+   is handled by an ABI/Python-version stamp on the target subdir (see
+   :func:`_ensure_target_ready`).
+@@ -152,7 +152,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
+     # small silk-v3 codec binding; installed on first .silk transcription.
+     "stt.silk": ("pilk==0.2.4",),
+ 
+-    # ─── Wake word ("Hey Hermes") engines ──────────────────────────────────
++    # ─── Wake word ("Hey Black Pool") engines ──────────────────────────────────
+     # Keep in sync with the `wake` extra in pyproject.toml. openWakeWord is the
+     # free, local default (ONNX runtime); Porcupine is the premium engine.
+     # openWakeWord's ONNX embedding model returns near-zero scores on macOS
+@@ -547,7 +547,7 @@ def _unsupported_feature_reason(feature: str) -> Optional[str]:
+         return (
+             "unsupported on Windows: Matrix E2EE depends on python-olm, "
+             "which has no Windows wheel and requires make + libolm to build "
+-            "from sdist. Run Hermes under WSL to use Matrix on Windows."
++            "from sdist. Run Black Pool under WSL to use Matrix on Windows."
+         )
+     return None
+ 
+@@ -743,7 +743,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
+ 
+         # Tier 1: uv (preferred — fast, doesn't need pip in the venv)
+         # Managed uv first: $HERMES_HOME/bin is never on PATH, so a bare
+-        # which() misses the uv Hermes installed and falls through to the
++        # which() misses the uv Black Pool installed and falls through to the
+         # slower pip tier. Deliberately a lookup and not ensure_uv(): this runs
+         # mid-turn to install an optional dependency, and downloading uv +
+         # migrating the Python runtime as a side effect of that is a far bigger
+@@ -867,7 +867,7 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
+     if unsupported:
+         raise FeatureUnavailable(feature, missing, unsupported)
+ 
+-    # Package-manager installs (NixOS, and any other distro that ships Hermes
++    # Package-manager installs (NixOS, and any other distro that ships Black Pool
+     # from a read-only store) cannot receive lazy pip installs: the venv's
+     # site-packages lives in the store, so the uv -> pip -> ensurepip ladder
+     # below burns ~15s bootstrapping ensurepip only to fail on a read-only
+@@ -891,9 +891,9 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
+             raise FeatureUnavailable(
+                 feature, missing,
+                 f"unsupported on {managed_by}-managed installs: this build's "
+-                f"packages come from {managed_by}, so Hermes cannot install "
++                f"packages come from {managed_by}, so Black Pool cannot install "
+                 f"them at runtime. Add the dependencies for {feature!r} via "
+-                f"{managed_by} (or run a pip/uv install of Hermes instead)."
++                f"{managed_by} (or run a pip/uv install of Black Pool instead)."
+             )
+ 
+     # Validate every spec against the allowlist + safety regex. Belt and
+diff --git a/tools/managed_tool_gateway.py b/tools/managed_tool_gateway.py
+index 0ec3b52..d005816 100644
+--- a/tools/managed_tool_gateway.py
++++ b/tools/managed_tool_gateway.py
+@@ -29,7 +29,7 @@ class ManagedToolGatewayConfig:
+ 
+ 
+ def auth_json_path():
+-    """Return the Hermes auth store path, respecting HERMES_HOME overrides."""
++    """Return the Black Pool auth store path, respecting HERMES_HOME overrides."""
+     return get_hermes_home() / "auth.json"
+ 
+ 
+@@ -221,7 +221,7 @@ def is_managed_tool_gateway_ready(
+ #
+ # Vendors the gateway serves on its own origin (rather than on a
+ # `{vendor}-gateway` host) are pinned HERE, in code, the same way every other
+-# managed vendor's gateway URL is pinned: adding one is a Hermes release, and
++# managed vendor's gateway URL is pinned: adding one is a Black Pool release, and
+ # the exact URL a user's agent may connect to is reviewable in this file. A
+ # runtime discovery catalog was tried and deliberately removed — a remote
+ # endpoint that can add tools to every entitled install is a bigger trust
 diff --git a/tools/mcp_oauth.py b/tools/mcp_oauth.py
-index 1eb6f57..f8e5379 100644
+index 1eb6f57..938f2e3 100644
 --- a/tools/mcp_oauth.py
 +++ b/tools/mcp_oauth.py
+@@ -12,7 +12,7 @@ refresh, and step-up authorization automatically.
+ 
+ Client identification follows the MCP 2026-07-28 spec: when the authorization
+ server advertises ``client_id_metadata_document_supported``, the SDK uses the
+-URL of Hermes' published Client ID Metadata Document (CIMD) as the
++URL of Black Pool' published Client ID Metadata Document (CIMD) as the
+ ``client_id``; otherwise it falls back to RFC 7591 dynamic client registration,
+ which that spec revision deprecated.
+ 
 @@ -37,7 +37,7 @@ Configuration in config.yaml::
            redirect_port: 0                      # 0 = auto-pick free port
            redirect_uri: "https://proxy/callback"  # default: loopback callback
@@ -49901,12 +64458,84 @@ index 1eb6f57..f8e5379 100644
            client_metadata_url: "https://me/cimd.json"  # self-hosted CIMD
            cimd: false                           # force DCR for this server
  """
+@@ -273,7 +273,7 @@ def _cached_redirect_port(storage: "HermesTokenStorage | None") -> int | None:
+     """Return the loopback callback port from cached client registration.
+ 
+     OAuth providers bind a dynamically-registered ``client_id`` to the exact
+-    redirect URI that was registered with it. If Hermes restarts and chooses a
++    redirect URI that was registered with it. If Black Pool restarts and chooses a
+     new random callback port while reusing the stored ``client_id``, providers
+     such as Summ reject the authorization request with ``redirect_uri does not
+     match any registered URIs``. Reusing the cached redirect port keeps the
+@@ -488,7 +488,7 @@ class HermesTokenStorage:
+             return None
+         if OAuthToken is None and not _ensure_sdk_loaded():
+             return None
+-        # Hermes records an absolute wall-clock ``expires_at`` alongside the
++        # Black Pool records an absolute wall-clock ``expires_at`` alongside the
+         # SDK's serialized token (see ``set_tokens``). On read we rewrite
+         # ``expires_in`` to the remaining seconds so the SDK's downstream
+         # ``update_token_expiry`` computes the correct absolute time and
+@@ -775,7 +775,7 @@ def _make_callback_handler() -> tuple[type, dict]:
+ 
+             body = (
+                 "<html><body><h2>Authorization Successful</h2>"
+-                "<p>You can close this tab and return to Hermes.</p></body></html>"
++                "<p>You can close this tab and return to Black Pool.</p></body></html>"
+             ) if code else (
+                 "<html><body><h2>Authorization Failed</h2>"
+                 f"<p>Error: {error or 'unknown'}</p></body></html>"
+@@ -1052,7 +1052,7 @@ def _make_callback_waiter(
+                 hint = (
+                     " If the browser showed an invalid-client error instead of "
+                     "an approval prompt, the authorization server rejected "
+-                    f"Hermes' Client ID Metadata Document ({cimd_url}); set "
++                    f"Black Pool' Client ID Metadata Document ({cimd_url}); set "
+                     "``cimd: false`` under that server's ``oauth:`` block in "
+                     "config.yaml to authorize via dynamic client registration "
+                     "instead."
+@@ -1295,7 +1295,7 @@ def remove_oauth_tokens(
+ # Under CIMD the client_id IS an HTTPS URL that the authorization server
+ # fetches to learn our app name, logo and permitted redirect URIs, replacing
+ # the per-install RFC 7591 registration that the MCP spec deprecated in
+-# 2026-07-28. The SDK does the protocol work; Hermes only decides whether a
++# 2026-07-28. The SDK does the protocol work; Black Pool only decides whether a
+ # given flow is eligible and hands the URL to ``OAuthClientProvider``.
+ # ---------------------------------------------------------------------------
+ 
+@@ -1310,7 +1310,7 @@ _CIMD_CLIENT_METADATA_URL = (
+ 
+ # Loopback callback ports declared in that document. The redirect URI in the
+ # authorization request must be an exact string match against a listed one
+-# (section 4.2), so a CIMD flow cannot use the ephemeral port Hermes picks
++# (section 4.2), so a CIMD flow cannot use the ephemeral port Black Pool picks
+ # otherwise. These sit below Linux's 32768 ephemeral floor, so the kernel never
+ # hands one to an unrelated process. Keep in sync with the document — the
+ # cross-artifact test in tests/tools/test_mcp_cimd.py enforces that.
+@@ -1418,7 +1418,7 @@ def _server_declined_cimd(storage: "HermesTokenStorage | None") -> bool:
+ 
+     Pinning a callback port is only needed for a flow that actually ends up
+     using CIMD, but the SDK decides that during its 401 branch — long after
+-    Hermes has to fix the redirect URI. Cached authorization-server metadata
++    Black Pool has to fix the redirect URI. Cached authorization-server metadata
+     from an earlier connection closes the gap for every server the user has
+     already reached: one that never advertised
+     ``client_id_metadata_document_supported`` keeps the reserved ephemeral
+@@ -1442,7 +1442,7 @@ def _maybe_use_cimd(
+ ) -> "tuple[str, int] | None":
+     """Return ``(client_id URL, pinned callback port)``, or None to use DCR.
+ 
+-    Every early return below is a case where the redirect URI Hermes would
++    Every early return below is a case where the redirect URI Black Pool would
+     send is not one the published document declares, where the client
+     identity is already settled, or where the server is known not to want a
+     document — DCR remains correct in all of them. Passing a metadata URL
 @@ -1627,7 +1627,7 @@ def _resolve_redirect_uri(cfg: dict, port: int) -> str:
  # of 2026-07, verified by live call against api.figma.com):
  #   "Claude Code" → 200
  #   "Codex"       → 200
 -#   "Hermes Agent" / "Hermes" / "Cursor" / "VS Code" / … → 403
-+#   "Black Pool Agent" / "Hermes" / "Cursor" / "VS Code" / … → 403
++#   "Black Pool Agent" / "Black Pool" / "Cursor" / "VS Code" / … → 403
  # pi-figma-remote-auth and similar tools work around this the same way — register
  # under an allowlisted name so the browser flow can start. User can still pin a
  # different name via oauth.client_name if Figma ever admits one.
@@ -49919,8 +64548,86 @@ index 1eb6f57..f8e5379 100644
      scope = cfg.get("scope")
      redirect_uri = _resolve_redirect_uri(cfg, port)
  
+@@ -1717,7 +1717,7 @@ def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
+         "token_endpoint_auth_method": auth_method,
+         # SEP-837 (2026-07-28 spec): clients MUST declare an application_type
+         # during registration so OIDC-strict authorization servers stop
+-        # rejecting loopback redirect_uris. Hermes is a CLI/desktop app
++        # rejecting loopback redirect_uris. Black Pool is a CLI/desktop app
+         # redirecting to 127.0.0.1/localhost — that is exactly "native".
+         # Overridable for the rare hosted-dashboard deployment fronting a
+         # real https redirect.
+@@ -1837,9 +1837,9 @@ def humanize_oauth_registration_error(
+     Returns a humanized message when the error is a registration 403/Forbidden,
+     else ``None`` so the caller keeps the original exception text.
+ 
+-    Figma's remote MCP gates DCR on exact ``client_name``. Hermes auto-sets
++    Figma's remote MCP gates DCR on exact ``client_name``. Black Pool auto-sets
+     ``Claude Code`` (known-good); this message fires when the user overrode
+-    that with something Figma still rejects, or an older Hermes is running.
++    that with something Figma still rejects, or an older Black Pool is running.
+     """
+     msg = str(exc)
+     lowered = msg.lower()
+@@ -1860,7 +1860,7 @@ def humanize_oauth_registration_error(
+         return (
+             f"'{server_name}' is Figma's remote MCP — DCR is allowlisted by "
+             f"exact client_name (\"{_FIGMA_DCR_CLIENT_NAME}\" and \"Codex\" "
+-            "work; most other names 403). Hermes defaults to "
++            "work; most other names 403). Black Pool defaults to "
+             f"client_name: {_FIGMA_DCR_CLIENT_NAME!r} automatically. If you "
+             "set oauth.client_name yourself, change it to one of those, or "
+             "clear it and re-run:\n"
+diff --git a/tools/mcp_oauth_manager.py b/tools/mcp_oauth_manager.py
+index d0bca49..e84801e 100644
+--- a/tools/mcp_oauth_manager.py
++++ b/tools/mcp_oauth_manager.py
+@@ -319,7 +319,7 @@ def _make_hermes_provider_class() -> Optional[type]:
+             builders and response handlers so we track whatever the SDK
+             version we're pinned to expects.
+             """
+-            # The SDK's httpx flavour, not Hermes' — mcp 2.0 builds on httpx2,
++            # The SDK's httpx flavour, not Black Pool' — mcp 2.0 builds on httpx2,
+             # and `create_oauth_metadata_request` below returns one of *its*
+             # Request objects, which only its own AsyncClient can send. See
+             # tools.mcp_tool.sdk_httpx.
+diff --git a/tools/mcp_schema_cache.py b/tools/mcp_schema_cache.py
+index 48bb5ae..8107e6a 100644
+--- a/tools/mcp_schema_cache.py
++++ b/tools/mcp_schema_cache.py
+@@ -1,6 +1,6 @@
+ """Persistent MCP tool-schema cache for lazy server startup.
+ 
+-Stores per-server tool manifests on disk so Hermes can register MCP tools
++Stores per-server tool manifests on disk so Black Pool can register MCP tools
+ into the agent snapshot without spawning the stdio child process at idle
+ dashboard startup. Cache entries are keyed by server name + a fingerprint
+ of the connection config (command/args/url/tools filters).
+diff --git a/tools/mcp_stdio_watchdog.py b/tools/mcp_stdio_watchdog.py
+index a39f36d..be9af9a 100644
+--- a/tools/mcp_stdio_watchdog.py
++++ b/tools/mcp_stdio_watchdog.py
+@@ -2,15 +2,15 @@
+ """Parent-death watchdog supervisor for stdio MCP subprocesses.
+ 
+ Problem this fixes (#TBD): a stdio MCP server (e.g. ``npx -y mcp-remote
+-<url>``) is spawned as a direct child of the Hermes process. Hermes's own
++<url>``) is spawned as a direct child of the Black Pool process. Black Pool's own
+ teardown path (``MCPServerTask.shutdown()`` / ``_kill_orphaned_mcp_children``
+ at final exit) reaps it cleanly on a *graceful* exit. But if the spawning
+-Hermes process dies hard — ``kill -9``, an OS-level crash, a force-quit of
++Black Pool process dies hard — ``kill -9``, an OS-level crash, a force-quit of
+ the TUI/desktop app — that teardown code never runs, and the child (plus any
+ of its own descendants, e.g. mcp-remote's spawned ``node`` process) is
+ orphaned. macOS has no direct equivalent of Linux's
+ ``prctl(PR_SET_PDEATHSIG)`` to make the kernel auto-kill a child when its
+-parent dies, so nothing reaps these until the next Hermes startup's opt-in
++parent dies, so nothing reaps these until the next Black Pool startup's opt-in
+ ``_kill_orphaned_mcp_children()`` sweep — which only runs if something calls
+ it. Repeated ungraceful session restarts can pile up N orphaned processes,
+ all racing to hold the same upstream SSE session, producing errors like
 diff --git a/tools/mcp_tool.py b/tools/mcp_tool.py
-index 08b15dc..c7a9135 100644
+index 08b15dc..04f59e5 100644
 --- a/tools/mcp_tool.py
 +++ b/tools/mcp_tool.py
 @@ -41,7 +41,7 @@ Example config::
@@ -49932,6 +64639,75 @@ index 08b15dc..c7a9135 100644
          timeout: 180
          skip_preflight: true  # bypass the content-type probe for a valid
                                # Streamable HTTP endpoint that answers HEAD/GET
+@@ -446,7 +446,7 @@ def sdk_httpx():
+ 
+     mcp 2.0 moved its HTTP transports and OAuth stack from ``httpx`` to
+     ``httpx2`` — a separate distribution with the same public API, importable
+-    side by side with Hermes' own pinned ``httpx``. Every object that crosses
++    side by side with Black Pool' own pinned ``httpx``. Every object that crosses
+     the SDK boundary has to come from the module the SDK itself imports:
+     the ``AsyncClient`` handed to ``streamable_http_client``, the client the
+     ``sse_client`` factory returns, the ``Request`` built by the SDK's OAuth
+@@ -524,7 +524,7 @@ def _check_logging_callback_support() -> bool:
+     Mirrors ``_check_message_handler_support`` for backward compatibility
+     with older MCP SDK versions.  Without a logging_callback, the SDK's
+     default handler silently discards every ``notifications/message`` a
+-    server emits, so server-side diagnostics never reach Hermes' logs.
++    server emits, so server-side diagnostics never reach Black Pool' logs.
+     """
+     if not _MCP_AVAILABLE:
+         return False
+@@ -712,12 +712,12 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
+     Only passes through safe baseline variables (PATH, HOME, etc.) and XDG_*
+     variables from the current process environment, secrets injected by an
+     external secret source (Bitwarden, 1Password, plugin backends) that
+-    Hermes explicitly tagged during dotenv loading, plus any variables
++    Black Pool explicitly tagged during dotenv loading, plus any variables
+     explicitly specified by the user in the server config.
+ 
+     This prevents accidentally leaking secrets like API keys, tokens, or
+     credentials to MCP server subprocesses.  Secret-source-injected vars are
+-    an exception: users configured that backend specifically so Hermes and
++    an exception: users configured that backend specifically so Black Pool and
+     its subprocesses can consume those credentials without duplicating them
+     in every MCP server's ``env:`` block.
+     """
+@@ -1018,7 +1018,7 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
+                 os.path.join(os.path.expanduser("~"), ".local", "bin", resolved_command),
+                 # /usr/local/bin is the canonical install location for Node on
+                 # Linux from-source builds, the upstream node:bookworm-slim
+-                # image (which the Hermes Docker image copies node + npm +
++                # image (which the Black Pool Docker image copies node + npm +
+                 # corepack from since #4977), and macOS Homebrew on Intel.
+                 # Without this candidate, any MCP server configured with an
+                 # env.PATH that omits /usr/local/bin (a common pattern when
+@@ -1069,7 +1069,7 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
+ 
+ 
+ # ---------------------------------------------------------------------------
+-# MCP ImageContent block → Hermes MEDIA tag
++# MCP ImageContent block → Black Pool MEDIA tag
+ # ---------------------------------------------------------------------------
+ 
+ 
+@@ -1117,7 +1117,7 @@ def _mcp_image_extension_for_mime_type(mime_type: str) -> str:
+ 
+ def _cache_mcp_image_block(block) -> str:
+     """Cache an MCP ``ImageContent`` block to the shared image cache and
+-    return a ``MEDIA:<path>`` tag that Hermes gateways know how to render.
++    return a ``MEDIA:<path>`` tag that Black Pool gateways know how to render.
+ 
+     Returns an empty string when *block* is not an image, when the base64
+     payload is malformed, or when the cache helper rejects the bytes (e.g.
+@@ -1252,7 +1252,7 @@ def _render_mcp_resource_block(block, server_name: str = "") -> str:
+ 
+     - ``EmbeddedResource`` with text contents → the text itself.
+     - ``EmbeddedResource`` with blob contents → bytes are decoded (size-capped)
+-      and materialized into the Hermes document cache; returns a marker with
++      and materialized into the Black Pool document cache; returns a marker with
+       the local path so file/terminal tools can consume it.
+     - ``ResourceLink`` → the URI plus a pointer at the server's read_resource
+       tool. No network fetch happens here; the link is only readable through
 @@ -1568,7 +1568,7 @@ def _resolve_identity_header(server_name: str, config: dict):
      Returns a ``(header_name, header_value)`` tuple, or ``None`` when the
      key is unset or invalid. Invalid configs warn and are ignored — an
@@ -49941,10 +64717,383 @@ index 08b15dc..c7a9135 100644
      connect time; there is no per-call mutation.
      """
      raw = config.get("identity_header")
+@@ -2182,7 +2182,7 @@ class ElicitationHandler:
+ 
+     Elicitation lets a server ask the client to collect structured input from
+     the user mid-tool-call (e.g. payment authorization, OAuth confirmation).
+-    Form-mode elicitations are routed through Hermes' existing approval
++    Form-mode elicitations are routed through Black Pool' existing approval
+     system (``tools.approval.prompt_dangerous_approval``), which surfaces
+     the prompt on whichever surface the active session uses -- CLI, TUI,
+     Telegram, Slack, etc. URL-mode elicitations are declined as unsupported.
+@@ -2617,7 +2617,7 @@ class MCPServerTask:
+         """Build a ``logging_callback`` for ``ClientSession``.
+ 
+         Routes MCP ``notifications/message`` log notifications from the
+-        server into Hermes' logging (agent.log via hermes_logging), tagged
++        server into Black Pool' logging (agent.log via hermes_logging), tagged
+         with the server name.  Without this, the SDK's default callback
+         silently discards them, so server-side warnings/errors during a
+         tool call were invisible.  Port of anomalyco/opencode#34529.
+@@ -3048,7 +3048,7 @@ class MCPServerTask:
+             )
+ 
+         # Wrap the real command in a parent-death watchdog supervisor so an
+-        # ungraceful exit of this Hermes process (kill -9, crash, force-quit)
++        # ungraceful exit of this Black Pool process (kill -9, crash, force-quit)
+         # can't leave the stdio MCP child (and its own descendants, e.g.
+         # mcp-remote's spawned `node`) running forever. On a clean exit,
+         # MCPServerTask.shutdown() / _kill_orphaned_mcp_children() still do
+@@ -3745,7 +3745,7 @@ class MCPServerTask:
+         # Set up elicitation handler if enabled and SDK types are available.
+         # Servers use elicitation/create to ask the client for structured
+         # input mid-tool-call (e.g. payment authorization). The handler
+-        # routes those requests through Hermes' approval system.
++        # routes those requests through Black Pool' approval system.
+         elicitation_config = config.get("elicitation", {})
+         if elicitation_config.get("enabled", True) and _MCP_ELICITATION_TYPES:
+             self._elicitation = ElicitationHandler(self.name, elicitation_config, owner=self)
+@@ -3895,7 +3895,7 @@ class MCPServerTask:
+                 # CancelledError inherits from BaseException (not Exception)
+                 # in Python 3.11+, so the broad ``except Exception`` below
+                 # would NOT catch it; we'd silently exit the reconnect loop
+-                # and the MCP server would stay dead until Hermes is fully
++                # and the MCP server would stay dead until Black Pool is fully
+                 # restarted. Re-raise so the task's cancellation propagates
+                 # correctly to asyncio's task machinery and ``shutdown()``'s
+                 # ``await self._task`` completes. See #9930.
+@@ -4607,7 +4607,7 @@ def _http_status_error_types() -> tuple:
+     """``HTTPStatusError`` classes that can reach us, from both httpx flavours.
+ 
+     A 401 can be raised either by the MCP SDK's own HTTP stack (``httpx2`` on
+-    mcp >= 2.0) or by Hermes' pinned ``httpx``, and the two define unrelated
++    mcp >= 2.0) or by Black Pool' pinned ``httpx``, and the two define unrelated
+     exception classes. Both go in the tuple so ``isinstance`` covers whichever
+     layer raised.
+     """
+@@ -4990,7 +4990,7 @@ _lock = threading.Lock()
+ # ---------------------------------------------------------------------------
+ # Cross-process MCP discovery guard
+ # ---------------------------------------------------------------------------
+-# Advisory file lock that prevents N concurrent Hermes processes (e.g.
++# Advisory file lock that prevents N concurrent Black Pool processes (e.g.
+ # gateway + CLI + TUI) from all running MCP discovery simultaneously.
+ # See issue #62771.
+ _LOCK_UNAVAILABLE: Any = object()  # sentinel: locking broken/unavailable
+@@ -5491,7 +5491,7 @@ def _filter_suspicious_mcp_servers(servers: Dict[str, dict]) -> Dict[str, dict]:
+ 
+ 
+ def _load_mcp_config() -> Dict[str, dict]:
+-    """Read ``mcp_servers`` from the Hermes config file.
++    """Read ``mcp_servers`` from the Black Pool config file.
+ 
+     Returns a dict of ``{server_name: server_config}`` or empty dict.
+     Server config can contain either ``command``/``args``/``env`` for stdio
+@@ -5859,13 +5859,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
+             # Collect text from content blocks. MCP tool results can also
+             # include ImageContent blocks (screenshot / Blockbench / Playwright
+             # etc.); cache those via the gateway's image-cache helper so they
+-            # flow through Hermes' MEDIA: tag convention and out to messaging
++            # flow through Black Pool' MEDIA: tag convention and out to messaging
+             # adapters that render images natively. Without this, image blocks
+             # were silently dropped and the agent got an empty response.
+             #
+             # Distilled from #17915 (c3115644151) and #10848 (gnanirahulnutakki),
+             # both too stale to cherry-pick. #10848's approach (integrate with
+-            # Hermes' MEDIA tag + cache_image_from_bytes) was the cleaner of
++            # Black Pool' MEDIA tag + cache_image_from_bytes) was the cleaner of
+             # the two — plugs into existing infrastructure.
+             parts: List[str] = []
+             for block in (result.content or []):
+@@ -6434,7 +6434,7 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
+ def sanitize_mcp_name_component(value: str) -> str:
+     """Return an MCP name component safe for tool and prefix generation.
+ 
+-    Preserves Hermes's historical behavior of converting hyphens to
++    Preserves Black Pool's historical behavior of converting hyphens to
+     underscores, and also replaces any other character outside
+     ``[A-Za-z0-9_]`` with ``_`` so generated tool names are compatible with
+     provider validation rules.
+@@ -6442,7 +6442,7 @@ def sanitize_mcp_name_component(value: str) -> str:
+     return re.sub(r"[^A-Za-z0-9_]", "_", str(value or ""))
+ 
+ 
+-# Native MCP tool-name prefix. Hermes uses the ``mcp__<server>__<tool>``
++# Native MCP tool-name prefix. Black Pool uses the ``mcp__<server>__<tool>``
+ # convention shared by Claude Code, Codex, and OpenCode (anomalyco/opencode
+ # #33533). The double-underscore delimiter disambiguates the server/tool
+ # boundary even when either component contains underscores, and matches the
+@@ -6464,7 +6464,7 @@ def mcp_prefixed_tool_name(server_name: str, tool_name: str) -> str:
+ 
+ 
+ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
+-    """Convert an MCP tool listing to the Hermes registry schema format.
++    """Convert an MCP tool listing to the Black Pool registry schema format.
+ 
+     Args:
+         server_name: The logical server name for prefixing.
+@@ -7624,7 +7624,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
+ 
+     Designed for ``hermes tools`` interactive configuration — connects to each
+     enabled server, grabs tool names and descriptions, then disconnects.
+-    Does NOT register tools in the Hermes registry.
++    Does NOT register tools in the Black Pool registry.
+ 
+     Returns:
+         Dict mapping server name to list of (tool_name, description) tuples.
+diff --git a/tools/open_preview_tool.py b/tools/open_preview_tool.py
+index 367a027..a4f86cc 100644
+--- a/tools/open_preview_tool.py
++++ b/tools/open_preview_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Open a URL, dev server, or file in the Hermes desktop GUI's preview pane.
++"""Open a URL, dev server, or file in the Black Pool desktop GUI's preview pane.
+ 
+ Lives in the ``desktop_ui`` toolset, which the GUI gateway enables only for a
+ session whose source is the desktop app — so the schema never reaches a CLI,
+@@ -48,7 +48,7 @@ def open_preview_tool(url: str, label: str = "") -> str:
+     except Exception as exc:
+         return tool_error(f"Failed to open the preview pane: {exc}")
+     if not ok:
+-        return tool_error("The preview pane is only available in the Hermes desktop app.")
++        return tool_error("The preview pane is only available in the Black Pool desktop app.")
+ 
+     return json.dumps({"success": True, "url": target, "label": label}, ensure_ascii=False)
+ 
+@@ -56,7 +56,7 @@ def open_preview_tool(url: str, label: str = "") -> str:
+ OPEN_PREVIEW_SCHEMA = {
+     "name": "open_preview",
+     "description": (
+-        "Open something in the preview pane beside the chat in the Hermes desktop "
++        "Open something in the preview pane beside the chat in the Black Pool desktop "
+         "app. Use this when the user asks to see a page, dev server, or file in the "
+         "preview pane — e.g. \"open cnn.com in the preview pane\" or \"preview "
+         "localhost:3000\". Accepts a web URL (a bare domain like www.cnn.com is fine), "
+diff --git a/tools/openrouter_client.py b/tools/openrouter_client.py
+index 9c85707..6bb35d8 100644
+--- a/tools/openrouter_client.py
++++ b/tools/openrouter_client.py
+@@ -1,4 +1,4 @@
+-"""Shared OpenRouter API client for Hermes tools.
++"""Shared OpenRouter API client for Black Pool tools.
+ 
+ Provides a single lazy-initialized AsyncOpenAI client that all tool modules
+ can share.  Routes through the centralized provider router in
+diff --git a/tools/plugin_guard.py b/tools/plugin_guard.py
+index 984337a..aef06ee 100644
+--- a/tools/plugin_guard.py
++++ b/tools/plugin_guard.py
+@@ -5,7 +5,7 @@ Plugin Guard — Security scanner for externally-installed plugins.
+ Inspired by Claude Cowork's skill & plugin security scanning (announced
+ 2026-08-06: third-party skills and plugins are automatically checked for
+ malicious content when someone uploads or edits them, returning pass /
+-warn / fail). Hermes already scans hub-installed *skills* via
++warn / fail). Black Pool already scans hub-installed *skills* via
+ ``tools/skills_guard.py``; this module extends the same static-analysis
+ engine to ``hermes plugins install`` and ``hermes plugins update``, which
+ previously cloned and executed arbitrary Git repositories unscanned.
+diff --git a/tools/process_registry.py b/tools/process_registry.py
+index b5fdf77..feded49 100644
+--- a/tools/process_registry.py
++++ b/tools/process_registry.py
+@@ -83,7 +83,7 @@ WATCH_GLOBAL_COOLDOWN_SECONDS = 30
+ # ---------------------------------------------------------------------------
+ # systemd cgroup isolation for gateway-spawned local executors (#70716)
+ # ---------------------------------------------------------------------------
+-# When Hermes runs as a systemd gateway with MemoryHigh/MemoryMax limits,
++# When Black Pool runs as a systemd gateway with MemoryHigh/MemoryMax limits,
+ # local background terminal commands inherit the gateway's cgroup.  A
+ # memory-heavy executor (Codex, tests, Node) can push the whole cgroup past
+ # MemoryMax and trigger systemd-oomd to kill the ENTIRE gateway — taking down
+@@ -246,7 +246,7 @@ def _systemd_run_user_scope_available() -> bool:
+ 
+ 
+ def _is_supervised_gateway_process() -> bool:
+-    """Return whether this process is in a supervised Hermes gateway runtime.
++    """Return whether this process is in a supervised Black Pool gateway runtime.
+ 
+     Both supervisor markers and ``_HERMES_GATEWAY`` are inherited by every
+     descendant, and importing ``gateway.run`` also sets the latter. Require
+@@ -2257,7 +2257,7 @@ class ProcessRegistry:
+         if sink is None:
+             return {
+                 "status": "error",
+-                "error": "close_terminal is only available in the Hermes desktop app.",
++                "error": "close_terminal is only available in the Black Pool desktop app.",
+             }
+         # The session may already be finished (or pruned) — the tab can still
+         # linger and be closed, so a missing session is not an error here.
+@@ -2963,7 +2963,7 @@ def format_process_notification(evt: dict) -> "str | None":
+     if _exit in {-15, 143, "-15", "143"}:
+         _signal = ", SIGTERM"
+     if _reason == "killed":
+-        _status = f"terminated by {_source or 'Hermes'}"
++        _status = f"terminated by {_source or 'Black Pool'}"
+     elif _reason == "lost":
+         _status = "marked lost because the process backend disappeared"
+     elif _reason == "failed_start":
+diff --git a/tools/react_to_message_tool.py b/tools/react_to_message_tool.py
+index 4fb759c..7509eb6 100644
+--- a/tools/react_to_message_tool.py
++++ b/tools/react_to_message_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Let the agent react to a message with an emoji in the Hermes desktop app.
++"""Let the agent react to a message with an emoji in the Black Pool desktop app.
+ 
+ The conversational counterpart to the user's tapback: the same reaction store,
+ the same one-per-author semantics, just written with ``author="agent"``.
+diff --git a/tools/read_preview_tool.py b/tools/read_preview_tool.py
+index b4cf196..493ca83 100644
+--- a/tools/read_preview_tool.py
++++ b/tools/read_preview_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Read the in-app browser / preview pane in the Hermes desktop GUI.
++"""Read the in-app browser / preview pane in the Black Pool desktop GUI.
+ 
+ The preview's content lives in the desktop renderer (a sandboxed ``<webview>``
+ for URL tabs), so this tool round-trips through the gateway's blocking-prompt
+@@ -25,7 +25,7 @@ def read_preview_tool(
+ ) -> str:
+     """Return the active preview tab's contents (+ metadata) as a JSON string."""
+     if callback is None:
+-        return tool_error("read_preview is only available in the Hermes desktop app.")
++        return tool_error("read_preview is only available in the Black Pool desktop app.")
+ 
+     try:
+         window = {
+@@ -55,7 +55,7 @@ READ_PREVIEW_SCHEMA = {
+     "name": "read_preview",
+     "description": (
+         "Read what's currently shown in the in-app browser / preview pane of the "
+-        "Hermes desktop GUI (the pane open_preview opens beside this chat). Call "
++        "Black Pool desktop GUI (the pane open_preview opens beside this chat). Call "
+         "with no arguments for the first window of the active tab's content. "
+         "Returns JSON {kind, url, title, text, start, end, total_chars, note?}: "
+         "a URL (Browser) tab's text is the rendered page's visible text — page "
+diff --git a/tools/read_terminal_tool.py b/tools/read_terminal_tool.py
+index 5cd977c..596138e 100644
+--- a/tools/read_terminal_tool.py
++++ b/tools/read_terminal_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Read the in-app terminal pane in the Hermes desktop GUI.
++"""Read the in-app terminal pane in the Black Pool desktop GUI.
+ 
+ The embedded terminal's buffer lives in the desktop renderer (xterm.js), so this
+ tool round-trips through the gateway's blocking-prompt bridge — the same one
+@@ -24,7 +24,7 @@ def read_terminal_tool(
+ ) -> str:
+     """Return the in-app terminal's contents (+ line metadata) as a JSON string."""
+     if callback is None:
+-        return tool_error("read_terminal is only available in the Hermes desktop app.")
++        return tool_error("read_terminal is only available in the Black Pool desktop app.")
+ 
+     try:
+         window = {
+@@ -53,7 +53,7 @@ def read_terminal_tool(
+ READ_TERMINAL_SCHEMA = {
+     "name": "read_terminal",
+     "description": (
+-        "Read what's currently shown in the in-app terminal pane of the Hermes "
++        "Read what's currently shown in the in-app terminal pane of the Black Pool "
+         "desktop GUI (the embedded shell beside this chat). Call with no arguments "
+         "to get the visible screen plus the total line count (`total_lines`). To "
+         "page through scrollback, pass `start_line` (0 = oldest line) and `count`; "
+diff --git a/tools/read_window_tool.py b/tools/read_window_tool.py
+index c5d3156..a976f23 100644
+--- a/tools/read_window_tool.py
++++ b/tools/read_window_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Read which OS window sits directly underneath the Hermes desktop window.
++"""Read which OS window sits directly underneath the Black Pool desktop window.
+ 
+ The window list lives with the OS, so this tool round-trips through the
+ gateway's blocking-prompt bridge — the same one `read_terminal` uses:
+@@ -16,10 +16,10 @@ from tools.registry import registry, tool_error
+ 
+ 
+ def read_window_below_tool(callback: Optional[Callable] = None) -> str:
+-    """Return the window underneath the Hermes window as a JSON string."""
++    """Return the window underneath the Black Pool window as a JSON string."""
+     if callback is None:
+         return tool_error(
+-            "read_window_below is only available in the Hermes desktop app."
++            "read_window_below is only available in the Black Pool desktop app."
+         )
+ 
+     try:
+@@ -44,11 +44,11 @@ READ_WINDOW_BELOW_SCHEMA = {
+     "name": "read_window_below",
+     "description": (
+         "Identify the application window directly underneath (behind) the "
+-        "Hermes desktop window — what the user is working in behind this app. "
++        "Black Pool desktop window — what the user is working in behind this app. "
+         "Returns JSON: {window: {app, title, bounds{x,y,width,height}, id}, "
+         "frontmost: {app, title}, platform}. `title` may be empty when the OS "
+         "withholds window titles (e.g. macOS without the Screen Recording "
+-        "permission — never prompted for, noted in `note`). Other Hermes "
++        "permission — never prompted for, noted in `note`). Other Black Pool "
+         "windows are skipped: the nearest non-Hermes window is reported. "
+         "Returns {error, platform} instead where the OS cannot enumerate "
+         "windows at all (e.g. a Wayland session); `error` says what would fix "
+diff --git a/tools/self_repo_guard.py b/tools/self_repo_guard.py
+index 53d3a96..0a82824 100644
+--- a/tools/self_repo_guard.py
++++ b/tools/self_repo_guard.py
+@@ -729,15 +729,15 @@ def detect_self_repo_git_mutation(
+ def _block_message(operation: str, root: Path) -> str:
+     scratch = _scratch_dir_hint()
+     return (
+-        f"Blocked: `{operation}` would rewrite Hermes's live source checkout "
++        f"Blocked: `{operation}` would rewrite Black Pool's live source checkout "
+         f"({root}) and can mix module versions in this running process. "
+         f"Use a separate worktree or a shared clone on real disk, e.g. "
+         f"`git clone --shared {root} {scratch}/<task>` — avoid /tmp for "
+         "clones that install node/python deps: /tmp is usually RAM-backed "
+         "tmpfs and a few dependency installs can fill it and ENOSPC other "
+         "work. Delete the clone when the branch is pushed. To change this "
+-        "checkout, stop Hermes, run the command externally, then restart "
+-        "Hermes."
++        "checkout, stop Black Pool, run the command externally, then restart "
++        "Black Pool."
+     )
+ 
+ 
 diff --git a/tools/session_search_tool.py b/tools/session_search_tool.py
-index c5752f5..0743a26 100644
+index c5752f5..e49181c 100644
 --- a/tools/session_search_tool.py
 +++ b/tools/session_search_tool.py
+@@ -1132,7 +1132,7 @@ SESSION_SEARCH_SCHEMA = {
+         "FTS5-backed retrieval over the SQLite message store. No LLM calls — every "
+         "shape returns actual messages from the DB.\n\n"
+         "SOURCE-FIRST LIMIT\n\n"
+-        "  This tool searches Hermes conversation history only. It is not evidence "
++        "  This tool searches Black Pool conversation history only. It is not evidence "
+         "about the current contents of external sources. If the user provided a "
+         "direct source such as a URL, phone number/contact, app/thread, file path, "
+         "account, website, or live system, inspect that original source before or "
+@@ -1184,7 +1184,7 @@ SESSION_SEARCH_SCHEMA = {
+         "  When you refer the user to a session, write its `link` value inline in "
+         "your reply — every result carries one, e.g. "
+         "`@session:default/20260722_204335_d62c16`. Copy it verbatim; do not "
+-        "reformat it as a markdown link or wrap it in backticks. Hermes renders "
++        "reformat it as a markdown link or wrap it in backticks. Black Pool renders "
+         "it as a link showing the session's title, so the link IS the title: "
+         "use it as a noun mid-sentence (\"that's @session:default/... — want me "
+         "to pick it up?\"), never alone on its own line, and never alongside the "
+@@ -1196,7 +1196,7 @@ SESSION_SEARCH_SCHEMA = {
+         "(`\"docker networking\"`), boolean (`python NOT java`), or prefix wildcards "
+         "(`deploy*`).\n\n"
+         "WHEN TO USE\n\n"
+-        "  Reach for this on questions about Hermes conversation history itself, such "
++        "  Reach for this on questions about Black Pool conversation history itself, such "
+         "as \"what did we do about X\", \"where did we leave Y\", or \"find the "
+         "session where Z\". If the user provided a direct source identifier, inspect "
+         "that source first when accessible; session_search can then supply historical "
 @@ -1284,7 +1284,7 @@ SESSION_SEARCH_SCHEMA = {
              "profile": {
                  "type": "string",
@@ -49954,10 +65103,41 @@ index c5752f5..0743a26 100644
                      "(read-only). Use when resolving an `@session:<profile>/<id>` link: "
                      "pass the profile segment here with session_id as the id segment. "
                      "Omit to use the current profile."
+diff --git a/tools/setup_mcp_tool.py b/tools/setup_mcp_tool.py
+index 765c502..c6fea35 100644
+--- a/tools/setup_mcp_tool.py
++++ b/tools/setup_mcp_tool.py
+@@ -31,7 +31,7 @@ def setup_mcp_tool(
+     """Ask the desktop GUI to run an MCP setup flow; return its JSON outcome."""
+     if callback is None:
+         return tool_error(
+-            "setup_mcp is only available in the Hermes desktop app. Use the "
++            "setup_mcp is only available in the Black Pool desktop app. Use the "
+             "terminal instead: `hermes mcp install <name>` for catalog entries, "
+             "`hermes mcp login <name>` for OAuth."
+         )
+@@ -75,7 +75,7 @@ SETUP_MCP_SCHEMA = {
+     "name": "setup_mcp",
+     "description": (
+         "Propose an MCP server to the user as an inline consent card in the "
+-        "Hermes desktop chat. The card lets them install a catalog entry, "
++        "Black Pool desktop chat. The card lets them install a catalog entry, "
+         "re-enable a disabled server, or run an OAuth login — right there, "
+         "without opening the Capabilities tab — and blocks until they act or "
+         "decline. Use when the user asks to add/set up an MCP (e.g. \"add the "
 diff --git a/tools/skill_linter.py b/tools/skill_linter.py
-index bce44d2..a11ab4e 100644
+index bce44d2..92be067 100644
 --- a/tools/skill_linter.py
 +++ b/tools/skill_linter.py
+@@ -11,7 +11,7 @@ instead of native tools, a missing author/license/metadata block, a
+ marketing words in the description, ``platforms:`` gating vs POSIX-only
+ primitives, and forbidden scaffolding files.
+ 
+-Design contract (matches the Hermes "no lazy-reading escape hatches / don't
++Design contract (matches the Black Pool "no lazy-reading escape hatches / don't
+ destroy the feature" posture):
+ 
+ * Findings are **advisory** by default. ``lint_skill`` returns a list of
 @@ -214,13 +214,13 @@ def _check_metadata_block(frontmatter: Dict[str, Any]) -> List[LintFinding]:
              )
      author = str(frontmatter.get("author", ""))
@@ -49975,7 +65155,7 @@ index bce44d2..a11ab4e 100644
              )
          )
 diff --git a/tools/skill_manager_tool.py b/tools/skill_manager_tool.py
-index b444056..2a8d6bc 100644
+index b444056..3d7c73b 100644
 --- a/tools/skill_manager_tool.py
 +++ b/tools/skill_manager_tool.py
 @@ -738,7 +738,7 @@ def _org_mirror_write_guard(name: str, skill_path: Path, action: str) -> Optiona
@@ -49987,21 +65167,607 @@ index b444056..2a8d6bc 100644
  
      Returns a list of ``(profile_name, skill_dir)`` pairs. Used to make
      the "Skill X not found" error explain when the user is editing the
+@@ -1000,7 +1000,7 @@ def _attach_lint_findings(result: Dict[str, Any], skill_md: Path) -> None:
+     result["lint_hint"] = (
+         "The skill was created. These are advisory authoring-convention "
+         "findings (not blockers) — fix them with skill_manage(action='patch') "
+-        "to match Hermes skill standards."
++        "to match Black Pool skill standards."
+     )
+ 
+ 
+diff --git a/tools/skill_usage.py b/tools/skill_usage.py
+index 4c30e86..8bf8d81 100644
+--- a/tools/skill_usage.py
++++ b/tools/skill_usage.py
+@@ -357,7 +357,7 @@ def list_agent_created_skill_names() -> List[str]:
+     names: List[str] = []
+     # Top-level SKILL.md files (flat layout) AND nested category/skill/SKILL.md
+     for skill_md in base.rglob("SKILL.md"):
+-        # Skip Hermes metadata, VCS, virtualenv/dependency, and cache dirs
++        # Skip Black Pool metadata, VCS, virtualenv/dependency, and cache dirs
+         if is_excluded_skill_path(skill_md):
+             continue
+         # External skill dirs can be mounted below the local skills tree.
+@@ -615,7 +615,7 @@ def adopt_skill(skill_name: str) -> Tuple[bool, str]:
+     if is_bundled(skill_name):
+         # Bundled skills already fall under the curator via
+         # ``curator.prune_builtins``; stamping created_by=agent on one would
+-        # claim Hermes' own shipped skill was agent-authored and change nothing
++        # claim Black Pool' own shipped skill was agent-authored and change nothing
+         # about its eligibility.
+         return False, (
+             f"'{skill_name}' is a bundled built-in — it is governed by "
+diff --git a/tools/skills_guard.py b/tools/skills_guard.py
+index 1f513fa..b9aeed7 100644
+--- a/tools/skills_guard.py
++++ b/tools/skills_guard.py
+@@ -9,7 +9,7 @@ and a trust-aware install policy that determines whether a skill is allowed
+ based on both the scan verdict and the source's trust level.
+ 
+ Trust levels:
+-  - builtin:   Ships with Hermes. Never scanned, always trusted.
++  - builtin:   Ships with Black Pool. Never scanned, always trusted.
+   - trusted:   openai/skills and anthropics/skills only. Caution verdicts allowed.
+   - community: Everything else. Any findings = blocked unless --force.
+ 
+@@ -137,7 +137,7 @@ THREAT_PATTERNS = [
+      "references Docker config (may contain registry creds)"),
+     (r'\$HOME/\.hermes/\.env|\~/\.hermes/\.env',
+      "hermes_env_access", "critical", "exfiltration",
+-     "directly references Hermes secrets file"),
++     "directly references Black Pool secrets file"),
+     # Match `cat <secrets-file>` (reading credentials) but NOT `cat > <file>`
+     # or `cat >> <file>`, which are output redirections that WRITE a file
+     # (e.g. a setup doc telling the user to write their own keys into their
+@@ -463,7 +463,7 @@ THREAT_PATTERNS = [
+      "references agent config files (could persist malicious instructions across sessions)"),
+     (r'\.hermes/config\.yaml|\.hermes/SOUL\.md',
+      "hermes_config_mod", "critical", "persistence",
+-     "references Hermes configuration files directly"),
++     "references Black Pool configuration files directly"),
+     (r'\.claude/settings|\.codex/config',
+      "other_agent_config", "high", "persistence",
+      "references other agent configuration files"),
+diff --git a/tools/skills_hub.py b/tools/skills_hub.py
+index aebc5a5..7b8d608 100644
+--- a/tools/skills_hub.py
++++ b/tools/skills_hub.py
+@@ -1,6 +1,6 @@
+ #!/usr/bin/env python3
+ """
+-Skills Hub — Source adapters and hub state management for the Hermes Skills Hub.
++Skills Hub — Source adapters and hub state management for the Black Pool Skills Hub.
+ 
+ This is a library module (not an agent tool). It provides:
+   - GitHubAuth: Shared GitHub API authentication (PAT, gh CLI, GitHub App)
+@@ -4217,7 +4217,7 @@ def check_for_skill_updates(
+ 
+ 
+ # ---------------------------------------------------------------------------
+-# Hermes centralized index source
++# Black Pool centralized index source
+ # ---------------------------------------------------------------------------
+ 
+ HERMES_INDEX_URL = "https://hermes-agent.nousresearch.com/docs/api/skills-index.json"
+@@ -4268,7 +4268,7 @@ def _load_hermes_index() -> Optional[dict]:
+                 headers={"Accept-Encoding": accept_encoding},
+             )
+             if resp.status_code != 200:
+-                logger.debug("Hermes index fetch returned %d", resp.status_code)
++                logger.debug("Black Pool index fetch returned %d", resp.status_code)
+                 return _load_stale_index_cache()
+             data = resp.json()
+             break
+@@ -4276,13 +4276,13 @@ def _load_hermes_index() -> Optional[dict]:
+             # Content-Encoding decode failed — retry once uncompressed before
+             # giving up on the network path entirely.
+             logger.debug(
+-                "Hermes index decode failed (Accept-Encoding=%s): %s",
++                "Black Pool index decode failed (Accept-Encoding=%s): %s",
+                 accept_encoding,
+                 e,
+             )
+             continue
+         except (httpx.HTTPError, json.JSONDecodeError) as e:
+-            logger.debug("Hermes index fetch failed: %s", e)
++            logger.debug("Black Pool index fetch failed: %s", e)
+             return _load_stale_index_cache()
+ 
+     if data is None:
+@@ -4314,7 +4314,7 @@ def _load_stale_index_cache() -> Optional[dict]:
+ 
+ 
+ class HermesIndexSource(SkillSource):
+-    """Skill source backed by the centralized Hermes Skills Index.
++    """Skill source backed by the centralized Black Pool Skills Index.
+ 
+     The index is a JSON catalog published to the docs site and rebuilt
+     daily by CI.  It contains metadata + resolved GitHub paths for every
+diff --git a/tools/skills_sync_client.py b/tools/skills_sync_client.py
+index 1689edb..8ad97f0 100644
+--- a/tools/skills_sync_client.py
++++ b/tools/skills_sync_client.py
+@@ -335,7 +335,7 @@ def resolve_sync_base_url() -> Optional[str]:
+ 
+ 
+ # ---------------------------------------------------------------------------
+-# Sync feature configuration — env-first, so a Hermes Cloud instance can be set
++# Sync feature configuration — env-first, so a Black Pool Cloud instance can be set
+ # up to use sync BY DEFAULT purely through environment variables (no per-user
+ # config.yaml edit, no per-skill CLI call). Every knob follows the same
+ # precedence as base_url: the HERMES_SYNC_* env var wins, else config.yaml
+@@ -392,7 +392,7 @@ def sync_feature_enabled() -> bool:
+     """Whether the sync feature is turned on for this instance (env-first).
+ 
+     ``HERMES_SYNC_ENABLED`` -> ``sync.enabled`` -> False. This is the master
+-    switch a Hermes Cloud deployment sets to opt its instances into sync by
++    switch a Black Pool Cloud deployment sets to opt its instances into sync by
+     default. It is checked by the gate-and-swallow entrypoints IN ADDITION to
+     the Nous-admin token gate and a configured base URL — all three must hold for
+     background sync to run.
+@@ -428,7 +428,7 @@ def sync_default_opt_in() -> bool:
+     ``hermes sync enable`` (or a plane manifest that opted it in). True: opt-OUT
+     — every sync-eligible skill is treated as opted in unless explicitly
+     disabled, which is the "your skills follow you with no setup" default a
+-    Hermes Cloud deployment wants. Per the design notes, this default is
++    Black Pool Cloud deployment wants. Per the design notes, this default is
+     provisional and expected to flip; exposing it as env config lets the
+     operator choose per deployment without a protocol change.
+     """
+@@ -486,7 +486,7 @@ def list_synced_skill_names() -> List[str]:
+ 
+     - **opt-in (default):** a skill syncs only when its usage record carries
+       ``sync: true`` AND it is eligible. Nothing syncs by default.
+-    - **opt-out (Hermes Cloud "on by default"):** every *eligible* skill syncs
++    - **opt-out (Black Pool Cloud "on by default"):** every *eligible* skill syncs
+       UNLESS its usage record explicitly carries ``sync: false``. This is what a
+       deployment sets (via ``HERMES_SYNC_DEFAULT_OPT_IN``) so a user's skills
+       follow them with no per-skill setup.
+@@ -692,7 +692,7 @@ def stable_device_id() -> str:
+     except OSError:
+         pass
+ 
+-    # Hermes Cloud (and any templated deployment) can seed the label
++    # Black Pool Cloud (and any templated deployment) can seed the label
+     # declaratively via HERMES_SYNC_DEVICE_NAME, so a hosted instance shows a
+     # recognizable name with no CLI call. Env seeds the FIRST-USE value only; it
+     # is then persisted, so a later `hermes sync device --name` (or editing the
+@@ -1246,8 +1246,8 @@ def _check_version(caps: Dict[str, Any]) -> None:
+     major = ver.split(".", 1)[0]
+     if major != WIRE_VERSION:
+         raise SyncError(
+-            f"this server speaks sync version {ver!r}, but this Hermes speaks "
+-            f"{WIRE_VERSION} — update Hermes to sync with it"
++            f"this server speaks sync version {ver!r}, but this Black Pool speaks "
++            f"{WIRE_VERSION} — update Black Pool to sync with it"
+         )
+ 
+ 
+diff --git a/tools/terminal_tool.py b/tools/terminal_tool.py
+index 0d90fe5..a279607 100644
+--- a/tools/terminal_tool.py
++++ b/tools/terminal_tool.py
+@@ -21,7 +21,7 @@ Features:
+ 
+ Cloud sandbox note:
+ - Persistent filesystems preserve working state across sandbox recreation
+-- Persistent filesystems do NOT guarantee the same live sandbox or long-running processes survive cleanup, idle reaping, or Hermes exit
++- Persistent filesystems do NOT guarantee the same live sandbox or long-running processes survive cleanup, idle reaping, or Black Pool exit
+ 
+ Usage:
+     from terminal_tool import terminal_tool
+@@ -1036,11 +1036,11 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
+     )
+ 
+     # Local hosts with sudoers NOPASSWD should not be forced through the
+-    # interactive Hermes password prompt or the sudo -S password-pipe path.
++    # interactive Black Pool password prompt or the sudo -S password-pipe path.
+     # Scoped to the local terminal backend so Docker/SSH/Modal/etc. can't
+     # inherit host sudo state. Re-probes every call (no process-lifetime
+     # cache) so an expired sudo timestamp doesn't make a later command block
+-    # silently without Hermes prompting.
++    # silently without Black Pool prompting.
+     if not has_configured_password and not sudo_password and _sudo_nopasswd_works():
+         return command, None
+ 
+@@ -1082,7 +1082,7 @@ NEVER pipe a build/test command through tail/head/cat to shorten output (e.g. `c
+ Environment state persists: activate a virtualenv or export variables once per session, not before every command.
+ 
+ Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.
+-Background: set background=true (returns a session_id). Pair with notify_on_complete=true for bounded tasks; leave silent only for servers/daemons that never exit. Never use nohup/setsid/trailing '&' — use background=true so Hermes tracks the process. After starting a server, verify readiness with a health check, then act in a separate call; no blind sleep loops. Manage with process(action="poll"/"wait").
++Background: set background=true (returns a session_id). Pair with notify_on_complete=true for bounded tasks; leave silent only for servers/daemons that never exit. Never use nohup/setsid/trailing '&' — use background=true so Black Pool tracks the process. After starting a server, verify readiness with a health check, then act in a separate call; no blind sleep loops. Manage with process(action="poll"/"wait").
+ Working directory: use 'workdir' for per-command cwd. When a command changes the session cwd (cd, pushd), the result includes a "cwd" field — trust it instead of prefixing every command with 'cd'.
+ PTY: set pty=true for interactive CLIs (they hang without it). Pipe git output to cat if it might page.
+ """
+@@ -1108,7 +1108,7 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
+ 
+     Sweeps long-Exited containers labeled ``hermes-agent=1`` for the current
+     profile that match the issue #20561 leak class — containers left behind
+-    by Hermes processes that exited without firing ``atexit`` (SIGKILL,
++    by Black Pool processes that exited without firing ``atexit`` (SIGKILL,
+     OOM, terminal-window-close). The reaper is conservative by default:
+     only Exited containers older than ``2 × lifetime_seconds`` and scoped to
+     the current profile.
+@@ -1117,7 +1117,7 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
+ 
+     * ``terminal.docker_orphan_reaper: false`` disables it entirely (the
+       operator opted out — usually because they're running multiple
+-      Hermes processes in the same profile and don't trust the
++      Black Pool processes in the same profile and don't trust the
+       conservative defaults).
+     * ``_docker_orphan_reaper_ran`` flag — sweep runs once per Python
+       interpreter, not on every subagent / RL-rollout / parallel
+@@ -1135,7 +1135,7 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
+             return
+         _docker_orphan_reaper_ran = True
+ 
+-    # 2 × lifetime_seconds gives sibling Hermes processes a generous grace
++    # 2 × lifetime_seconds gives sibling Black Pool processes a generous grace
+     # window. Floor at 60s so an operator with TERMINAL_LIFETIME_SECONDS=0
+     # doesn't get an instant-reap that races their own setup.
+     # ``container_config`` only carries container_* keys, so read
+@@ -1791,7 +1791,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
+     
+     elif env_type == "docker":
+         # One-shot orphan reaper: clean up labeled containers left behind by
+-        # prior Hermes processes that hit SIGKILL / OOM / a closed terminal
++        # prior Black Pool processes that hit SIGKILL / OOM / a closed terminal
+         # before the atexit cleanup hook could run.  Gated to once per
+         # process so concurrent _create_environment calls (parallel
+         # subagents, RL benchmarks) don't run the reaper N times.
+@@ -2512,7 +2512,7 @@ def _foreground_background_guidance(command: str) -> str | None:
+         return (
+             "Foreground command uses shell-level background wrappers (nohup/disown/setsid). "
+             "Re-send WITHOUT the wrapper as terminal(command=\"<cmd>\", background=true, "
+-            "notify_on_complete=true) so Hermes tracks the process, then run readiness "
++            "notify_on_complete=true) so Black Pool tracks the process, then run readiness "
+             "checks and tests in separate commands."
+         )
+ 
+@@ -2866,7 +2866,7 @@ def terminal_tool(
+                     "error": (
+                         "Blocked: launchctl submit/bootstrap registers a persistent "
+                         "KeepAlive job and is unsafe from inside the gateway process. "
+-                        "Use Hermes cron for one-shot delayed work, or install an "
++                        "Use Black Pool cron for one-shot delayed work, or install an "
+                         "explicit LaunchAgent from a separate shell."
+                     ),
+                     "status": "error",
+diff --git a/tools/thread_context.py b/tools/thread_context.py
+index 8d9a272..d361697 100644
+--- a/tools/thread_context.py
++++ b/tools/thread_context.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Propagate agent-turn context into worker threads that dispatch Hermes tools.
++"""Propagate agent-turn context into worker threads that dispatch Black Pool tools.
+ 
+ A bare ``threading.Thread`` / ``ThreadPoolExecutor`` worker starts with an
+ empty ``contextvars.Context`` and no thread-local approval/sudo callbacks.
+diff --git a/tools/tirith_security.py b/tools/tirith_security.py
+index a284c6d..886c3ac 100644
+--- a/tools/tirith_security.py
++++ b/tools/tirith_security.py
+@@ -163,7 +163,7 @@ _MARKER_TTL = 86400  # 24 hours
+ 
+ 
+ def _get_hermes_home() -> str:
+-    """Return the Hermes home directory, respecting HERMES_HOME env var."""
++    """Return the Black Pool home directory, respecting HERMES_HOME env var."""
+     return str(get_hermes_home())
+ 
+ 
 diff --git a/tools/tool_search.py b/tools/tool_search.py
-index 1357054..910be9d 100644
+index 1357054..453a37e 100644
 --- a/tools/tool_search.py
 +++ b/tools/tool_search.py
-@@ -1,4 +1,4 @@
+@@ -1,8 +1,8 @@
 -"""Progressive tool disclosure ("tool search") for Hermes Agent.
 +"""Progressive tool disclosure ("tool search") for Black Pool Agent.
  
  When enabled, MCP and non-core plugin tools are replaced in the model-visible
  tools array by three bridge tools — ``tool_search``, ``tool_describe``,
+-``tool_call`` — and surfaced on demand. Core Hermes tools never defer.
++``tool_call`` — and surfaced on demand. Core Black Pool tools never defer.
+ 
+ Design constraints this module is built around (see ``openclaw-tool-search-report``
+ for the full rationale):
+diff --git a/tools/tour_tool.py b/tools/tour_tool.py
+index 9893020..d0a6222 100644
+--- a/tools/tour_tool.py
++++ b/tools/tour_tool.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-"""Run a guided tour (highlight + narrate UI elements) in the Hermes desktop GUI.
++"""Run a guided tour (highlight + narrate UI elements) in the Black Pool desktop GUI.
+ 
+ One generic tool, no baked-in tour definitions: the agent discovers what is on
+ screen (``action="targets"``), then highlights any element by CSS selector with
+@@ -8,7 +8,7 @@ full step list the user pages through with Next/Prev (``start``).
+ 
+ Two surfaces share the same engine (driver.js in the renderer):
+ 
+-- ``surface="app"`` — the Hermes desktop app's own DOM (tours of Hermes itself).
++- ``surface="app"`` — the Black Pool desktop app's own DOM (tours of Black Pool itself).
+ - ``surface="preview"`` — the page loaded in the in-app browser/preview pane
+   (tours of ANY web app, e.g. a project open via open_preview).
+ 
+@@ -45,7 +45,7 @@ def tour_tool(
+ ) -> str:
+     """Dispatch one tour action to the desktop renderer and return its outcome."""
+     if callback is None:
+-        return tool_error("tour is only available in the Hermes desktop app.")
++        return tool_error("tour is only available in the Black Pool desktop app.")
+ 
+     verb = (action or "").strip().lower()
+     if verb not in ACTIONS:
+@@ -127,9 +127,9 @@ _STEP_SCHEMA = {
+ TOUR_SCHEMA = {
+     "name": "tour",
+     "description": (
+-        "Give a live guided tour in the Hermes desktop GUI: dim the screen, "
++        "Give a live guided tour in the Black Pool desktop GUI: dim the screen, "
+         "highlight an element, and attach a popover with your own title/text. "
+-        "Works on two surfaces — 'app' (the Hermes app itself) and 'preview' "
++        "Works on two surfaces — 'app' (the Black Pool app itself) and 'preview' "
+         "(whatever page is open in the in-app browser, so any web app can be "
+         "toured). ALWAYS call action='targets' first to discover what is on "
+         "screen instead of guessing selectors; each target reports "
+@@ -155,7 +155,7 @@ TOUR_SCHEMA = {
+             "surface": {
+                 "type": "string",
+                 "enum": list(SURFACES),
+-                "description": "Where the tour runs: 'app' (Hermes desktop UI, default) or 'preview' (the page in the in-app browser pane).",
++                "description": "Where the tour runs: 'app' (Black Pool desktop UI, default) or 'preview' (the page in the in-app browser pane).",
+             },
+             "selector": {
+                 "type": "string",
+diff --git a/tools/transcription_tools.py b/tools/transcription_tools.py
+index 9a38929..829886d 100644
+--- a/tools/transcription_tools.py
++++ b/tools/transcription_tools.py
+@@ -360,7 +360,7 @@ def _try_lazy_install_stt() -> bool:
+     except Exception as exc:
+         logger.warning(
+             "Lazy install of faster-whisper failed: %s. "
+-            "This is often a permission issue: the Hermes process user cannot "
++            "This is often a permission issue: the Black Pool process user cannot "
+             "write to the virtual environment. Try running manually as the "
+             "venv owner: `stat -c '%%u' '$(dirname $(dirname $(which python3)))'` "
+             "then `su - <owner> -c 'VIRTUAL_ENV=/opt/hermes/.venv "
+@@ -485,7 +485,7 @@ def _resolve_command_stt_provider_config(
+ 
+ 
+ def _is_local_stt_provider(provider: str, stt_config: Dict[str, Any]) -> bool:
+-    """Return whether *provider* is exempt from Hermes's remote upload cap."""
++    """Return whether *provider* is exempt from Black Pool's remote upload cap."""
+     key = (provider or "").lower().strip()
+     if key in {"local", "local_command"}:
+         return True
+@@ -696,7 +696,7 @@ def _command_stt_env_passthrough(config: Dict[str, Any]) -> list:
+     """Return the provider's ``env_passthrough`` allowlist (opt-out of scrub).
+ 
+     Command providers legitimately reference their own API keys in the shell
+-    template (curl one-liners). The child env is scrubbed of Hermes secrets by
++    template (curl one-liners). The child env is scrubbed of Black Pool secrets by
+     default; ``env_passthrough: [MY_API_KEY, ...]`` copies the named variables
+     back from the parent environment so a trusted template keeps working.
+     Mirrors ``tools.tts_tool._command_provider_env_passthrough``.
+@@ -718,7 +718,7 @@ def _run_command_stt(
+     timeout, reset whenever the command emits output on stdout/stderr —
+     a slow-but-alive provider survives, a silently stalled one is killed
+     (same progress-based stuck detection as the TTS runner, #50081).
+-    Child env is scrubbed of Hermes secrets (salvage of #56332) while still
++    Child env is scrubbed of Black Pool secrets (salvage of #56332) while still
+     propagating delegated-child lineage markers when applicable.
+     """
+     from agent.delegation_context import delegated_child_subprocess_env
+@@ -2111,7 +2111,7 @@ def _transcribe_local_command(
+                 language=shlex.quote(language),
+                 model=shlex.quote(normalized_model),
+             )
+-            # Scrub Hermes secrets from the child env (sibling path to #56332 /
++            # Scrub Black Pool secrets from the child env (sibling path to #56332 /
+             # _run_command_stt — this local-whisper path previously inherited
+             # the full process environment).
+             from tools.environments.local import hermes_subprocess_env
+diff --git a/tools/tts_streaming.py b/tools/tts_streaming.py
+index aa0f1e4..ce98e92 100644
+--- a/tools/tts_streaming.py
++++ b/tools/tts_streaming.py
+@@ -1,6 +1,6 @@
+ """Provider-agnostic streaming TTS: sentence text → int16 PCM chunk iterator.
+ 
+-The keystone of Hermes' conversational voice UX. `stream_tts_to_speaker`
++The keystone of Black Pool' conversational voice UX. `stream_tts_to_speaker`
+ (``tools.tts_tool``) owns the sentence buffer, sounddevice output, and
+ stop/queue protocol; this module owns the *provider* half — turning one
+ sentence into audio the moment it's ready, so playback starts on sentence one
+diff --git a/tools/tts_tool.py b/tools/tts_tool.py
+index 3aa4875..72ff180 100644
+--- a/tools/tts_tool.py
++++ b/tools/tts_tool.py
+@@ -16,7 +16,7 @@ Built-in TTS providers:
+ 
+ Custom command providers:
+ - Users can declare any number of named providers with ``type: command``
+-  under ``tts.providers.<name>`` in ``~/.hermes/config.yaml``. Hermes
++  under ``tts.providers.<name>`` in ``~/.hermes/config.yaml``. Black Pool
+   writes the input text to a temp file and runs the configured shell
+   command, which must produce the audio file at the expected path.
+   See the Local Command section of ``website/docs/user-guide/features/tts.md``.
+@@ -752,7 +752,7 @@ def _resolve_minimax_tts_runtime(
+ #
+ # Users can declare any number of command-type providers alongside the
+ # built-ins so they can plug any local CLI (Piper, VoxCPM, Kokoro CLIs,
+-# custom voice-cloning scripts, etc.) into Hermes without any Python code
++# custom voice-cloning scripts, etc.) into Black Pool without any Python code
+ # changes. The config shape is::
+ #
+ #     tts:
+@@ -763,7 +763,7 @@ def _resolve_minimax_tts_runtime(
+ #           command: "piper -m ~/model.onnx -f {output_path} < {input_path}"
+ #           output_format: wav
+ #
+-# Hermes writes the input text to a temp UTF-8 file, runs the command with
++# Black Pool writes the input text to a temp UTF-8 file, runs the command with
+ # placeholder substitution, and reads the audio file the command wrote to
+ # ``{output_path}``. Supported placeholders: ``{input_path}``,
+ # ``{text_path}`` (alias for input_path), ``{output_path}``, ``{format}``,
+@@ -1175,7 +1175,7 @@ def _command_provider_env_passthrough(config: Dict[str, Any]) -> list:
+     """Return the provider's ``env_passthrough`` allowlist (opt-out of scrub).
+ 
+     Command providers legitimately reference their own API keys in the shell
+-    template (curl one-liners). The child env is scrubbed of Hermes secrets by
++    template (curl one-liners). The child env is scrubbed of Black Pool secrets by
+     default; ``env_passthrough: [MY_API_KEY, ...]`` copies the named variables
+     back from the parent environment so a trusted template keeps working.
+     """
+@@ -1192,7 +1192,7 @@ def _run_command_tts(
+ ) -> subprocess.CompletedProcess:
+     """Run a command-provider shell command with process-tree idle cleanup.
+ 
+-    Child env is scrubbed of Hermes secrets (salvage of #56332) while still
++    Child env is scrubbed of Black Pool secrets (salvage of #56332) while still
+     propagating delegated-child lineage markers when applicable.
+     """
+     from agent.delegation_context import delegated_child_subprocess_env
+@@ -2169,7 +2169,7 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
+         ).strip().rstrip("/")
+ 
+     # Match the documented minimal POST /v1/tts shape by default. Only send
+-    # output_format when Hermes actually needs a non-default format/override.
++    # output_format when Black Pool actually needs a non-default format/override.
+     codec = "wav" if output_path.endswith(".wav") else "mp3"
+     payload: Dict[str, Any] = {
+         "text": text,
+@@ -2680,7 +2680,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
+             _hermes_version = str(_hermes_cli.__version__)
+         except Exception:
+             _hermes_version = "0.0.0"
+-        # Include Hermes client context following Gemini's partner
++        # Include Black Pool client context following Gemini's partner
+         # integration guidance:
+         # https://ai.google.dev/gemini-api/docs/partner-integration
+         headers["X-Goog-Api-Client"] = f"hermes-agent/{_hermes_version}"
+@@ -2909,7 +2909,7 @@ def _check_piper_available() -> bool:
+ 
+ 
+ def _get_piper_voices_dir() -> Path:
+-    """Return the directory where Hermes caches Piper voice models.
++    """Return the directory where Black Pool caches Piper voice models.
+ 
+     Resolves to ``~/.hermes/cache/piper-voices/`` under the active
+     HERMES_HOME so voice downloads follow profile boundaries.
+diff --git a/tools/voice_mode.py b/tools/voice_mode.py
+index 80652bd..f081d38 100644
+--- a/tools/voice_mode.py
++++ b/tools/voice_mode.py
+@@ -124,7 +124,7 @@ from hermes_constants import is_termux as _is_termux_environment
+ def _voice_capture_install_hint() -> str:
+     if _is_termux_environment():
+         return "pkg install python-numpy portaudio && python -m pip install sounddevice"
+-    # If we're running inside a venv (e.g. the bundled Hermes venv at
++    # If we're running inside a venv (e.g. the bundled Black Pool venv at
+     # ~/.hermes/profiles/<name>/hermes-agent/venv/), `pip install` on the
+     # user's PATH won't reach the right site-packages — the bare hint sends
+     # them off to whichever Python their shell resolves first, which on macOS
+@@ -302,7 +302,7 @@ def detect_audio_environment() -> dict:
+             warnings.append(
+                 "Running over SSH -- no audio devices available.\n"
+                 "  If a sound server (PulseAudio/PipeWire) is running on this host,\n"
+-                "  point Hermes at it, e.g.:\n"
++                "  point Black Pool at it, e.g.:\n"
+                 "    export XDG_RUNTIME_DIR=/run/user/$(id -u)\n"
+                 "    # or: export PULSE_SERVER=unix:$XDG_RUNTIME_DIR/pulse/native"
+             )
+@@ -1312,7 +1312,7 @@ def is_voice_stop_phrase(transcript: str, stop_phrases: Optional[tuple] = None)
+ 
+ 
+ # Similarity ratio (difflib.SequenceMatcher, 0..1) above which a
+-# playback-phase barge transcript is treated as a self-capture of Hermes'
++# playback-phase barge transcript is treated as a self-capture of Black Pool'
+ # own just-spoken TTS rather than genuine user speech. See #75780: the
+ # full-duplex listener has no acoustic echo cancellation, so speaker bleed
+ # on the mic can trip the barge trigger and get transcribed nearly
+@@ -1342,9 +1342,9 @@ def is_tts_echo(
+     """Return True when *transcript* looks like a self-capture of *spoken_text*.
+ 
+     Compares a playback-phase barge-in transcript against the TTS text
+-    Hermes just spoke using a character-level similarity ratio, which works
++    Black Pool just spoke using a character-level similarity ratio, which works
+     across languages without word-tokenization. A genuine user interjection
+-    is very unlikely to closely match Hermes' own words, so a high ratio is
++    is very unlikely to closely match Black Pool' own words, so a high ratio is
+     a strong signal of speaker-bleed self-capture (fail-closed guard for the
+     playback-phase full-duplex listener, which has no acoustic echo
+     cancellation; see #75780).
+@@ -1707,7 +1707,7 @@ def _play_audio_file_impl(file_path: str) -> bool:
+     # ffmpeg are available, convert the audio to a uniquely-named WAV in the
+     # Windows %TEMP% directory and play it via Media.SoundPlayer -- which
+     # always has a working audio device on the Windows host (#17608).
+-    # A unique suffix prevents concurrent Hermes TTS calls from colliding on
++    # A unique suffix prevents concurrent Black Pool TTS calls from colliding on
+     # the same filename. The WAV is deleted in the shell pipeline
+     # unconditionally (success or failure), and the ORIGINAL ffmpeg/
+     # powershell exit status is preserved past that cleanup so the player
+diff --git a/tools/wake_word.py b/tools/wake_word.py
+index f433dc6..12367fa 100644
+--- a/tools/wake_word.py
++++ b/tools/wake_word.py
+@@ -1,9 +1,9 @@
+-"""Wake-word ("Hey Hermes") detection — hands-free session trigger.
++"""Wake-word ("Hey Black Pool") detection — hands-free session trigger.
+ 
+ A lightweight, always-on hotword listener that fires a callback when a wake
+ phrase is spoken — the "Hey Siri" / "Alexa" pattern. Shared by the CLI, TUI, and
+ desktop GUI (one of them owns it, gated by ``wake_surface_enabled``): say the
+-wake word, Hermes opens a fresh session and captures voice via the existing
++wake word, Black Pool opens a fresh session and captures voice via the existing
+ pipeline, then answers.
+ 
+ Three engines, all fully on-device (no audio leaves the machine for detection):
+@@ -476,7 +476,7 @@ def silent_audio_hint(details: Dict[str, Any]) -> str:
+     """Platform-specific remediation for an armed stream delivering silence."""
+     if sys.platform == "darwin":
+         return (
+-            "Microphone delivers only silence. Grant the Hermes backend "
++            "Microphone delivers only silence. Grant the Black Pool backend "
+             "microphone access in System Settings > Privacy & Security > "
+             "Microphone, then toggle the wake word."
+         )
+diff --git a/tools/web_tools.py b/tools/web_tools.py
+index d215b9e..17541cb 100644
+--- a/tools/web_tools.py
++++ b/tools/web_tools.py
+@@ -4,7 +4,7 @@ Standalone Web Tools Module
+ 
+ This module provides generic web tools that work with multiple backend providers.
+ Backend is selected during ``hermes tools`` setup (web.backend in config.yaml).
+-When available, Hermes can route Firecrawl calls through a Nous-hosted tool-gateway
++When available, Black Pool can route Firecrawl calls through a Nous-hosted tool-gateway
+ for Nous Subscribers only.
+ 
+ Available tools:
+@@ -121,10 +121,10 @@ def _web_extract_url(value: Any) -> Optional[str]:
+ # ─── Backend Selection ────────────────────────────────────────────────────────
+ 
+ def _env_value(name: str) -> str:
+-    """Resolve ``name`` via Hermes config-aware env, falling back to process env.
++    """Resolve ``name`` via Black Pool config-aware env, falling back to process env.
+ 
+     Mirrors the SearXNG provider's ``_searxng_url()`` so that values set
+-    through Hermes' config/.env layer (``hermes config set``, ``hermes tools``)
++    through Black Pool' config/.env layer (``hermes config set``, ``hermes tools``)
+     are honored here too — not just raw process-env exports. Without this,
+     a config-only ``SEARXNG_URL`` (or any provider key) leaves the backend
+     auto-detect cascade and ``check_web_api_key()`` blind to it. See #34290.
 diff --git a/tools/xai_http.py b/tools/xai_http.py
-index 58a7941..1b8f998 100644
+index 58a7941..ee90ad6 100644
 --- a/tools/xai_http.py
 +++ b/tools/xai_http.py
-@@ -105,7 +105,7 @@ def hermes_xai_default_headers() -> Dict[str, str]:
+@@ -105,14 +105,14 @@ def hermes_xai_default_headers() -> Dict[str, str]:
      """Default headers for OpenAI-SDK and raw HTTP clients talking to xAI.
  
      Replaces the OpenAI Python SDK's identifying ``User-Agent: OpenAI/Python …``
@@ -50010,6 +65776,32 @@ index 58a7941..1b8f998 100644
      matching the direct HTTP integrations (search, TTS, STT, image, video).
      """
      return {"User-Agent": hermes_xai_user_agent()}
+ 
+ 
+ def _load_config_section(section_name: str) -> Dict[str, Any]:
+-    """Return a top-level Hermes config section as a dict, or empty."""
++    """Return a top-level Black Pool config section as a dict, or empty."""
+     try:
+         from hermes_cli.config import load_config
+ 
+@@ -236,7 +236,7 @@ def xai_storage_notice_text(section_name: str) -> str:
+ 
+ 
+ def maybe_mark_xai_storage_notice_seen(section_name: str) -> Optional[str]:
+-    """Return the storage notice once per Hermes home, then mark it seen."""
++    """Return the storage notice once per Black Pool home, then mark it seen."""
+     notice = xai_storage_notice_text(section_name)
+     if not notice:
+         return None
+@@ -303,7 +303,7 @@ def resolve_xai_http_credentials(
+ 
+     Prefers Hermes-managed xAI OAuth credentials when available, then falls back
+     to ``XAI_API_KEY`` resolved via ``hermes_cli.config.get_env_value`` so keys
+-    stored in ``~/.hermes/.env`` (the standard Hermes location) are honored —
++    stored in ``~/.hermes/.env`` (the standard Black Pool location) are honored —
+     not just ones already exported into ``os.environ``. This keeps direct xAI
+     endpoints (images, TTS, STT, etc.) aligned with the main runtime auth model
+     and preserves the regression contract from PR #17140 / #17163.
 diff --git a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
 index d36dbfa..fe0a017 100644
 --- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -51990,10 +67782,10 @@ index 3285469..a85ed57 100644
    },
  
 diff --git a/web/src/index.css b/web/src/index.css
-index e4b5e27..808f04d 100644
+index e4b5e27..c06eb76 100644
 --- a/web/src/index.css
 +++ b/web/src/index.css
-@@ -43,13 +43,13 @@
+@@ -43,7 +43,7 @@
  }
  
  /* ------------------------------------------------------------------ */
@@ -52002,13 +67794,6 @@ index e4b5e27..808f04d 100644
     statically as the default dashboard theme. */
  /* ------------------------------------------------------------------ */
  
- :root {
-   /* LENS_0 — from design-language/src/ui/components/overlays/index.tsx.
--     These are the defaults for the `default` (Hermes Teal) dashboard theme;
-+     These are the defaults for the `default` (Black Pool Teal) dashboard theme;
-      ThemeProvider rewrites them as inline styles when a user switches themes. */
-   --foreground: color-mix(in srgb, #ffffff 0%, transparent);
-   --foreground-base: #ffffff;
 diff --git a/web/src/lib/gatewayClient.ts b/web/src/lib/gatewayClient.ts
 index 29fd891..ce6f02b 100644
 --- a/web/src/lib/gatewayClient.ts
@@ -52346,28 +68131,15 @@ index f040a58..832fd55 100644
   *  - `header-banner`    — injected below the top nav bar, full-width
   *  - `sidebar`          — the cockpit sidebar rail (only rendered when
 diff --git a/web/src/themes/presets.ts b/web/src/themes/presets.ts
-index fdf1593..0179ce1 100644
+index fdf1593..7d689e7 100644
 --- a/web/src/themes/presets.ts
 +++ b/web/src/themes/presets.ts
-@@ -40,8 +40,8 @@ const DEFAULT_LAYOUT: ThemeLayout = {
- 
+@@ -41,7 +41,7 @@ const DEFAULT_LAYOUT: ThemeLayout = {
  export const defaultTheme: DashboardTheme = {
    name: "default",
--  label: "Hermes Teal",
+   label: "Hermes Teal",
 -  description: "Classic dark teal — the canonical Hermes look",
-+  label: "Black Pool Teal",
 +  description: "Classic dark teal — the canonical Black Pool look",
    palette: {
      background: { hex: "#041c1c", alpha: 1 },
      midground: { hex: "#ffe6cb", alpha: 1 },
-@@ -214,8 +214,8 @@ export const nousBlueTheme: DashboardTheme = {
-  */
- export const defaultLargeTheme: DashboardTheme = {
-   name: "default-large",
--  label: "Hermes Teal (Large)",
--  description: "Hermes Teal with bigger fonts and roomier spacing",
-+  label: "Black Pool Teal (Large)",
-+  description: "Black Pool Teal with bigger fonts and roomier spacing",
-   palette: defaultTheme.palette,
-   typography: {
-     ...DEFAULT_TYPOGRAPHY,

--- a/tests/test_hermes_charter.py
+++ b/tests/test_hermes_charter.py
@@ -111,9 +111,14 @@ def test_bare_word_scope_safety():
 
     前端三处目录的风险面已由上一条守着；agent/ 入列带来的是 Python 侧的新风险：
     产物路径（`Hermes.app`/`.exe`）、URL、环境变量名、import 语句里若含裸词，
-    换成含空格的品牌名即坏功能。入列前逐条核过为零命中，此测锁住这个状态——
-    下一层（hermes_cli / gateway / tools）铺开时，这些模式会真的出现，届时必须
-    先加豁免再入列，而不是让它无声打断。
+    换成含空格的品牌名即坏功能。入列前逐条核过为零命中，此测锁住这个状态。
+
+    **下一层已于 2026-08-25 铺开**（hermes_cli / gateway / tools / plugins /
+    acp_adapter / skills 六目录，守密人四项交互裁定）。届时逐条复核的结论与本测
+    第 121 行注释既有的判词一致：`.exe`/`.app`/`.desktop` 不入豁免——它们指的是
+    黑池自己的 electron-builder 产物，名字随 productName 走。真正入豁免的只有
+    上游/外部自有名（Hermes Teal / Hermes Index / Hermes Tools），见
+    `rebrand.BARE_WORD_EXEMPT` 与 test_upstream_own_names_stay_exempt。
     """
     added = [l for l in PATCH_BRAND.read_text(encoding="utf-8").splitlines()
              if l.startswith("+") and not l.startswith("+++")]
@@ -130,6 +135,80 @@ def test_bare_word_scope_safety():
             for why, rx in patterns.items()}
     hits = {k: v for k, v in hits.items() if v}
     assert not hits, f"裸词换装打断了功能标识: {hits}"
+
+
+def test_bare_word_rollout_reaches_six_new_dirs():
+    """裸词换装铺开六目录（2026-08-25 守密人裁定）后的**有效性**守卫。
+
+    与上一条互补：上一条问「有没有误伤功能标识」，本条问「该换的到底换没换」。
+    起因是守密人现场反馈「品牌补丁不够完整，很多状态提示还是 hermes」——实测
+    hermes_cli 420 / plugins 115 / tools 70 / gateway 38 / acp_adapter 11 /
+    skills 5 共 659 处生产字符串从没进过射程。逐条挑的是**用户直面**的状态提示，
+    退一条即意味着某个目录悄悄掉出射程（例如只改 BARE_WORD_DIRS 忘了改
+    RUNTIME_DIRS——那是本轮真踩过的坑，两表是两道闸，须同进同退）。
+    """
+    rebrand = _load_rebrand()
+    # 两道闸必须同进同退：裸词目录不得有任何一个落在扫描白名单之外。
+    runtime = set(rebrand.RUNTIME_DIRS)
+    missing = [d for d in rebrand.BARE_WORD_DIRS if d not in runtime]
+    assert not missing, f"这些目录进了裸词表却没进扫描白名单（配了钥匙没开门）: {missing}"
+
+    text = PATCH_BRAND.read_text(encoding="utf-8")
+    for phrase, why in (
+        ("⚕ Black Pool", "CLI Rich 面板标题"),
+        ("Starting Black Pool Gateway...", "网关启动日志"),
+        ("Black Pool Console", "控制台标题"),
+        ("Show Black Pool component status.", "console status 命令描述"),
+        ("StartupWMClass=Black Pool", "Linux 桌面项窗口类（须与 executableName 一致）"),
+        ('release_dir / "win-unpacked" / "Black Pool.exe"', "桌面产物路径随 productName"),
+    ):
+        assert phrase in text, f"该换的没换（{why}）: {phrase!r}"
+
+
+def test_upstream_own_names_stay_exempt():
+    """外部 / 上游自有名九处豁免（守密人 2026-08-25 裁定）。
+
+    入 2026-08-03 Nous Portal 图标先例：对方自有之物不戴黑池面具。改了不只是失礼——
+    `Hermes Teal` 描述的是上游青调皮肤（黑池自己的皮肤是鎏金 black-pool），改成
+    「the canonical Black Pool look」即说假话；`Hermes Index` 是外部技能注册表，
+    改名会让用户搜不到它。
+    """
+    added = [l for l in PATCH_BRAND.read_text(encoding="utf-8").splitlines()
+             if l.startswith("+") and not l.startswith("+++")]
+    for bad in ("Black Pool Teal", "Black Pool Index", "Black Pool Tools"):
+        hits = [l.strip()[:110] for l in added if bad in l]
+        assert not hits, f"外部自有名被误换（应豁免）: {bad} -> {hits[:3]}"
+
+
+def test_masking_preserves_functional_tokens_on_rebranded_lines():
+    """掩码法（2026-08-25 守密人裁定）取代整行跳线后的双向守卫。
+
+    改法的意义：原先整行跳过，同一行的用户文案跟着功能标识符一起免疫——12 处生产
+    残留正出自此（i18n 四语种「远程主机上未安装 Hermes」因行内含安装 URL 而整行豁免，
+    electron 托盘标签 `Hermes at ${ACTIVE_HERMES_ROOT}` 因变量名含 HERMES_ 而整行豁免）。
+    掩码后同一行两件事各归各位，故本测两头都验：文案换了，且片段一字未动。
+    """
+    rebrand = _load_rebrand()
+    line = ("        '远程主机上未安装 Hermes。请在远程安装"
+            "（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）"
+            "或设置 Hermes 路径。',\n")
+    out = rebrand.transform_brand(line, bare_word=True)
+    assert "未安装 Black Pool。" in out and "设置 Black Pool 路径" in out, f"显示文案未换装: {out}"
+    assert "https://hermes-agent.nousresearch.com/install.sh" in out, f"URL 被打断: {out}"
+
+    tray = "    label: `Hermes at ${ACTIVE_HERMES_ROOT}`,\n"
+    out = rebrand.transform_brand(tray, bare_word=True)
+    assert "`Black Pool at ${ACTIVE_HERMES_ROOT}`" in out, f"托盘标签换装失败: {out}"
+
+    # 转义序列不再挡住词边界（`\n` 的 n 曾被当成字母左边界，静默漏换 1 处）。
+    esc = '                f"\\nHermes relaunch failed: {exc}\\n"\n'
+    out = rebrand.transform_brand(esc, bare_word=True)
+    assert "Black Pool relaunch failed" in out, f"转义序列后的裸词未换装: {out}"
+    assert "\\n" in out, f"转义序列被吞: {out}"
+
+    # 版权行仍走整行跳过（来源事实整行都是，不做片段掩码）。
+    cw = "# Copyright (c) Nous Research — Hermes Agent\n"
+    assert rebrand.transform_brand(cw, bare_word=True) == cw, "版权行必须整行跳过"
 
 
 def test_agent_prompt_text_rebranded():


### PR DESCRIPTION
## 概述

守密人现场反馈「品牌补丁不够完整，很多状态提示还是 hermes」。在**换装后的私有版树上实测**后，查明是两个互不相干的缺陷（补丁本身没坏，`--check` 一直是绿的）：裸词换装的射程从没盖到后端六个目录（659 处生产字符串），以及跳线谓词整行豁免误伤了同行的显示文案（12 处）。本 PR 按守密人四项交互裁定一并修掉，残留降至 9 处且全部为有意保留。

---

## 变更类型

- [ ] 数据补全（Wiki characters / wheels / items / banners / stages / lore）
- [ ] 翻译贡献（zh / en / ja）
- [x] 文档完善（CLAUDE.md / README.md / 子项目 CONTEXT.md / memory 档案）— `projects/black-pool-agent/BRANDING.md` 四处措辞随本轮作废并订正
- [x] Bug 修复 — 品牌换装漏换 + 跳线误伤 + 转义序列假阴性
- [ ] 视觉/前端改进（site / wiki theme / news 模板）
- [x] 其他：规则引擎（`build/rebrand.py`）结构改动 + 守卫扩容

---

## 来源声明

> 所有数据必须可追溯至**公开来源**。

- [x] 本 PR 不涉及游戏数据补全。改动对象为本仓自有工程产物（品牌换装规则引擎 + 其生成的补丁 + 守卫测试），事实依据均取自 `projects/black-pool-agent/upstream/` 内的 MIT 开源上游快照与本仓既有档案。

- [x] 翻译类 PR：不适用。

---

## 安全声明（强制）

- [x] **本贡献不包含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据。** 全部改动落在银芯自有的规则引擎、补丁与测试上，§1.1-HC 黑池防火墙未涉。

- [x] **本贡献的游戏图片 / 数据 / 文本仅引用公开素材**；未新增任何美术资产或解包文件。

- [x] **同意按 MIT License 提交贡献。** 上游 `LICENSE`、版权行、SPDX 标识与来源 URL 一律未触碰（守卫 `test_patches_never_touch_license_or_copyright`）；对外口径仍为「基于 MIT 开源组件二次开发」。

---

## 验证清单

- [x] 本地跑通对应校验脚本
  - `python3 projects/black-pool-agent/build/rebrand.py --check` → in sync（零漂移）
  - `pytest tests/test_hermes_charter.py` → **21 passed**（新增 3 条守卫）
  - `python3 scripts/premerge_gate.py` → **3158 passed / 49 skipped**
  - 三条新守卫均做过**反向对照**：恢复旧「整行跳线」行为后掩码守卫当场转红；构造一个只进裸词表不进扫描白名单的目录后一致性守卫当场逮到
- [x] 若涉及 site / wiki / news 视觉：不适用
- [x] 不引入 emoji（按 `CLAUDE.md` 硬约束）
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md` 等档案（这些归主控台）

---

## 改动要点

### 一、裸词换装铺开六目录（守密人裁定「全铺六目录 + 豁免名单」）

`BARE_WORD_DIRS` 由 4 个目录扩到 10 个，新增 `hermes_cli` / `gateway` / `tools` / `plugins` / `acp_adapter` / `skills`。挂账自 2026-08-05 的「须先定豁免名单」在实测中拿到了名单：这六个目录的 Python **代码 token 里裸词 `Hermes` 为 0 处**（659 处全部落在字符串字面量），故铺开不改动任何类名 / 模块名 / 变量名。

`RUNTIME_DIRS` 同步补入 `acp_adapter` / `skills`——**两表是两道闸**（前者管「这里换不换裸词」，后者管「这里扫不扫」），本轮先只改前者时实测 16 处残留纹丝不动，即「配了钥匙没开门」。新守卫已把两表钉死为同进同退。

### 二、跳线谓词整行改片段掩码（守密人裁定「掩码法」）

版权 / SPDX 仍整行跳过；URL / `HERMES_*` / `X-Client-Name` 改为掩码占位符 → 规则照跑 → 还原。原代价面 12 处生产残留随之消失（i18n 四语种「远程主机上未安装 Hermes」、electron 托盘标签 `Hermes at ${ACTIVE_HERMES_ROOT}`），而 URL 与环境变量名一字未动。同一改法附带修掉一处同族假阴性：`"\nHermes relaunch failed"` 里 `\n` 的那个 `n` 被词边界当成字母，静默漏换。

### 三、豁免名单只留「不是我们的东西」

| 豁免项 | 理由 |
|---|---|
| `Hermes Teal` / `(Large)` | 上游自有主题名，与 `Nous Blue` / `Ember` 并列；其描述「the canonical Hermes look」指的正是上游青调皮肤，换了即说假话 |
| `Hermes Index` | 外部技能注册表标签，与 `Official (Nous)` / `ClawHub` 并列，改名会让用户搜不到它 |
| `Hermes Tools` | 上游子系统名 |
| `; Hermes/`（qqbot UA） | 发给腾讯接口的线上标识符、非用户感知显示名，与已受保护的 `X-Client-Name` 同类；含空格品牌名会把产品令牌劈成两截（lesson #57 同病灶） |

**原拟豁免的 `Hermes.exe` / `.app` / `.desktop` / `StartupWMClass` 共 27 处已由守密人翻案改为照换**：`productName` 与 `executableName` 换装后均为 `Black Pool`，electron-builder 产出的就是 `Black Pool.exe`——这些是**黑池自己产物**的门牌号，豁免反而会去找一个不存在的文件。旁证：`apps/` 早在射程内，`desktop-uninstall.ts` 的同类路径此前已是 `Black Pool.app`。

### 四、点火台账扩容 + 两条 POST 规则退役留痕

豁免名单纳入「全树一次没命中即响亮失败」的既有纪律——豁免哑火比替换哑火更隐蔽（症状是某个功能标识符被顺手改掉，要等组装线甚至出厂才炸）。

台账当场逮到两条 POST 规则失锚（APP_NAME 兜底、CLI 面板标题 `⚕ Hermes`）。核实后确认**换装没丢，是被铺宽后的行级规则提前接管**（实测 `|| 'Black Pool'`、`⚕ Black Pool`），故按「退役留痕」处置而非静默删除。

### 结果

补丁换装面 **560 → 830 个文件**；生产字符串残留 **659 → 9**，9 处全部有意保留（7 处豁免名 + 1 处自家规则故意注入的旧名并收 + 1 处豁免 UA）。

---

## 关联 Issue

- Closes #
- Refs # — 销 `BRANDING.md`「后端裸词下一层挂账（守密人 2026-08-05 分层裁定）」

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmJDvun8dcB5TjUqAqHuTy)_