### PR TITLE
fix(bpa): 退役 windows-user-env 测试对齐规则（掩码法上线后已自愈）

### DIFF
--- a/projects/black-pool-agent/build/rebrand.py
+++ b/projects/black-pool-agent/build/rebrand.py
@@ -515,15 +515,15 @@ BRAND_POST_RULES = [
         "You run on Black Pool Agent (by Nous Research). ",
         f"You run on {BRAND_AGENT} (by B.I.A.V. Studio). ",
     ),
-    # 裸词换装的一处自伤（守密人 2026-08-05「装配线接上 desktop 单测」时暴露）：
-    # windows-user-env 的用例喂给 mock 的注册表行含 `HERMES_HOME`，整行命中
-    # LINE_SKIP_MARKERS 被跳过，值里的 `%DRIVE%\Hermes` 原样留着；而下面那句断言
-    # 不含跳线标记，裸词规则照改不误——同一个用例的输入与期望就此对不上。
-    # 这里测的是 `%VAR%` 展开逻辑，与品牌无关，故把期望改回与 mock 输入一致。
-    (
-        "  assert.equal(value, 'F:\\\\Black Pool')\n",
-        "  assert.equal(value, 'F:\\\\Hermes')\n",
-    ),
+    # 【已退役 2026-08-25 · 掩码法上线后自愈，勿再加回】windows-user-env 用例的
+    # 输入/期望自伤。原病灶是**整行跳线**：mock 喂的注册表行含 `HERMES_HOME`、
+    # 整行豁免，值里的 `%DRIVE%\Hermes` 原样留着，而下面那句断言不含跳线标记、
+    # 裸词照改——同一个用例的输入与期望对不上，故当年补一条规则把期望改回 Hermes。
+    # 掩码法只掩 `HERMES_HOME` 本身，值里的 `Hermes` 与断言里的一起换成 Black Pool，
+    # 两边自然一致，这条规则反而成了唯一的不一致来源：组装线 run #25 的**唯一**
+    # 红项（1 failed / 6,952）就是它——mock 返回 `%DRIVE%\Black Pool`、断言被它
+    # 强行改回 `F:\Hermes`。这里测的是 `%VAR%` 展开逻辑，与品牌无关，两边同为
+    # Black Pool 一样测得到，故整条退役而非重锚。
     # 2026-08-19 移 pin 新撞的同类自伤（find-in-page 大小写不敏感回归用例，
     # 新增于本次移 pin）：夹具字符串拿 'Hermes' 当纯占位样本文本（测的是查找
     # 大小写不敏感，与品牌无关），裸词规则照改不误；但断言用的搜索词

--- a/projects/black-pool-agent/patches/black-pool-rebrand.patch
+++ b/projects/black-pool-agent/patches/black-pool-rebrand.patch
@@ -27073,7 +27073,7 @@ index 1b24aaa..7a9b0d2 100644
      execFileSync() {
        throw new Error('access denied')
 diff --git a/apps/desktop/electron/windows-user-env.test.ts b/apps/desktop/electron/windows-user-env.test.ts
-index 6b92650..1c4ca3d 100644
+index 6b92650..00def06 100644
 --- a/apps/desktop/electron/windows-user-env.test.ts
 +++ b/apps/desktop/electron/windows-user-env.test.ts
 @@ -7,8 +7,8 @@ import { expandWindowsEnvRefs, parseRegQueryValue, readWindowsUserEnvVar } from
@@ -27116,6 +27116,15 @@ index 6b92650..1c4ca3d 100644
    }
  
    const value = readWindowsUserEnvVar('HERMES_HOME', {
+@@ -69,7 +69,7 @@ test('readWindowsUserEnvVar queries HKCU\\Environment and expands the value', ()
+     exec
+   })
+ 
+-  assert.equal(value, 'F:\\Hermes')
++  assert.equal(value, 'F:\\Black Pool')
+   assert.deepEqual(calls, [['reg', ['query', 'HKCU\\Environment', '/v', 'HERMES_HOME']]])
+ })
+ 
 diff --git a/apps/desktop/electron/windows-user-env.ts b/apps/desktop/electron/windows-user-env.ts
 index 890cd6f..f87eef7 100644
 --- a/apps/desktop/electron/windows-user-env.ts


### PR DESCRIPTION
## 概述

组装 run #25（跑在 #1001 的合并提交上）回归网红，**1 failed / 6,952**。根因不是功能坏，是 2026-08-05 留的一条测试对齐规则在掩码法上线后过期——它的存在前提「整行跳线」已被 #1001 拆掉。本 PR 退役该规则。

---

## 变更类型

- [x] Bug 修复 — 组装线回归网唯一红项
- [ ] 数据补全 / 翻译 / 视觉
- [x] 其他：规则引擎（`build/rebrand.py`）退役一条 POST 规则 + 补丁重出

---

## 来源声明

- [x] 本 PR 不涉及游戏数据。事实依据为 [run #25 日志](https://github.com/lightproud/BIAV-SC-CODE/actions/runs/33013967372) 与本仓自有规则引擎。

---

## 安全声明（强制）

- [x] **不含来自 BIAV 内网 / 黑池 / 未发布渠道的任何数据**，§1.1-HC 防火墙未涉。
- [x] **不新增任何美术资产或解包文件**。
- [x] **同意按 MIT License 提交**；上游 LICENSE / 版权行 / URL 未触碰。

---

## 验证清单

- [x] **先复现红、再证明绿**：红态由 run #25 日志逐字确证（`Expected: "F:\Hermes" / Received: "F:\Black Pool"`）；修后本地换装树跑同一档 → 10 项全绿
- [x] **本地全量回归网**：`npx vitest run` → **674 档通过 / 1 跳过，6,929 项通过 / 3 跳过，exit 0**（322.98 秒）
- [x] `pytest tests/test_hermes_charter.py` → 21 passed
- [x] `rebrand.py --check` → in sync
- [x] `python3 scripts/premerge_gate.py` → 3,158 passed / 49 skipped
- [x] 不引入 emoji
- [x] 不动 `memory/decisions.md` / `memory/lessons-learned.md`

**验证缺口照实记录**：本容器收集 675 档，CI 侧 676 档——差的 1 档（约 20 例）因环境件缺失（无 ssh 等）在本地不收集。该档在 run #25 中本就属通过的 674 档，且本次 diff 只动 `windows-user-env.test.ts` 的一行断言，与它无涉。

---

## 根因

| 时期 | mock 输入行（含 `HERMES_HOME`）| 断言行 | 结果 |
|---|---|---|---|
| 整行跳线时代 | 整行豁免 → 留 `%DRIVE%\Hermes` | 裸词照改 → `Black Pool` | 对不上 → 2026-08-05 加规则把**断言**拽回 `Hermes` |
| #1001 掩码法之后 | 只掩 `HERMES_HOME`，值随裸词改 → `Black Pool` | 被那条老规则**强行拽回** `Hermes` | 又对不上，方向翻转 |

掩码法让输入与断言两边自然一致，这条规则遂从「唯一的补丁」变成「唯一的不一致来源」。该用例测的是 `%VAR%` 环境变量展开逻辑、与品牌无关，两边同为 `Black Pool` 一样测得到，故**整条退役而非重锚**，并在原位留痕注明「勿再加回」。

---

## 关联 Issue

- Closes #
- Refs [#1001](https://github.com/lightproud/BIAV-SC-CODE/pull/1001)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmJDvun8dcB5TjUqAqHuTy)_